### PR TITLE
Change input optional text to HTML content from CSS content

### DIFF
--- a/src/components/07-form/templates/address-form.njk
+++ b/src/components/07-form/templates/address-form.njk
@@ -5,8 +5,7 @@
       <label for="mailing-address-1">Street address 1</label>
       <input id="mailing-address-1" name="mailing-address-1" type="text">
 
-      <label for="mailing-address-2" class="usa-input-optional">
-        Street address 2</label>
+      <label for="mailing-address-2">Street address 2 <span class="usa-input-label-helper">(optional)</span></label>
       <input id="mailing-address-2" name="mailing-address-2" type="text">
 
       <div>

--- a/src/components/07-form/templates/name-form.njk
+++ b/src/components/07-form/templates/name-form.njk
@@ -2,17 +2,17 @@
   <form class="usa-form">
     <fieldset>
       <legend>Name</legend>
-      <label for="title" class="usa-input-optional">Title</label>
+      <label for="title">Title <span class="usa-input-label-helper">(optional)</span></label>
       <input class="usa-input-tiny" id="title" name="title" type="text">
 
       <label for="first-name">First name</label>
-      <input id="first-name" name="first-name" type="text" required="" aria-required="true">
+      <input id="first-name" name="first-name" type="text" required aria-required="true">
 
-      <label for="middle-name" class="usa-input-optional">Middle name</label>
+      <label for="middle-name">Middle name <span class="usa-input-label-helper">(optional)</span></label>
       <input id="middle-name" name="middle-name" type="text">
 
       <label for="last-name">Last name</label>
-      <input id="last-name" name="last-name" type="text" required="" aria-required="true">
+      <input id="last-name" name="last-name" type="text" required aria-required="true">
 
     </fieldset>
   </form>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -86,13 +86,15 @@ select {
   padding-top: 3px;
 }
 
-// Deprecated
+// Deprecated: Some screen readers can't read CSS content.
+// Will be removed in 2.0.
 .usa-input-required:after {
   color: $color-secondary-darkest;
   content: ' (*required)';
 }
 
-// Deprecated
+// Deprecated: Some screen readers can't read CSS content.
+// Will be removed in 2.0.
 .usa-input-optional:after {
   color: $color-gray-medium;
   content: ' (optional)';

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -86,14 +86,24 @@ select {
   padding-top: 3px;
 }
 
+// Deprecated
 .usa-input-required:after {
   color: $color-secondary-darkest;
   content: ' (*required)';
 }
 
+// Deprecated
 .usa-input-optional:after {
   color: $color-gray-medium;
   content: ' (optional)';
+}
+
+.usa-input-label-helper {
+  color: $color-gray-medium;
+}
+
+.usa-input-label-required {
+  color: $color-secondary-darkest;
 }
 
 label {


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-input-label-helper/components/detail/name-form)

Question: do we leave the CSS content CSS in or remove it? Is it a breaking change?

Fixes #2367.

