### PR TITLE
Add circle utility for both settings and units

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -180,7 +180,7 @@
 
 // ------------------------------------------------------------
 
-@mixin render-utility($selector, $property, $value, $val-props) {
+@mixin render-utility($utility, $selector, $property, $value, $val-props) {
   $this-namespace: null;
 
   @if $utility-type == settings {
@@ -193,6 +193,10 @@
 
     @each $this-property in $property {
       #{$this-property}: $value;
+    }
+
+    @if map-has-key($utility, extend) {
+      #{map-deep-get($utility, extend, property)}: strunquote(map-deep-get($utility, extend, value));
     }
   }
 }
@@ -230,7 +234,7 @@
   }
 }
 
-@mixin render-media-queries($selector, $property, $value, $val-props) {
+@mixin render-media-queries($utility, $selector, $property, $value, $val-props) {
   $this-namespace: null;
 
   @if $utility-type == settings {
@@ -246,6 +250,10 @@
 
         @each $this-property in $property {
           #{$this-property}: $value;
+        }
+        
+        @if map-has-key($utility, extend) {
+          #{map-deep-get($utility, extend, property)}: strunquote(map-deep-get($utility, extend, value));
         }
       }
     }
@@ -506,7 +514,7 @@
           // FINALLY, "BUILD THE RULE, MAX!"
           // https://www.youtube.com/watch?v=R3Igz5SfBCE
 
-          @include render-utility($selector, $property, $value, $val-props);
+          @include render-utility($utility, $selector, $property, $value, $val-props);
 
           // Add the pseudoclass variants, if applicable
 
@@ -523,7 +531,7 @@
           // And add the responsive prefixes, if applicable
 
           @if map-get($utility, responsive) {
-            @include render-media-queries($selector, $property, $value, $val-props);
+            @include render-media-queries($utility, $selector, $property, $value, $val-props);
           } // ･ﾟ✧
         } // end the modifier loop
       } // end the value loop

