### PR TITLE
Add variable to indicate if site is on .mil TLD to [banner]

### DIFF
--- a/src/components/banner/banner.config.yml
+++ b/src/components/banner/banner.config.yml
@@ -1,1 +1,5 @@
 label: U.S. Government banner
+
+context:
+  banner:
+    is_dot_mil: False

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -15,7 +15,7 @@
         <img class="usa-banner-icon usa-media_block-img" src="{{ uswds.path }}/img/icon-dot-gov.svg" alt="Dot gov">
         <div class="usa-media_block-body">
           <p>
-            <strong>The .gov means it’s official.</strong>
+            <strong>The {% if banner.is_dot_mil %} .mil {% else %} .gov {% endif %} means it’s official.</strong>
             <br>
             Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
           </p>


### PR DESCRIPTION
## Description

See #2401, deptofdefense/code.mil#182

I went with this approach (context boolean) as only two TLDs are supported now (.mil and .gov). If a third option is ever added it might be worth considering defaulting to a list, and using JS to determine the site's TLD

## Additional information

<img width="1000" alt="screen shot 2018-03-20 at 7 36 36 am" src="https://user-images.githubusercontent.com/30699219/37652429-e352b560-2c11-11e8-8104-5785336d4f30.png">
