### PR TITLE
Change h1 copy to "Page heading" on typography page

### DIFF
--- a/src/components/01-type/typesetting.njk
+++ b/src/components/01-type/typesetting.njk
@@ -13,7 +13,7 @@
 
   <h6 class="usa-heading-alt">Spacing</h6>
 
-  <h1>Section heading</h1>
+  <h1>Page heading</h1>
   <p class="usa-font-lead">Great Smoky Mountains National Park straddles the border of North Carolina and Tennessee.</p>
 
   <h2>Section heading</h2>


### PR DESCRIPTION
Changes the `<h1>` copy to "Page heading" from "Section heading" as `<h1>` s are used once per page. 

This would keep it consistent with what we use on the [docs template](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/develop/components/detail/layout--docs.html).

Alternatively, could also be called "Page title."