### PR TITLE
Add ability to have a basic alert with no icon

### DIFF
--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -77,12 +77,6 @@ $icon-size: 3rem;
   padding-right: $spacing-small;
 }
 
-[class*='usa-alert-'] {
-  .usa-alert-body {
-    padding-left: $icon-size + $h-padding;
-  }
-}
-
 .usa-alert-body {
   display: table-cell;
   vertical-align: top;
@@ -112,6 +106,10 @@ $icon-size: 3rem;
 
     &::before {
       background-color: map-get($alerts-bar, $name);
+    }
+
+    .usa-alert-body {
+      padding-left: $icon-size + $h-padding;
     }
   }
 }

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -77,7 +77,7 @@ $icon-size: 3rem;
   padding-right: $spacing-small;
 }
 
-[class*="usa-alert-"] {
+[class*='usa-alert-'] {
   .usa-alert-body {
     padding-left: $icon-size + $h-padding;
   }

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -77,9 +77,14 @@ $icon-size: 3rem;
   padding-right: $spacing-small;
 }
 
+[class*="usa-alert-"] {
+  .usa-alert-body {
+    padding-left: $icon-size + $h-padding;
+  }
+}
+
 .usa-alert-body {
   display: table-cell;
-  padding-left: $icon-size + $h-padding;
   vertical-align: top;
 }
 


### PR DESCRIPTION
If you just use `usa-alert` now you'll get no icon and no extra padding. Before you had to know to also remove `usa-alert-body` which isn't super clear. This works for the slim alert too.

## Before
<img width="1095" alt="screen shot 2018-02-14 at 4 54 51 pm" src="https://user-images.githubusercontent.com/5249443/36235866-e0d57a90-11a7-11e8-85a2-2374ac9cbe46.png">

## After
<img width="1095" alt="screen shot 2018-02-14 at 4 54 16 pm" src="https://user-images.githubusercontent.com/5249443/36235875-e8fa0a1a-11a7-11e8-95f8-bfb636c7583e.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-alerts/components/preview/alerts--default.html)

