### PR TITLE
Remove unused CSS from typography

### DIFF
--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -169,26 +169,6 @@ dfn {
   max-width: $lead-max-width;
 }
 
-.usa-image-block {
-  position: relative;
-}
-
-.usa-image-text-block {
-  color: $color-white;
-  left: 0;
-  margin-left: 8%;
-  position: absolute;
-  top: 0;
-}
-
-.usa-image-text {
-  margin-top: 0;
-}
-
-.usa-drop_text {
-  margin-bottom: 0;
-}
-
 .usa-background-dark {
   background-color: $color-gray-dark;
 


### PR DESCRIPTION
Found CSS that is not in use and this removes it. The `usa-image-block` was replaced with `usa-media_block-*` with this functionality https://v4-alpha.getbootstrap.com/layout/media-object/. `usa-drop_text` is only used in the password reset form but it has no effect by removing it.