### PR TITLE
Remove unnecessary build step from circle build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:6-browsers
-    parallelism: 4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ jobs:
           name: Run code coverage report
           command: npm run cover
       - run:
-          name: Build the USWDS package
-          command: npm run build
-      - run:
           name: Checking build
           command: |
             ls -agolf dist/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:6-browsers
+    parallelism: 4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
As part of #2348 I learned that this step is no longer necessary. I think it was left over from the time before the circle 2.0 migration where building/testing/deploying were all part of one process and not two separate parts of a workflow that happen one after another. 

