### PR TITLE
Trap focus to mobile navigation menu and other accessibility fixes

### DIFF
--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -9,7 +9,7 @@ const PREFIX = require('../config').prefix;
 
 const NAV = `.${PREFIX}-nav`;
 const NAV_LINKS = `${NAV} a`;
-const OPENERS = `.${PREFIX}-menu-btn`;
+const OPENERS = `.${PREFIX}-menu-btn`; // Will hold previously focused element
 const CLOSE_BUTTON = `.${PREFIX}-nav-close`;
 const OVERLAY = `.${PREFIX}-overlay`;
 const CLOSERS = `${CLOSE_BUTTON}, .${PREFIX}-overlay`;
@@ -18,21 +18,20 @@ const TOGGLES = [ NAV, OVERLAY ].join(', ');
 const ACTIVE_CLASS = 'usa-mobile_nav-active';
 const VISIBLE_CLASS = 'is-visible';
 
-const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
+const isActive = () => document.classList.contains(ACTIVE_CLASS);
 
 const toggleNav = function (active) {
-  const body = document.body;
   if (typeof active !== 'boolean') {
     active = !isActive();
   }
-  body.classList.toggle(ACTIVE_CLASS, active);
+  document.classList.toggle(ACTIVE_CLASS, active);
 
   forEach(select(TOGGLES), el => {
     el.classList.toggle(VISIBLE_CLASS, active);
   });
 
-  const closeButton = body.querySelector(CLOSE_BUTTON);
-  const menuButton = body.querySelector(OPENERS);
+  const closeButton = document.querySelector(CLOSE_BUTTON);
+  const menuButton = document.querySelector(OPENERS);
 
   if (active && closeButton) {
     // The mobile nav was just activated, so focus on the close button,
@@ -52,7 +51,7 @@ const toggleNav = function (active) {
 };
 
 const resize = () => {
-  const closer = document.body.querySelector(CLOSE_BUTTON);
+  const closer = document.querySelector(CLOSE_BUTTON);
 
   if (isActive() && closer && closer.getBoundingClientRect().width === 0) {
     // The mobile nav is active, but the close box isn't visible, which

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -25,9 +25,6 @@ const focusTrap = ((element) => {
   // Find all focusable children
   const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
   const focusableElements = trapContainer.querySelectorAll(focusableElementsString);
-  // // Convert NodeList to Array
-  // focusableElements = Array.prototype.slice.call(focusableElements);
-
   const firstTabStop = focusableElements[ 0 ];
   const lastTabStop = focusableElements[ focusableElements.length - 1 ];
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -20,7 +20,7 @@ const VISIBLE_CLASS = 'is-visible';
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 
-const focusTrap = ((element) => {
+const _focusTrap = (element) => {
   const trapContainer = document.querySelector(element);
   // Find all focusable children
   const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
@@ -58,16 +58,18 @@ const focusTrap = ((element) => {
   firstTabStop.focus();
 
   return {
-    enable() {
+    enable () {
       // Listen for and trap the keyboard
       trapContainer.addEventListener('keydown', trapTabKey);
     },
 
-    release() {
+    release () {
       trapContainer.removeEventListener('keydown', trapTabKey);
-    }
-  }
-})(NAV);
+    },
+  };
+};
+
+let focusTrap;
 
 const toggleNav = function (active) {
   const body = document.body;
@@ -142,6 +144,7 @@ const navigation = behavior({
   },
 }, {
   init () {
+    focusTrap = _focusTrap(NAV);
     resize();
     window.addEventListener('resize', resize, false);
   },

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -90,6 +90,9 @@ const toggleNav = function (active) {
     // visible (this may have been what the user was just focused on,
     // if they triggered the mobile nav by mistake).
     menuButton.focus();
+
+    // Remove the keydown event listener
+    nav.removeEventListener('keydown', trapTabKey);
   }
 
   return active;

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -9,7 +9,7 @@ const PREFIX = require('../config').prefix;
 
 const NAV = `.${PREFIX}-nav`;
 const NAV_LINKS = `${NAV} a`;
-const OPENERS = `.${PREFIX}-menu-btn`; // Will hold previously focused element
+const OPENERS = `.${PREFIX}-menu-btn`; // Will hold previously focused
 const CLOSE_BUTTON = `.${PREFIX}-nav-close`;
 const OVERLAY = `.${PREFIX}-overlay`;
 const CLOSERS = `${CLOSE_BUTTON}, .${PREFIX}-overlay`;
@@ -18,20 +18,65 @@ const TOGGLES = [ NAV, OVERLAY ].join(', ');
 const ACTIVE_CLASS = 'usa-mobile_nav-active';
 const VISIBLE_CLASS = 'is-visible';
 
-const isActive = () => document.classList.contains(ACTIVE_CLASS);
+const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 
 const toggleNav = function (active) {
+
+  const body = document.body;
   if (typeof active !== 'boolean') {
     active = !isActive();
   }
-  document.classList.toggle(ACTIVE_CLASS, active);
+  body.classList.toggle(ACTIVE_CLASS, active);
 
   forEach(select(TOGGLES), el => {
     el.classList.toggle(VISIBLE_CLASS, active);
   });
 
-  const closeButton = document.querySelector(CLOSE_BUTTON);
-  const menuButton = document.querySelector(OPENERS);
+  var nav = document.querySelector(NAV);
+
+  // Listen for and trap the keyboard
+  nav.addEventListener('keydown', trapTabKey);
+
+  // Find all focusable children
+  var focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+  var focusableElements = nav.querySelectorAll(focusableElementsString);
+  // Convert NodeList to Array
+  focusableElements = Array.prototype.slice.call(focusableElements);
+
+  var firstTabStop = focusableElements[ 0 ];
+  var lastTabStop = focusableElements[ focusableElements.length - 1 ];
+
+  // Focus first child
+  firstTabStop.focus();
+
+  function trapTabKey (e) {
+    // Check for TAB key press
+    if (e.keyCode === 9) {
+
+      // SHIFT + TAB
+      if (e.shiftKey) {
+        if (document.activeElement === firstTabStop) {
+          e.preventDefault();
+          lastTabStop.focus();
+        }
+
+      // TAB
+      } else {
+        if (document.activeElement === lastTabStop) {
+          e.preventDefault();
+          firstTabStop.focus();
+        }
+      }
+    }
+
+    // ESCAPE
+    if (e.keyCode === 27) {
+      toggleNav.call(this, false);
+    }
+  }
+
+  const closeButton = body.querySelector(CLOSE_BUTTON);
+  const menuButton = body.querySelector(OPENERS);
 
   if (active && closeButton) {
     // The mobile nav was just activated, so focus on the close button,
@@ -51,7 +96,7 @@ const toggleNav = function (active) {
 };
 
 const resize = () => {
-  const closer = document.querySelector(CLOSE_BUTTON);
+  const closer = document.body.querySelector(CLOSE_BUTTON);
 
   if (isActive() && closer && closer.getBoundingClientRect().width === 0) {
     // The mobile nav is active, but the close box isn't visible, which

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -20,33 +20,16 @@ const VISIBLE_CLASS = 'is-visible';
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 
-const toggleNav = function (active) {
-  const body = document.body;
-  if (typeof active !== 'boolean') {
-    active = !isActive();
-  }
-  body.classList.toggle(ACTIVE_CLASS, active);
-
-  forEach(select(TOGGLES), el => {
-    el.classList.toggle(VISIBLE_CLASS, active);
-  });
-
-  var nav = document.querySelector(NAV);
-
-  // Listen for and trap the keyboard
-  nav.addEventListener('keydown', trapTabKey);
-
+const focusTrap = ((element) => {
+  const trapContainer = document.querySelector(element);
   // Find all focusable children
-  var focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
-  var focusableElements = nav.querySelectorAll(focusableElementsString);
-  // Convert NodeList to Array
-  focusableElements = Array.prototype.slice.call(focusableElements);
+  const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+  const focusableElements = trapContainer.querySelectorAll(focusableElementsString);
+  // // Convert NodeList to Array
+  // focusableElements = Array.prototype.slice.call(focusableElements);
 
-  var firstTabStop = focusableElements[ 0 ];
-  var lastTabStop = focusableElements[ focusableElements.length - 1 ];
-
-  // Focus first child
-  firstTabStop.focus();
+  const firstTabStop = focusableElements[ 0 ];
+  const lastTabStop = focusableElements[ focusableElements.length - 1 ];
 
   function trapTabKey (e) {
     // Check for TAB key press
@@ -74,6 +57,38 @@ const toggleNav = function (active) {
     }
   }
 
+  // Focus first child
+  firstTabStop.focus();
+
+  return {
+    enable() {
+      // Listen for and trap the keyboard
+      trapContainer.addEventListener('keydown', trapTabKey);
+    },
+
+    release() {
+      trapContainer.removeEventListener('keydown', trapTabKey);
+    }
+  }
+})(NAV);
+
+const toggleNav = function (active) {
+  const body = document.body;
+  if (typeof active !== 'boolean') {
+    active = !isActive();
+  }
+  body.classList.toggle(ACTIVE_CLASS, active);
+
+  forEach(select(TOGGLES), el => {
+    el.classList.toggle(VISIBLE_CLASS, active);
+  });
+
+  if (active) {
+    focusTrap.enable();
+  } else {
+    focusTrap.release();
+  }
+
   const closeButton = body.querySelector(CLOSE_BUTTON);
   const menuButton = body.querySelector(OPENERS);
 
@@ -89,9 +104,6 @@ const toggleNav = function (active) {
     // visible (this may have been what the user was just focused on,
     // if they triggered the mobile nav by mistake).
     menuButton.focus();
-
-    // Remove the keydown event listener
-    nav.removeEventListener('keydown', trapTabKey);
   }
 
   return active;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -53,7 +53,7 @@
 .usa-nav {
   $sliding-panel-width: 26rem;
 
-  @keyframes slide-left {
+  @keyframes slidein-left {
     from {
       transform: translateX($sliding-panel-width);
     }
@@ -86,7 +86,7 @@
   }
 
   &.is-visible {
-    animation: slide-left 0.3s ease-in-out;
+    animation: slidein-left 0.3s ease-in-out;
     display: flex;
   }
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -50,18 +50,18 @@
   }
 }
 
-@keyframes slide-left {
-  from {
-    transform: translateX(26rem);
-  }
-
-  to {
-    transform: translateX(0);
-  }
-}
-
 .usa-nav {
   $sliding-panel-width: 26rem;
+
+  @keyframes slide-left {
+    from {
+      transform: translateX($sliding-panel-width);
+    }
+
+    to {
+      transform: translateX(0);
+    }
+  }
 
   @include position(fixed, 0 0 0 auto);
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -50,6 +50,16 @@
   }
 }
 
+@keyframes slide-left {
+  from {
+    transform: translateX(26rem);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
 .usa-nav {
   $sliding-panel-width: 26rem;
 
@@ -58,11 +68,10 @@
   background: $color-white;
   border-left: 1px solid $color-gray-light;
   border-right: 0;
-  display: flex;
+  display: none;
   flex-direction: column;
   overflow-y: auto;
   padding: 2rem;
-  transform: translateX($sliding-panel-width);
   width: $sliding-panel-width;
   z-index: $z-index-nav;
 
@@ -78,8 +87,8 @@
   }
 
   &.is-visible {
-    transform: translateX(0);
-    transition: all 0.3s ease-in-out;
+    animation: slide-left 0.3s ease-in-out;
+    display: flex;
   }
 
   nav {

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -64,7 +64,6 @@
   }
 
   @include position(fixed, 0 0 0 auto);
-
   background: $color-white;
   border-left: 1px solid $color-gray-light;
   border-right: 0;


### PR DESCRIPTION
This does a few things:
* Trap focus to mobile navigation menu so that the user cannot <kbd>Tab</kbd> outside the menu
* Add ability to close navigation by <kbd>Esc</kbd> key
* Change nav display to none in order to properly skip navigation when tabbing through
    * Change back to display flex when is-visible is active
    * Use keyframes animation in order to re-add animation that was not working bc of display none

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-mobile-nav-a11y/components/preview/layout--landing.html)

## TODO 

- [x] When it's mobile size and I tab through, then make it full size again, focus is stuck in the menu. How can I untrap it when moving from mobile to desktop? -- worked on this with @el-mapache ✅ 
- [x] Review JavaScript quality and style, this was written in a specific manner and want to make sure it's consistent -- worked on this with @el-mapache ✅ 

Fixes #2031