### PR TITLE
Increase timeout for release script

### DIFF
--- a/spec/headless-chrome.spec.js
+++ b/spec/headless-chrome.spec.js
@@ -45,7 +45,9 @@ fractalLoad.then(() => {
   const chromeFractalTester = new ChromeFractalTester();
   const { handles } = chromeFractalTester;
 
-  describe('fractal component', () => {
+  describe('fractal component', function () {
+    this.timeout(20000);
+
     before('setup ChromeFractalTester', chromeFractalTester.setup);
 
     after('teardown ChromeFractalTester', chromeFractalTester.teardown);
@@ -74,7 +76,7 @@ fractalLoad.then(() => {
         });
 
         before(`load fractal component in chrome`, function () {
-          this.timeout(40000);
+          this.timeout(20000);
           return chromeFractalTester.loadFractalPreview(cdp, handle);
         });
 


### PR DESCRIPTION
The specs were failing at the point where `ChromeFractalTester` was being setup, so I increased the timeout at that point from `2000ms` to `20000ms` and rolled back the increased timeout that was previously added when building out each individual Fractal component since that does not seem to be the problem area.