### PR TITLE
USWDS  - navigation.js

### DIFF
--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -20,8 +20,7 @@ const VISIBLE_CLASS = 'is-visible';
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 
-const _focusTrap = (element) => {
-  const trapContainer = document.querySelector(element);
+const _focusTrap = (trapContainer) => {
   // Find all focusable children
   const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
   const focusableElements = trapContainer.querySelectorAll(focusableElementsString);
@@ -144,7 +143,12 @@ const navigation = behavior({
   },
 }, {
   init () {
-    focusTrap = _focusTrap(NAV);
+    const trapContainer = document.querySelector(NAV);
+
+    if (trapContainer) {
+      focusTrap = _focusTrap(trapContainer);
+    }
+
     resize();
     window.addEventListener('resize', resize, false);
   },


### PR DESCRIPTION
* Necessary since all the js components are included everywhere
* In the future we might want to audit how these components are
instantiated, components such as `navigation` should probably be opt-in

## Check for existence of nav node when instantiating trapFocus

## Description

Fixes issue in which the navigation.js component throws an error on each page without the expected DOM nodes.

## Additional information

* Necessary since all the js components are included on each page.
* In the future we might want to audit how these components are
instantiated, components such as `navigation` should probably be opt-in.

Ran through this locally and pages appear to be error free!
