### PR TITLE
increasing timeout for testing

### DIFF
--- a/spec/headless-chrome.spec.js
+++ b/spec/headless-chrome.spec.js
@@ -74,7 +74,7 @@ fractalLoad.then(() => {
         });
 
         before(`load fractal component in chrome`, function () {
-          this.timeout(20000);
+          this.timeout(40000);
           return chromeFractalTester.loadFractalPreview(cdp, handle);
         });
 


### PR DESCRIPTION
Gives the test suite more time (40s up from 20s) to load components into chrome