### PR TITLE
Allow text to be used in close button

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -442,10 +442,15 @@
 .usa-nav-close {
   @include button-unstyled;
   @include margin(-1.2rem -1.5rem 1.5rem auto);
+  color: currentColor;
   float: right;
   height: $hit-area;
   text-align: center;
   width: $hit-area;
+
+  &:hover {
+    color: currentColor;
+  }
 
   @include media($nav-width) {
     display: none;


### PR DESCRIPTION
This allows text to be added inside the close button, i.e. if you want to add the word "Close." Previously, it was white text on a white background.

## Screenshot with the word "close" added inside the close button

<img width="261" alt="screen shot 2018-02-13 at 5 16 04 pm" src="https://user-images.githubusercontent.com/5249443/36183220-3d339914-10e2-11e8-93d9-d1580ea752e6.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/allow-text-close-btn/components/detail/header--extended)

Closes #1616.