### PR TITLE
Remove browser prefixes on appearance where possible

### DIFF
--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -81,7 +81,7 @@ $usa-btn-big-width:     11.6rem;
 // Extra specificity to override rules set in reset.css.
 input[type=search] { /* stylelint-disable-line selector-no-qualifying-type */
   box-sizing: border-box;
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 [type=search],

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -107,12 +107,10 @@ textarea {
 }
 
 select {
-  -moz-appearance: none;
-  -webkit-appearance: none;
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.png');
-  // Ensure browsers that don't support SVG in background-image (IE 11 and below) fall back to PNG. 
+  // Ensure browsers that don't support SVG in background-image (IE 11 and below) fall back to PNG.
   // See https://www.broken-links.com/2010/06/14/using-svg-in-backgrounds-with-png-fallback/
   background-image: none, url('#{$image-path}/arrow-both.svg'), url('#{$image-path}/arrow-both.png');
   background-position: right 1.3rem center;
@@ -249,7 +247,7 @@ legend {
 // Range inputs
 
 [type=range] {
-  -webkit-appearance: none;
+  appearance: none;
   border: none;
   padding-left: 0;
   width: 100%;
@@ -329,7 +327,6 @@ legend {
 
   [type=number]::-webkit-inner-spin-button,
   [type=number]::-webkit-outer-spin-button {
-    -webkit-appearance: none;
     appearance: none;
     margin: 0;
   }


### PR DESCRIPTION
Use appearance rather the browser-prefixer version. Unless for a specific browser pseudo element such as some are defined in inputs.scss.

Taken from the  `ms-use_appearance_autoprefixer` branch.