### PR TITLE
Simplify Sass asset path variable overrides 

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -125,7 +125,7 @@ $uswds-path: '../' !default;
 
 // Relative font and image file paths
 $font-path: '#{$uswds-path}fonts' !default;
-$img-path: '#{$uswds-path}img' !default;
+$image-path: '#{$uswds-path}img' !default;
 
 // Set $asset-pipeline to true if you're using the Rails Asset Pipeline
 $asset-pipeline:      false !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -121,11 +121,11 @@ $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium) !default;
 $large: new-breakpoint(min-width $large-screen $grid-columns-large) !default;
 
 // Set the base path for assets (used for font and image paths below)
-$uswds-path: '../' !default;
+$asset-path: '../' !default;
 
 // Relative font and image file paths
-$font-path: '#{$uswds-path}fonts' !default;
-$image-path: '#{$uswds-path}img' !default;
+$font-path: '#{$asset-path}fonts' !default;
+$image-path: '#{$asset-path}img' !default;
 
 // Set $asset-pipeline to true if you're using the Rails Asset Pipeline
 $asset-pipeline:      false !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -120,7 +120,7 @@ $small: new-breakpoint(min-width $small-screen $grid-columns-small) !default;
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium) !default;
 $large: new-breakpoint(min-width $large-screen $grid-columns-large) !default;
 
-// Set the base path for assets (used for font and image paths)
+// Set the base path for assets (used for font and image paths below)
 $uswds-path: '../' !default;
 
 // Relative font and image file paths

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -120,9 +120,12 @@ $small: new-breakpoint(min-width $small-screen $grid-columns-small) !default;
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium) !default;
 $large: new-breakpoint(min-width $large-screen $grid-columns-large) !default;
 
+// Set the base path for assets (used for font and image paths)
+$uswds-path: '../' !default;
+
 // Relative font and image file paths
-$font-path:   '../fonts' !default;
-$image-path:  '../img' !default;
+$font-path: '#{$uswds-path}fonts' !default;
+$img-path: '#{$uswds-path}img' !default;
 
 // Set $asset-pipeline to true if you're using the Rails Asset Pipeline
 $asset-pipeline:      false !default;


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/simplify-asset-path)

@donjo @thisisdano Does the variable `$uswds-path` make sense? Could also be `$asset-path`.

TODO:

- [x]  Add documentation in https://github.com/uswds/uswds-site, https://github.com/uswds/uswds-site/pull/504 (this PR is not dependent on it)

Fixes #1797.
