### PR TITLE
Toggle footer menus on click

### DIFF
--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -79,8 +79,21 @@ describe('big footer accordion', function () {
   });
 
   it('opens panel when clicked', function () {
-    buttons[ 0 ].click();
-    assertHidden(lists[ 0 ], false);
+    return resizeTo(400)
+      .then(() => {
+        buttons[ 0 ].click();
+        assertHidden(lists[ 0 ], false);
+      });
+  });
+
+  it('closes panel on subsequent click', function () {
+    return resizeTo(400)
+      .then(() => {
+        buttons[ 0 ].click();
+        assertHidden(lists[ 0 ], false);
+        buttons[ 0 ].click();
+        assertHidden(lists[ 0 ], true);
+      });
   });
 
   it('closes other panels on small screens', function () {

--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -86,6 +86,11 @@ describe('big footer accordion', function () {
       });
   });
 
+  it('does not open panels when clicked on larger screens', function () {
+    buttons[ 0 ].click();
+    assertHidden(lists[ 0 ], false);
+  });
+
   it('closes panel on subsequent click', function () {
     return resizeTo(400)
       .then(() => {

--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -20,7 +20,7 @@ const DEBOUNCE_RATE = 180;
 const showPanel = function () {
   if (window.innerWidth < HIDE_MAX_WIDTH) {
     const list = this.closest(LIST);
-    list.classList.remove(HIDDEN);
+    list.classList.toggle(HIDDEN);
 
     // NB: this *should* always succeed because the button
     // selector is scoped to ".{prefix}-footer-big nav"

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -17,9 +17,11 @@
     }
 
     &:hover {
+      cursor: pointer;
       text-decoration: underline;
 
       @include media($medium-screen) {
+        cursor: auto;
         text-decoration: none;
       }
     }


### PR DESCRIPTION
Allow the collapsable footer menu to be closed with a subsequent click. Fixes https://github.com/uswds/uswds/issues/1857

[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-toggle-footer-menus/components/detail/footer--big.html)