### PR TITLE
Update repo url to new uswds org and repo name

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ Use the title line as the title of your pull request, then delete these lines.
 
 ## Title line template: [Title]: Brief description
 
-Website: For issues that impact standards.usa.gov’s look, feel, or functionality, please open an issue on the web-design-standards-docs repo (https://github.com/18F/web-design-standards-docs/issues/new).
+Website: For issues that impact standards.usa.gov’s look, feel, or functionality, please open an issue on the web-design-standards-docs repo (https://github.com/uswds/uswds-docs/issues/new).
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Use the title line as the title of your pull request, then delete these lines.
 
 ## Title line template: [Title]: Brief description
 
-Website: For pull requests that impact standards.usa.gov’s look, feel, or functionality, please open a pull request on the web-design-standards-docs repo (https://github.com/18F/web-design-standards-docs).
+Website: For pull requests that impact standards.usa.gov’s look, feel, or functionality, please open a pull request on the web-design-standards-docs repo (https://github.com/uswds/uswds-docs).
 
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We’re so glad you’re thinking about contributing to an 18F open source proje
 
 One of our goals is to ensure a welcoming environment for all contributors to our projects. Our staff follows the [18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/), and all contributors should do the same.
 
-We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](https://github.com/18F/web-design-standards/blob/develop/LICENSE.md), [README](https://github.com/18F/web-design-standards/blob/develop/README.md) and its [Workflow](https://github.com/18F/web-design-standards/wiki/Workflow) process.
+We encourage you to read this project’s CONTRIBUTING policy (you are here), its [LICENSE](https://github.com/uswds/uswds/blob/develop/LICENSE.md), [README](https://github.com/uswds/uswds/blob/develop/README.md) and its [Workflow](https://github.com/uswds/uswds/wiki/Workflow) process.
 
 If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository]( https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
 
@@ -12,7 +12,7 @@ If you have any questions or want to read more, check out the [18F Open Source P
 
 ### Contributor Guidelines for Design
 
-We have provided some guidelines for folks that would like to submit new components to the U.S. Web Design Standards and the lifecycle those new components will go through. For more detail, please visit the [guidelines on our wiki](https://github.com/18F/web-design-standards/wiki/Contribution-Guidelines:-Design).
+We have provided some guidelines for folks that would like to submit new components to the U.S. Web Design Standards and the lifecycle those new components will go through. For more detail, please visit the [guidelines on our wiki](https://github.com/uswds/uswds/wiki/Contribution-Guidelines:-Design).
 
 ### Submitting an issue
 
@@ -30,7 +30,7 @@ Here are a few guidelines to follow when submitting a pull request:
 1. Once you’re ready to submit a pull request, fill out the PULL REQUEST template provided.
 1. Submit your pull request against the `develop` branch.
 
-[Open an issue](https://github.com/18F/web-design-standards/issues/new) if you have questions or need help with setup.
+[Open an issue](https://github.com/uswds/uswds/issues/new) if you have questions or need help with setup.
 
 ### Running locally
 
@@ -156,11 +156,11 @@ See the [release documentation](RELEASE.md#release-process) for more information
 
 ### A few parts of this project are not in the public domain
 
-For complete attribution and licensing information for parts of the project that are not in the public domain, see [LICENSE.md](https://github.com/18F/web-design-standards/blob/develop/LICENSE.md).
+For complete attribution and licensing information for parts of the project that are not in the public domain, see [LICENSE.md](https://github.com/uswds/uswds/blob/develop/LICENSE.md).
 
 ### The rest of this project is in the public domain
 
-The rest of this project is in the worldwide [public domain](https://github.com/18F/web-design-standards/blob/develop/LICENSE.md).
+The rest of this project is in the worldwide [public domain](https://github.com/uswds/uswds/blob/develop/LICENSE.md).
 
 This project is in the public domain within the United States, and
 copyright and related rights in the work worldwide are waived through

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,7 +1,7 @@
 # Migration guide
 
 ## v1.2.0
-[Version 1.2.0](https://github.com/18F/web-design-standards/releases/tag/v1.2.0)
+[Version 1.2.0](https://github.com/uswds/uswds/releases/tag/v1.2.0)
 includes a complete refactor of our JavaScript to modernize our code, and provides
 better compatibility with third-party frameworks, such as React and Angular. You
 can read more about the rationale and techniques in [this update][] **link needed**,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The [U.S. Web Design Standards](https://standards.usa.gov) include a library of open source UI components and a visual style guide for U.S. federal government websites.
 
-This repository is for the Standards themselves. 18F maintains [another repository for the documentation and website](https://github.com/18F/web-design-standards-docs). To see the Standards and documentation on the web, visit [https://standards.usa.gov](https://standards.usa.gov).
+This repository is for the Standards themselves. 18F maintains [another repository for the documentation and website](https://github.com/uswds/uswds-docs). To see the Standards and documentation on the web, visit [https://standards.usa.gov](https://standards.usa.gov).
 
 
 ## Contents
@@ -33,7 +33,7 @@ The components and style guide of the U.S. Web Design Standards follow industry-
 
 ## Recent updates
 
-Information about the most recent release of the Standards can always be found in the [release history](https://github.com/18F/web-design-standards/releases). We include details about significant updates and any backwards incompatible changes along with a list of all changes.
+Information about the most recent release of the Standards can always be found in the [release history](https://github.com/uswds/uswds/releases). We include details about significant updates and any backwards incompatible changes along with a list of all changes.
 
 
 ## Getting started
@@ -41,9 +41,9 @@ Information about the most recent release of the Standards can always be found i
 We’re glad you’d like to use the Standards — here’s how you can get started:
 
 * Designers: [Check out our Getting Started for Designers information](https://standards.usa.gov/getting-started/designers/).
-  * [Design files of all the assets included in the Standards are available for download](https://github.com/18F/web-design-standards-assets/archive/master.zip).
+  * [Design files of all the assets included in the Standards are available for download](https://github.com/uswds/uswds-assets/archive/master.zip).
 * Developers: [Follow the instructions in this README to get started.](#using-the-standards)
-  * [CSS, JavaScript, image, and font files of all the assets on this site are available for download](https://github.com/18F/web-design-standards/releases/download/v1.0.0/uswds-1.0.0.zip).
+  * [CSS, JavaScript, image, and font files of all the assets on this site are available for download](https://github.com/uswds/uswds/releases/download/v1.0.0/uswds-1.0.0.zip).
 
 
 ## Using the Standards
@@ -59,7 +59,7 @@ There are a few different ways to use the Standards within your project. Which o
 
 ### Download
 
-1. Download the [Standards zip file](https://github.com/18F/web-design-standards/releases/latest) from the latest release and open that file.
+1. Download the [Standards zip file](https://github.com/uswds/uswds/releases/latest) from the latest release and open that file.
 
   After extracting the zip file you should see the following file and folder structure:
 
@@ -163,9 +163,9 @@ node_modules/uswds/
 
 Since you are already using `npm`, the U.S. Web Design Standards team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
 
-[Link to `npm` scripts example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/develop/package.json#L4)
+[Link to `npm` scripts example in `web-design-standards-docs`](https://github.com/uswds/uswds-docs/blob/develop/package.json#L4)
 
-[Link to gulpfile.js example in `web-design-standards-docs`](https://github.com/18F/web-design-standards-docs/blob/develop/gulpfile.js)
+[Link to gulpfile.js example in `web-design-standards-docs`](https://github.com/uswds/uswds-docs/blob/develop/gulpfile.js)
 
 #### Sass
 
@@ -192,7 +192,7 @@ You can now use your copied version of `_variables.scss` to override any styles 
 
 ### Use another framework or package manager
 
-If you’re using another framework or package manager that doesn’t support `npm`, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
+If you’re using another framework or package manager that doesn’t support `npm`, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/uswds/uswds/issues/877).
 
 If you’re interested in maintaining a package that helps us distribute the U.S. Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
 
@@ -221,7 +221,7 @@ Many of our Fractal view templates are compatible with [Nunjucks](https://mozill
 
 Do you have questions or need help with setup? Did you run into any weird errors while following these instructions? Feel free to open an issue here:
 
-[https://github.com/18F/web-design-standards/issues](https://github.com/18F/web-design-standards/issues).
+[https://github.com/uswds/uswds/issues](https://github.com/uswds/uswds/issues).
 
 You can also email us directly at uswebdesignstandards@gsa.gov.
 
@@ -230,9 +230,9 @@ You can also email us directly at uswebdesignstandards@gsa.gov.
 
 For complete instructions on how to contribute code, please read [CONTRIBUTING.md](CONTRIBUTING.md). These instructions also include guidance on how to set up your own copy of the Standards style guide website for development.
 
-If you would like to learn more about our workflow process, check out the [Workflow](https://github.com/18F/web-design-standards/wiki/Workflow) and [Issue label Glossary](https://github.com/18F/web-design-standards/wiki/Issue-label-glossary) pages on the wiki.
+If you would like to learn more about our workflow process, check out the [Workflow](https://github.com/uswds/uswds/wiki/Workflow) and [Issue label Glossary](https://github.com/uswds/uswds/wiki/Issue-label-glossary) pages on the wiki.
 
-If you have questions or concerns about our contributing workflow, please contact us by [filing a GitHub issue](https://github.com/18F/web-design-standards/issues) or [emailing our team](mailto:uswebdesignstandards@gsa.gov).
+If you have questions or concerns about our contributing workflow, please contact us by [filing a GitHub issue](https://github.com/uswds/uswds/issues) or [emailing our team](mailto:uswebdesignstandards@gsa.gov).
 
 
 ## Reuse of open-source style guides

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,7 +133,7 @@ Otherwise, proceed with the next versioned release!
 
 - [ ] Push the version branch up to Github
 - [ ] Open a pull request from your release branch into `master`.
-- [ ] List the key changes in the release in the pull request description. [See the v1.0.0 pull request](https://github.com/18F/web-design-standards/pull/1726) for an example.
+- [ ] List the key changes in the release in the pull request description. [See the v1.0.0 pull request](https://github.com/uswds/uswds/pull/1726) for an example.
 - [ ] Wait for all tests to complete successfully.
 - [ ] Have at least one team member to approved the pull request
 - [ ] Once the pull request is approved, merge it into `master`. This will trigger a two actions:
@@ -153,7 +153,7 @@ Otherwise, proceed with the next versioned release!
 
 - [ ] Close all running USWDS processes in the terminal
 - [ ] In the `master` branch run `npm run prepublish` to build the assets zip file. It will be created at `dist/uswds-{{ version }}.zip`.
-- [ ] In [Github releases](https://github.com/18F/web-design-standards/releases) select `Draft a new release`
+- [ ] In [Github releases](https://github.com/uswds/uswds/releases) select `Draft a new release`
 - [ ] `tag`: `v{{ version }}`
 - [ ] `target`: `master`
 - [ ] Add release notes to the body
@@ -206,17 +206,17 @@ npm install --save-exact uswds@{{ version }}
 ## Questions?
 If you need help or have any questions, please reach out to us:
 
-* File an [issue on GitHub](https://github.com/18F/web-design-standards/issues/new).
+* File an [issue on GitHub](https://github.com/uswds/uswds/issues/new).
 * Email us at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov).
 * [Sign up](https://chat.18f.gov/) for our public [Slack] channel.
 
 
-[draft release]: https://github.com/18F/web-design-standards/releases/new
+[draft release]: https://github.com/uswds/uswds/releases/new
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
-[new release]: https://github.com/18F/web-design-standards/releases/new
+[new release]: https://github.com/uswds/uswds/releases/new
 [npm version]: https://docs.npmjs.com/cli/version
-[pull request]: https://github.com/18F/web-design-standards/compare
-[releases]: https://github.com/18F/web-design-standards/releases
+[pull request]: https://github.com/uswds/uswds/compare
+[releases]: https://github.com/uswds/uswds/releases
 [semver]: http://semver.org/
 [uswds on npm]: https://npmjs.com/package/uswds
 [what is npm]: https://docs.npmjs.com/getting-started/what-is-npm

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/18F/web-design-standards.git"
+    "url": "git+https://github.com/uswds/uswds.git"
   },
   "author": "18F",
   "contributors": [
@@ -44,9 +44,9 @@
   ],
   "license": "SEE LICENSE IN LICENSE.md",
   "bugs": {
-    "url": "https://github.com/18F/web-design-standards/issues"
+    "url": "https://github.com/uswds/uswds/issues"
   },
-  "homepage": "https://github.com/18F/web-design-standards#readme",
+  "homepage": "https://github.com/uswds/uswds#readme",
   "dependencies": {
     "@types/node": "^8.5.5",
     "array-filter": "^1.0.0",

--- a/spec/screenshots/index.html
+++ b/spec/screenshots/index.html
@@ -39,7 +39,7 @@ details[open] > summary::before {
       <div class="usa-logo" id="logo">
         <em class="usa-logo-text">
           <a href="#" title="Home" aria-label="Visual regression screenshot viewer">
-            <!-- Until https://github.com/18F/web-design-standards/issues/1729
+            <!-- Until https://github.com/uswds/uswds/issues/1729
                  is fixed, we need to keep this title ridiculously terse. -->
             Screenshot Viewer
           </a>

--- a/src/components/_uswds.njk
+++ b/src/components/_uswds.njk
@@ -11,7 +11,7 @@
     <script>
     window.addEventListener('load', function() {
       document.body.addEventListener('submit', function(e) {
-        // https://github.com/18F/web-design-standards/issues/2101
+        // https://github.com/uswds/uswds/issues/2101
         e.preventDefault();
       }, true);
     }, false);


### PR DESCRIPTION
When we move to the new org and change our repo name.

Related: https://github.com/18F/web-design-standards-docs/pull/486, https://github.com/18F/web-design-standards/issues/2317.

See https://github.com/18F/web-design-standards/issues/2300.