### PR TITLE
Fix file input type styling by removing text border

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -318,6 +318,12 @@ legend {
   border-radius: 2rem;
 }
 
+// File input type
+[type="file"] {
+  border: none;
+  padding-left: 0;
+}
+
 // Memorable dates
 
 .usa-date-of-birth {

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -319,7 +319,7 @@ legend {
 }
 
 // File input type
-[type="file"] {
+[type='file'] {
   border: none;
   padding-left: 0;
 }


### PR DESCRIPTION
Removes text border from file input type.

## Screenshot
<img width="340" alt="screen shot 2018-02-21 at 11 21 49 am" src="https://user-images.githubusercontent.com/5249443/36500576-8dba5450-16f9-11e8-821d-585440394d6f.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-file-input/components/preview/text-input) (just change the type from text to file to test)

Fixes #2182.