### PR TITLE
GIT repository URL fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uswds/uswds.git"
+    "url": "https://github.com/uswds/uswds.git"
   },
   "author": "18F",
   "contributors": [


### PR DESCRIPTION
The git repository URL is been fixed in package.json.

