### PR TITLE
Adds color maps

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -229,6 +229,26 @@ to a set target
 
 /*
 ----------------------------------------
+color()
+----------------------------------------
+Derive a color from its $family and
+value
+----------------------------------------
+ex:
+background-color: color($red-warm, 50v);
+----------------------------------------
+*/
+
+@function color($hue, $value){
+  @if unit($value) == '' {
+    @return map-get($hue, $value);
+  } @else {
+    @return map-deep-get($hue, vivid, strip-unit($value));
+  }
+}
+
+/*
+----------------------------------------
 @render-utility
 ----------------------------------------
 Build a utility from values calculated

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -239,13 +239,14 @@ background-color: color($red-warm, 50v);
 ----------------------------------------
 */
 
-@function color($hue, $value){
-  @if unit($value) == '' {
+@function color($hue, $value, $variant...){
+  @if length($variant) == 0 {
     @return map-get($hue, $value);
   } @else {
-    @return map-deep-get($hue, vivid, strip-unit($value));
+    @return map-deep-get($hue, nth($variant, 1), $value);
   }
 }
+
 
 /*
 ----------------------------------------

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -197,7 +197,6 @@ $u-lh-body-tight:	 1.5;
 
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
-/* stylelint-disable unit-no-unknown */
 // violet-warm
 $violet-warm: (
   5:   #fef7ff,
@@ -211,16 +210,16 @@ $violet-warm: (
   80:  #332431,
   90:  #211a21,
   vivid: (
-    5v:  #fdedff,
-    10v: #f9c9ff,
-    20v: #f3a8ff,
-    30v: #ee82ff,
-    40v: #e05ef7,
-    50v: #c132d4,
-    60v: false,
-    70v: false,
-    80v: false,
-    90v: false,
+    5:  #fdedff,
+    10: #f9c9ff,
+    20: #f3a8ff,
+    30: #ee82ff,
+    40: #e05ef7,
+    50: #c132d4,
+    60: null,
+    70: null,
+    80: null,
+    90: null,
   ),
 );
 $violet-warm-5 :  color($violet-warm, 5);
@@ -233,16 +232,16 @@ $violet-warm-60:  color($violet-warm, 60);
 $violet-warm-70:  color($violet-warm, 70);
 $violet-warm-80:  color($violet-warm, 80);
 $violet-warm-90:  color($violet-warm, 90);
-$violet-warm-5v:  color($violet-warm, 5v);
-$violet-warm-10v: color($violet-warm, 10v);
-$violet-warm-20v: color($violet-warm, 20v);
-$violet-warm-30v: color($violet-warm, 30v);
-$violet-warm-40v: color($violet-warm, 40v);
-$violet-warm-50v: color($violet-warm, 50v);
-$violet-warm-60v: color($violet-warm, 60v);
-$violet-warm-70v: color($violet-warm, 70v);
-$violet-warm-80v: color($violet-warm, 80v);
-$violet-warm-90v: color($violet-warm, 90v);
+$violet-warm-5v:  color($violet-warm, 5, vivid);
+$violet-warm-10v: color($violet-warm, 10, vivid);
+$violet-warm-20v: color($violet-warm, 20, vivid);
+$violet-warm-30v: color($violet-warm, 30, vivid);
+$violet-warm-40v: color($violet-warm, 40, vivid);
+$violet-warm-50v: color($violet-warm, 50, vivid);
+$violet-warm-60v: color($violet-warm, 60, vivid);
+$violet-warm-70v: color($violet-warm, 70, vivid);
+$violet-warm-80v: color($violet-warm, 80, vivid);
+$violet-warm-90v: color($violet-warm, 90, vivid);
 
 // violet
 $violet: (
@@ -279,16 +278,16 @@ $violet-60:   color($violet, 60);
 $violet-70:   color($violet, 70);
 $violet-80:   color($violet, 80);
 $violet-90:   color($violet, 90);
-$violet-5v:   color($violet, 5v);
-$violet-10v:  color($violet, 10v);
-$violet-20v:  color($violet, 20v);
-$violet-30v:  color($violet, 30v);
-$violet-40v:  color($violet, 40v);
-$violet-50v:  color($violet, 50v);
-$violet-60v:  color($violet, 60v);
-$violet-70v:  color($violet, 70v);
-$violet-80v:  color($violet, 80v);
-$violet-90v:  color($violet, 90v);
+$violet-5v:   color($violet, 5, vivid);
+$violet-10v:  color($violet, 10, vivid);
+$violet-20v:  color($violet, 20, vivid);
+$violet-30v:  color($violet, 30, vivid);
+$violet-40v:  color($violet, 40, vivid);
+$violet-50v:  color($violet, 50, vivid);
+$violet-60v:  color($violet, 60, vivid);
+$violet-70v:  color($violet, 70, vivid);
+$violet-80v:  color($violet, 80, vivid);
+$violet-90v:  color($violet, 90, vivid);
 
 // indigo-warm
 $indigo-warm:(
@@ -325,16 +324,16 @@ $indigo-warm-60:  color($indigo-warm, 60);
 $indigo-warm-70:  color($indigo-warm, 70);
 $indigo-warm-80:  color($indigo-warm, 80);
 $indigo-warm-90:  color($indigo-warm, 90);
-$indigo-warm-5v:  color($indigo-warm, 5v);
-$indigo-warm-10v: color($indigo-warm, 10v);
-$indigo-warm-20v: color($indigo-warm, 20v);
-$indigo-warm-30v: color($indigo-warm, 30v);
-$indigo-warm-40v: color($indigo-warm, 40v);
-$indigo-warm-50v: color($indigo-warm, 50v);
-$indigo-warm-60v: color($indigo-warm, 60v);
-$indigo-warm-70v: color($indigo-warm, 70v);
-$indigo-warm-80v: color($indigo-warm, 80v);
-$indigo-warm-90v: color($indigo-warm, 90v);
+$indigo-warm-5v:  color($indigo-warm, 5, vivid);
+$indigo-warm-10v: color($indigo-warm, 10, vivid);
+$indigo-warm-20v: color($indigo-warm, 20, vivid);
+$indigo-warm-30v: color($indigo-warm, 30, vivid);
+$indigo-warm-40v: color($indigo-warm, 40, vivid);
+$indigo-warm-50v: color($indigo-warm, 50, vivid);
+$indigo-warm-60v: color($indigo-warm, 60, vivid);
+$indigo-warm-70v: color($indigo-warm, 70, vivid);
+$indigo-warm-80v: color($indigo-warm, 80, vivid);
+$indigo-warm-90v: color($indigo-warm, 90, vivid);
 
 // indigo
 $indigo:(
@@ -371,16 +370,16 @@ $indigo-60:   color($indigo, 60);
 $indigo-70:   color($indigo, 70);
 $indigo-80:   color($indigo, 80);
 $indigo-90:   color($indigo, 90);
-$indigo-5v:   color($indigo, 5v);
-$indigo-10v:  color($indigo, 10v);
-$indigo-20v:  color($indigo, 20v);
-$indigo-30v:  color($indigo, 30v);
-$indigo-40v:  color($indigo, 40v);
-$indigo-50v:  color($indigo, 50v);
-$indigo-60v:  color($indigo, 60v);
-$indigo-70v:  color($indigo, 70v);
-$indigo-80v:  color($indigo, 80v);
-$indigo-90v:  color($indigo, 90v);
+$indigo-5v:   color($indigo, 5, vivid);
+$indigo-10v:  color($indigo, 10, vivid);
+$indigo-20v:  color($indigo, 20, vivid);
+$indigo-30v:  color($indigo, 30, vivid);
+$indigo-40v:  color($indigo, 40, vivid);
+$indigo-50v:  color($indigo, 50, vivid);
+$indigo-60v:  color($indigo, 60, vivid);
+$indigo-70v:  color($indigo, 70, vivid);
+$indigo-80v:  color($indigo, 80, vivid);
+$indigo-90v:  color($indigo, 90, vivid);
 
 // indigo-cool
 $indigo-cool: (
@@ -417,16 +416,16 @@ $indigo-cool-60:  color($indigo-cool, 60);
 $indigo-cool-70:  color($indigo-cool, 70);
 $indigo-cool-80:  color($indigo-cool, 80);
 $indigo-cool-90:  color($indigo-cool, 90);
-$indigo-cool-5v:  color($indigo-cool, 5v);
-$indigo-cool-10v: color($indigo-cool, 10v);
-$indigo-cool-20v: color($indigo-cool, 20v);
-$indigo-cool-30v: color($indigo-cool, 30v);
-$indigo-cool-40v: color($indigo-cool, 40v);
-$indigo-cool-50v: color($indigo-cool, 50v);
-$indigo-cool-60v: color($indigo-cool, 60v);
-$indigo-cool-70v: color($indigo-cool, 70v);
-$indigo-cool-80v: color($indigo-cool, 80v);
-$indigo-cool-90v: color($indigo-cool, 90v);
+$indigo-cool-5v:  color($indigo-cool, 5, vivid);
+$indigo-cool-10v: color($indigo-cool, 10, vivid);
+$indigo-cool-20v: color($indigo-cool, 20, vivid);
+$indigo-cool-30v: color($indigo-cool, 30, vivid);
+$indigo-cool-40v: color($indigo-cool, 40, vivid);
+$indigo-cool-50v: color($indigo-cool, 50, vivid);
+$indigo-cool-60v: color($indigo-cool, 60, vivid);
+$indigo-cool-70v: color($indigo-cool, 70, vivid);
+$indigo-cool-80v: color($indigo-cool, 80, vivid);
+$indigo-cool-90v: color($indigo-cool, 90, vivid);
 
 // blue-warm
 $blue-warm: (
@@ -463,16 +462,16 @@ $blue-warm-60:  color($blue-warm, 60);
 $blue-warm-70:  color($blue-warm, 70);
 $blue-warm-80:  color($blue-warm, 80);
 $blue-warm-90:  color($blue-warm, 90);
-$blue-warm-5v:  color($blue-warm, 5v);
-$blue-warm-10v: color($blue-warm, 10v);
-$blue-warm-20v: color($blue-warm, 20v);
-$blue-warm-30v: color($blue-warm, 30v);
-$blue-warm-40v: color($blue-warm, 40v);
-$blue-warm-50v: color($blue-warm, 50v);
-$blue-warm-60v: color($blue-warm, 60v);
-$blue-warm-70v: color($blue-warm, 70v);
-$blue-warm-80v: color($blue-warm, 80v);
-$blue-warm-90v: color($blue-warm, 90v);
+$blue-warm-5v:  color($blue-warm, 5, vivid);
+$blue-warm-10v: color($blue-warm, 10, vivid);
+$blue-warm-20v: color($blue-warm, 20, vivid);
+$blue-warm-30v: color($blue-warm, 30, vivid);
+$blue-warm-40v: color($blue-warm, 40, vivid);
+$blue-warm-50v: color($blue-warm, 50, vivid);
+$blue-warm-60v: color($blue-warm, 60, vivid);
+$blue-warm-70v: color($blue-warm, 70, vivid);
+$blue-warm-80v: color($blue-warm, 80, vivid);
+$blue-warm-90v: color($blue-warm, 90, vivid);
 
 // blue
 $blue: (
@@ -499,26 +498,26 @@ $blue: (
     90:        null,
   ),
 );
-$blue-5:    color($blue, 5);
-$blue-10:   color($blue, 10);
-$blue-20:   color($blue, 20);
-$blue-30:   color($blue, 30);
-$blue-40:   color($blue, 40);
-$blue-50:   color($blue, 50);
-$blue-60:   color($blue, 60);
-$blue-70:   color($blue, 70);
-$blue-80:   color($blue, 80);
-$blue-90:   color($blue, 90);
-$blue-5v:   color($blue, 5v);
-$blue-10v:  color($blue, 10v);
-$blue-20v:  color($blue, 20v);
-$blue-30v:  color($blue, 30v);
-$blue-40v:  color($blue, 40v);
-$blue-50v:  color($blue, 50v);
-$blue-60v:  color($blue, 60v);
-$blue-70v:  color($blue, 70v);
-$blue-80v:  color($blue, 80v);
-$blue-90v:  color($blue, 90v);
+$blue-5:    color-test($blue, 5);
+$blue-10:   color-test($blue, 10);
+$blue-20:   color-test($blue, 20);
+$blue-30:   color-test($blue, 30);
+$blue-40:   color-test($blue, 40);
+$blue-50:   color-test($blue, 50);
+$blue-60:   color-test($blue, 60);
+$blue-70:   color-test($blue, 70);
+$blue-80:   color-test($blue, 80);
+$blue-90:   color-test($blue, 90);
+$blue-5v:   color-test($blue, 5, vivid);
+$blue-10v:  color-test($blue, 10, vivid);
+$blue-20v:  color-test($blue, 20, vivid);
+$blue-30v:  color-test($blue, 30, vivid);
+$blue-40v:  color-test($blue, 40, vivid);
+$blue-50v:  color-test($blue, 50, vivid);
+$blue-60v:  color-test($blue, 60, vivid);
+$blue-70v:  color-test($blue, 70, vivid);
+$blue-80v:  color-test($blue, 80, vivid);
+$blue-90v:  color-test($blue, 90, vivid);
 
 // cyan
 $cyan: (
@@ -555,16 +554,16 @@ $cyan-60:   color($cyan, 60);
 $cyan-70:   color($cyan, 70);
 $cyan-80:   color($cyan, 80);
 $cyan-90:   color($cyan, 90);
-$cyan-5v:   color($cyan, 5v);
-$cyan-10v:  color($cyan, 10v);
-$cyan-20v:  color($cyan, 20v);
-$cyan-30v:  color($cyan, 30v);
-$cyan-40v:  color($cyan, 40v);
-$cyan-50v:  color($cyan, 50v);
-$cyan-60v:  color($cyan, 60v);
-$cyan-70v:  color($cyan, 70v);
-$cyan-80v:  color($cyan, 80v);
-$cyan-90v:  color($cyan, 90v);
+$cyan-5v:   color($cyan, 5, vivid);
+$cyan-10v:  color($cyan, 10, vivid);
+$cyan-20v:  color($cyan, 20, vivid);
+$cyan-30v:  color($cyan, 30, vivid);
+$cyan-40v:  color($cyan, 40, vivid);
+$cyan-50v:  color($cyan, 50, vivid);
+$cyan-60v:  color($cyan, 60, vivid);
+$cyan-70v:  color($cyan, 70, vivid);
+$cyan-80v:  color($cyan, 80, vivid);
+$cyan-90v:  color($cyan, 90, vivid);
 
 // mint-cool
 $mint-cool: (
@@ -601,16 +600,16 @@ $mint-cool-60:  color($mint-cool, 60);
 $mint-cool-70:  color($mint-cool, 70);
 $mint-cool-80:  color($mint-cool, 80);
 $mint-cool-90:  color($mint-cool, 90);
-$mint-cool-5v:  color($mint-cool, 5v);
-$mint-cool-10v: color($mint-cool, 10v);
-$mint-cool-20v: color($mint-cool, 20v);
-$mint-cool-30v: color($mint-cool, 30v);
-$mint-cool-40v: color($mint-cool, 40v);
-$mint-cool-50v: color($mint-cool, 50v);
-$mint-cool-60v: color($mint-cool, 60v);
-$mint-cool-70v: color($mint-cool, 70v);
-$mint-cool-80v: color($mint-cool, 80v);
-$mint-cool-90v: color($mint-cool, 90v);
+$mint-cool-5v:  color($mint-cool, 5, vivid);
+$mint-cool-10v: color($mint-cool, 10, vivid);
+$mint-cool-20v: color($mint-cool, 20, vivid);
+$mint-cool-30v: color($mint-cool, 30, vivid);
+$mint-cool-40v: color($mint-cool, 40, vivid);
+$mint-cool-50v: color($mint-cool, 50, vivid);
+$mint-cool-60v: color($mint-cool, 60, vivid);
+$mint-cool-70v: color($mint-cool, 70, vivid);
+$mint-cool-80v: color($mint-cool, 80, vivid);
+$mint-cool-90v: color($mint-cool, 90, vivid);
 
 // mint
 $mint: (
@@ -647,17 +646,17 @@ $mint-60:   color($mint, 60);
 $mint-70:   color($mint, 70);
 $mint-80:   color($mint, 80);
 $mint-90:   color($mint, 90);
-$mint-5v:   color($mint, 5v);
-$mint-5v:   color($mint, 5v);
-$mint-10v:  color($mint, 10v);
-$mint-20v:  color($mint, 20v);
-$mint-30v:  color($mint, 30v);
-$mint-40v:  color($mint, 40v);
-$mint-50v:  color($mint, 50v);
-$mint-60v:  color($mint, 60v);
-$mint-70v:  color($mint, 70v);
-$mint-80v:  color($mint, 80v);
-$mint-90v:  color($mint, 90v);
+$mint-5v:   color($mint, 5, vivid);
+$mint-5v:   color($mint, 5, vivid);
+$mint-10v:  color($mint, 10, vivid);
+$mint-20v:  color($mint, 20, vivid);
+$mint-30v:  color($mint, 30, vivid);
+$mint-40v:  color($mint, 40, vivid);
+$mint-50v:  color($mint, 50, vivid);
+$mint-60v:  color($mint, 60, vivid);
+$mint-70v:  color($mint, 70, vivid);
+$mint-80v:  color($mint, 80, vivid);
+$mint-90v:  color($mint, 90, vivid);
 
 // green-cool
 $green-cool: (
@@ -694,16 +693,16 @@ $green-cool-60:   color($green-cool, 60);
 $green-cool-70:   color($green-cool, 70);
 $green-cool-80:   color($green-cool, 80);
 $green-cool-90:   color($green-cool, 90);
-$green-cool-5v:   color($green-cool, 5v);
-$green-cool-10v:  color($green-cool, 10v);
-$green-cool-20v:  color($green-cool, 20v);
-$green-cool-30v:  color($green-cool, 30v);
-$green-cool-40v:  color($green-cool, 40v);
-$green-cool-50v:  color($green-cool, 50v);
-$green-cool-60v:  color($green-cool, 60v);
-$green-cool-70v:  color($green-cool, 70v);
-$green-cool-80v:  color($green-cool, 80v);
-$green-cool-90v:  color($green-cool, 90v);
+$green-cool-5v:   color($green-cool, 5, vivid);
+$green-cool-10v:  color($green-cool, 10, vivid);
+$green-cool-20v:  color($green-cool, 20, vivid);
+$green-cool-30v:  color($green-cool, 30, vivid);
+$green-cool-40v:  color($green-cool, 40, vivid);
+$green-cool-50v:  color($green-cool, 50, vivid);
+$green-cool-60v:  color($green-cool, 60, vivid);
+$green-cool-70v:  color($green-cool, 70, vivid);
+$green-cool-80v:  color($green-cool, 80, vivid);
+$green-cool-90v:  color($green-cool, 90, vivid);
 
 // green
 $green: (
@@ -740,16 +739,16 @@ $green-60:  color($green, 60);
 $green-70:  color($green, 70);
 $green-80:  color($green, 80);
 $green-90:  color($green, 90);
-$green-5v:  color($green, 5v);
-$green-10v: color($green, 10v);
-$green-20v: color($green, 20v);
-$green-30v: color($green, 30v);
-$green-40v: color($green, 40v);
-$green-50v: color($green, 50v);
-$green-60v: color($green, 60v);
-$green-70v: color($green, 70v);
-$green-80v: color($green, 80v);
-$green-90v: color($green, 90v);
+$green-5v:  color($green, 5, vivid);
+$green-10v: color($green, 10, vivid);
+$green-20v: color($green, 20, vivid);
+$green-30v: color($green, 30, vivid);
+$green-40v: color($green, 40, vivid);
+$green-50v: color($green, 50, vivid);
+$green-60v: color($green, 60, vivid);
+$green-70v: color($green, 70, vivid);
+$green-80v: color($green, 80, vivid);
+$green-90v: color($green, 90, vivid);
 
 // green-warm
 $green-warm: (
@@ -786,16 +785,16 @@ $green-warm-60:   color($green-warm, 60);
 $green-warm-70:   color($green-warm, 70);
 $green-warm-80:   color($green-warm, 80);
 $green-warm-90:   color($green-warm, 90);
-$green-warm-5v:   color($green-warm, 5v);
-$green-warm-10v:  color($green-warm, 10v);
-$green-warm-20v:  color($green-warm, 20v);
-$green-warm-30v:  color($green-warm, 30v);
-$green-warm-40v:  color($green-warm, 40v);
-$green-warm-50v:  color($green-warm, 50v);
-$green-warm-60v:  color($green-warm, 60v);
-$green-warm-70v:  color($green-warm, 70v);
-$green-warm-80v:  color($green-warm, 80v);
-$green-warm-90v:  color($green-warm, 90v);
+$green-warm-5v:   color($green-warm, 5, vivid);
+$green-warm-10v:  color($green-warm, 10, vivid);
+$green-warm-20v:  color($green-warm, 20, vivid);
+$green-warm-30v:  color($green-warm, 30, vivid);
+$green-warm-40v:  color($green-warm, 40, vivid);
+$green-warm-50v:  color($green-warm, 50, vivid);
+$green-warm-60v:  color($green-warm, 60, vivid);
+$green-warm-70v:  color($green-warm, 70, vivid);
+$green-warm-80v:  color($green-warm, 80, vivid);
+$green-warm-90v:  color($green-warm, 90, vivid);
 
 // yellow
 $yellow: (
@@ -832,16 +831,16 @@ $yellow-60:   color($yellow, 60);
 $yellow-70:   color($yellow, 70);
 $yellow-80:   color($yellow, 80);
 $yellow-90:   color($yellow, 90);
-$yellow-5v:   color($yellow, 5v);
-$yellow-10v:  color($yellow, 10v);
-$yellow-20v:  color($yellow, 20v);
-$yellow-30v:  color($yellow, 30v);
-$yellow-40v:  color($yellow, 40v);
-$yellow-50v:  color($yellow, 50v);
-$yellow-60v:  color($yellow, 60v);
-$yellow-70v:  color($yellow, 70v);
-$yellow-80v:  color($yellow, 80v);
-$yellow-90v:  color($yellow, 90v);
+$yellow-5v:   color($yellow, 5, vivid);
+$yellow-10v:  color($yellow, 10, vivid);
+$yellow-20v:  color($yellow, 20, vivid);
+$yellow-30v:  color($yellow, 30, vivid);
+$yellow-40v:  color($yellow, 40, vivid);
+$yellow-50v:  color($yellow, 50, vivid);
+$yellow-60v:  color($yellow, 60, vivid);
+$yellow-70v:  color($yellow, 70, vivid);
+$yellow-80v:  color($yellow, 80, vivid);
+$yellow-90v:  color($yellow, 90, vivid);
 
 // gold
 $gold: (
@@ -878,16 +877,16 @@ $gold-60:   color($gold, 60);
 $gold-70:   color($gold, 70);
 $gold-80:   color($gold, 80);
 $gold-90:   color($gold, 90);
-$gold-5v:   color($gold, 5v);
-$gold-10v:  color($gold, 10v);
-$gold-20v:  color($gold, 20v);
-$gold-30v:  color($gold, 30v);
-$gold-40v:  color($gold, 40v);
-$gold-50v:  color($gold, 50v);
-$gold-60v:  color($gold, 60v);
-$gold-70v:  color($gold, 70v);
-$gold-80v:  color($gold, 80v);
-$gold-90v:  color($gold, 90v);
+$gold-5v:   color($gold, 5, vivid);
+$gold-10v:  color($gold, 10, vivid);
+$gold-20v:  color($gold, 20, vivid);
+$gold-30v:  color($gold, 30, vivid);
+$gold-40v:  color($gold, 40, vivid);
+$gold-50v:  color($gold, 50, vivid);
+$gold-60v:  color($gold, 60, vivid);
+$gold-70v:  color($gold, 70, vivid);
+$gold-80v:  color($gold, 80, vivid);
+$gold-90v:  color($gold, 90, vivid);
 
 // orange
 $orange: (
@@ -924,16 +923,16 @@ $orange-60:   color($orange, 60);
 $orange-70:   color($orange, 70);
 $orange-80:   color($orange, 80);
 $orange-90:   color($orange, 90);
-$orange-5v:   color($orange, 5v);
-$orange-10v:  color($orange, 10v);
-$orange-20v:  color($orange, 20v);
-$orange-30v:  color($orange, 30v);
-$orange-40v:  color($orange, 40v);
-$orange-50v:  color($orange, 50v);
-$orange-60v:  color($orange, 60v);
-$orange-70v:  color($orange, 70v);
-$orange-80v:  color($orange, 80v);
-$orange-90v:  color($orange, 90v);
+$orange-5v:   color($orange, 5, vivid);
+$orange-10v:  color($orange, 10, vivid);
+$orange-20v:  color($orange, 20, vivid);
+$orange-30v:  color($orange, 30, vivid);
+$orange-40v:  color($orange, 40, vivid);
+$orange-50v:  color($orange, 50, vivid);
+$orange-60v:  color($orange, 60, vivid);
+$orange-70v:  color($orange, 70, vivid);
+$orange-80v:  color($orange, 80, vivid);
+$orange-90v:  color($orange, 90, vivid);
 
 // orange-warm
 $orange-warm: (
@@ -970,16 +969,16 @@ $orange-warm-60:  color($orange-warm, 60);
 $orange-warm-70:  color($orange-warm, 70);
 $orange-warm-80:  color($orange-warm, 80);
 $orange-warm-90:  color($orange-warm, 90);
-$orange-warm-5v:  color($orange-warm, 5v);
-$orange-warm-10v: color($orange-warm, 10v);
-$orange-warm-20v: color($orange-warm, 20v);
-$orange-warm-30v: color($orange-warm, 30v);
-$orange-warm-40v: color($orange-warm, 40v);
-$orange-warm-50v: color($orange-warm, 50v);
-$orange-warm-60v: color($orange-warm, 60v);
-$orange-warm-70v: color($orange-warm, 70v);
-$orange-warm-80v: color($orange-warm, 80v);
-$orange-warm-90v: color($orange-warm, 90v);
+$orange-warm-5v:  color($orange-warm, 5, vivid);
+$orange-warm-10v: color($orange-warm, 10, vivid);
+$orange-warm-20v: color($orange-warm, 20, vivid);
+$orange-warm-30v: color($orange-warm, 30, vivid);
+$orange-warm-40v: color($orange-warm, 40, vivid);
+$orange-warm-50v: color($orange-warm, 50, vivid);
+$orange-warm-60v: color($orange-warm, 60, vivid);
+$orange-warm-70v: color($orange-warm, 70, vivid);
+$orange-warm-80v: color($orange-warm, 80, vivid);
+$orange-warm-90v: color($orange-warm, 90, vivid);
 
 // red-warm
 $red-warm: (
@@ -1016,16 +1015,16 @@ $red-warm-60:   color($red-warm, 60);
 $red-warm-70:   color($red-warm, 70);
 $red-warm-80:   color($red-warm, 80);
 $red-warm-90:   color($red-warm, 90);
-$red-warm-5v:   color($red-warm, 5v);
-$red-warm-10v:  color($red-warm, 10v);
-$red-warm-20v:  color($red-warm, 20v);
-$red-warm-30v:  color($red-warm, 30v);
-$red-warm-40v:  color($red-warm, 40v);
-$red-warm-50v:  color($red-warm, 50v);
-$red-warm-60v:  color($red-warm, 60v);
-$red-warm-70v:  color($red-warm, 70v);
-$red-warm-80v:  color($red-warm, 80v);
-$red-warm-90v:  color($red-warm, 90v);
+$red-warm-5v:   color($red-warm, 5, vivid);
+$red-warm-10v:  color($red-warm, 10, vivid);
+$red-warm-20v:  color($red-warm, 20, vivid);
+$red-warm-30v:  color($red-warm, 30, vivid);
+$red-warm-40v:  color($red-warm, 40, vivid);
+$red-warm-50v:  color($red-warm, 50, vivid);
+$red-warm-60v:  color($red-warm, 60, vivid);
+$red-warm-70v:  color($red-warm, 70, vivid);
+$red-warm-80v:  color($red-warm, 80, vivid);
+$red-warm-90v:  color($red-warm, 90, vivid);
 
 // red
 $red: (
@@ -1062,16 +1061,16 @@ $red-60:  color($red, 60);
 $red-70:  color($red, 70);
 $red-80:  color($red, 80);
 $red-90:  color($red, 90);
-$red-5v:  color($red, 5v);
-$red-10v: color($red, 10v);
-$red-20v: color($red, 20v);
-$red-30v: color($red, 30v);
-$red-40v: color($red, 40v);
-$red-50v: color($red, 50v);
-$red-60v: color($red, 60v);
-$red-70v: color($red, 70v);
-$red-80v: color($red, 80v);
-$red-90v: color($red, 90v);
+$red-5v:  color($red, 5, vivid);
+$red-10v: color($red, 10, vivid);
+$red-20v: color($red, 20, vivid);
+$red-30v: color($red, 30, vivid);
+$red-40v: color($red, 40, vivid);
+$red-50v: color($red, 50, vivid);
+$red-60v: color($red, 60, vivid);
+$red-70v: color($red, 70, vivid);
+$red-80v: color($red, 80, vivid);
+$red-90v: color($red, 90, vivid);
 
 // magenta
 $magenta: (
@@ -1108,16 +1107,16 @@ $magenta-60:  color($magenta, 60);
 $magenta-70:  color($magenta, 70);
 $magenta-80:  color($magenta, 80);
 $magenta-90:  color($magenta, 90);
-$magenta-5v:  color($magenta, 5v);
-$magenta-10v: color($magenta, 10v);
-$magenta-20v: color($magenta, 20v);
-$magenta-30v: color($magenta, 30v);
-$magenta-40v: color($magenta, 40v);
-$magenta-50v: color($magenta, 50v);
-$magenta-60v: color($magenta, 60v);
-$magenta-70v: color($magenta, 70v);
-$magenta-80v: color($magenta, 80v);
-$magenta-90v: color($magenta, 90v);
+$magenta-5v:  color($magenta, 5);
+$magenta-10v: color($magenta, 10, vivid);
+$magenta-20v: color($magenta, 20, vivid);
+$magenta-30v: color($magenta, 30, vivid);
+$magenta-40v: color($magenta, 40, vivid);
+$magenta-50v: color($magenta, 50, vivid);
+$magenta-60v: color($magenta, 60, vivid);
+$magenta-70v: color($magenta, 70, vivid);
+$magenta-80v: color($magenta, 80, vivid);
+$magenta-90v: color($magenta, 90, vivid);
 
 // black-cool
 $black-cool: (
@@ -1278,4 +1277,3 @@ $white-warm-1: color($white-warm, 1);
 $white-warm-2: color($white-warm, 2);
 $white-warm-3: color($white-warm, 3);
 $white-warm-4: color($white-warm, 4);
-/* stylelint-enable */

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -198,6 +198,28 @@ $u-lh-body-tight:	 1.5;
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
 // violet-warm
+$violet-warm: (
+  5 :  #fef7ff,
+  10:  #f5dcf7,
+  20:  #e0bae3,
+  30:  #d096d6,
+  40:  #bd73c7,
+  50:  #b24bbf,
+  60:  #854180,
+  70:  #573455,
+  80:  #332431,
+  90:  #211a21,
+  5v:  #fdedff,
+  10v: #f9c9ff,
+  20v: #f3a8ff,
+  30v: #ee82ff,
+  40v: #e05ef7,
+  50v: #c132d4,
+  60v: null,
+  70v: null,
+  80v: null,
+  90v: null,
+);
 $violet-warm-5 :  #fef7ff;
 $violet-warm-10:  #f5dcf7;
 $violet-warm-20:  #e0bae3;
@@ -220,6 +242,28 @@ $violet-warm-80v: null;
 $violet-warm-90v: null;
 
 // violet
+$violet: (
+  5 :       #f7f5fa,
+  10:       #ebe3fa,
+  20:       #cec1e8,
+  30:       #b7a1e3,
+  40:       #9c82d1,
+  50:       #8369b5,
+  60:       #644f8f,
+  70:       #493a66,
+  80:       #2d273b,
+  90:       #1e1b24,
+  5v:       null,
+  10v:      null,
+  20v:      null,
+  30v:      #be95e9,
+  40v:      #b07bed,
+  50v:      #9455dd,
+  60v:      #7639b8,
+  70v:      #552996,
+  80v:      null,
+  90v:      null,
+);
 $violet-5 :       #f7f5fa;
 $violet-10:       #ebe3fa;
 $violet-20:       #cec1e8;
@@ -242,6 +286,28 @@ $violet-80v:      null;
 $violet-90v:      null;
 
 // indigo-warm
+$indigo-warm:(
+  5 :  #f9f7ff,
+  10:  #e5e1fa,
+  20:  #c9c2f2,
+  30:  #b1a7eb,
+  40:  #968ade,
+  50:  #7766d3,
+  60:  #5e519e,
+  70:  #433a7a,
+  80:  #29263b,
+  90:  #1d1b24,
+  5v:  null,
+  10v: null,
+  20v: null,
+  30v: #b59eff,
+  40v: #9980ff,
+  50v: #7560eb,
+  60v: #5740d1,
+  70v: null,
+  80v: null,
+  90v: null,
+);
 $indigo-warm-5 :  #f9f7ff;
 $indigo-warm-10:  #e5e1fa;
 $indigo-warm-20:  #c9c2f2;
@@ -264,6 +330,28 @@ $indigo-warm-80v: null;
 $indigo-warm-90v: null;
 
 // indigo
+$indigo:(
+  5 :       #fafaff,
+  10:       #e4e3fa,
+  20:       #c2c3f2,
+  30:       #a4a7eb,
+  40:       #8889db,
+  50:       #686dca,
+  60:       #5055b5,
+  70:       #3b3e75,
+  80:       #28293d,
+  90:       #1b1c26,
+  5v:       null,
+  10v:      null,
+  20v:      #acaeec,
+  30v:      #8c8fe1,
+  40v:      null,
+  50v:      #656bd7,
+  60v:      #353aa5,
+  70v:      null,
+  80v:      null,
+  90v:      null,
+);
 $indigo-5 :       #fafaff;
 $indigo-10:       #e4e3fa;
 $indigo-20:       #c2c3f2;
@@ -286,6 +374,28 @@ $indigo-80v:      null;
 $indigo-90v:      null;
 
 // indigo-cool
+$indigo-cool: (
+  5 :  #f5f6fc,
+  10:  #e1e6fa,
+  20:  #bac7f5,
+  30:  #97acf0,
+  40:  #6d91ed,
+  50:  #4a70d9,
+  60:  #425bad,
+  70:  #364173,
+  80:  #23273d,
+  90:  #1b1c2b,
+  5v:  null,
+  10v: null,
+  20v: null,
+  30v: null,
+  40v: #6694ff,
+  50v: null,
+  60v: #4150f2,
+  70v: null,
+  80v: null,
+  90v: null,
+);
 $indigo-cool-5 :  #f5f6fc;
 $indigo-cool-10:  #e1e6fa;
 $indigo-cool-20:  #bac7f5;
@@ -308,6 +418,28 @@ $indigo-cool-80v: null;
 $indigo-cool-90v: null;
 
 // blue-warm
+$blue-warm: (
+  5 :    #f0f5fc,
+  10:    #dfe7f5,
+  20:    #bccae6,
+  30:    #91add9,
+  40:    #7397d1,
+  50:    #3d75c2,
+  60:    #37629e,
+  70:    #31486b,
+  80:    #232d3d,
+  90:    #161b24,
+  5v:    null,
+  10v:   null,
+  20v:   #b8cbf2,
+  30v:   #81aefc,
+  40v:   #5e99ff,
+  50v:   #2673df,
+  60v:   #0052de,
+  70v:   #1e4f94,
+  80v:   #112a4d,
+  90v:   null,
+);
 $blue-warm-5 :    #f0f5fc;
 $blue-warm-10:    #dfe7f5;
 $blue-warm-20:    #bccae6;
@@ -330,6 +462,28 @@ $blue-warm-80v:   #112a4d;
 $blue-warm-90v:   null;
 
 // blue
+$blue: (
+  5 :         #f5fbff,
+  10:         #dae9f7,
+  20:         #add1f0,
+  30:         #79bcf2,
+  40:         #56a4e3,
+  50:         #317cb9,
+  60:         #2f6794,
+  70:         #294c69,
+  80:         #1e2f3d,
+  90:         #161e24,
+  5v:         null,
+  10v:        null,
+  20v:        null,
+  30v:        #57b3ff,
+  40v:        #009afa,
+  50v:        #007ade,
+  60v:        #0069b4,
+  70v:        #0c4d82,
+  80v:        #11304f,
+  90v:        null,
+);
 $blue-5 :         #f5fbff;
 $blue-10:         #dae9f7;
 $blue-20:         #add1f0;
@@ -352,6 +506,28 @@ $blue-80v:        #11304f;
 $blue-90v:        null;
 
 // cyan
+$cyan: (
+  5 :         #e8f7fa,
+  10:         #d0f1f7,
+  20:         #9ddceb,
+  30:         #6ecbdb,
+  40:         #4bacbd,
+  50:         #167f91,
+  60:         #2f707a,
+  70:         #2d4b4f,
+  80:         #203133,
+  90:         #151e1f,
+  5v:         null,
+  10v:        #a8f2ff,
+  20v:        #55e1fa,
+  30v:        #02c2e8,
+  40v:        #00abd1,
+  50v:        null,
+  60v:        null,
+  70v:        null,
+  80v:        null,
+  90v:        null,
+);
 $cyan-5 :         #e8f7fa;
 $cyan-10:         #d0f1f7;
 $cyan-20:         #9ddceb;
@@ -374,6 +550,28 @@ $cyan-80v:        null;
 $cyan-90v:        null;
 
 // mint-cool
+$mint-cool: (
+  5 :    #f2fffe,
+  10:    #c7f2ef,
+  20:    #a2ded9,
+  30:    #77c7c0,
+  40:    #57ada8,
+  50:    #21827f,
+  60:    #3b6b69,
+  70:    #2b4d47,
+  80:    #1f3030,
+  90:    #151f1f,
+  5v:    #dbfff8,
+  10v:   #7efce1,
+  20v:   #02dbc2,
+  30v:   #00baa4,
+  40v:   #00b5a9,
+  50v:   null,
+  60v:   null,
+  70v:   null,
+  80v:   null,
+  90v:   null,
+);
 $mint-cool-5 :    #f2fffe;
 $mint-cool-10:    #c7f2ef;
 $mint-cool-20:    #a2ded9;
@@ -396,6 +594,29 @@ $mint-cool-80v:   null;
 $mint-cool-90v:   null;
 
 // mint
+$mint: (
+  5 :         #cafcec,
+  10:         #79f7cd,
+  20:         #49e3b0,
+  30:         #4ac79d,
+  40:         #36a882,
+  50:         #1e8461,
+  60:         #266644,
+  70:         #225237,
+  80:         #1d3b29,
+  90:         #1d3b29,
+  5v:         #befde9,
+  5v:         null,
+  10v:        #30f8b5,
+  20v:        #06ec9f,
+  30v:        #04c786,
+  40v:        null,
+  50v:        null,
+  60v:        #16754f,
+  70v:        null,
+  80v:        null,
+  90v:        null,
+);
 $mint-5 :         #cafcec;
 $mint-10:         #79f7cd;
 $mint-20:         #49e3b0;
@@ -419,6 +640,28 @@ $mint-80v:        null;
 $mint-90v:        null;
 
 // green-cool
+$green-cool: (
+  5 :   #e8fae6,
+  10:   #d0f7cd,
+  20:   #a4e3a1,
+  30:   #80cc7e,
+  40:   #5db85c,
+  50:   #3d841f,
+  60:   #4d6e37,
+  70:   #384d2a,
+  80:   #272e22,
+  90:   #1a1f1a,
+  5v:   #caf4c7,
+  10v:  #91e48b,
+  20v:  #61cf59,
+  30v:  #16c20a,
+  40v:  #0caf00,
+  50v:  #178800,
+  60v:  null,
+  70v:  null,
+  80v:  null,
+  90v:  null,
+);
 $green-cool-5 :   #e8fae6;
 $green-cool-10:   #d0f7cd;
 $green-cool-20:   #a4e3a1;
@@ -441,6 +684,28 @@ $green-cool-80v:  null;
 $green-cool-90v:  null;
 
 // green
+$green: (
+  $green-5 :        #f7fcf0,
+  $green-10:        #e0ebce,
+  $green-20:        #bcd696,
+  $green-30:        #a2bf77,
+  $green-40:        #83a352,
+  $green-50:        #607f35,
+  $green-60:        #526b27,
+  $green-70:        #3c4a29,
+  $green-80:        #293021,
+  $green-90:        #1a1c18,
+  $green-5v:        #d7f4bd,
+  $green-10v:       #b4e876,
+  $green-20v:       #93cc2e,
+  $green-30v:       #81b532,
+  $green-40v:       #73a22b,
+  $green-50v:       #538200,
+  $green-60v:       null,
+  $green-70v:       null,
+  $green-80v:       null,
+  $green-90v:       null,
+);
 $green-5 :        #f7fcf0;
 $green-10:        #e0ebce;
 $green-20:        #bcd696;
@@ -463,6 +728,28 @@ $green-80v:       null;
 $green-90v:       null;
 
 // green-warm
+$green-warm: (
+  5 :   #f9faed,
+  10:   #eaedb9,
+  20:   #ced47f,
+  30:   #aebd5b,
+  40:   #93a150,
+  50:   #717d41,
+  60:   #5e633a,
+  70:   #43452d,
+  80:   #2c2e20,
+  90:   #1c1c16,
+  5v:   #f3f8a7,
+  10v:  #e6f50f,
+  20v:  #cedc0a,
+  30v:  #a9bd2d,
+  40v:  #7f9e1d,
+  50v:  #6b7e00,
+  60v:  null,
+  70v:  null,
+  80v:  null,
+  90v:  null,
+);
 $green-warm-5 :   #f9faed;
 $green-warm-10:   #eaedb9;
 $green-warm-20:   #ced47f;
@@ -485,6 +772,28 @@ $green-warm-80v:  null;
 $green-warm-90v:  null;
 
 // yellow
+$yellow: (
+  5 :       #faf7ed,
+  10:       #f7e8b0,
+  20:       #f0d04f,
+  30:       #cfb04a,
+  40:       #ab9149,
+  50:       #8a7237,
+  60:       #6b5a39,
+  70:       #4d402f,
+  80:       #302a24,
+  90:       #1f1b18,
+  5v:       null,
+  10v:      #fdd430,
+  20v:      #edc730,
+  30v:      null,
+  40v:      null,
+  50v:      null,
+  60v:      null,
+  70v:      null,
+  80v:      null,
+  90v:      null,
+);
 $yellow-5 :       #faf7ed;
 $yellow-10:       #f7e8b0;
 $yellow-20:       #f0d04f;
@@ -507,6 +816,28 @@ $yellow-80v:      null;
 $yellow-90v:      null;
 
 // gold
+$gold: (
+  5 :         #faf5eb,
+  10:         #f2e6ce,
+  20:         #dec699,
+  30:         #c7a97b,
+  40:         #ad8b65,
+  50:         #8d6f4e,
+  60:         #6b5947,
+  70:         #4a4034,
+  80:         #302b24,
+  90:         #1f1c19,
+  5v:         #faf2d9,
+  10v:        #ffcb52,
+  20v:        #faaf00,
+  30v:        #e6a100,
+  40v:        #c98a0c,
+  50v:        #946f38,
+  60v:        null,
+  70v:        null,
+  80v:        null,
+  90v:        null,
+);
 $gold-5 :         #faf5eb;
 $gold-10:         #f2e6ce;
 $gold-20:         #dec699;
@@ -529,6 +860,28 @@ $gold-80v:        null;
 $gold-90v:        null;
 
 // orange
+$orange: (
+  $orange-5 :       #fffbf7,
+  $orange-10:       #fce2c5,
+  $orange-20:       #fabd87,
+  $orange-30:       #ed9c5a,
+  $orange-40:       #eb8028,
+  $orange-50:       #a56931,
+  $orange-60:       #73563e,
+  $orange-70:       #4f3f33,
+  $orange-80:       #302a24,
+  $orange-90:       #211b18,
+  $orange-5v:       #ffebd5,
+  $orange-10v:      null,
+  $orange-20v:      #ffba75,
+  $orange-30v:      #ff9742,
+  $orange-40v:      #ff7b0f,
+  $orange-50v:      #c25700,
+  $orange-60v:      null,
+  $orange-70v:      null,
+  $orange-80v:      null,
+  $orange-90v:      null,
+);
 $orange-5 :       #fffbf7;
 $orange-10:       #fce2c5;
 $orange-20:       #fabd87;
@@ -551,6 +904,28 @@ $orange-80v:      null;
 $orange-90v:      null;
 
 // orange-warm
+$orange-warm: (
+  5 :  #fcf6f2,
+  10:  #f7e1d5,
+  20:  #f7b99e,
+  30:  #f5976e,
+  40:  #e87543,
+  50:  #be5727,
+  60:  #944835,
+  70:  #61382f,
+  80:  #3b2723,
+  90:  #211a19,
+  5v:  null,
+  10v: null,
+  20v: #faad96,
+  30v: #fc835c,
+  40v: #ff5201,
+  50v: #d24200,
+  60v: null,
+  70v: null,
+  80v: null,
+  90v: null,
+);
 $orange-warm-5 :  #fcf6f2;
 $orange-warm-10:  #f7e1d5;
 $orange-warm-20:  #f7b99e;
@@ -573,6 +948,28 @@ $orange-warm-80v: null;
 $orange-warm-90v: null;
 
 // red-warm
+$red-warm: (
+  5 :     #faf7f5,
+  10:     #f2ded5,
+  20:     #ebbda2,
+  30:     #db9e7f,
+  40:     #d67c58,
+  50:     #c7532c,
+  60:     #805039,
+  70:     #4f3f33,
+  80:     #302a26,
+  90:     #1f1c18,
+  5v:     null,
+  10v:    null,
+  20v:    #eaa076,
+  30v:    #e67549,
+  40v:    #ee601d,
+  50v:    #df4206,
+  60v:    null,
+  70v:    null,
+  80v:    null,
+  90v:    null,
+);
 $red-warm-5 :     #faf7f5;
 $red-warm-10:     #f2ded5;
 $red-warm-20:     #ebbda2;
@@ -595,6 +992,28 @@ $red-warm-80v:    null;
 $red-warm-90v:    null;
 
 // red
+$red: (
+  5 :          #fcf5f5,
+  10:          #f7ddda,
+  20:          #f7b7ad,
+  30:          #f28f88,
+  40:          #ed6b61,
+  50:          #d83731,
+  60:          #ab3a3a,
+  70:          #6e312f,
+  80:          #3b2523,
+  90:          #211b1b,
+  5v:          null,
+  10v:         #fccec7,
+  20v:         #fda99c,
+  30v:         #ff806c,
+  40v:         #ff5c48,
+  50v:         #e92106,
+  60v:         #c31f0a,
+  70v:         #9c1503,
+  80v:         #631212,
+  90v:         null,
+);
 $red-5 :          #fcf5f5;
 $red-10:          #f7ddda;
 $red-20:          #f7b7ad;
@@ -617,6 +1036,28 @@ $red-80v:         #631212;
 $red-90v:         null;
 
 // magenta
+$magenta: (
+  5 :      #faf5f6,
+  10:      #f5dce4,
+  20:      #f0b9cb,
+  30:      #e68eae,
+  40:      #e0699f,
+  50:      #c84180,
+  60:      #8a4365,
+  70:      #613046,
+  80:      #3b212c,
+  90:      #211b1d,
+  5v:      null,
+  10v:     #ffd1e2,
+  20v:     #ffadca,
+  30v:     #ff80ae,
+  40v:     #fa3c91,
+  50v:     #e1277a,
+  60v:     #a91b61,
+  70v:     null,
+  80v:     null,
+  90v:     null,
+);
 $magenta-5 :      #faf5f6;
 $magenta-10:      #f5dce4;
 $magenta-20:      #f0b9cb;
@@ -639,6 +1080,18 @@ $magenta-80v:     null;
 $magenta-90v:     null;
 
 // black-cool
+$black-cool: (
+  5 :   #edeff0,
+  10:   #d5d8db,
+  20:   #b8bdc2,
+  30:   #9da2a6,
+  40:   #8c9196,
+  50:   #6f7478,
+  60:   #595d63,
+  70:   #404347,
+  80:   #292a2b,
+  90:   #1c1d1f,
+)
 $black-cool-5 :   #edeff0;
 $black-cool-10:   #d5d8db;
 $black-cool-20:   #b8bdc2;
@@ -651,6 +1104,19 @@ $black-cool-80:   #292a2b;
 $black-cool-90:   #1c1d1f;
 
 // black
+$black: (
+  5 :        #fafafa,
+  10:        #e6e6e6,
+  20:        #c9c9c9,
+  30:        #adadad,
+  40:        #919191,
+  50:        #757575,
+  60:        #5c5c5c,
+  70:        #454545,
+  80:        #2e2e2e,
+  90:        #171717,
+  100:       #000000,
+)
 $black-5 :        #fafafa;
 $black-10:        #e6e6e6;
 $black-20:        #c9c9c9;
@@ -663,6 +1129,18 @@ $black-80:        #2e2e2e;
 $black-90:        #171717;
 
 // black-warm
+$black-warm: (
+  5 :   #f5f5f1,
+  10:   #e0e0da,
+  20:   #d6d5cb,
+  30:   #c2c1b4,
+  40:   #969689,
+  50:   #707064,
+  60:   #5e5e53,
+  70:   #42423c,
+  80:   #2b2b27,
+  90:   #1c1c1b,
+);
 $black-warm-5 :   #f5f5f1;
 $black-warm-10:   #e0e0da;
 $black-warm-20:   #d6d5cb;
@@ -675,6 +1153,18 @@ $black-warm-80:   #2b2b27;
 $black-warm-90:   #1c1c1b;
 
 // black-op
+$black-transparent: (
+  5 :     rgba(0, 0, 0, 0.01),
+  10:     rgba(0, 0, 0, 0.1),
+  20:     rgba(0, 0, 0, 0.2),
+  30:     rgba(0, 0, 0, 0.3),
+  40:     rgba(0, 0, 0, 0.4),
+  50:     rgba(0, 0, 0, 0.5),
+  60:     rgba(0, 0, 0, 0.6),
+  70:     rgba(0, 0, 0, 0.7),
+  80:     rgba(0, 0, 0, 0.8),
+  90:     rgba(0, 0, 0, 0.9),
+);
 $black-transparent-5 :     rgba(0, 0, 0, 0.01);
 $black-transparent-10:     rgba(0, 0, 0, 0.1);
 $black-transparent-20:     rgba(0, 0, 0, 0.2);
@@ -687,6 +1177,18 @@ $black-transparent-80:     rgba(0, 0, 0, 0.8);
 $black-transparent-90:     rgba(0, 0, 0, 0.9);
 
 // white-op
+$white-transparent: (
+  5 :     rgba(255, 255, 255, 0.01),
+  10:     rgba(255, 255, 255, 0.1),
+  20:     rgba(255, 255, 255, 0.2),
+  30:     rgba(255, 255, 255, 0.3),
+  40:     rgba(255, 255, 255, 0.4),
+  50:     rgba(255, 255, 255, 0.5),
+  60:     rgba(255, 255, 255, 0.6),
+  70:     rgba(255, 255, 255, 0.7),
+  80:     rgba(255, 255, 255, 0.8),
+  90:     rgba(255, 255, 255, 0.9),
+);
 $white-transparent-5 :     rgba(255, 255, 255, 0.01);
 $white-transparent-10:     rgba(255, 255, 255, 0.1);
 $white-transparent-20:     rgba(255, 255, 255, 0.2);
@@ -699,12 +1201,25 @@ $white-transparent-80:     rgba(255, 255, 255, 0.8);
 $white-transparent-90:     rgba(255, 255, 255, 0.9);
 
 // white-cool
+$white-cool: (
+  1:    #fafbfc,
+  2:    #f7f9fa,
+  3:    #f5f6f7,
+  4:    #f0f2f5,
+)
 $white-cool-1:    #fafbfc;
 $white-cool-2:    #f7f9fa;
 $white-cool-3:    #f5f6f7;
 $white-cool-4:    #f0f2f5;
 
 // white
+$white: (
+  0:         #ffffff,
+  1:         #fcfcfc,
+  2:         #f9f9f9,
+  3:         #f6f6f6,
+  4:         #f3f3f3,
+);
 $white-0:         #ffffff;
 $white-1:         #fcfcfc;
 $white-2:         #f9f9f9;
@@ -712,10 +1227,13 @@ $white-3:         #f6f6f6;
 $white-4:         #f3f3f3;
 
 // white-warm
+$white-warm: (
+  1:    #fdfdfc,
+  2:    #fafaf8,
+  3:    #f7f7f3,
+  4:    #f5f5f0,
+);
 $white-warm-1:    #fdfdfc;
 $white-warm-2:    #fafaf8;
 $white-warm-3:    #f7f7f3;
 $white-warm-4:    #f5f5f0;
-
-// black
-$black-100:       #000000;

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -197,419 +197,419 @@ $u-lh-body-tight:	 1.5;
 
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
-// violet-warm
-$violet-warm: (
-  5:   #fef7ff,
-  10:  #f5dcf7,
-  20:  #e0bae3,
-  30:  #d096d6,
-  40:  #bd73c7,
-  50:  #b24bbf,
-  60:  #854180,
-  70:  #573455,
-  80:  #332431,
-  90:  #211a21,
+// red
+$red: (
+  5 :          #fcf5f5,
+  10:          #f7ddda,
+  20:          #f7b7ad,
+  30:          #f28f88,
+  40:          #ed6b61,
+  50:          #d83731,
+  60:          #ab3a3a,
+  70:          #6e312f,
+  80:          #3b2523,
+  90:          #211b1b,
   vivid: (
-    5:  #fdedff,
-    10: #f9c9ff,
-    20: #f3a8ff,
-    30: #ee82ff,
-    40: #e05ef7,
-    50: #c132d4,
+    5:          null,
+    10:         #fccec7,
+    20:         #fda99c,
+    30:         #ff806c,
+    40:         #ff5c48,
+    50:         #e92106,
+    60:         #c31f0a,
+    70:         #9c1503,
+    80:         #631212,
+    90:         null,
+  ),
+);
+$red-5:   color($red, 5);
+$red-10:  color($red, 10);
+$red-20:  color($red, 20);
+$red-30:  color($red, 30);
+$red-40:  color($red, 40);
+$red-50:  color($red, 50);
+$red-60:  color($red, 60);
+$red-70:  color($red, 70);
+$red-80:  color($red, 80);
+$red-90:  color($red, 90);
+$red-5v:  color($red, 5, vivid);
+$red-10v: color($red, 10, vivid);
+$red-20v: color($red, 20, vivid);
+$red-30v: color($red, 30, vivid);
+$red-40v: color($red, 40, vivid);
+$red-50v: color($red, 50, vivid);
+$red-60v: color($red, 60, vivid);
+$red-70v: color($red, 70, vivid);
+$red-80v: color($red, 80, vivid);
+$red-90v: color($red, 90, vivid);
+
+// red-warm
+$red-warm: (
+  5 :     #faf7f5,
+  10:     #f2ded5,
+  20:     #ebbda2,
+  30:     #db9e7f,
+  40:     #d67c58,
+  50:     #c7532c,
+  60:     #805039,
+  70:     #4f3f33,
+  80:     #302a26,
+  90:     #1f1c18,
+  vivid: (
+    5:     null,
+    10:    null,
+    20:    #eaa076,
+    30:    #e67549,
+    40:    #ee601d,
+    50:    #df4206,
+    60:    null,
+    70:    null,
+    80:    null,
+    90:    null,
+  ),
+);
+$red-warm-5:    color($red-warm, 5);
+$red-warm-10:   color($red-warm, 10);
+$red-warm-20:   color($red-warm, 20);
+$red-warm-30:   color($red-warm, 30);
+$red-warm-40:   color($red-warm, 40);
+$red-warm-50:   color($red-warm, 50);
+$red-warm-60:   color($red-warm, 60);
+$red-warm-70:   color($red-warm, 70);
+$red-warm-80:   color($red-warm, 80);
+$red-warm-90:   color($red-warm, 90);
+$red-warm-5v:   color($red-warm, 5, vivid);
+$red-warm-10v:  color($red-warm, 10, vivid);
+$red-warm-20v:  color($red-warm, 20, vivid);
+$red-warm-30v:  color($red-warm, 30, vivid);
+$red-warm-40v:  color($red-warm, 40, vivid);
+$red-warm-50v:  color($red-warm, 50, vivid);
+$red-warm-60v:  color($red-warm, 60, vivid);
+$red-warm-70v:  color($red-warm, 70, vivid);
+$red-warm-80v:  color($red-warm, 80, vivid);
+$red-warm-90v:  color($red-warm, 90, vivid);
+
+// orange-warm
+$orange-warm: (
+  5 :  #fcf6f2,
+  10:  #f7e1d5,
+  20:  #f7b99e,
+  30:  #f5976e,
+  40:  #e87543,
+  50:  #be5727,
+  60:  #944835,
+  70:  #61382f,
+  80:  #3b2723,
+  90:  #211a19,
+  vivid: (
+    5:  null,
+    10: null,
+    20: #faad96,
+    30: #fc835c,
+    40: #ff5201,
+    50: #d24200,
     60: null,
     70: null,
     80: null,
     90: null,
   ),
 );
-$violet-warm-5 :  color($violet-warm, 5);
-$violet-warm-10:  color($violet-warm, 10);
-$violet-warm-20:  color($violet-warm, 20);
-$violet-warm-30:  color($violet-warm, 30);
-$violet-warm-40:  color($violet-warm, 40);
-$violet-warm-50:  color($violet-warm, 50);
-$violet-warm-60:  color($violet-warm, 60);
-$violet-warm-70:  color($violet-warm, 70);
-$violet-warm-80:  color($violet-warm, 80);
-$violet-warm-90:  color($violet-warm, 90);
-$violet-warm-5v:  color($violet-warm, 5, vivid);
-$violet-warm-10v: color($violet-warm, 10, vivid);
-$violet-warm-20v: color($violet-warm, 20, vivid);
-$violet-warm-30v: color($violet-warm, 30, vivid);
-$violet-warm-40v: color($violet-warm, 40, vivid);
-$violet-warm-50v: color($violet-warm, 50, vivid);
-$violet-warm-60v: color($violet-warm, 60, vivid);
-$violet-warm-70v: color($violet-warm, 70, vivid);
-$violet-warm-80v: color($violet-warm, 80, vivid);
-$violet-warm-90v: color($violet-warm, 90, vivid);
+$orange-warm-5:   color($orange-warm, 5);
+$orange-warm-10:  color($orange-warm, 10);
+$orange-warm-20:  color($orange-warm, 20);
+$orange-warm-30:  color($orange-warm, 30);
+$orange-warm-40:  color($orange-warm, 40);
+$orange-warm-50:  color($orange-warm, 50);
+$orange-warm-60:  color($orange-warm, 60);
+$orange-warm-70:  color($orange-warm, 70);
+$orange-warm-80:  color($orange-warm, 80);
+$orange-warm-90:  color($orange-warm, 90);
+$orange-warm-5v:  color($orange-warm, 5, vivid);
+$orange-warm-10v: color($orange-warm, 10, vivid);
+$orange-warm-20v: color($orange-warm, 20, vivid);
+$orange-warm-30v: color($orange-warm, 30, vivid);
+$orange-warm-40v: color($orange-warm, 40, vivid);
+$orange-warm-50v: color($orange-warm, 50, vivid);
+$orange-warm-60v: color($orange-warm, 60, vivid);
+$orange-warm-70v: color($orange-warm, 70, vivid);
+$orange-warm-80v: color($orange-warm, 80, vivid);
+$orange-warm-90v: color($orange-warm, 90, vivid);
 
-// violet
-$violet: (
-  5 :       #f7f5fa,
-  10:       #ebe3fa,
-  20:       #cec1e8,
-  30:       #b7a1e3,
-  40:       #9c82d1,
-  50:       #8369b5,
-  60:       #644f8f,
-  70:       #493a66,
-  80:       #2d273b,
-  90:       #1e1b24,
+// orange
+$orange: (
+  5 :       #fffbf7,
+  10:       #fce2c5,
+  20:       #fabd87,
+  30:       #ed9c5a,
+  40:       #eb8028,
+  50:       #a56931,
+  60:       #73563e,
+  70:       #4f3f33,
+  80:       #302a24,
+  90:       #211b18,
   vivid: (
-    5:       null,
+    5:       #ffebd5,
     10:      null,
-    20:      null,
-    30:      #be95e9,
-    40:      #b07bed,
-    50:      #9455dd,
-    60:      #7639b8,
-    70:      #552996,
-    80:      null,
-    90:      null,
-  ),
-);
-$violet-5:    color($violet, 5);
-$violet-10:   color($violet, 10);
-$violet-20:   color($violet, 20);
-$violet-30:   color($violet, 30);
-$violet-40:   color($violet, 40);
-$violet-50:   color($violet, 50);
-$violet-60:   color($violet, 60);
-$violet-70:   color($violet, 70);
-$violet-80:   color($violet, 80);
-$violet-90:   color($violet, 90);
-$violet-5v:   color($violet, 5, vivid);
-$violet-10v:  color($violet, 10, vivid);
-$violet-20v:  color($violet, 20, vivid);
-$violet-30v:  color($violet, 30, vivid);
-$violet-40v:  color($violet, 40, vivid);
-$violet-50v:  color($violet, 50, vivid);
-$violet-60v:  color($violet, 60, vivid);
-$violet-70v:  color($violet, 70, vivid);
-$violet-80v:  color($violet, 80, vivid);
-$violet-90v:  color($violet, 90, vivid);
-
-// indigo-warm
-$indigo-warm:(
-  5 :  #f9f7ff,
-  10:  #e5e1fa,
-  20:  #c9c2f2,
-  30:  #b1a7eb,
-  40:  #968ade,
-  50:  #7766d3,
-  60:  #5e519e,
-  70:  #433a7a,
-  80:  #29263b,
-  90:  #1d1b24,
-  vivid: (
-    5:  null,
-    10: null,
-    20: null,
-    30: #b59eff,
-    40: #9980ff,
-    50: #7560eb,
-    60: #5740d1,
-    70: null,
-    80: null,
-    90: null,
-  ),
-);
-$indigo-warm-5:   color($indigo-warm, 5);
-$indigo-warm-10:  color($indigo-warm, 10);
-$indigo-warm-20:  color($indigo-warm, 20);
-$indigo-warm-30:  color($indigo-warm, 30);
-$indigo-warm-40:  color($indigo-warm, 40);
-$indigo-warm-50:  color($indigo-warm, 50);
-$indigo-warm-60:  color($indigo-warm, 60);
-$indigo-warm-70:  color($indigo-warm, 70);
-$indigo-warm-80:  color($indigo-warm, 80);
-$indigo-warm-90:  color($indigo-warm, 90);
-$indigo-warm-5v:  color($indigo-warm, 5, vivid);
-$indigo-warm-10v: color($indigo-warm, 10, vivid);
-$indigo-warm-20v: color($indigo-warm, 20, vivid);
-$indigo-warm-30v: color($indigo-warm, 30, vivid);
-$indigo-warm-40v: color($indigo-warm, 40, vivid);
-$indigo-warm-50v: color($indigo-warm, 50, vivid);
-$indigo-warm-60v: color($indigo-warm, 60, vivid);
-$indigo-warm-70v: color($indigo-warm, 70, vivid);
-$indigo-warm-80v: color($indigo-warm, 80, vivid);
-$indigo-warm-90v: color($indigo-warm, 90, vivid);
-
-// indigo
-$indigo:(
-  5 :       #fafaff,
-  10:       #e4e3fa,
-  20:       #c2c3f2,
-  30:       #a4a7eb,
-  40:       #8889db,
-  50:       #686dca,
-  60:       #5055b5,
-  70:       #3b3e75,
-  80:       #28293d,
-  90:       #1b1c26,
-  vivid: (
-    5:       null,
-    10:      null,
-    20:      #acaeec,
-    30:      #8c8fe1,
-    40:      null,
-    50:      #656bd7,
-    60:      #353aa5,
+    20:      #ffba75,
+    30:      #ff9742,
+    40:      #ff7b0f,
+    50:      #c25700,
+    60:      null,
     70:      null,
     80:      null,
     90:      null,
   ),
 );
-$indigo-5:    color($indigo, 5);
-$indigo-10:   color($indigo, 10);
-$indigo-20:   color($indigo, 20);
-$indigo-30:   color($indigo, 30);
-$indigo-40:   color($indigo, 40);
-$indigo-50:   color($indigo, 50);
-$indigo-60:   color($indigo, 60);
-$indigo-70:   color($indigo, 70);
-$indigo-80:   color($indigo, 80);
-$indigo-90:   color($indigo, 90);
-$indigo-5v:   color($indigo, 5, vivid);
-$indigo-10v:  color($indigo, 10, vivid);
-$indigo-20v:  color($indigo, 20, vivid);
-$indigo-30v:  color($indigo, 30, vivid);
-$indigo-40v:  color($indigo, 40, vivid);
-$indigo-50v:  color($indigo, 50, vivid);
-$indigo-60v:  color($indigo, 60, vivid);
-$indigo-70v:  color($indigo, 70, vivid);
-$indigo-80v:  color($indigo, 80, vivid);
-$indigo-90v:  color($indigo, 90, vivid);
+$orange-5:    color($orange, 5);
+$orange-10:   color($orange, 10);
+$orange-20:   color($orange, 20);
+$orange-30:   color($orange, 30);
+$orange-40:   color($orange, 40);
+$orange-50:   color($orange, 50);
+$orange-60:   color($orange, 60);
+$orange-70:   color($orange, 70);
+$orange-80:   color($orange, 80);
+$orange-90:   color($orange, 90);
+$orange-5v:   color($orange, 5, vivid);
+$orange-10v:  color($orange, 10, vivid);
+$orange-20v:  color($orange, 20, vivid);
+$orange-30v:  color($orange, 30, vivid);
+$orange-40v:  color($orange, 40, vivid);
+$orange-50v:  color($orange, 50, vivid);
+$orange-60v:  color($orange, 60, vivid);
+$orange-70v:  color($orange, 70, vivid);
+$orange-80v:  color($orange, 80, vivid);
+$orange-90v:  color($orange, 90, vivid);
 
-// indigo-cool
-$indigo-cool: (
-  5 :  #f5f6fc,
-  10:  #e1e6fa,
-  20:  #bac7f5,
-  30:  #97acf0,
-  40:  #6d91ed,
-  50:  #4a70d9,
-  60:  #425bad,
-  70:  #364173,
-  80:  #23273d,
-  90:  #1b1c2b,
+// gold
+$gold: (
+  5 :         #faf5eb,
+  10:         #f2e6ce,
+  20:         #dec699,
+  30:         #c7a97b,
+  40:         #ad8b65,
+  50:         #8d6f4e,
+  60:         #6b5947,
+  70:         #4a4034,
+  80:         #302b24,
+  90:         #1f1c19,
   vivid: (
-    5:  null,
-    10: null,
-    20: null,
-    30: null,
-    40: #6694ff,
-    50: null,
-    60: #4150f2,
-    70: null,
-    80: null,
-    90: null,
-  ),
-);
-$indigo-cool-5:   color($indigo-cool, 5);
-$indigo-cool-10:  color($indigo-cool, 10);
-$indigo-cool-20:  color($indigo-cool, 20);
-$indigo-cool-30:  color($indigo-cool, 30);
-$indigo-cool-40:  color($indigo-cool, 40);
-$indigo-cool-50:  color($indigo-cool, 50);
-$indigo-cool-60:  color($indigo-cool, 60);
-$indigo-cool-70:  color($indigo-cool, 70);
-$indigo-cool-80:  color($indigo-cool, 80);
-$indigo-cool-90:  color($indigo-cool, 90);
-$indigo-cool-5v:  color($indigo-cool, 5, vivid);
-$indigo-cool-10v: color($indigo-cool, 10, vivid);
-$indigo-cool-20v: color($indigo-cool, 20, vivid);
-$indigo-cool-30v: color($indigo-cool, 30, vivid);
-$indigo-cool-40v: color($indigo-cool, 40, vivid);
-$indigo-cool-50v: color($indigo-cool, 50, vivid);
-$indigo-cool-60v: color($indigo-cool, 60, vivid);
-$indigo-cool-70v: color($indigo-cool, 70, vivid);
-$indigo-cool-80v: color($indigo-cool, 80, vivid);
-$indigo-cool-90v: color($indigo-cool, 90, vivid);
-
-// blue-warm
-$blue-warm: (
-  5 :    #f0f5fc,
-  10:    #dfe7f5,
-  20:    #bccae6,
-  30:    #91add9,
-  40:    #7397d1,
-  50:    #3d75c2,
-  60:    #37629e,
-  70:    #31486b,
-  80:    #232d3d,
-  90:    #161b24,
-  vivid: (
-    5:    null,
-    10:   null,
-    20:   #b8cbf2,
-    30:   #81aefc,
-    40:   #5e99ff,
-    50:   #2673df,
-    60:   #0052de,
-    70:   #1e4f94,
-    80:   #112a4d,
-    90:   null,
-  ),
-);
-$blue-warm-5:   color($blue-warm, 5);
-$blue-warm-10:  color($blue-warm, 10);
-$blue-warm-20:  color($blue-warm, 20);
-$blue-warm-30:  color($blue-warm, 30);
-$blue-warm-40:  color($blue-warm, 40);
-$blue-warm-50:  color($blue-warm, 50);
-$blue-warm-60:  color($blue-warm, 60);
-$blue-warm-70:  color($blue-warm, 70);
-$blue-warm-80:  color($blue-warm, 80);
-$blue-warm-90:  color($blue-warm, 90);
-$blue-warm-5v:  color($blue-warm, 5, vivid);
-$blue-warm-10v: color($blue-warm, 10, vivid);
-$blue-warm-20v: color($blue-warm, 20, vivid);
-$blue-warm-30v: color($blue-warm, 30, vivid);
-$blue-warm-40v: color($blue-warm, 40, vivid);
-$blue-warm-50v: color($blue-warm, 50, vivid);
-$blue-warm-60v: color($blue-warm, 60, vivid);
-$blue-warm-70v: color($blue-warm, 70, vivid);
-$blue-warm-80v: color($blue-warm, 80, vivid);
-$blue-warm-90v: color($blue-warm, 90, vivid);
-
-// blue
-$blue: (
-  5 :         #f5fbff,
-  10:         #dae9f7,
-  20:         #add1f0,
-  30:         #79bcf2,
-  40:         #56a4e3,
-  50:         #317cb9,
-  60:         #2f6794,
-  70:         #294c69,
-  80:         #1e2f3d,
-  90:         #161e24,
-  vivid: (
-    5:         null,
-    10:        null,
-    20:        null,
-    30:        #57b3ff,
-    40:        #009afa,
-    50:        #007ade,
-    60:        #0069b4,
-    70:        #0c4d82,
-    80:        #11304f,
-    90:        null,
-  ),
-);
-$blue-5:    color($blue, 5);
-$blue-10:   color($blue, 10);
-$blue-20:   color($blue, 20);
-$blue-30:   color($blue, 30);
-$blue-40:   color($blue, 40);
-$blue-50:   color($blue, 50);
-$blue-60:   color($blue, 60);
-$blue-70:   color($blue, 70);
-$blue-80:   color($blue, 80);
-$blue-90:   color($blue, 90);
-$blue-5v:   color($blue, 5, vivid);
-$blue-10v:  color($blue, 10, vivid);
-$blue-20v:  color($blue, 20, vivid);
-$blue-30v:  color($blue, 30, vivid);
-$blue-40v:  color($blue, 40, vivid);
-$blue-50v:  color($blue, 50, vivid);
-$blue-60v:  color($blue, 60, vivid);
-$blue-70v:  color($blue, 70, vivid);
-$blue-80v:  color($blue, 80, vivid);
-$blue-90v:  color($blue, 90, vivid);
-
-// cyan
-$cyan: (
-  5 :         #e8f7fa,
-  10:         #d0f1f7,
-  20:         #9ddceb,
-  30:         #6ecbdb,
-  40:         #4bacbd,
-  50:         #167f91,
-  60:         #2f707a,
-  70:         #2d4b4f,
-  80:         #203133,
-  90:         #151e1f,
-  vivid: (
-    5:         null,
-    10:        #a8f2ff,
-    20:        #55e1fa,
-    30:        #02c2e8,
-    40:        #00abd1,
-    50:        null,
+    5:         #faf2d9,
+    10:        #ffcb52,
+    20:        #faaf00,
+    30:        #e6a100,
+    40:        #c98a0c,
+    50:        #946f38,
     60:        null,
     70:        null,
     80:        null,
     90:        null,
   ),
 );
-$cyan-5:    color($cyan, 5);
-$cyan-10:   color($cyan, 10);
-$cyan-20:   color($cyan, 20);
-$cyan-30:   color($cyan, 30);
-$cyan-40:   color($cyan, 40);
-$cyan-50:   color($cyan, 50);
-$cyan-60:   color($cyan, 60);
-$cyan-70:   color($cyan, 70);
-$cyan-80:   color($cyan, 80);
-$cyan-90:   color($cyan, 90);
-$cyan-5v:   color($cyan, 5, vivid);
-$cyan-10v:  color($cyan, 10, vivid);
-$cyan-20v:  color($cyan, 20, vivid);
-$cyan-30v:  color($cyan, 30, vivid);
-$cyan-40v:  color($cyan, 40, vivid);
-$cyan-50v:  color($cyan, 50, vivid);
-$cyan-60v:  color($cyan, 60, vivid);
-$cyan-70v:  color($cyan, 70, vivid);
-$cyan-80v:  color($cyan, 80, vivid);
-$cyan-90v:  color($cyan, 90, vivid);
+$gold-5:    color($gold, 5);
+$gold-10:   color($gold, 10);
+$gold-20:   color($gold, 20);
+$gold-30:   color($gold, 30);
+$gold-40:   color($gold, 40);
+$gold-50:   color($gold, 50);
+$gold-60:   color($gold, 60);
+$gold-70:   color($gold, 70);
+$gold-80:   color($gold, 80);
+$gold-90:   color($gold, 90);
+$gold-5v:   color($gold, 5, vivid);
+$gold-10v:  color($gold, 10, vivid);
+$gold-20v:  color($gold, 20, vivid);
+$gold-30v:  color($gold, 30, vivid);
+$gold-40v:  color($gold, 40, vivid);
+$gold-50v:  color($gold, 50, vivid);
+$gold-60v:  color($gold, 60, vivid);
+$gold-70v:  color($gold, 70, vivid);
+$gold-80v:  color($gold, 80, vivid);
+$gold-90v:  color($gold, 90, vivid);
 
-// mint-cool
-$mint-cool: (
-  5 :    #f2fffe,
-  10:    #c7f2ef,
-  20:    #a2ded9,
-  30:    #77c7c0,
-  40:    #57ada8,
-  50:    #21827f,
-  60:    #3b6b69,
-  70:    #2b4d47,
-  80:    #1f3030,
-  90:    #151f1f,
+// yellow
+$yellow: (
+  5 :       #faf7ed,
+  10:       #f7e8b0,
+  20:       #f0d04f,
+  30:       #cfb04a,
+  40:       #ab9149,
+  50:       #8a7237,
+  60:       #6b5a39,
+  70:       #4d402f,
+  80:       #302a24,
+  90:       #1f1b18,
   vivid: (
-    5:    #dbfff8,
-    10:   #7efce1,
-    20:   #02dbc2,
-    30:   #00baa4,
-    40:   #00b5a9,
-    50:   null,
-    60:   null,
-    70:   null,
-    80:   null,
-    90:   null,
+    5:       null,
+    10:      #fdd430,
+    20:      #edc730,
+    30:      null,
+    40:      null,
+    50:      null,
+    60:      null,
+    70:      null,
+    80:      null,
+    90:      null,
   ),
 );
-$mint-cool-5:   color($mint-cool, 5);
-$mint-cool-10:  color($mint-cool, 10);
-$mint-cool-20:  color($mint-cool, 20);
-$mint-cool-30:  color($mint-cool, 30);
-$mint-cool-40:  color($mint-cool, 40);
-$mint-cool-50:  color($mint-cool, 50);
-$mint-cool-60:  color($mint-cool, 60);
-$mint-cool-70:  color($mint-cool, 70);
-$mint-cool-80:  color($mint-cool, 80);
-$mint-cool-90:  color($mint-cool, 90);
-$mint-cool-5v:  color($mint-cool, 5, vivid);
-$mint-cool-10v: color($mint-cool, 10, vivid);
-$mint-cool-20v: color($mint-cool, 20, vivid);
-$mint-cool-30v: color($mint-cool, 30, vivid);
-$mint-cool-40v: color($mint-cool, 40, vivid);
-$mint-cool-50v: color($mint-cool, 50, vivid);
-$mint-cool-60v: color($mint-cool, 60, vivid);
-$mint-cool-70v: color($mint-cool, 70, vivid);
-$mint-cool-80v: color($mint-cool, 80, vivid);
-$mint-cool-90v: color($mint-cool, 90, vivid);
+$yellow-5:    color($yellow, 5);
+$yellow-10:   color($yellow, 10);
+$yellow-20:   color($yellow, 20);
+$yellow-30:   color($yellow, 30);
+$yellow-40:   color($yellow, 40);
+$yellow-50:   color($yellow, 50);
+$yellow-60:   color($yellow, 60);
+$yellow-70:   color($yellow, 70);
+$yellow-80:   color($yellow, 80);
+$yellow-90:   color($yellow, 90);
+$yellow-5v:   color($yellow, 5, vivid);
+$yellow-10v:  color($yellow, 10, vivid);
+$yellow-20v:  color($yellow, 20, vivid);
+$yellow-30v:  color($yellow, 30, vivid);
+$yellow-40v:  color($yellow, 40, vivid);
+$yellow-50v:  color($yellow, 50, vivid);
+$yellow-60v:  color($yellow, 60, vivid);
+$yellow-70v:  color($yellow, 70, vivid);
+$yellow-80v:  color($yellow, 80, vivid);
+$yellow-90v:  color($yellow, 90, vivid);
+
+// green-warm
+$green-warm: (
+  5 :   #f9faed,
+  10:   #eaedb9,
+  20:   #ced47f,
+  30:   #aebd5b,
+  40:   #93a150,
+  50:   #717d41,
+  60:   #5e633a,
+  70:   #43452d,
+  80:   #2c2e20,
+  90:   #1c1c16,
+  vivid: (
+    5:   #f3f8a7,
+    10:  #e6f50f,
+    20:  #cedc0a,
+    30:  #a9bd2d,
+    40:  #7f9e1d,
+    50:  #6b7e00,
+    60:  null,
+    70:  null,
+    80:  null,
+    90:  null,
+  ),
+);
+$green-warm-5:    color($green-warm, 5);
+$green-warm-10:   color($green-warm, 10);
+$green-warm-20:   color($green-warm, 20);
+$green-warm-30:   color($green-warm, 30);
+$green-warm-40:   color($green-warm, 40);
+$green-warm-50:   color($green-warm, 50);
+$green-warm-60:   color($green-warm, 60);
+$green-warm-70:   color($green-warm, 70);
+$green-warm-80:   color($green-warm, 80);
+$green-warm-90:   color($green-warm, 90);
+$green-warm-5v:   color($green-warm, 5, vivid);
+$green-warm-10v:  color($green-warm, 10, vivid);
+$green-warm-20v:  color($green-warm, 20, vivid);
+$green-warm-30v:  color($green-warm, 30, vivid);
+$green-warm-40v:  color($green-warm, 40, vivid);
+$green-warm-50v:  color($green-warm, 50, vivid);
+$green-warm-60v:  color($green-warm, 60, vivid);
+$green-warm-70v:  color($green-warm, 70, vivid);
+$green-warm-80v:  color($green-warm, 80, vivid);
+$green-warm-90v:  color($green-warm, 90, vivid);
+
+// green
+$green: (
+  5 :        #f7fcf0,
+  10:        #e0ebce,
+  20:        #bcd696,
+  30:        #a2bf77,
+  40:        #83a352,
+  50:        #607f35,
+  60:        #526b27,
+  70:        #3c4a29,
+  80:        #293021,
+  90:        #1a1c18,
+  vivid: (
+    5:        #d7f4bd,
+    10:       #b4e876,
+    20:       #93cc2e,
+    30:       #81b532,
+    40:       #73a22b,
+    50:       #538200,
+    60:       null,
+    70:       null,
+    80:       null,
+    90:       null,
+  ),
+);
+$green-5:   color($green, 5);
+$green-10:  color($green, 10);
+$green-20:  color($green, 20);
+$green-30:  color($green, 30);
+$green-40:  color($green, 40);
+$green-50:  color($green, 50);
+$green-60:  color($green, 60);
+$green-70:  color($green, 70);
+$green-80:  color($green, 80);
+$green-90:  color($green, 90);
+$green-5v:  color($green, 5, vivid);
+$green-10v: color($green, 10, vivid);
+$green-20v: color($green, 20, vivid);
+$green-30v: color($green, 30, vivid);
+$green-40v: color($green, 40, vivid);
+$green-50v: color($green, 50, vivid);
+$green-60v: color($green, 60, vivid);
+$green-70v: color($green, 70, vivid);
+$green-80v: color($green, 80, vivid);
+$green-90v: color($green, 90, vivid);
+
+// green-cool
+$green-cool: (
+  5 :   #e8fae6,
+  10:   #d0f7cd,
+  20:   #a4e3a1,
+  30:   #80cc7e,
+  40:   #5db85c,
+  50:   #3d841f,
+  60:   #4d6e37,
+  70:   #384d2a,
+  80:   #272e22,
+  90:   #1a1f1a,
+  vivid: (
+    5:   #caf4c7,
+    10:  #91e48b,
+    20:  #61cf59,
+    30:  #16c20a,
+    40:  #0caf00,
+    50:  #178800,
+    60:  null,
+    70:  null,
+    80:  null,
+    90:  null,
+  ),
+);
+$green-cool-5:    color($green-cool, 5);
+$green-cool-10:   color($green-cool, 10);
+$green-cool-20:   color($green-cool, 20);
+$green-cool-30:   color($green-cool, 30);
+$green-cool-40:   color($green-cool, 40);
+$green-cool-50:   color($green-cool, 50);
+$green-cool-60:   color($green-cool, 60);
+$green-cool-70:   color($green-cool, 70);
+$green-cool-80:   color($green-cool, 80);
+$green-cool-90:   color($green-cool, 90);
+$green-cool-5v:   color($green-cool, 5, vivid);
+$green-cool-10v:  color($green-cool, 10, vivid);
+$green-cool-20v:  color($green-cool, 20, vivid);
+$green-cool-30v:  color($green-cool, 30, vivid);
+$green-cool-40v:  color($green-cool, 40, vivid);
+$green-cool-50v:  color($green-cool, 50, vivid);
+$green-cool-60v:  color($green-cool, 60, vivid);
+$green-cool-70v:  color($green-cool, 70, vivid);
+$green-cool-80v:  color($green-cool, 80, vivid);
+$green-cool-90v:  color($green-cool, 90, vivid);
 
 // mint
 $mint: (
@@ -658,419 +658,419 @@ $mint-70v:  color($mint, 70, vivid);
 $mint-80v:  color($mint, 80, vivid);
 $mint-90v:  color($mint, 90, vivid);
 
-// green-cool
-$green-cool: (
-  5 :   #e8fae6,
-  10:   #d0f7cd,
-  20:   #a4e3a1,
-  30:   #80cc7e,
-  40:   #5db85c,
-  50:   #3d841f,
-  60:   #4d6e37,
-  70:   #384d2a,
-  80:   #272e22,
-  90:   #1a1f1a,
+// mint-cool
+$mint-cool: (
+  5 :    #f2fffe,
+  10:    #c7f2ef,
+  20:    #a2ded9,
+  30:    #77c7c0,
+  40:    #57ada8,
+  50:    #21827f,
+  60:    #3b6b69,
+  70:    #2b4d47,
+  80:    #1f3030,
+  90:    #151f1f,
   vivid: (
-    5:   #caf4c7,
-    10:  #91e48b,
-    20:  #61cf59,
-    30:  #16c20a,
-    40:  #0caf00,
-    50:  #178800,
-    60:  null,
-    70:  null,
-    80:  null,
-    90:  null,
+    5:    #dbfff8,
+    10:   #7efce1,
+    20:   #02dbc2,
+    30:   #00baa4,
+    40:   #00b5a9,
+    50:   null,
+    60:   null,
+    70:   null,
+    80:   null,
+    90:   null,
   ),
 );
-$green-cool-5:    color($green-cool, 5);
-$green-cool-10:   color($green-cool, 10);
-$green-cool-20:   color($green-cool, 20);
-$green-cool-30:   color($green-cool, 30);
-$green-cool-40:   color($green-cool, 40);
-$green-cool-50:   color($green-cool, 50);
-$green-cool-60:   color($green-cool, 60);
-$green-cool-70:   color($green-cool, 70);
-$green-cool-80:   color($green-cool, 80);
-$green-cool-90:   color($green-cool, 90);
-$green-cool-5v:   color($green-cool, 5, vivid);
-$green-cool-10v:  color($green-cool, 10, vivid);
-$green-cool-20v:  color($green-cool, 20, vivid);
-$green-cool-30v:  color($green-cool, 30, vivid);
-$green-cool-40v:  color($green-cool, 40, vivid);
-$green-cool-50v:  color($green-cool, 50, vivid);
-$green-cool-60v:  color($green-cool, 60, vivid);
-$green-cool-70v:  color($green-cool, 70, vivid);
-$green-cool-80v:  color($green-cool, 80, vivid);
-$green-cool-90v:  color($green-cool, 90, vivid);
+$mint-cool-5:   color($mint-cool, 5);
+$mint-cool-10:  color($mint-cool, 10);
+$mint-cool-20:  color($mint-cool, 20);
+$mint-cool-30:  color($mint-cool, 30);
+$mint-cool-40:  color($mint-cool, 40);
+$mint-cool-50:  color($mint-cool, 50);
+$mint-cool-60:  color($mint-cool, 60);
+$mint-cool-70:  color($mint-cool, 70);
+$mint-cool-80:  color($mint-cool, 80);
+$mint-cool-90:  color($mint-cool, 90);
+$mint-cool-5v:  color($mint-cool, 5, vivid);
+$mint-cool-10v: color($mint-cool, 10, vivid);
+$mint-cool-20v: color($mint-cool, 20, vivid);
+$mint-cool-30v: color($mint-cool, 30, vivid);
+$mint-cool-40v: color($mint-cool, 40, vivid);
+$mint-cool-50v: color($mint-cool, 50, vivid);
+$mint-cool-60v: color($mint-cool, 60, vivid);
+$mint-cool-70v: color($mint-cool, 70, vivid);
+$mint-cool-80v: color($mint-cool, 80, vivid);
+$mint-cool-90v: color($mint-cool, 90, vivid);
 
-// green
-$green: (
-  5 :        #f7fcf0,
-  10:        #e0ebce,
-  20:        #bcd696,
-  30:        #a2bf77,
-  40:        #83a352,
-  50:        #607f35,
-  60:        #526b27,
-  70:        #3c4a29,
-  80:        #293021,
-  90:        #1a1c18,
+// cyan
+$cyan: (
+  5 :         #e8f7fa,
+  10:         #d0f1f7,
+  20:         #9ddceb,
+  30:         #6ecbdb,
+  40:         #4bacbd,
+  50:         #167f91,
+  60:         #2f707a,
+  70:         #2d4b4f,
+  80:         #203133,
+  90:         #151e1f,
   vivid: (
-    5:        #d7f4bd,
-    10:       #b4e876,
-    20:       #93cc2e,
-    30:       #81b532,
-    40:       #73a22b,
-    50:       #538200,
-    60:       null,
-    70:       null,
-    80:       null,
-    90:       null,
-  ),
-);
-$green-5:   color($green, 5);
-$green-10:  color($green, 10);
-$green-20:  color($green, 20);
-$green-30:  color($green, 30);
-$green-40:  color($green, 40);
-$green-50:  color($green, 50);
-$green-60:  color($green, 60);
-$green-70:  color($green, 70);
-$green-80:  color($green, 80);
-$green-90:  color($green, 90);
-$green-5v:  color($green, 5, vivid);
-$green-10v: color($green, 10, vivid);
-$green-20v: color($green, 20, vivid);
-$green-30v: color($green, 30, vivid);
-$green-40v: color($green, 40, vivid);
-$green-50v: color($green, 50, vivid);
-$green-60v: color($green, 60, vivid);
-$green-70v: color($green, 70, vivid);
-$green-80v: color($green, 80, vivid);
-$green-90v: color($green, 90, vivid);
-
-// green-warm
-$green-warm: (
-  5 :   #f9faed,
-  10:   #eaedb9,
-  20:   #ced47f,
-  30:   #aebd5b,
-  40:   #93a150,
-  50:   #717d41,
-  60:   #5e633a,
-  70:   #43452d,
-  80:   #2c2e20,
-  90:   #1c1c16,
-  vivid: (
-    5:   #f3f8a7,
-    10:  #e6f50f,
-    20:  #cedc0a,
-    30:  #a9bd2d,
-    40:  #7f9e1d,
-    50:  #6b7e00,
-    60:  null,
-    70:  null,
-    80:  null,
-    90:  null,
-  ),
-);
-$green-warm-5:    color($green-warm, 5);
-$green-warm-10:   color($green-warm, 10);
-$green-warm-20:   color($green-warm, 20);
-$green-warm-30:   color($green-warm, 30);
-$green-warm-40:   color($green-warm, 40);
-$green-warm-50:   color($green-warm, 50);
-$green-warm-60:   color($green-warm, 60);
-$green-warm-70:   color($green-warm, 70);
-$green-warm-80:   color($green-warm, 80);
-$green-warm-90:   color($green-warm, 90);
-$green-warm-5v:   color($green-warm, 5, vivid);
-$green-warm-10v:  color($green-warm, 10, vivid);
-$green-warm-20v:  color($green-warm, 20, vivid);
-$green-warm-30v:  color($green-warm, 30, vivid);
-$green-warm-40v:  color($green-warm, 40, vivid);
-$green-warm-50v:  color($green-warm, 50, vivid);
-$green-warm-60v:  color($green-warm, 60, vivid);
-$green-warm-70v:  color($green-warm, 70, vivid);
-$green-warm-80v:  color($green-warm, 80, vivid);
-$green-warm-90v:  color($green-warm, 90, vivid);
-
-// yellow
-$yellow: (
-  5 :       #faf7ed,
-  10:       #f7e8b0,
-  20:       #f0d04f,
-  30:       #cfb04a,
-  40:       #ab9149,
-  50:       #8a7237,
-  60:       #6b5a39,
-  70:       #4d402f,
-  80:       #302a24,
-  90:       #1f1b18,
-  vivid: (
-    5:       null,
-    10:      #fdd430,
-    20:      #edc730,
-    30:      null,
-    40:      null,
-    50:      null,
-    60:      null,
-    70:      null,
-    80:      null,
-    90:      null,
-  ),
-);
-$yellow-5:    color($yellow, 5);
-$yellow-10:   color($yellow, 10);
-$yellow-20:   color($yellow, 20);
-$yellow-30:   color($yellow, 30);
-$yellow-40:   color($yellow, 40);
-$yellow-50:   color($yellow, 50);
-$yellow-60:   color($yellow, 60);
-$yellow-70:   color($yellow, 70);
-$yellow-80:   color($yellow, 80);
-$yellow-90:   color($yellow, 90);
-$yellow-5v:   color($yellow, 5, vivid);
-$yellow-10v:  color($yellow, 10, vivid);
-$yellow-20v:  color($yellow, 20, vivid);
-$yellow-30v:  color($yellow, 30, vivid);
-$yellow-40v:  color($yellow, 40, vivid);
-$yellow-50v:  color($yellow, 50, vivid);
-$yellow-60v:  color($yellow, 60, vivid);
-$yellow-70v:  color($yellow, 70, vivid);
-$yellow-80v:  color($yellow, 80, vivid);
-$yellow-90v:  color($yellow, 90, vivid);
-
-// gold
-$gold: (
-  5 :         #faf5eb,
-  10:         #f2e6ce,
-  20:         #dec699,
-  30:         #c7a97b,
-  40:         #ad8b65,
-  50:         #8d6f4e,
-  60:         #6b5947,
-  70:         #4a4034,
-  80:         #302b24,
-  90:         #1f1c19,
-  vivid: (
-    5:         #faf2d9,
-    10:        #ffcb52,
-    20:        #faaf00,
-    30:        #e6a100,
-    40:        #c98a0c,
-    50:        #946f38,
+    5:         null,
+    10:        #a8f2ff,
+    20:        #55e1fa,
+    30:        #02c2e8,
+    40:        #00abd1,
+    50:        null,
     60:        null,
     70:        null,
     80:        null,
     90:        null,
   ),
 );
-$gold-5:    color($gold, 5);
-$gold-10:   color($gold, 10);
-$gold-20:   color($gold, 20);
-$gold-30:   color($gold, 30);
-$gold-40:   color($gold, 40);
-$gold-50:   color($gold, 50);
-$gold-60:   color($gold, 60);
-$gold-70:   color($gold, 70);
-$gold-80:   color($gold, 80);
-$gold-90:   color($gold, 90);
-$gold-5v:   color($gold, 5, vivid);
-$gold-10v:  color($gold, 10, vivid);
-$gold-20v:  color($gold, 20, vivid);
-$gold-30v:  color($gold, 30, vivid);
-$gold-40v:  color($gold, 40, vivid);
-$gold-50v:  color($gold, 50, vivid);
-$gold-60v:  color($gold, 60, vivid);
-$gold-70v:  color($gold, 70, vivid);
-$gold-80v:  color($gold, 80, vivid);
-$gold-90v:  color($gold, 90, vivid);
+$cyan-5:    color($cyan, 5);
+$cyan-10:   color($cyan, 10);
+$cyan-20:   color($cyan, 20);
+$cyan-30:   color($cyan, 30);
+$cyan-40:   color($cyan, 40);
+$cyan-50:   color($cyan, 50);
+$cyan-60:   color($cyan, 60);
+$cyan-70:   color($cyan, 70);
+$cyan-80:   color($cyan, 80);
+$cyan-90:   color($cyan, 90);
+$cyan-5v:   color($cyan, 5, vivid);
+$cyan-10v:  color($cyan, 10, vivid);
+$cyan-20v:  color($cyan, 20, vivid);
+$cyan-30v:  color($cyan, 30, vivid);
+$cyan-40v:  color($cyan, 40, vivid);
+$cyan-50v:  color($cyan, 50, vivid);
+$cyan-60v:  color($cyan, 60, vivid);
+$cyan-70v:  color($cyan, 70, vivid);
+$cyan-80v:  color($cyan, 80, vivid);
+$cyan-90v:  color($cyan, 90, vivid);
 
-// orange
-$orange: (
-  5 :       #fffbf7,
-  10:       #fce2c5,
-  20:       #fabd87,
-  30:       #ed9c5a,
-  40:       #eb8028,
-  50:       #a56931,
-  60:       #73563e,
-  70:       #4f3f33,
-  80:       #302a24,
-  90:       #211b18,
+// blue
+$blue: (
+  5 :         #f5fbff,
+  10:         #dae9f7,
+  20:         #add1f0,
+  30:         #79bcf2,
+  40:         #56a4e3,
+  50:         #317cb9,
+  60:         #2f6794,
+  70:         #294c69,
+  80:         #1e2f3d,
+  90:         #161e24,
   vivid: (
-    5:       #ffebd5,
+    5:         null,
+    10:        null,
+    20:        null,
+    30:        #57b3ff,
+    40:        #009afa,
+    50:        #007ade,
+    60:        #0069b4,
+    70:        #0c4d82,
+    80:        #11304f,
+    90:        null,
+  ),
+);
+$blue-5:    color($blue, 5);
+$blue-10:   color($blue, 10);
+$blue-20:   color($blue, 20);
+$blue-30:   color($blue, 30);
+$blue-40:   color($blue, 40);
+$blue-50:   color($blue, 50);
+$blue-60:   color($blue, 60);
+$blue-70:   color($blue, 70);
+$blue-80:   color($blue, 80);
+$blue-90:   color($blue, 90);
+$blue-5v:   color($blue, 5, vivid);
+$blue-10v:  color($blue, 10, vivid);
+$blue-20v:  color($blue, 20, vivid);
+$blue-30v:  color($blue, 30, vivid);
+$blue-40v:  color($blue, 40, vivid);
+$blue-50v:  color($blue, 50, vivid);
+$blue-60v:  color($blue, 60, vivid);
+$blue-70v:  color($blue, 70, vivid);
+$blue-80v:  color($blue, 80, vivid);
+$blue-90v:  color($blue, 90, vivid);
+
+// blue-warm
+$blue-warm: (
+  5 :    #f0f5fc,
+  10:    #dfe7f5,
+  20:    #bccae6,
+  30:    #91add9,
+  40:    #7397d1,
+  50:    #3d75c2,
+  60:    #37629e,
+  70:    #31486b,
+  80:    #232d3d,
+  90:    #161b24,
+  vivid: (
+    5:    null,
+    10:   null,
+    20:   #b8cbf2,
+    30:   #81aefc,
+    40:   #5e99ff,
+    50:   #2673df,
+    60:   #0052de,
+    70:   #1e4f94,
+    80:   #112a4d,
+    90:   null,
+  ),
+);
+$blue-warm-5:   color($blue-warm, 5);
+$blue-warm-10:  color($blue-warm, 10);
+$blue-warm-20:  color($blue-warm, 20);
+$blue-warm-30:  color($blue-warm, 30);
+$blue-warm-40:  color($blue-warm, 40);
+$blue-warm-50:  color($blue-warm, 50);
+$blue-warm-60:  color($blue-warm, 60);
+$blue-warm-70:  color($blue-warm, 70);
+$blue-warm-80:  color($blue-warm, 80);
+$blue-warm-90:  color($blue-warm, 90);
+$blue-warm-5v:  color($blue-warm, 5, vivid);
+$blue-warm-10v: color($blue-warm, 10, vivid);
+$blue-warm-20v: color($blue-warm, 20, vivid);
+$blue-warm-30v: color($blue-warm, 30, vivid);
+$blue-warm-40v: color($blue-warm, 40, vivid);
+$blue-warm-50v: color($blue-warm, 50, vivid);
+$blue-warm-60v: color($blue-warm, 60, vivid);
+$blue-warm-70v: color($blue-warm, 70, vivid);
+$blue-warm-80v: color($blue-warm, 80, vivid);
+$blue-warm-90v: color($blue-warm, 90, vivid);
+
+// indigo-cool
+$indigo-cool: (
+  5 :  #f5f6fc,
+  10:  #e1e6fa,
+  20:  #bac7f5,
+  30:  #97acf0,
+  40:  #6d91ed,
+  50:  #4a70d9,
+  60:  #425bad,
+  70:  #364173,
+  80:  #23273d,
+  90:  #1b1c2b,
+  vivid: (
+    5:  null,
+    10: null,
+    20: null,
+    30: null,
+    40: #6694ff,
+    50: null,
+    60: #4150f2,
+    70: null,
+    80: null,
+    90: null,
+  ),
+);
+$indigo-cool-5:   color($indigo-cool, 5);
+$indigo-cool-10:  color($indigo-cool, 10);
+$indigo-cool-20:  color($indigo-cool, 20);
+$indigo-cool-30:  color($indigo-cool, 30);
+$indigo-cool-40:  color($indigo-cool, 40);
+$indigo-cool-50:  color($indigo-cool, 50);
+$indigo-cool-60:  color($indigo-cool, 60);
+$indigo-cool-70:  color($indigo-cool, 70);
+$indigo-cool-80:  color($indigo-cool, 80);
+$indigo-cool-90:  color($indigo-cool, 90);
+$indigo-cool-5v:  color($indigo-cool, 5, vivid);
+$indigo-cool-10v: color($indigo-cool, 10, vivid);
+$indigo-cool-20v: color($indigo-cool, 20, vivid);
+$indigo-cool-30v: color($indigo-cool, 30, vivid);
+$indigo-cool-40v: color($indigo-cool, 40, vivid);
+$indigo-cool-50v: color($indigo-cool, 50, vivid);
+$indigo-cool-60v: color($indigo-cool, 60, vivid);
+$indigo-cool-70v: color($indigo-cool, 70, vivid);
+$indigo-cool-80v: color($indigo-cool, 80, vivid);
+$indigo-cool-90v: color($indigo-cool, 90, vivid);
+
+// indigo
+$indigo:(
+  5 :       #fafaff,
+  10:       #e4e3fa,
+  20:       #c2c3f2,
+  30:       #a4a7eb,
+  40:       #8889db,
+  50:       #686dca,
+  60:       #5055b5,
+  70:       #3b3e75,
+  80:       #28293d,
+  90:       #1b1c26,
+  vivid: (
+    5:       null,
     10:      null,
-    20:      #ffba75,
-    30:      #ff9742,
-    40:      #ff7b0f,
-    50:      #c25700,
-    60:      null,
+    20:      #acaeec,
+    30:      #8c8fe1,
+    40:      null,
+    50:      #656bd7,
+    60:      #353aa5,
     70:      null,
     80:      null,
     90:      null,
   ),
 );
-$orange-5:    color($orange, 5);
-$orange-10:   color($orange, 10);
-$orange-20:   color($orange, 20);
-$orange-30:   color($orange, 30);
-$orange-40:   color($orange, 40);
-$orange-50:   color($orange, 50);
-$orange-60:   color($orange, 60);
-$orange-70:   color($orange, 70);
-$orange-80:   color($orange, 80);
-$orange-90:   color($orange, 90);
-$orange-5v:   color($orange, 5, vivid);
-$orange-10v:  color($orange, 10, vivid);
-$orange-20v:  color($orange, 20, vivid);
-$orange-30v:  color($orange, 30, vivid);
-$orange-40v:  color($orange, 40, vivid);
-$orange-50v:  color($orange, 50, vivid);
-$orange-60v:  color($orange, 60, vivid);
-$orange-70v:  color($orange, 70, vivid);
-$orange-80v:  color($orange, 80, vivid);
-$orange-90v:  color($orange, 90, vivid);
+$indigo-5:    color($indigo, 5);
+$indigo-10:   color($indigo, 10);
+$indigo-20:   color($indigo, 20);
+$indigo-30:   color($indigo, 30);
+$indigo-40:   color($indigo, 40);
+$indigo-50:   color($indigo, 50);
+$indigo-60:   color($indigo, 60);
+$indigo-70:   color($indigo, 70);
+$indigo-80:   color($indigo, 80);
+$indigo-90:   color($indigo, 90);
+$indigo-5v:   color($indigo, 5, vivid);
+$indigo-10v:  color($indigo, 10, vivid);
+$indigo-20v:  color($indigo, 20, vivid);
+$indigo-30v:  color($indigo, 30, vivid);
+$indigo-40v:  color($indigo, 40, vivid);
+$indigo-50v:  color($indigo, 50, vivid);
+$indigo-60v:  color($indigo, 60, vivid);
+$indigo-70v:  color($indigo, 70, vivid);
+$indigo-80v:  color($indigo, 80, vivid);
+$indigo-90v:  color($indigo, 90, vivid);
 
-// orange-warm
-$orange-warm: (
-  5 :  #fcf6f2,
-  10:  #f7e1d5,
-  20:  #f7b99e,
-  30:  #f5976e,
-  40:  #e87543,
-  50:  #be5727,
-  60:  #944835,
-  70:  #61382f,
-  80:  #3b2723,
-  90:  #211a19,
+// indigo-warm
+$indigo-warm:(
+  5 :  #f9f7ff,
+  10:  #e5e1fa,
+  20:  #c9c2f2,
+  30:  #b1a7eb,
+  40:  #968ade,
+  50:  #7766d3,
+  60:  #5e519e,
+  70:  #433a7a,
+  80:  #29263b,
+  90:  #1d1b24,
   vivid: (
     5:  null,
     10: null,
-    20: #faad96,
-    30: #fc835c,
-    40: #ff5201,
-    50: #d24200,
+    20: null,
+    30: #b59eff,
+    40: #9980ff,
+    50: #7560eb,
+    60: #5740d1,
+    70: null,
+    80: null,
+    90: null,
+  ),
+);
+$indigo-warm-5:   color($indigo-warm, 5);
+$indigo-warm-10:  color($indigo-warm, 10);
+$indigo-warm-20:  color($indigo-warm, 20);
+$indigo-warm-30:  color($indigo-warm, 30);
+$indigo-warm-40:  color($indigo-warm, 40);
+$indigo-warm-50:  color($indigo-warm, 50);
+$indigo-warm-60:  color($indigo-warm, 60);
+$indigo-warm-70:  color($indigo-warm, 70);
+$indigo-warm-80:  color($indigo-warm, 80);
+$indigo-warm-90:  color($indigo-warm, 90);
+$indigo-warm-5v:  color($indigo-warm, 5, vivid);
+$indigo-warm-10v: color($indigo-warm, 10, vivid);
+$indigo-warm-20v: color($indigo-warm, 20, vivid);
+$indigo-warm-30v: color($indigo-warm, 30, vivid);
+$indigo-warm-40v: color($indigo-warm, 40, vivid);
+$indigo-warm-50v: color($indigo-warm, 50, vivid);
+$indigo-warm-60v: color($indigo-warm, 60, vivid);
+$indigo-warm-70v: color($indigo-warm, 70, vivid);
+$indigo-warm-80v: color($indigo-warm, 80, vivid);
+$indigo-warm-90v: color($indigo-warm, 90, vivid);
+
+// violet
+$violet: (
+  5 :       #f7f5fa,
+  10:       #ebe3fa,
+  20:       #cec1e8,
+  30:       #b7a1e3,
+  40:       #9c82d1,
+  50:       #8369b5,
+  60:       #644f8f,
+  70:       #493a66,
+  80:       #2d273b,
+  90:       #1e1b24,
+  vivid: (
+    5:       null,
+    10:      null,
+    20:      null,
+    30:      #be95e9,
+    40:      #b07bed,
+    50:      #9455dd,
+    60:      #7639b8,
+    70:      #552996,
+    80:      null,
+    90:      null,
+  ),
+);
+$violet-5:    color($violet, 5);
+$violet-10:   color($violet, 10);
+$violet-20:   color($violet, 20);
+$violet-30:   color($violet, 30);
+$violet-40:   color($violet, 40);
+$violet-50:   color($violet, 50);
+$violet-60:   color($violet, 60);
+$violet-70:   color($violet, 70);
+$violet-80:   color($violet, 80);
+$violet-90:   color($violet, 90);
+$violet-5v:   color($violet, 5, vivid);
+$violet-10v:  color($violet, 10, vivid);
+$violet-20v:  color($violet, 20, vivid);
+$violet-30v:  color($violet, 30, vivid);
+$violet-40v:  color($violet, 40, vivid);
+$violet-50v:  color($violet, 50, vivid);
+$violet-60v:  color($violet, 60, vivid);
+$violet-70v:  color($violet, 70, vivid);
+$violet-80v:  color($violet, 80, vivid);
+$violet-90v:  color($violet, 90, vivid);
+
+// violet-warm
+$violet-warm: (
+  5:   #fef7ff,
+  10:  #f5dcf7,
+  20:  #e0bae3,
+  30:  #d096d6,
+  40:  #bd73c7,
+  50:  #b24bbf,
+  60:  #854180,
+  70:  #573455,
+  80:  #332431,
+  90:  #211a21,
+  vivid: (
+    5:  #fdedff,
+    10: #f9c9ff,
+    20: #f3a8ff,
+    30: #ee82ff,
+    40: #e05ef7,
+    50: #c132d4,
     60: null,
     70: null,
     80: null,
     90: null,
   ),
 );
-$orange-warm-5:   color($orange-warm, 5);
-$orange-warm-10:  color($orange-warm, 10);
-$orange-warm-20:  color($orange-warm, 20);
-$orange-warm-30:  color($orange-warm, 30);
-$orange-warm-40:  color($orange-warm, 40);
-$orange-warm-50:  color($orange-warm, 50);
-$orange-warm-60:  color($orange-warm, 60);
-$orange-warm-70:  color($orange-warm, 70);
-$orange-warm-80:  color($orange-warm, 80);
-$orange-warm-90:  color($orange-warm, 90);
-$orange-warm-5v:  color($orange-warm, 5, vivid);
-$orange-warm-10v: color($orange-warm, 10, vivid);
-$orange-warm-20v: color($orange-warm, 20, vivid);
-$orange-warm-30v: color($orange-warm, 30, vivid);
-$orange-warm-40v: color($orange-warm, 40, vivid);
-$orange-warm-50v: color($orange-warm, 50, vivid);
-$orange-warm-60v: color($orange-warm, 60, vivid);
-$orange-warm-70v: color($orange-warm, 70, vivid);
-$orange-warm-80v: color($orange-warm, 80, vivid);
-$orange-warm-90v: color($orange-warm, 90, vivid);
-
-// red-warm
-$red-warm: (
-  5 :     #faf7f5,
-  10:     #f2ded5,
-  20:     #ebbda2,
-  30:     #db9e7f,
-  40:     #d67c58,
-  50:     #c7532c,
-  60:     #805039,
-  70:     #4f3f33,
-  80:     #302a26,
-  90:     #1f1c18,
-  vivid: (
-    5:     null,
-    10:    null,
-    20:    #eaa076,
-    30:    #e67549,
-    40:    #ee601d,
-    50:    #df4206,
-    60:    null,
-    70:    null,
-    80:    null,
-    90:    null,
-  ),
-);
-$red-warm-5:    color($red-warm, 5);
-$red-warm-10:   color($red-warm, 10);
-$red-warm-20:   color($red-warm, 20);
-$red-warm-30:   color($red-warm, 30);
-$red-warm-40:   color($red-warm, 40);
-$red-warm-50:   color($red-warm, 50);
-$red-warm-60:   color($red-warm, 60);
-$red-warm-70:   color($red-warm, 70);
-$red-warm-80:   color($red-warm, 80);
-$red-warm-90:   color($red-warm, 90);
-$red-warm-5v:   color($red-warm, 5, vivid);
-$red-warm-10v:  color($red-warm, 10, vivid);
-$red-warm-20v:  color($red-warm, 20, vivid);
-$red-warm-30v:  color($red-warm, 30, vivid);
-$red-warm-40v:  color($red-warm, 40, vivid);
-$red-warm-50v:  color($red-warm, 50, vivid);
-$red-warm-60v:  color($red-warm, 60, vivid);
-$red-warm-70v:  color($red-warm, 70, vivid);
-$red-warm-80v:  color($red-warm, 80, vivid);
-$red-warm-90v:  color($red-warm, 90, vivid);
-
-// red
-$red: (
-  5 :          #fcf5f5,
-  10:          #f7ddda,
-  20:          #f7b7ad,
-  30:          #f28f88,
-  40:          #ed6b61,
-  50:          #d83731,
-  60:          #ab3a3a,
-  70:          #6e312f,
-  80:          #3b2523,
-  90:          #211b1b,
-  vivid: (
-    5:          null,
-    10:         #fccec7,
-    20:         #fda99c,
-    30:         #ff806c,
-    40:         #ff5c48,
-    50:         #e92106,
-    60:         #c31f0a,
-    70:         #9c1503,
-    80:         #631212,
-    90:         null,
-  ),
-);
-$red-5:   color($red, 5);
-$red-10:  color($red, 10);
-$red-20:  color($red, 20);
-$red-30:  color($red, 30);
-$red-40:  color($red, 40);
-$red-50:  color($red, 50);
-$red-60:  color($red, 60);
-$red-70:  color($red, 70);
-$red-80:  color($red, 80);
-$red-90:  color($red, 90);
-$red-5v:  color($red, 5, vivid);
-$red-10v: color($red, 10, vivid);
-$red-20v: color($red, 20, vivid);
-$red-30v: color($red, 30, vivid);
-$red-40v: color($red, 40, vivid);
-$red-50v: color($red, 50, vivid);
-$red-60v: color($red, 60, vivid);
-$red-70v: color($red, 70, vivid);
-$red-80v: color($red, 80, vivid);
-$red-90v: color($red, 90, vivid);
+$violet-warm-5 :  color($violet-warm, 5);
+$violet-warm-10:  color($violet-warm, 10);
+$violet-warm-20:  color($violet-warm, 20);
+$violet-warm-30:  color($violet-warm, 30);
+$violet-warm-40:  color($violet-warm, 40);
+$violet-warm-50:  color($violet-warm, 50);
+$violet-warm-60:  color($violet-warm, 60);
+$violet-warm-70:  color($violet-warm, 70);
+$violet-warm-80:  color($violet-warm, 80);
+$violet-warm-90:  color($violet-warm, 90);
+$violet-warm-5v:  color($violet-warm, 5, vivid);
+$violet-warm-10v: color($violet-warm, 10, vivid);
+$violet-warm-20v: color($violet-warm, 20, vivid);
+$violet-warm-30v: color($violet-warm, 30, vivid);
+$violet-warm-40v: color($violet-warm, 40, vivid);
+$violet-warm-50v: color($violet-warm, 50, vivid);
+$violet-warm-60v: color($violet-warm, 60, vivid);
+$violet-warm-70v: color($violet-warm, 70, vivid);
+$violet-warm-80v: color($violet-warm, 80, vivid);
+$violet-warm-90v: color($violet-warm, 90, vivid);
 
 // magenta
 $magenta: (

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -197,14 +197,6 @@ $u-lh-body-tight:	 1.5;
 
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
-@function color($hue, $value){
-  @if unit($value) == '' {
-    @return map-get($hue, $value);
-  } @else {
-    @return map-deep-get($hue, vivid, strip-unit($value));
-  }
-}
-
 // violet-warm
 $violet-warm: (
   5:   #fef7ff,

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -1131,7 +1131,7 @@ $black-cool: (
   80:   #292a2b,
   90:   #1c1d1f,
 );
-$black-cool-5:  red;
+$black-cool-5:  color($black-cool, 5);
 $black-cool-10: color($black-cool, 10);
 $black-cool-20: color($black-cool, 20);
 $black-cool-30: color($black-cool, 30);

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -197,9 +197,17 @@ $u-lh-body-tight:	 1.5;
 
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
+@function color($hue, $value){
+  @if unit($value) == '' {
+    @return map-get($hue, $value);
+  } @else {
+    @return map-deep-get($hue, vivid, strip-unit($value));
+  }
+}
+
 // violet-warm
 $violet-warm: (
-  5 :  #fef7ff,
+  5:   #fef7ff,
   10:  #f5dcf7,
   20:  #e0bae3,
   30:  #d096d6,
@@ -209,37 +217,39 @@ $violet-warm: (
   70:  #573455,
   80:  #332431,
   90:  #211a21,
-  5v:  #fdedff,
-  10v: #f9c9ff,
-  20v: #f3a8ff,
-  30v: #ee82ff,
-  40v: #e05ef7,
-  50v: #c132d4,
-  60v: null,
-  70v: null,
-  80v: null,
-  90v: null,
+  vivid: (
+    5:  #fdedff,
+    10: #f9c9ff,
+    20: #f3a8ff,
+    30: #ee82ff,
+    40: #e05ef7,
+    50: #c132d4,
+    60: false,
+    70: false,
+    80: false,
+    90: false,
+  ),
 );
-$violet-warm-5 :  #fef7ff;
-$violet-warm-10:  #f5dcf7;
-$violet-warm-20:  #e0bae3;
-$violet-warm-30:  #d096d6;
-$violet-warm-40:  #bd73c7;
-$violet-warm-50:  #b24bbf;
-$violet-warm-60:  #854180;
-$violet-warm-70:  #573455;
-$violet-warm-80:  #332431;
-$violet-warm-90:  #211a21;
-$violet-warm-5v:  #fdedff;
-$violet-warm-10v: #f9c9ff;
-$violet-warm-20v: #f3a8ff;
-$violet-warm-30v: #ee82ff;
-$violet-warm-40v: #e05ef7;
-$violet-warm-50v: #c132d4;
-$violet-warm-60v: null;
-$violet-warm-70v: null;
-$violet-warm-80v: null;
-$violet-warm-90v: null;
+$violet-warm-5 :  color($violet-warm, 5);
+$violet-warm-10:  color($violet-warm, 10);
+$violet-warm-20:  color($violet-warm, 20);
+$violet-warm-30:  color($violet-warm, 30);
+$violet-warm-40:  color($violet-warm, 40);
+$violet-warm-50:  color($violet-warm, 50);
+$violet-warm-60:  color($violet-warm, 60);
+$violet-warm-70:  color($violet-warm, 70);
+$violet-warm-80:  color($violet-warm, 80);
+$violet-warm-90:  color($violet-warm, 90);
+$violet-warm-5v:  color($violet-warm, 5v);
+$violet-warm-10v: color($violet-warm, 10v);
+$violet-warm-20v: color($violet-warm, 20v);
+$violet-warm-30v: color($violet-warm, 30v);
+$violet-warm-40v: color($violet-warm, 40v);
+$violet-warm-50v: color($violet-warm, 50v);
+$violet-warm-60v: color($violet-warm, 60v);
+$violet-warm-70v: color($violet-warm, 70v);
+$violet-warm-80v: color($violet-warm, 80v);
+$violet-warm-90v: color($violet-warm, 90v);
 
 // violet
 $violet: (
@@ -253,37 +263,39 @@ $violet: (
   70:       #493a66,
   80:       #2d273b,
   90:       #1e1b24,
-  5v:       null,
-  10v:      null,
-  20v:      null,
-  30v:      #be95e9,
-  40v:      #b07bed,
-  50v:      #9455dd,
-  60v:      #7639b8,
-  70v:      #552996,
-  80v:      null,
-  90v:      null,
+  vivid: (
+    5:       null,
+    10:      null,
+    20:      null,
+    30:      #be95e9,
+    40:      #b07bed,
+    50:      #9455dd,
+    60:      #7639b8,
+    70:      #552996,
+    80:      null,
+    90:      null,
+  ),
 );
-$violet-5 :       #f7f5fa;
-$violet-10:       #ebe3fa;
-$violet-20:       #cec1e8;
-$violet-30:       #b7a1e3;
-$violet-40:       #9c82d1;
-$violet-50:       #8369b5;
-$violet-60:       #644f8f;
-$violet-70:       #493a66;
-$violet-80:       #2d273b;
-$violet-90:       #1e1b24;
-$violet-5v:       null;
-$violet-10v:      null;
-$violet-20v:      null;
-$violet-30v:      #be95e9;
-$violet-40v:      #b07bed;
-$violet-50v:      #9455dd;
-$violet-60v:      #7639b8;
-$violet-70v:      #552996;
-$violet-80v:      null;
-$violet-90v:      null;
+$violet-5:    color($violet, 5);
+$violet-10:   color($violet, 10);
+$violet-20:   color($violet, 20);
+$violet-30:   color($violet, 30);
+$violet-40:   color($violet, 40);
+$violet-50:   color($violet, 50);
+$violet-60:   color($violet, 60);
+$violet-70:   color($violet, 70);
+$violet-80:   color($violet, 80);
+$violet-90:   color($violet, 90);
+$violet-5v:   color($violet, 5v);
+$violet-10v:  color($violet, 10v);
+$violet-20v:  color($violet, 20v);
+$violet-30v:  color($violet, 30v);
+$violet-40v:  color($violet, 40v);
+$violet-50v:  color($violet, 50v);
+$violet-60v:  color($violet, 60v);
+$violet-70v:  color($violet, 70v);
+$violet-80v:  color($violet, 80v);
+$violet-90v:  color($violet, 90v);
 
 // indigo-warm
 $indigo-warm:(
@@ -297,37 +309,39 @@ $indigo-warm:(
   70:  #433a7a,
   80:  #29263b,
   90:  #1d1b24,
-  5v:  null,
-  10v: null,
-  20v: null,
-  30v: #b59eff,
-  40v: #9980ff,
-  50v: #7560eb,
-  60v: #5740d1,
-  70v: null,
-  80v: null,
-  90v: null,
+  vivid: (
+    5:  null,
+    10: null,
+    20: null,
+    30: #b59eff,
+    40: #9980ff,
+    50: #7560eb,
+    60: #5740d1,
+    70: null,
+    80: null,
+    90: null,
+  ),
 );
-$indigo-warm-5 :  #f9f7ff;
-$indigo-warm-10:  #e5e1fa;
-$indigo-warm-20:  #c9c2f2;
-$indigo-warm-30:  #b1a7eb;
-$indigo-warm-40:  #968ade;
-$indigo-warm-50:  #7766d3;
-$indigo-warm-60:  #5e519e;
-$indigo-warm-70:  #433a7a;
-$indigo-warm-80:  #29263b;
-$indigo-warm-90:  #1d1b24;
-$indigo-warm-5v:  null;
-$indigo-warm-10v: null;
-$indigo-warm-20v: null;
-$indigo-warm-30v: #b59eff;
-$indigo-warm-40v: #9980ff;
-$indigo-warm-50v: #7560eb;
-$indigo-warm-60v: #5740d1;
-$indigo-warm-70v: null;
-$indigo-warm-80v: null;
-$indigo-warm-90v: null;
+$indigo-warm-5:   color($indigo-warm, 5);
+$indigo-warm-10:  color($indigo-warm, 10);
+$indigo-warm-20:  color($indigo-warm, 20);
+$indigo-warm-30:  color($indigo-warm, 30);
+$indigo-warm-40:  color($indigo-warm, 40);
+$indigo-warm-50:  color($indigo-warm, 50);
+$indigo-warm-60:  color($indigo-warm, 60);
+$indigo-warm-70:  color($indigo-warm, 70);
+$indigo-warm-80:  color($indigo-warm, 80);
+$indigo-warm-90:  color($indigo-warm, 90);
+$indigo-warm-5v:  color($indigo-warm, 5v);
+$indigo-warm-10v: color($indigo-warm, 10v);
+$indigo-warm-20v: color($indigo-warm, 20v);
+$indigo-warm-30v: color($indigo-warm, 30v);
+$indigo-warm-40v: color($indigo-warm, 40v);
+$indigo-warm-50v: color($indigo-warm, 50v);
+$indigo-warm-60v: color($indigo-warm, 60v);
+$indigo-warm-70v: color($indigo-warm, 70v);
+$indigo-warm-80v: color($indigo-warm, 80v);
+$indigo-warm-90v: color($indigo-warm, 90v);
 
 // indigo
 $indigo:(
@@ -341,37 +355,39 @@ $indigo:(
   70:       #3b3e75,
   80:       #28293d,
   90:       #1b1c26,
-  5v:       null,
-  10v:      null,
-  20v:      #acaeec,
-  30v:      #8c8fe1,
-  40v:      null,
-  50v:      #656bd7,
-  60v:      #353aa5,
-  70v:      null,
-  80v:      null,
-  90v:      null,
+  vivid: (
+    5:       null,
+    10:      null,
+    20:      #acaeec,
+    30:      #8c8fe1,
+    40:      null,
+    50:      #656bd7,
+    60:      #353aa5,
+    70:      null,
+    80:      null,
+    90:      null,
+  ),
 );
-$indigo-5 :       #fafaff;
-$indigo-10:       #e4e3fa;
-$indigo-20:       #c2c3f2;
-$indigo-30:       #a4a7eb;
-$indigo-40:       #8889db;
-$indigo-50:       #686dca;
-$indigo-60:       #5055b5;
-$indigo-70:       #3b3e75;
-$indigo-80:       #28293d;
-$indigo-90:       #1b1c26;
-$indigo-5v:       null;
-$indigo-10v:      null;
-$indigo-20v:      #acaeec;
-$indigo-30v:      #8c8fe1;
-$indigo-40v:      null;
-$indigo-50v:      #656bd7;
-$indigo-60v:      #353aa5;
-$indigo-70v:      null;
-$indigo-80v:      null;
-$indigo-90v:      null;
+$indigo-5:    color($indigo, 5);
+$indigo-10:   color($indigo, 10);
+$indigo-20:   color($indigo, 20);
+$indigo-30:   color($indigo, 30);
+$indigo-40:   color($indigo, 40);
+$indigo-50:   color($indigo, 50);
+$indigo-60:   color($indigo, 60);
+$indigo-70:   color($indigo, 70);
+$indigo-80:   color($indigo, 80);
+$indigo-90:   color($indigo, 90);
+$indigo-5v:   color($indigo, 5v);
+$indigo-10v:  color($indigo, 10v);
+$indigo-20v:  color($indigo, 20v);
+$indigo-30v:  color($indigo, 30v);
+$indigo-40v:  color($indigo, 40v);
+$indigo-50v:  color($indigo, 50v);
+$indigo-60v:  color($indigo, 60v);
+$indigo-70v:  color($indigo, 70v);
+$indigo-80v:  color($indigo, 80v);
+$indigo-90v:  color($indigo, 90v);
 
 // indigo-cool
 $indigo-cool: (
@@ -385,37 +401,39 @@ $indigo-cool: (
   70:  #364173,
   80:  #23273d,
   90:  #1b1c2b,
-  5v:  null,
-  10v: null,
-  20v: null,
-  30v: null,
-  40v: #6694ff,
-  50v: null,
-  60v: #4150f2,
-  70v: null,
-  80v: null,
-  90v: null,
+  vivid: (
+    5:  null,
+    10: null,
+    20: null,
+    30: null,
+    40: #6694ff,
+    50: null,
+    60: #4150f2,
+    70: null,
+    80: null,
+    90: null,
+  ),
 );
-$indigo-cool-5 :  #f5f6fc;
-$indigo-cool-10:  #e1e6fa;
-$indigo-cool-20:  #bac7f5;
-$indigo-cool-30:  #97acf0;
-$indigo-cool-40:  #6d91ed;
-$indigo-cool-50:  #4a70d9;
-$indigo-cool-60:  #425bad;
-$indigo-cool-70:  #364173;
-$indigo-cool-80:  #23273d;
-$indigo-cool-90:  #1b1c2b;
-$indigo-cool-5v:  null;
-$indigo-cool-10v: null;
-$indigo-cool-20v: null;
-$indigo-cool-30v: null;
-$indigo-cool-40v: #6694ff;
-$indigo-cool-50v: null;
-$indigo-cool-60v: #4150f2;
-$indigo-cool-70v: null;
-$indigo-cool-80v: null;
-$indigo-cool-90v: null;
+$indigo-cool-5:   color($indigo-cool, 5);
+$indigo-cool-10:  color($indigo-cool, 10);
+$indigo-cool-20:  color($indigo-cool, 20);
+$indigo-cool-30:  color($indigo-cool, 30);
+$indigo-cool-40:  color($indigo-cool, 40);
+$indigo-cool-50:  color($indigo-cool, 50);
+$indigo-cool-60:  color($indigo-cool, 60);
+$indigo-cool-70:  color($indigo-cool, 70);
+$indigo-cool-80:  color($indigo-cool, 80);
+$indigo-cool-90:  color($indigo-cool, 90);
+$indigo-cool-5v:  color($indigo-cool, 5v);
+$indigo-cool-10v: color($indigo-cool, 10v);
+$indigo-cool-20v: color($indigo-cool, 20v);
+$indigo-cool-30v: color($indigo-cool, 30v);
+$indigo-cool-40v: color($indigo-cool, 40v);
+$indigo-cool-50v: color($indigo-cool, 50v);
+$indigo-cool-60v: color($indigo-cool, 60v);
+$indigo-cool-70v: color($indigo-cool, 70v);
+$indigo-cool-80v: color($indigo-cool, 80v);
+$indigo-cool-90v: color($indigo-cool, 90v);
 
 // blue-warm
 $blue-warm: (
@@ -429,37 +447,39 @@ $blue-warm: (
   70:    #31486b,
   80:    #232d3d,
   90:    #161b24,
-  5v:    null,
-  10v:   null,
-  20v:   #b8cbf2,
-  30v:   #81aefc,
-  40v:   #5e99ff,
-  50v:   #2673df,
-  60v:   #0052de,
-  70v:   #1e4f94,
-  80v:   #112a4d,
-  90v:   null,
+  vivid: (
+    5:    null,
+    10:   null,
+    20:   #b8cbf2,
+    30:   #81aefc,
+    40:   #5e99ff,
+    50:   #2673df,
+    60:   #0052de,
+    70:   #1e4f94,
+    80:   #112a4d,
+    90:   null,
+  ),
 );
-$blue-warm-5 :    #f0f5fc;
-$blue-warm-10:    #dfe7f5;
-$blue-warm-20:    #bccae6;
-$blue-warm-30:    #91add9;
-$blue-warm-40:    #7397d1;
-$blue-warm-50:    #3d75c2;
-$blue-warm-60:    #37629e;
-$blue-warm-70:    #31486b;
-$blue-warm-80:    #232d3d;
-$blue-warm-90:    #161b24;
-$blue-warm-5v:    null;
-$blue-warm-10v:   null;
-$blue-warm-20v:   #b8cbf2;
-$blue-warm-30v:   #81aefc;
-$blue-warm-40v:   #5e99ff;
-$blue-warm-50v:   #2673df;
-$blue-warm-60v:   #0052de;
-$blue-warm-70v:   #1e4f94;
-$blue-warm-80v:   #112a4d;
-$blue-warm-90v:   null;
+$blue-warm-5:   color($blue-warm, 5);
+$blue-warm-10:  color($blue-warm, 10);
+$blue-warm-20:  color($blue-warm, 20);
+$blue-warm-30:  color($blue-warm, 30);
+$blue-warm-40:  color($blue-warm, 40);
+$blue-warm-50:  color($blue-warm, 50);
+$blue-warm-60:  color($blue-warm, 60);
+$blue-warm-70:  color($blue-warm, 70);
+$blue-warm-80:  color($blue-warm, 80);
+$blue-warm-90:  color($blue-warm, 90);
+$blue-warm-5v:  color($blue-warm, 5v);
+$blue-warm-10v: color($blue-warm, 10v);
+$blue-warm-20v: color($blue-warm, 20v);
+$blue-warm-30v: color($blue-warm, 30v);
+$blue-warm-40v: color($blue-warm, 40v);
+$blue-warm-50v: color($blue-warm, 50v);
+$blue-warm-60v: color($blue-warm, 60v);
+$blue-warm-70v: color($blue-warm, 70v);
+$blue-warm-80v: color($blue-warm, 80v);
+$blue-warm-90v: color($blue-warm, 90v);
 
 // blue
 $blue: (
@@ -473,37 +493,39 @@ $blue: (
   70:         #294c69,
   80:         #1e2f3d,
   90:         #161e24,
-  5v:         null,
-  10v:        null,
-  20v:        null,
-  30v:        #57b3ff,
-  40v:        #009afa,
-  50v:        #007ade,
-  60v:        #0069b4,
-  70v:        #0c4d82,
-  80v:        #11304f,
-  90v:        null,
+  vivid: (
+    5:         null,
+    10:        null,
+    20:        null,
+    30:        #57b3ff,
+    40:        #009afa,
+    50:        #007ade,
+    60:        #0069b4,
+    70:        #0c4d82,
+    80:        #11304f,
+    90:        null,
+  ),
 );
-$blue-5 :         #f5fbff;
-$blue-10:         #dae9f7;
-$blue-20:         #add1f0;
-$blue-30:         #79bcf2;
-$blue-40:         #56a4e3;
-$blue-50:         #317cb9;
-$blue-60:         #2f6794;
-$blue-70:         #294c69;
-$blue-80:         #1e2f3d;
-$blue-90:         #161e24;
-$blue-5v:         null;
-$blue-10v:        null;
-$blue-20v:        null;
-$blue-30v:        #57b3ff;
-$blue-40v:        #009afa;
-$blue-50v:        #007ade;
-$blue-60v:        #0069b4;
-$blue-70v:        #0c4d82;
-$blue-80v:        #11304f;
-$blue-90v:        null;
+$blue-5:    color($blue, 5);
+$blue-10:   color($blue, 10);
+$blue-20:   color($blue, 20);
+$blue-30:   color($blue, 30);
+$blue-40:   color($blue, 40);
+$blue-50:   color($blue, 50);
+$blue-60:   color($blue, 60);
+$blue-70:   color($blue, 70);
+$blue-80:   color($blue, 80);
+$blue-90:   color($blue, 90);
+$blue-5v:   color($blue, 5v);
+$blue-10v:  color($blue, 10v);
+$blue-20v:  color($blue, 20v);
+$blue-30v:  color($blue, 30v);
+$blue-40v:  color($blue, 40v);
+$blue-50v:  color($blue, 50v);
+$blue-60v:  color($blue, 60v);
+$blue-70v:  color($blue, 70v);
+$blue-80v:  color($blue, 80v);
+$blue-90v:  color($blue, 90v);
 
 // cyan
 $cyan: (
@@ -517,37 +539,39 @@ $cyan: (
   70:         #2d4b4f,
   80:         #203133,
   90:         #151e1f,
-  5v:         null,
-  10v:        #a8f2ff,
-  20v:        #55e1fa,
-  30v:        #02c2e8,
-  40v:        #00abd1,
-  50v:        null,
-  60v:        null,
-  70v:        null,
-  80v:        null,
-  90v:        null,
+  vivid: (
+    5:         null,
+    10:        #a8f2ff,
+    20:        #55e1fa,
+    30:        #02c2e8,
+    40:        #00abd1,
+    50:        null,
+    60:        null,
+    70:        null,
+    80:        null,
+    90:        null,
+  ),
 );
-$cyan-5 :         #e8f7fa;
-$cyan-10:         #d0f1f7;
-$cyan-20:         #9ddceb;
-$cyan-30:         #6ecbdb;
-$cyan-40:         #4bacbd;
-$cyan-50:         #167f91;
-$cyan-60:         #2f707a;
-$cyan-70:         #2d4b4f;
-$cyan-80:         #203133;
-$cyan-90:         #151e1f;
-$cyan-5v:         null;
-$cyan-10v:        #a8f2ff;
-$cyan-20v:        #55e1fa;
-$cyan-30v:        #02c2e8;
-$cyan-40v:        #00abd1;
-$cyan-50v:        null;
-$cyan-60v:        null;
-$cyan-70v:        null;
-$cyan-80v:        null;
-$cyan-90v:        null;
+$cyan-5:    color($cyan, 5);
+$cyan-10:   color($cyan, 10);
+$cyan-20:   color($cyan, 20);
+$cyan-30:   color($cyan, 30);
+$cyan-40:   color($cyan, 40);
+$cyan-50:   color($cyan, 50);
+$cyan-60:   color($cyan, 60);
+$cyan-70:   color($cyan, 70);
+$cyan-80:   color($cyan, 80);
+$cyan-90:   color($cyan, 90);
+$cyan-5v:   color($cyan, 5v);
+$cyan-10v:  color($cyan, 10v);
+$cyan-20v:  color($cyan, 20v);
+$cyan-30v:  color($cyan, 30v);
+$cyan-40v:  color($cyan, 40v);
+$cyan-50v:  color($cyan, 50v);
+$cyan-60v:  color($cyan, 60v);
+$cyan-70v:  color($cyan, 70v);
+$cyan-80v:  color($cyan, 80v);
+$cyan-90v:  color($cyan, 90v);
 
 // mint-cool
 $mint-cool: (
@@ -561,37 +585,39 @@ $mint-cool: (
   70:    #2b4d47,
   80:    #1f3030,
   90:    #151f1f,
-  5v:    #dbfff8,
-  10v:   #7efce1,
-  20v:   #02dbc2,
-  30v:   #00baa4,
-  40v:   #00b5a9,
-  50v:   null,
-  60v:   null,
-  70v:   null,
-  80v:   null,
-  90v:   null,
+  vivid: (
+    5:    #dbfff8,
+    10:   #7efce1,
+    20:   #02dbc2,
+    30:   #00baa4,
+    40:   #00b5a9,
+    50:   null,
+    60:   null,
+    70:   null,
+    80:   null,
+    90:   null,
+  ),
 );
-$mint-cool-5 :    #f2fffe;
-$mint-cool-10:    #c7f2ef;
-$mint-cool-20:    #a2ded9;
-$mint-cool-30:    #77c7c0;
-$mint-cool-40:    #57ada8;
-$mint-cool-50:    #21827f;
-$mint-cool-60:    #3b6b69;
-$mint-cool-70:    #2b4d47;
-$mint-cool-80:    #1f3030;
-$mint-cool-90:    #151f1f;
-$mint-cool-5v:    #dbfff8;
-$mint-cool-10v:   #7efce1;
-$mint-cool-20v:   #02dbc2;
-$mint-cool-30v:   #00baa4;
-$mint-cool-40v:   #00b5a9;
-$mint-cool-50v:   null;
-$mint-cool-60v:   null;
-$mint-cool-70v:   null;
-$mint-cool-80v:   null;
-$mint-cool-90v:   null;
+$mint-cool-5:   color($mint-cool, 5);
+$mint-cool-10:  color($mint-cool, 10);
+$mint-cool-20:  color($mint-cool, 20);
+$mint-cool-30:  color($mint-cool, 30);
+$mint-cool-40:  color($mint-cool, 40);
+$mint-cool-50:  color($mint-cool, 50);
+$mint-cool-60:  color($mint-cool, 60);
+$mint-cool-70:  color($mint-cool, 70);
+$mint-cool-80:  color($mint-cool, 80);
+$mint-cool-90:  color($mint-cool, 90);
+$mint-cool-5v:  color($mint-cool, 5v);
+$mint-cool-10v: color($mint-cool, 10v);
+$mint-cool-20v: color($mint-cool, 20v);
+$mint-cool-30v: color($mint-cool, 30v);
+$mint-cool-40v: color($mint-cool, 40v);
+$mint-cool-50v: color($mint-cool, 50v);
+$mint-cool-60v: color($mint-cool, 60v);
+$mint-cool-70v: color($mint-cool, 70v);
+$mint-cool-80v: color($mint-cool, 80v);
+$mint-cool-90v: color($mint-cool, 90v);
 
 // mint
 $mint: (
@@ -605,39 +631,40 @@ $mint: (
   70:         #225237,
   80:         #1d3b29,
   90:         #1d3b29,
-  5v:         #befde9,
-  5v:         null,
-  10v:        #30f8b5,
-  20v:        #06ec9f,
-  30v:        #04c786,
-  40v:        null,
-  50v:        null,
-  60v:        #16754f,
-  70v:        null,
-  80v:        null,
-  90v:        null,
+  vivid: (
+    5:         #befde9,
+    10:        #30f8b5,
+    20:        #06ec9f,
+    30:        #04c786,
+    40:        null,
+    50:        null,
+    60:        #16754f,
+    70:        null,
+    80:        null,
+    90:        null,
+  ),
 );
-$mint-5 :         #cafcec;
-$mint-10:         #79f7cd;
-$mint-20:         #49e3b0;
-$mint-30:         #4ac79d;
-$mint-40:         #36a882;
-$mint-50:         #1e8461;
-$mint-60:         #266644;
-$mint-70:         #225237;
-$mint-80:         #1d3b29;
-$mint-90:         #1d3b29;
-$mint-5v:         #befde9;
-$mint-5v:         null;
-$mint-10v:        #30f8b5;
-$mint-20v:        #06ec9f;
-$mint-30v:        #04c786;
-$mint-40v:        null;
-$mint-50v:        null;
-$mint-60v:        #16754f;
-$mint-70v:        null;
-$mint-80v:        null;
-$mint-90v:        null;
+$mint-5:    color($mint, 5);
+$mint-10:   color($mint, 10);
+$mint-20:   color($mint, 20);
+$mint-30:   color($mint, 30);
+$mint-40:   color($mint, 40);
+$mint-50:   color($mint, 50);
+$mint-60:   color($mint, 60);
+$mint-70:   color($mint, 70);
+$mint-80:   color($mint, 80);
+$mint-90:   color($mint, 90);
+$mint-5v:   color($mint, 5v);
+$mint-5v:   color($mint, 5v);
+$mint-10v:  color($mint, 10v);
+$mint-20v:  color($mint, 20v);
+$mint-30v:  color($mint, 30v);
+$mint-40v:  color($mint, 40v);
+$mint-50v:  color($mint, 50v);
+$mint-60v:  color($mint, 60v);
+$mint-70v:  color($mint, 70v);
+$mint-80v:  color($mint, 80v);
+$mint-90v:  color($mint, 90v);
 
 // green-cool
 $green-cool: (
@@ -651,81 +678,85 @@ $green-cool: (
   70:   #384d2a,
   80:   #272e22,
   90:   #1a1f1a,
-  5v:   #caf4c7,
-  10v:  #91e48b,
-  20v:  #61cf59,
-  30v:  #16c20a,
-  40v:  #0caf00,
-  50v:  #178800,
-  60v:  null,
-  70v:  null,
-  80v:  null,
-  90v:  null,
+  vivid: (
+    5:   #caf4c7,
+    10:  #91e48b,
+    20:  #61cf59,
+    30:  #16c20a,
+    40:  #0caf00,
+    50:  #178800,
+    60:  null,
+    70:  null,
+    80:  null,
+    90:  null,
+  ),
 );
-$green-cool-5 :   #e8fae6;
-$green-cool-10:   #d0f7cd;
-$green-cool-20:   #a4e3a1;
-$green-cool-30:   #80cc7e;
-$green-cool-40:   #5db85c;
-$green-cool-50:   #3d841f;
-$green-cool-60:   #4d6e37;
-$green-cool-70:   #384d2a;
-$green-cool-80:   #272e22;
-$green-cool-90:   #1a1f1a;
-$green-cool-5v:   #caf4c7;
-$green-cool-10v:  #91e48b;
-$green-cool-20v:  #61cf59;
-$green-cool-30v:  #16c20a;
-$green-cool-40v:  #0caf00;
-$green-cool-50v:  #178800;
-$green-cool-60v:  null;
-$green-cool-70v:  null;
-$green-cool-80v:  null;
-$green-cool-90v:  null;
+$green-cool-5:    color($green-cool, 5);
+$green-cool-10:   color($green-cool, 10);
+$green-cool-20:   color($green-cool, 20);
+$green-cool-30:   color($green-cool, 30);
+$green-cool-40:   color($green-cool, 40);
+$green-cool-50:   color($green-cool, 50);
+$green-cool-60:   color($green-cool, 60);
+$green-cool-70:   color($green-cool, 70);
+$green-cool-80:   color($green-cool, 80);
+$green-cool-90:   color($green-cool, 90);
+$green-cool-5v:   color($green-cool, 5v);
+$green-cool-10v:  color($green-cool, 10v);
+$green-cool-20v:  color($green-cool, 20v);
+$green-cool-30v:  color($green-cool, 30v);
+$green-cool-40v:  color($green-cool, 40v);
+$green-cool-50v:  color($green-cool, 50v);
+$green-cool-60v:  color($green-cool, 60v);
+$green-cool-70v:  color($green-cool, 70v);
+$green-cool-80v:  color($green-cool, 80v);
+$green-cool-90v:  color($green-cool, 90v);
 
 // green
 $green: (
-  $green-5 :        #f7fcf0,
-  $green-10:        #e0ebce,
-  $green-20:        #bcd696,
-  $green-30:        #a2bf77,
-  $green-40:        #83a352,
-  $green-50:        #607f35,
-  $green-60:        #526b27,
-  $green-70:        #3c4a29,
-  $green-80:        #293021,
-  $green-90:        #1a1c18,
-  $green-5v:        #d7f4bd,
-  $green-10v:       #b4e876,
-  $green-20v:       #93cc2e,
-  $green-30v:       #81b532,
-  $green-40v:       #73a22b,
-  $green-50v:       #538200,
-  $green-60v:       null,
-  $green-70v:       null,
-  $green-80v:       null,
-  $green-90v:       null,
+  5 :        #f7fcf0,
+  10:        #e0ebce,
+  20:        #bcd696,
+  30:        #a2bf77,
+  40:        #83a352,
+  50:        #607f35,
+  60:        #526b27,
+  70:        #3c4a29,
+  80:        #293021,
+  90:        #1a1c18,
+  vivid: (
+    5:        #d7f4bd,
+    10:       #b4e876,
+    20:       #93cc2e,
+    30:       #81b532,
+    40:       #73a22b,
+    50:       #538200,
+    60:       null,
+    70:       null,
+    80:       null,
+    90:       null,
+  ),
 );
-$green-5 :        #f7fcf0;
-$green-10:        #e0ebce;
-$green-20:        #bcd696;
-$green-30:        #a2bf77;
-$green-40:        #83a352;
-$green-50:        #607f35;
-$green-60:        #526b27;
-$green-70:        #3c4a29;
-$green-80:        #293021;
-$green-90:        #1a1c18;
-$green-5v:        #d7f4bd;
-$green-10v:       #b4e876;
-$green-20v:       #93cc2e;
-$green-30v:       #81b532;
-$green-40v:       #73a22b;
-$green-50v:       #538200;
-$green-60v:       null;
-$green-70v:       null;
-$green-80v:       null;
-$green-90v:       null;
+$green-5:   color($green, 5);
+$green-10:  color($green, 10);
+$green-20:  color($green, 20);
+$green-30:  color($green, 30);
+$green-40:  color($green, 40);
+$green-50:  color($green, 50);
+$green-60:  color($green, 60);
+$green-70:  color($green, 70);
+$green-80:  color($green, 80);
+$green-90:  color($green, 90);
+$green-5v:  color($green, 5v);
+$green-10v: color($green, 10v);
+$green-20v: color($green, 20v);
+$green-30v: color($green, 30v);
+$green-40v: color($green, 40v);
+$green-50v: color($green, 50v);
+$green-60v: color($green, 60v);
+$green-70v: color($green, 70v);
+$green-80v: color($green, 80v);
+$green-90v: color($green, 90v);
 
 // green-warm
 $green-warm: (
@@ -739,37 +770,39 @@ $green-warm: (
   70:   #43452d,
   80:   #2c2e20,
   90:   #1c1c16,
-  5v:   #f3f8a7,
-  10v:  #e6f50f,
-  20v:  #cedc0a,
-  30v:  #a9bd2d,
-  40v:  #7f9e1d,
-  50v:  #6b7e00,
-  60v:  null,
-  70v:  null,
-  80v:  null,
-  90v:  null,
+  vivid: (
+    5:   #f3f8a7,
+    10:  #e6f50f,
+    20:  #cedc0a,
+    30:  #a9bd2d,
+    40:  #7f9e1d,
+    50:  #6b7e00,
+    60:  null,
+    70:  null,
+    80:  null,
+    90:  null,
+  ),
 );
-$green-warm-5 :   #f9faed;
-$green-warm-10:   #eaedb9;
-$green-warm-20:   #ced47f;
-$green-warm-30:   #aebd5b;
-$green-warm-40:   #93a150;
-$green-warm-50:   #717d41;
-$green-warm-60:   #5e633a;
-$green-warm-70:   #43452d;
-$green-warm-80:   #2c2e20;
-$green-warm-90:   #1c1c16;
-$green-warm-5v:   #f3f8a7;
-$green-warm-10v:  #e6f50f;
-$green-warm-20v:  #cedc0a;
-$green-warm-30v:  #a9bd2d;
-$green-warm-40v:  #7f9e1d;
-$green-warm-50v:  #6b7e00;
-$green-warm-60v:  null;
-$green-warm-70v:  null;
-$green-warm-80v:  null;
-$green-warm-90v:  null;
+$green-warm-5:    color($green-warm, 5);
+$green-warm-10:   color($green-warm, 10);
+$green-warm-20:   color($green-warm, 20);
+$green-warm-30:   color($green-warm, 30);
+$green-warm-40:   color($green-warm, 40);
+$green-warm-50:   color($green-warm, 50);
+$green-warm-60:   color($green-warm, 60);
+$green-warm-70:   color($green-warm, 70);
+$green-warm-80:   color($green-warm, 80);
+$green-warm-90:   color($green-warm, 90);
+$green-warm-5v:   color($green-warm, 5v);
+$green-warm-10v:  color($green-warm, 10v);
+$green-warm-20v:  color($green-warm, 20v);
+$green-warm-30v:  color($green-warm, 30v);
+$green-warm-40v:  color($green-warm, 40v);
+$green-warm-50v:  color($green-warm, 50v);
+$green-warm-60v:  color($green-warm, 60v);
+$green-warm-70v:  color($green-warm, 70v);
+$green-warm-80v:  color($green-warm, 80v);
+$green-warm-90v:  color($green-warm, 90v);
 
 // yellow
 $yellow: (
@@ -783,37 +816,39 @@ $yellow: (
   70:       #4d402f,
   80:       #302a24,
   90:       #1f1b18,
-  5v:       null,
-  10v:      #fdd430,
-  20v:      #edc730,
-  30v:      null,
-  40v:      null,
-  50v:      null,
-  60v:      null,
-  70v:      null,
-  80v:      null,
-  90v:      null,
+  vivid: (
+    5:       null,
+    10:      #fdd430,
+    20:      #edc730,
+    30:      null,
+    40:      null,
+    50:      null,
+    60:      null,
+    70:      null,
+    80:      null,
+    90:      null,
+  ),
 );
-$yellow-5 :       #faf7ed;
-$yellow-10:       #f7e8b0;
-$yellow-20:       #f0d04f;
-$yellow-30:       #cfb04a;
-$yellow-40:       #ab9149;
-$yellow-50:       #8a7237;
-$yellow-60:       #6b5a39;
-$yellow-70:       #4d402f;
-$yellow-80:       #302a24;
-$yellow-90:       #1f1b18;
-$yellow-5v:       null;
-$yellow-10v:      #fdd430;
-$yellow-20v:      #edc730;
-$yellow-30v:      null;
-$yellow-40v:      null;
-$yellow-50v:      null;
-$yellow-60v:      null;
-$yellow-70v:      null;
-$yellow-80v:      null;
-$yellow-90v:      null;
+$yellow-5:    color($yellow, 5);
+$yellow-10:   color($yellow, 10);
+$yellow-20:   color($yellow, 20);
+$yellow-30:   color($yellow, 30);
+$yellow-40:   color($yellow, 40);
+$yellow-50:   color($yellow, 50);
+$yellow-60:   color($yellow, 60);
+$yellow-70:   color($yellow, 70);
+$yellow-80:   color($yellow, 80);
+$yellow-90:   color($yellow, 90);
+$yellow-5v:   color($yellow, 5v);
+$yellow-10v:  color($yellow, 10v);
+$yellow-20v:  color($yellow, 20v);
+$yellow-30v:  color($yellow, 30v);
+$yellow-40v:  color($yellow, 40v);
+$yellow-50v:  color($yellow, 50v);
+$yellow-60v:  color($yellow, 60v);
+$yellow-70v:  color($yellow, 70v);
+$yellow-80v:  color($yellow, 80v);
+$yellow-90v:  color($yellow, 90v);
 
 // gold
 $gold: (
@@ -827,81 +862,85 @@ $gold: (
   70:         #4a4034,
   80:         #302b24,
   90:         #1f1c19,
-  5v:         #faf2d9,
-  10v:        #ffcb52,
-  20v:        #faaf00,
-  30v:        #e6a100,
-  40v:        #c98a0c,
-  50v:        #946f38,
-  60v:        null,
-  70v:        null,
-  80v:        null,
-  90v:        null,
+  vivid: (
+    5:         #faf2d9,
+    10:        #ffcb52,
+    20:        #faaf00,
+    30:        #e6a100,
+    40:        #c98a0c,
+    50:        #946f38,
+    60:        null,
+    70:        null,
+    80:        null,
+    90:        null,
+  ),
 );
-$gold-5 :         #faf5eb;
-$gold-10:         #f2e6ce;
-$gold-20:         #dec699;
-$gold-30:         #c7a97b;
-$gold-40:         #ad8b65;
-$gold-50:         #8d6f4e;
-$gold-60:         #6b5947;
-$gold-70:         #4a4034;
-$gold-80:         #302b24;
-$gold-90:         #1f1c19;
-$gold-5v:         #faf2d9;
-$gold-10v:        #ffcb52;
-$gold-20v:        #faaf00;
-$gold-30v:        #e6a100;
-$gold-40v:        #c98a0c;
-$gold-50v:        #946f38;
-$gold-60v:        null;
-$gold-70v:        null;
-$gold-80v:        null;
-$gold-90v:        null;
+$gold-5:    color($gold, 5);
+$gold-10:   color($gold, 10);
+$gold-20:   color($gold, 20);
+$gold-30:   color($gold, 30);
+$gold-40:   color($gold, 40);
+$gold-50:   color($gold, 50);
+$gold-60:   color($gold, 60);
+$gold-70:   color($gold, 70);
+$gold-80:   color($gold, 80);
+$gold-90:   color($gold, 90);
+$gold-5v:   color($gold, 5v);
+$gold-10v:  color($gold, 10v);
+$gold-20v:  color($gold, 20v);
+$gold-30v:  color($gold, 30v);
+$gold-40v:  color($gold, 40v);
+$gold-50v:  color($gold, 50v);
+$gold-60v:  color($gold, 60v);
+$gold-70v:  color($gold, 70v);
+$gold-80v:  color($gold, 80v);
+$gold-90v:  color($gold, 90v);
 
 // orange
 $orange: (
-  $orange-5 :       #fffbf7,
-  $orange-10:       #fce2c5,
-  $orange-20:       #fabd87,
-  $orange-30:       #ed9c5a,
-  $orange-40:       #eb8028,
-  $orange-50:       #a56931,
-  $orange-60:       #73563e,
-  $orange-70:       #4f3f33,
-  $orange-80:       #302a24,
-  $orange-90:       #211b18,
-  $orange-5v:       #ffebd5,
-  $orange-10v:      null,
-  $orange-20v:      #ffba75,
-  $orange-30v:      #ff9742,
-  $orange-40v:      #ff7b0f,
-  $orange-50v:      #c25700,
-  $orange-60v:      null,
-  $orange-70v:      null,
-  $orange-80v:      null,
-  $orange-90v:      null,
+  5 :       #fffbf7,
+  10:       #fce2c5,
+  20:       #fabd87,
+  30:       #ed9c5a,
+  40:       #eb8028,
+  50:       #a56931,
+  60:       #73563e,
+  70:       #4f3f33,
+  80:       #302a24,
+  90:       #211b18,
+  vivid: (
+    5:       #ffebd5,
+    10:      null,
+    20:      #ffba75,
+    30:      #ff9742,
+    40:      #ff7b0f,
+    50:      #c25700,
+    60:      null,
+    70:      null,
+    80:      null,
+    90:      null,
+  ),
 );
-$orange-5 :       #fffbf7;
-$orange-10:       #fce2c5;
-$orange-20:       #fabd87;
-$orange-30:       #ed9c5a;
-$orange-40:       #eb8028;
-$orange-50:       #a56931;
-$orange-60:       #73563e;
-$orange-70:       #4f3f33;
-$orange-80:       #302a24;
-$orange-90:       #211b18;
-$orange-5v:       #ffebd5;
-$orange-10v:      null;
-$orange-20v:      #ffba75;
-$orange-30v:      #ff9742;
-$orange-40v:      #ff7b0f;
-$orange-50v:      #c25700;
-$orange-60v:      null;
-$orange-70v:      null;
-$orange-80v:      null;
-$orange-90v:      null;
+$orange-5:    color($orange, 5);
+$orange-10:   color($orange, 10);
+$orange-20:   color($orange, 20);
+$orange-30:   color($orange, 30);
+$orange-40:   color($orange, 40);
+$orange-50:   color($orange, 50);
+$orange-60:   color($orange, 60);
+$orange-70:   color($orange, 70);
+$orange-80:   color($orange, 80);
+$orange-90:   color($orange, 90);
+$orange-5v:   color($orange, 5v);
+$orange-10v:  color($orange, 10v);
+$orange-20v:  color($orange, 20v);
+$orange-30v:  color($orange, 30v);
+$orange-40v:  color($orange, 40v);
+$orange-50v:  color($orange, 50v);
+$orange-60v:  color($orange, 60v);
+$orange-70v:  color($orange, 70v);
+$orange-80v:  color($orange, 80v);
+$orange-90v:  color($orange, 90v);
 
 // orange-warm
 $orange-warm: (
@@ -915,37 +954,39 @@ $orange-warm: (
   70:  #61382f,
   80:  #3b2723,
   90:  #211a19,
-  5v:  null,
-  10v: null,
-  20v: #faad96,
-  30v: #fc835c,
-  40v: #ff5201,
-  50v: #d24200,
-  60v: null,
-  70v: null,
-  80v: null,
-  90v: null,
+  vivid: (
+    5:  null,
+    10: null,
+    20: #faad96,
+    30: #fc835c,
+    40: #ff5201,
+    50: #d24200,
+    60: null,
+    70: null,
+    80: null,
+    90: null,
+  ),
 );
-$orange-warm-5 :  #fcf6f2;
-$orange-warm-10:  #f7e1d5;
-$orange-warm-20:  #f7b99e;
-$orange-warm-30:  #f5976e;
-$orange-warm-40:  #e87543;
-$orange-warm-50:  #be5727;
-$orange-warm-60:  #944835;
-$orange-warm-70:  #61382f;
-$orange-warm-80:  #3b2723;
-$orange-warm-90:  #211a19;
-$orange-warm-5v:  null;
-$orange-warm-10v: null;
-$orange-warm-20v: #faad96;
-$orange-warm-30v: #fc835c;
-$orange-warm-40v: #ff5201;
-$orange-warm-50v: #d24200;
-$orange-warm-60v: null;
-$orange-warm-70v: null;
-$orange-warm-80v: null;
-$orange-warm-90v: null;
+$orange-warm-5:   color($orange-warm, 5);
+$orange-warm-10:  color($orange-warm, 10);
+$orange-warm-20:  color($orange-warm, 20);
+$orange-warm-30:  color($orange-warm, 30);
+$orange-warm-40:  color($orange-warm, 40);
+$orange-warm-50:  color($orange-warm, 50);
+$orange-warm-60:  color($orange-warm, 60);
+$orange-warm-70:  color($orange-warm, 70);
+$orange-warm-80:  color($orange-warm, 80);
+$orange-warm-90:  color($orange-warm, 90);
+$orange-warm-5v:  color($orange-warm, 5v);
+$orange-warm-10v: color($orange-warm, 10v);
+$orange-warm-20v: color($orange-warm, 20v);
+$orange-warm-30v: color($orange-warm, 30v);
+$orange-warm-40v: color($orange-warm, 40v);
+$orange-warm-50v: color($orange-warm, 50v);
+$orange-warm-60v: color($orange-warm, 60v);
+$orange-warm-70v: color($orange-warm, 70v);
+$orange-warm-80v: color($orange-warm, 80v);
+$orange-warm-90v: color($orange-warm, 90v);
 
 // red-warm
 $red-warm: (
@@ -959,37 +1000,39 @@ $red-warm: (
   70:     #4f3f33,
   80:     #302a26,
   90:     #1f1c18,
-  5v:     null,
-  10v:    null,
-  20v:    #eaa076,
-  30v:    #e67549,
-  40v:    #ee601d,
-  50v:    #df4206,
-  60v:    null,
-  70v:    null,
-  80v:    null,
-  90v:    null,
+  vivid: (
+    5:     null,
+    10:    null,
+    20:    #eaa076,
+    30:    #e67549,
+    40:    #ee601d,
+    50:    #df4206,
+    60:    null,
+    70:    null,
+    80:    null,
+    90:    null,
+  ),
 );
-$red-warm-5 :     #faf7f5;
-$red-warm-10:     #f2ded5;
-$red-warm-20:     #ebbda2;
-$red-warm-30:     #db9e7f;
-$red-warm-40:     #d67c58;
-$red-warm-50:     #c7532c;
-$red-warm-60:     #805039;
-$red-warm-70:     #4f3f33;
-$red-warm-80:     #302a26;
-$red-warm-90:     #1f1c18;
-$red-warm-5v:     null;
-$red-warm-10v:    null;
-$red-warm-20v:    #eaa076;
-$red-warm-30v:    #e67549;
-$red-warm-40v:    #ee601d;
-$red-warm-50v:    #df4206;
-$red-warm-60v:    null;
-$red-warm-70v:    null;
-$red-warm-80v:    null;
-$red-warm-90v:    null;
+$red-warm-5:    color($red-warm, 5);
+$red-warm-10:   color($red-warm, 10);
+$red-warm-20:   color($red-warm, 20);
+$red-warm-30:   color($red-warm, 30);
+$red-warm-40:   color($red-warm, 40);
+$red-warm-50:   color($red-warm, 50);
+$red-warm-60:   color($red-warm, 60);
+$red-warm-70:   color($red-warm, 70);
+$red-warm-80:   color($red-warm, 80);
+$red-warm-90:   color($red-warm, 90);
+$red-warm-5v:   color($red-warm, 5v);
+$red-warm-10v:  color($red-warm, 10v);
+$red-warm-20v:  color($red-warm, 20v);
+$red-warm-30v:  color($red-warm, 30v);
+$red-warm-40v:  color($red-warm, 40v);
+$red-warm-50v:  color($red-warm, 50v);
+$red-warm-60v:  color($red-warm, 60v);
+$red-warm-70v:  color($red-warm, 70v);
+$red-warm-80v:  color($red-warm, 80v);
+$red-warm-90v:  color($red-warm, 90v);
 
 // red
 $red: (
@@ -1003,37 +1046,39 @@ $red: (
   70:          #6e312f,
   80:          #3b2523,
   90:          #211b1b,
-  5v:          null,
-  10v:         #fccec7,
-  20v:         #fda99c,
-  30v:         #ff806c,
-  40v:         #ff5c48,
-  50v:         #e92106,
-  60v:         #c31f0a,
-  70v:         #9c1503,
-  80v:         #631212,
-  90v:         null,
+  vivid: (
+    5:          null,
+    10:         #fccec7,
+    20:         #fda99c,
+    30:         #ff806c,
+    40:         #ff5c48,
+    50:         #e92106,
+    60:         #c31f0a,
+    70:         #9c1503,
+    80:         #631212,
+    90:         null,
+  ),
 );
-$red-5 :          #fcf5f5;
-$red-10:          #f7ddda;
-$red-20:          #f7b7ad;
-$red-30:          #f28f88;
-$red-40:          #ed6b61;
-$red-50:          #d83731;
-$red-60:          #ab3a3a;
-$red-70:          #6e312f;
-$red-80:          #3b2523;
-$red-90:          #211b1b;
-$red-5v:          null;
-$red-10v:         #fccec7;
-$red-20v:         #fda99c;
-$red-30v:         #ff806c;
-$red-40v:         #ff5c48;
-$red-50v:         #e92106;
-$red-60v:         #c31f0a;
-$red-70v:         #9c1503;
-$red-80v:         #631212;
-$red-90v:         null;
+$red-5:   color($red, 5);
+$red-10:  color($red, 10);
+$red-20:  color($red, 20);
+$red-30:  color($red, 30);
+$red-40:  color($red, 40);
+$red-50:  color($red, 50);
+$red-60:  color($red, 60);
+$red-70:  color($red, 70);
+$red-80:  color($red, 80);
+$red-90:  color($red, 90);
+$red-5v:  color($red, 5v);
+$red-10v: color($red, 10v);
+$red-20v: color($red, 20v);
+$red-30v: color($red, 30v);
+$red-40v: color($red, 40v);
+$red-50v: color($red, 50v);
+$red-60v: color($red, 60v);
+$red-70v: color($red, 70v);
+$red-80v: color($red, 80v);
+$red-90v: color($red, 90v);
 
 // magenta
 $magenta: (
@@ -1047,37 +1092,39 @@ $magenta: (
   70:      #613046,
   80:      #3b212c,
   90:      #211b1d,
-  5v:      null,
-  10v:     #ffd1e2,
-  20v:     #ffadca,
-  30v:     #ff80ae,
-  40v:     #fa3c91,
-  50v:     #e1277a,
-  60v:     #a91b61,
-  70v:     null,
-  80v:     null,
-  90v:     null,
+  vivid: (
+    5:      null,
+    10:     #ffd1e2,
+    20:     #ffadca,
+    30:     #ff80ae,
+    40:     #fa3c91,
+    50:     #e1277a,
+    60:     #a91b61,
+    70:     null,
+    80:     null,
+    90:     null,
+  ),
 );
-$magenta-5 :      #faf5f6;
-$magenta-10:      #f5dce4;
-$magenta-20:      #f0b9cb;
-$magenta-30:      #e68eae;
-$magenta-40:      #e0699f;
-$magenta-50:      #c84180;
-$magenta-60:      #8a4365;
-$magenta-70:      #613046;
-$magenta-80:      #3b212c;
-$magenta-90:      #211b1d;
-$magenta-5v:      null;
-$magenta-10v:     #ffd1e2;
-$magenta-20v:     #ffadca;
-$magenta-30v:     #ff80ae;
-$magenta-40v:     #fa3c91;
-$magenta-50v:     #e1277a;
-$magenta-60v:     #a91b61;
-$magenta-70v:     null;
-$magenta-80v:     null;
-$magenta-90v:     null;
+$magenta-5:   color($magenta, 5);
+$magenta-10:  color($magenta, 10);
+$magenta-20:  color($magenta, 20);
+$magenta-30:  color($magenta, 30);
+$magenta-40:  color($magenta, 40);
+$magenta-50:  color($magenta, 50);
+$magenta-60:  color($magenta, 60);
+$magenta-70:  color($magenta, 70);
+$magenta-80:  color($magenta, 80);
+$magenta-90:  color($magenta, 90);
+$magenta-5v:  color($magenta, 5v);
+$magenta-10v: color($magenta, 10v);
+$magenta-20v: color($magenta, 20v);
+$magenta-30v: color($magenta, 30v);
+$magenta-40v: color($magenta, 40v);
+$magenta-50v: color($magenta, 50v);
+$magenta-60v: color($magenta, 60v);
+$magenta-70v: color($magenta, 70v);
+$magenta-80v: color($magenta, 80v);
+$magenta-90v: color($magenta, 90v);
 
 // black-cool
 $black-cool: (
@@ -1091,17 +1138,17 @@ $black-cool: (
   70:   #404347,
   80:   #292a2b,
   90:   #1c1d1f,
-)
-$black-cool-5 :   #edeff0;
-$black-cool-10:   #d5d8db;
-$black-cool-20:   #b8bdc2;
-$black-cool-30:   #9da2a6;
-$black-cool-40:   #8c9196;
-$black-cool-50:   #6f7478;
-$black-cool-60:   #595d63;
-$black-cool-70:   #404347;
-$black-cool-80:   #292a2b;
-$black-cool-90:   #1c1d1f;
+);
+$black-cool-5:  red;
+$black-cool-10: color($black-cool, 10);
+$black-cool-20: color($black-cool, 20);
+$black-cool-30: color($black-cool, 30);
+$black-cool-40: color($black-cool, 40);
+$black-cool-50: color($black-cool, 50);
+$black-cool-60: color($black-cool, 60);
+$black-cool-70: color($black-cool, 70);
+$black-cool-80: color($black-cool, 80);
+$black-cool-90: color($black-cool, 90);
 
 // black
 $black: (
@@ -1116,17 +1163,18 @@ $black: (
   80:        #2e2e2e,
   90:        #171717,
   100:       #000000,
-)
-$black-5 :        #fafafa;
-$black-10:        #e6e6e6;
-$black-20:        #c9c9c9;
-$black-30:        #adadad;
-$black-40:        #919191;
-$black-50:        #757575;
-$black-60:        #5c5c5c;
-$black-70:        #454545;
-$black-80:        #2e2e2e;
-$black-90:        #171717;
+);
+$black-5:   color($black, 5);
+$black-10:  color($black, 10);
+$black-20:  color($black, 20);
+$black-30:  color($black, 30);
+$black-40:  color($black, 40);
+$black-50:  color($black, 50);
+$black-60:  color($black, 60);
+$black-70:  color($black, 70);
+$black-80:  color($black, 80);
+$black-90:  color($black, 90);
+$black-100: color($black,100);
 
 // black-warm
 $black-warm: (
@@ -1141,16 +1189,16 @@ $black-warm: (
   80:   #2b2b27,
   90:   #1c1c1b,
 );
-$black-warm-5 :   #f5f5f1;
-$black-warm-10:   #e0e0da;
-$black-warm-20:   #d6d5cb;
-$black-warm-30:   #c2c1b4;
-$black-warm-40:   #969689;
-$black-warm-50:   #707064;
-$black-warm-60:   #5e5e53;
-$black-warm-70:   #42423c;
-$black-warm-80:   #2b2b27;
-$black-warm-90:   #1c1c1b;
+$black-warm-5:  color($black-warm, 5);
+$black-warm-10: color($black-warm, 10);
+$black-warm-20: color($black-warm, 20);
+$black-warm-30: color($black-warm, 30);
+$black-warm-40: color($black-warm, 40);
+$black-warm-50: color($black-warm, 50);
+$black-warm-60: color($black-warm, 60);
+$black-warm-70: color($black-warm, 70);
+$black-warm-80: color($black-warm, 80);
+$black-warm-90: color($black-warm, 90);
 
 // black-op
 $black-transparent: (
@@ -1165,16 +1213,16 @@ $black-transparent: (
   80:     rgba(0, 0, 0, 0.8),
   90:     rgba(0, 0, 0, 0.9),
 );
-$black-transparent-5 :     rgba(0, 0, 0, 0.01);
-$black-transparent-10:     rgba(0, 0, 0, 0.1);
-$black-transparent-20:     rgba(0, 0, 0, 0.2);
-$black-transparent-30:     rgba(0, 0, 0, 0.3);
-$black-transparent-40:     rgba(0, 0, 0, 0.4);
-$black-transparent-50:     rgba(0, 0, 0, 0.5);
-$black-transparent-60:     rgba(0, 0, 0, 0.6);
-$black-transparent-70:     rgba(0, 0, 0, 0.7);
-$black-transparent-80:     rgba(0, 0, 0, 0.8);
-$black-transparent-90:     rgba(0, 0, 0, 0.9);
+$black-transparent-5:   color($black-transparent, 5);
+$black-transparent-10:  color($black-transparent, 10);
+$black-transparent-20:  color($black-transparent, 20);
+$black-transparent-30:  color($black-transparent, 30);
+$black-transparent-40:  color($black-transparent, 40);
+$black-transparent-50:  color($black-transparent, 50);
+$black-transparent-60:  color($black-transparent, 60);
+$black-transparent-70:  color($black-transparent, 70);
+$black-transparent-80:  color($black-transparent, 80);
+$black-transparent-90:  color($black-transparent, 90);
 
 // white-op
 $white-transparent: (
@@ -1189,16 +1237,16 @@ $white-transparent: (
   80:     rgba(255, 255, 255, 0.8),
   90:     rgba(255, 255, 255, 0.9),
 );
-$white-transparent-5 :     rgba(255, 255, 255, 0.01);
-$white-transparent-10:     rgba(255, 255, 255, 0.1);
-$white-transparent-20:     rgba(255, 255, 255, 0.2);
-$white-transparent-30:     rgba(255, 255, 255, 0.3);
-$white-transparent-40:     rgba(255, 255, 255, 0.4);
-$white-transparent-50:     rgba(255, 255, 255, 0.5);
-$white-transparent-60:     rgba(255, 255, 255, 0.6);
-$white-transparent-70:     rgba(255, 255, 255, 0.7);
-$white-transparent-80:     rgba(255, 255, 255, 0.8);
-$white-transparent-90:     rgba(255, 255, 255, 0.9);
+$white-transparent-5:   color($white-transparent, 5);
+$white-transparent-10:  color($white-transparent, 10);
+$white-transparent-20:  color($white-transparent, 20);
+$white-transparent-30:  color($white-transparent, 30);
+$white-transparent-40:  color($white-transparent, 40);
+$white-transparent-50:  color($white-transparent, 50);
+$white-transparent-60:  color($white-transparent, 60);
+$white-transparent-70:  color($white-transparent, 70);
+$white-transparent-80:  color($white-transparent, 80);
+$white-transparent-90:  color($white-transparent, 90);
 
 // white-cool
 $white-cool: (
@@ -1206,11 +1254,11 @@ $white-cool: (
   2:    #f7f9fa,
   3:    #f5f6f7,
   4:    #f0f2f5,
-)
-$white-cool-1:    #fafbfc;
-$white-cool-2:    #f7f9fa;
-$white-cool-3:    #f5f6f7;
-$white-cool-4:    #f0f2f5;
+);
+$white-cool-1: color($white-cool, 1);
+$white-cool-2: color($white-cool, 2);
+$white-cool-3: color($white-cool, 3);
+$white-cool-4: color($white-cool, 4);
 
 // white
 $white: (
@@ -1220,11 +1268,11 @@ $white: (
   3:         #f6f6f6,
   4:         #f3f3f3,
 );
-$white-0:         #ffffff;
-$white-1:         #fcfcfc;
-$white-2:         #f9f9f9;
-$white-3:         #f6f6f6;
-$white-4:         #f3f3f3;
+$white-0: color($white, 0);
+$white-1: color($white, 1);
+$white-2: color($white, 2);
+$white-3: color($white, 3);
+$white-4: color($white, 4);
 
 // white-warm
 $white-warm: (
@@ -1233,7 +1281,7 @@ $white-warm: (
   3:    #f7f7f3,
   4:    #f5f5f0,
 );
-$white-warm-1:    #fdfdfc;
-$white-warm-2:    #fafaf8;
-$white-warm-3:    #f7f7f3;
-$white-warm-4:    #f5f5f0;
+$white-warm-1: color($white-warm, 1);
+$white-warm-2: color($white-warm, 2);
+$white-warm-3: color($white-warm, 3);
+$white-warm-4: color($white-warm, 4);

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -498,26 +498,26 @@ $blue: (
     90:        null,
   ),
 );
-$blue-5:    color-test($blue, 5);
-$blue-10:   color-test($blue, 10);
-$blue-20:   color-test($blue, 20);
-$blue-30:   color-test($blue, 30);
-$blue-40:   color-test($blue, 40);
-$blue-50:   color-test($blue, 50);
-$blue-60:   color-test($blue, 60);
-$blue-70:   color-test($blue, 70);
-$blue-80:   color-test($blue, 80);
-$blue-90:   color-test($blue, 90);
-$blue-5v:   color-test($blue, 5, vivid);
-$blue-10v:  color-test($blue, 10, vivid);
-$blue-20v:  color-test($blue, 20, vivid);
-$blue-30v:  color-test($blue, 30, vivid);
-$blue-40v:  color-test($blue, 40, vivid);
-$blue-50v:  color-test($blue, 50, vivid);
-$blue-60v:  color-test($blue, 60, vivid);
-$blue-70v:  color-test($blue, 70, vivid);
-$blue-80v:  color-test($blue, 80, vivid);
-$blue-90v:  color-test($blue, 90, vivid);
+$blue-5:    color($blue, 5);
+$blue-10:   color($blue, 10);
+$blue-20:   color($blue, 20);
+$blue-30:   color($blue, 30);
+$blue-40:   color($blue, 40);
+$blue-50:   color($blue, 50);
+$blue-60:   color($blue, 60);
+$blue-70:   color($blue, 70);
+$blue-80:   color($blue, 80);
+$blue-90:   color($blue, 90);
+$blue-5v:   color($blue, 5, vivid);
+$blue-10v:  color($blue, 10, vivid);
+$blue-20v:  color($blue, 20, vivid);
+$blue-30v:  color($blue, 30, vivid);
+$blue-40v:  color($blue, 40, vivid);
+$blue-50v:  color($blue, 50, vivid);
+$blue-60v:  color($blue, 60, vivid);
+$blue-70v:  color($blue, 70, vivid);
+$blue-80v:  color($blue, 80, vivid);
+$blue-90v:  color($blue, 90, vivid);
 
 // cyan
 $cyan: (

--- a/src/stylesheets/core/_units.scss
+++ b/src/stylesheets/core/_units.scss
@@ -197,6 +197,7 @@ $u-lh-body-tight:	 1.5;
 
 // See this palette at https://federalist-proxy.app.cloud.gov/site/18f/united/build/prototypes/colors.html
 
+/* stylelint-disable unit-no-unknown */
 // violet-warm
 $violet-warm: (
   5:   #fef7ff,
@@ -210,16 +211,16 @@ $violet-warm: (
   80:  #332431,
   90:  #211a21,
   vivid: (
-    5:  #fdedff,
-    10: #f9c9ff,
-    20: #f3a8ff,
-    30: #ee82ff,
-    40: #e05ef7,
-    50: #c132d4,
-    60: false,
-    70: false,
-    80: false,
-    90: false,
+    5v:  #fdedff,
+    10v: #f9c9ff,
+    20v: #f3a8ff,
+    30v: #ee82ff,
+    40v: #e05ef7,
+    50v: #c132d4,
+    60v: false,
+    70v: false,
+    80v: false,
+    90v: false,
   ),
 );
 $violet-warm-5 :  color($violet-warm, 5);
@@ -1166,7 +1167,7 @@ $black-60:  color($black, 60);
 $black-70:  color($black, 70);
 $black-80:  color($black, 80);
 $black-90:  color($black, 90);
-$black-100: color($black,100);
+$black-100: color($black, 100);
 
 // black-warm
 $black-warm: (
@@ -1277,3 +1278,4 @@ $white-warm-1: color($white-warm, 1);
 $white-warm-2: color($white-warm, 2);
 $white-warm-3: color($white-warm, 3);
 $white-warm-4: color($white-warm, 4);
+/* stylelint-enable */


### PR DESCRIPTION
This defines the unit colors with sass maps formatted like 
```sass
// violet-warm
$violet-warm: (
  5:   #fef7ff,
  10:  #f5dcf7,
  20:  #e0bae3,
  30:  #d096d6,
  40:  #bd73c7,
  50:  #b24bbf,
  60:  #854180,
  70:  #573455,
  80:  #332431,
  90:  #211a21,
  vivid: (
    5:  #fdedff,
    10: #f9c9ff,
    20: #f3a8ff,
    30: #ee82ff,
    40: #e05ef7,
    50: #c132d4,
    60: false,
    70: false,
    80: false,
    90: false,
  ),
);
```
it also adds a function (`color()`) to get the value from the map:

- - -

EDIT:
I've modified this function to avoid ambiguous units.

Now, for a vivid variant, use `color($hue, $value, vivid)` like `color($indigo, 50, vivid)`

- - -

I have not rewritten the builder and the color palette presets to pull directly from these maps. Instead, they continue to pull from hardcoded vars like `$violet-warm-50v` which are, themselves defined with the `color()` function. 

Rewriting the palette and builder is possible, but nontrivial — I think we should wait for a compelling use-case for rewrite before going any farther down that road.

- - -

As an aside, the following map throws errors due to sass miscasting `##v` values as numbers (with `v` as the unit), thus seeing these maps as containing duplicate keys. Since it seemed good to keep the keys as numbers for potential use with math, I didn't stringify them or manually cast them as strings with `'`s.
```sass
$violet-warm: (
  5:   #fef7ff,
  10:  #f5dcf7,
  20:  #e0bae3,
  30:  #d096d6,
  40:  #bd73c7,
  50:  #b24bbf,
  60:  #854180,
  70:  #573455,
  80:  #332431,
  90:  #211a21,
  5v:  #fdedff,
  10v: #f9c9ff,
  20v: #f3a8ff,
  30v: #ee82ff,
  40v: #e05ef7,
  50v: #c132d4,
  60v: false,
  70v: false,
  80v: false,
  90v: false,
);
```