--- a/src/stylesheets/utilities/_package.scss
+++ b/src/stylesheets/utilities/_package.scss
@@ -7,6 +7,7 @@ $utilities-package: map-collect(
   $border-radius,
   $border-style,
   $border-width,
+  $circle,
   $clear,
   $clearfix,
   $color,

--- a/src/stylesheets/utilities/settings/_all.scss
+++ b/src/stylesheets/utilities/settings/_all.scss
@@ -3,6 +3,7 @@
 @import "rules/border-radius";
 @import "rules/border-style";
 @import "rules/border-width";
+@import "rules/circle";
 @import "rules/clear";
 @import "rules/clearfix";
 @import "rules/color";

--- a/src/stylesheets/utilities/settings/rules/border-radius.scss
+++ b/src/stylesheets/utilities/settings/rules/border-radius.scss
@@ -3,17 +3,17 @@
 Border Radius
 ----------------------------------------
 usage:
-  .br[-]*[value]
+  .radius-[value]
 ----------------------------------------
 output:
   border-radius: [value];
 ----------------------------------------
 example:
-  .br0 {
-    border-radius: 0; }
+  .radius-md {
+    border-radius: $s-spacing-md; }
 
-  .br-pill {
-    border-radius: 10em; }
+  .radius-pill {
+    border-radius: 9999em; }
 ----------------------------------------
 */
 
@@ -23,7 +23,8 @@ $border-radius: (
     modifiers: null,
     values: (
       0: '0',
-      pill: ('10em', isReadable),
+      pill: ('9999em', isReadable),
+      circle: ('50%', isReadable),
       sm: ($s-radius-sm, isReadable),
       md: ($s-radius-md, isReadable),
       lg: ($s-radius-lg, isReadable),

--- a/src/stylesheets/utilities/settings/rules/circle.scss
+++ b/src/stylesheets/utilities/settings/rules/circle.scss
@@ -1,0 +1,37 @@
+/*
+----------------------------------------
+Circle
+----------------------------------------
+usage:
+  .circle-[value]
+----------------------------------------
+output:
+  height: [value];
+  width: [value];
+  border-radius: 50%;
+----------------------------------------
+example:
+  .circle-6 {
+    height: 3rem;
+    width: 3rem; }
+----------------------------------------
+*/
+
+$circle: (
+  circle: (
+    base: ('circle', isReadable),
+    modifiers: null,
+    values: map-collect(
+      map-get($values-settings, spacing),
+      map-get($values-units, pixels)
+    ),
+    property: (height, width),
+    extend: (
+      property: 'border-radius',
+      value: '50%',
+    ),
+    output: true,
+    responsive: true,
+    pseudoclasses: false,
+  )
+)

--- a/src/stylesheets/utilities/settings/rules/circle.scss
+++ b/src/stylesheets/utilities/settings/rules/circle.scss
@@ -22,8 +22,7 @@ $circle: (
     base: ('circle', isReadable),
     modifiers: null,
     values: map-collect(
-      map-get($values-settings, spacing),
-      map-get($values-units, pixels)
+      map-get($values-settings, spacing)
     ),
     property: (height, width),
     extend: (

--- a/src/stylesheets/utilities/settings/rules/square.scss
+++ b/src/stylesheets/utilities/settings/rules/square.scss
@@ -23,7 +23,6 @@ $square: (
       sq: (height, width),
     ),
     values: map-collect(
-      map-get($values-units, percentage),
       map-get($values-units, grid),
       map-get($values-units, pixels)
     ),

--- a/src/stylesheets/utilities/units/_all.scss
+++ b/src/stylesheets/utilities/units/_all.scss
@@ -3,6 +3,7 @@
 @import "rules/border-radius";
 @import "rules/border-style";
 @import "rules/border-width";
+@import "rules/circle";
 @import "rules/clear";
 @import "rules/clearfix";
 @import "rules/color";

--- a/src/stylesheets/utilities/units/rules/border-radius.scss
+++ b/src/stylesheets/utilities/units/rules/border-radius.scss
@@ -3,16 +3,16 @@
 Border Radius
 ----------------------------------------
 usage:
-  .br[-]*[value]
+  .radius-*[value]
 ----------------------------------------
 output:
   border-radius: [value];
 ----------------------------------------
 example:
-  .br0 {
+  .radius-0 {
     border-radius: 0; }
 
-  .br-pill {
+  .radius-pill {
     border-radius: 10em; }
 ----------------------------------------
 */
@@ -20,10 +20,17 @@ example:
 $border-radius: (
   border-radius: (
     base: ('radius', isReadable),
-    modifiers: null,
+    modifiers: (
+      t: ('border-top-left-radius', 'border-top-right-radius'),
+      r: ('border-top-right-radius', 'border-bottom-right-radius'),
+      b: ('border-bottom-left-radius', 'border-bottom-right-radius'),
+      l: ('border-top-left-radius', 'border-bottom-left-radius'),
+      noModifier: 'border-radius',
+    ),
     values: (
       0: '0',
-      pill: ('10em', isReadable),
+      pill: ('9999em', isReadable),
+      circle: ('50%', isReadable),
       rounded: ($border-radius, isReadable),
       1px: 1px,
       2px: 2px,
@@ -32,7 +39,7 @@ $border-radius: (
       '105': $u-spacing-105,
       '2': $u-spacing-2,
     ),
-    property: 'border-radius',
+    property: '',
     output: true,
     responsive: false,
     pseudoclasses: false,

--- a/src/stylesheets/utilities/units/rules/circle.scss
+++ b/src/stylesheets/utilities/units/rules/circle.scss
@@ -1,0 +1,37 @@
+/*
+----------------------------------------
+Circle
+----------------------------------------
+usage:
+  .circle-[value]
+----------------------------------------
+output:
+  height: [value];
+  width: [value];
+  border-radius: 50%;
+----------------------------------------
+example:
+  .circle-6 {
+    height: 3rem;
+    width: 3rem; }
+----------------------------------------
+*/
+
+$circle: (
+  circle: (
+    base: ('circle', isReadable),
+    modifiers: null,
+    values: map-collect(
+      map-get($values-units, grid),
+      map-get($values-units, pixels)
+    ),
+    property: (height, width),
+    extend: (
+      property: 'border-radius',
+      value: '50%',
+    ),
+    output: true,
+    responsive: true,
+    pseudoclasses: false,
+  )
+)


### PR DESCRIPTION
This also modifies the build function to allow multiple properties in a utility, as well as a utility-level extend.

- **Prototype utility** accepts all grid unit values and pixel values
- **Production utility** accepts spacing settings values

- - -

This also removes the percentage values from `square` since they don't work.

- - -

```
/*
----------------------------------------
Circle
----------------------------------------
usage:
  .circle-[value]
----------------------------------------
output:
  height: [value];
  width: [value];
  border-radius: 50%;
----------------------------------------
example:
  .circle-6 {
    height: 3rem;
    width: 3rem; }
----------------------------------------
*/
```

- - -

- This also adds a `-circle` value to prod and proto `radius` utilities
- Changes the value of `pill` to `9999em`... _it's the only way to be sure._
- It adds top (`t`), right (`r`), bottom (`b`), and left (`l`) modifiers to the proto `radius` utility to allow setting border radius on only one side of a box