### PR TITLE
Change footer logo alt text to null (empty)

### DIFF
--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -57,7 +57,7 @@
   <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
-        <img class="usa-footer-big-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="Logo image">
+        <img class="usa-footer-big-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
         <h3 class="usa-footer-big-logo-heading">Name of Agency</h3>
       </div>
       <div class="usa-footer-contact-links usa-width-one-half">

--- a/src/components/10-footer/footer--slim.njk
+++ b/src/components/10-footer/footer--slim.njk
@@ -38,7 +38,7 @@
   <div class="usa-footer-secondary_section">
     <div class="usa-grid">
       <div class="usa-footer-logo">
-        <img class="usa-footer-slim-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="Logo image">
+        <img class="usa-footer-slim-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
         <h3 class="usa-footer-slim-logo-heading">Name of Agency</h3>
       </div>
     </div>

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -29,7 +29,7 @@
   <div class="usa-footer-secondary_section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
-        <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="Logo image">
+        <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
         <h3 class="usa-footer-logo-heading">Name of Agency</h3>
       </div>
       <div class="usa-footer-contact-links usa-width-one-half">


### PR DESCRIPTION
Since the logo's text appears beside the logo image, the logo is decorative and alt text should be set to null (empty).

Related #1658.