### PR TITLE
Lower specificity of form SCSS

### DIFF
--- a/src/components/07-form/controls/text-input.njk
+++ b/src/components/07-form/controls/text-input.njk
@@ -1,4 +1,4 @@
-
+<form>
   <label for="input-type-text">Text input label</label>
   <input id="input-type-text" name="input-type-text" type="text">
 
@@ -16,4 +16,4 @@
 
   <label for="input-type-textarea">Text area label</label>
   <textarea id="input-type-textarea" name="input-type-textarea"></textarea>
-
+</form>

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -1,32 +1,44 @@
 $usa-form-width: 32rem;
 
-form {
-  a {
-    border-bottom: 0;
-  }
+[type=submit],
+[type=submit] {
+  display: block;
+  margin-bottom: 1.5em;
+  margin-top: 2.5rem;
 
-  [type=submit],
-  [type=submit] {
-    display: block;
-    margin-bottom: 1.5em;
-    margin-top: 2.5rem;
-
-    @include media($medium-screen) {
-      padding-left: 2.7em;
-      padding-right: 2.7em;
-      width: auto;
-    }
+  @include media($medium-screen) {
+    padding-left: 2.7em;
+    padding-right: 2.7em;
+    width: auto;
   }
+}
 
-  [name=password],
-  [name=confirmPassword] {
-    margin-bottom: 1.1rem;
-  }
+[name=password],
+[name=confirmPassword] {
+  margin-bottom: 1.1rem;
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
 }
 
 .usa-form {
   @include media($medium-screen) {
     max-width: $usa-form-width;
+  }
+}
+
+.usa-input-tiny {
+  @include media($medium-screen) {
+    max-width: 6rem;
+  }
+}
+
+.usa-input-medium {
+  @include media($medium-screen) {
+    max-width: 12rem;
   }
 }
 
@@ -41,29 +53,9 @@ form {
   }
 }
 
-fieldset {
-  border: none;
-  margin: 0;
-  padding: 0;
-}
-
 .usa-form-large {
   @include media($medium-screen) {
     max-width: 46rem;
-  }
-}
-
-input {
-  &.usa-input-tiny { /* stylelint-disable-line selector-no-qualifying-type */
-    @include media($medium-screen) {
-      max-width: 6rem;
-    }
-  }
-
-  &.usa-input-medium { /* stylelint-disable-line selector-no-qualifying-type */
-    @include media($medium-screen) {
-      max-width: 12rem;
-    }
   }
 }
 


### PR DESCRIPTION
This is a branch from @msecret from a while ago:

He wrote on the commit:
>By removing qualifying types that I tested and weren't required, at least for the forms on the form template components.
>
>Also ensured the form section is wrapped in an actual form, because that's generally how it will be used on sites

The only visual diff I noticed was extra spacing above the text inputs bc it doesn't clip the top margins. 
