### PR TITLE
Disable hiding footer menus on desktop

### DIFF
--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -83,16 +83,25 @@ describe('big footer accordion', function () {
     assertHidden(lists[ 0 ], false);
   });
 
-  it('closes other panels', function () {
-    buttons[ 0 ].click();
-    assertHidden(lists[ 0 ], false);
-    assertHidden(lists[ 1 ], true);
-    assertHidden(lists[ 2 ], true);
+  it('closes other panels on small screens', function () {
+    return resizeTo(400)
+      .then(() => {
+        buttons[ 0 ].click();
+        assertHidden(lists[ 0 ], false);
+        assertHidden(lists[ 1 ], true);
+        assertHidden(lists[ 2 ], true);
 
-    buttons[ 1 ].click();
-    assertHidden(lists[ 0 ], true);
-    assertHidden(lists[ 1 ], false);
-    assertHidden(lists[ 2 ], true);
+        buttons[ 1 ].click();
+        assertHidden(lists[ 0 ], true);
+        assertHidden(lists[ 1 ], false);
+        assertHidden(lists[ 2 ], true);
+      });
   });
 
+  it('does not close other panels on larger screens', function () {
+    buttons[ 0 ].click();
+    assertHidden(lists[ 0 ], false);
+    assertHidden(lists[ 1 ], false);
+    assertHidden(lists[ 2 ], false);
+  });
 });

--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -18,19 +18,21 @@ const HIDE_MAX_WIDTH = 600;
 const DEBOUNCE_RATE = 180;
 
 const showPanel = function () {
-  const list = this.closest(LIST);
-  list.classList.remove(HIDDEN);
+  if (window.innerWidth < HIDE_MAX_WIDTH) {
+    const list = this.closest(LIST);
+    list.classList.remove(HIDDEN);
 
-  // NB: this *should* always succeed because the button
-  // selector is scoped to ".{prefix}-footer-big nav"
-  const lists = list.closest(NAV)
-    .querySelectorAll('ul');
+    // NB: this *should* always succeed because the button
+    // selector is scoped to ".{prefix}-footer-big nav"
+    const lists = list.closest(NAV)
+      .querySelectorAll('ul');
 
-  forEach(lists, el => {
-    if (el !== list) {
-      el.classList.add(HIDDEN);
-    }
-  });
+    forEach(lists, el => {
+      if (el !== list) {
+        el.classList.add(HIDDEN);
+      }
+    });
+  }
 };
 
 const resize = debounce(() => {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -18,6 +18,10 @@
 
     &:hover {
       text-decoration: underline;
+
+      @include media($medium-screen) {
+        text-decoration: none;
+      }
     }
   }
 


### PR DESCRIPTION
It looks like the javascript for the mobile footer accordion was set up in a way that it will run regardless of screen size. This adds a conditional statement to make sure we are in a mobile layout before running. Fixes https://github.com/uswds/uswds/issues/2344

I also added a quick test to confirm it's working (but may revisit later once I get more familiar with how testing is being done).
