### PR TITLE
Remove text color and decoration from usa-footer-return-to-top

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -41,10 +41,8 @@
 }
 
 .usa-footer-return-to-top {
-  color: $color-primary;
   padding-bottom: $spacing-medium;
   padding-top: $spacing-medium;
-  text-decoration: underline;
 }
 
 .usa-footer-primary-section {


### PR DESCRIPTION
Remove text color and decoration from usa-footer-return-to-top section.

Let the styles for the link element do their thing :)

### Reasoning
I'm wanting to put some other content into the `usa-footer-return-to-top ` div that is not a link and therefore don't want the text to be blue and underlined. I'm thinking of using this return to top section as a page footer with meta information like last updated date and a link to take you to GitHub for editing.

### Screenshot
The first item and last item are links and the last updated date/time is just text

![screen shot 2018-01-30 at 12 36 12 pm](https://user-images.githubusercontent.com/1449852/35581454-ce70ce30-05b9-11e8-845d-83dba3976b32.png)