### PR TITLE
Make return to top link set focus on main content

### DIFF
--- a/spec/unit/skipnav/skipnav.spec.js
+++ b/spec/unit/skipnav/skipnav.spec.js
@@ -8,12 +8,14 @@ const TEMPLATE = fs.readFileSync(__dirname + '/template.html').toString();
 describe('skip nav link', function () {
   const body = document.body;
 
-  let link;
+  let skipLink;
+  let topLink;
   let main;
 
   beforeEach(function () {
     body.innerHTML = TEMPLATE;
-    link = body.querySelector('.usa-skipnav');
+    skipLink = body.querySelector('.usa-skipnav');
+    topLink = body.querySelector('.usa-footer-return-to-top a');
     main = body.querySelector('main');
     skipnav.on(body);
   });
@@ -23,13 +25,13 @@ describe('skip nav link', function () {
     skipnav.off(body);
   });
 
-  it('sets tabindex="0" when clicked', function () {
-    link.click();
+  it('skipnav link sets tabindex="0" when clicked', function () {
+    skipLink.click();
     assert.equal(main.getAttribute('tabindex'), '0');
   });
 
-  it('sets tabindex="-1" when blurred', function () {
-    link.click();
+  it('skipnav link sets tabindex="-1" when blurred', function () {
+    skipLink.click();
     assert.equal(main.getAttribute('tabindex'), '0');
 
     main.focus(); // XXX jsdom doesn't do this for us
@@ -37,4 +39,8 @@ describe('skip nav link', function () {
     assert.equal(main.getAttribute('tabindex'), '-1');
   });
 
+  it('return to top link sets tabindex="0" when clicked', function () {
+    topLink.click();
+    assert.equal(main.getAttribute('tabindex'), '0');
+  });
 });

--- a/spec/unit/skipnav/template.html
+++ b/spec/unit/skipnav/template.html
@@ -2,3 +2,7 @@
 
 <main id="main-content">
 </main>
+
+<div class="usa-grid usa-footer-return-to-top">
+  <a href="#">Return to top</a>
+</div>

--- a/src/js/components/skipnav.js
+++ b/src/js/components/skipnav.js
@@ -4,14 +4,19 @@ const once = require('receptor/once');
 
 const CLICK = require('../events').CLICK;
 const PREFIX = require('../config').prefix;
-const LINK = `.${PREFIX}-skipnav[href^="#"]`;
+const LINK = `.${PREFIX}-skipnav[href^="#"], .${PREFIX}-footer-return-to-top [href^="#"]`;
+const MAINCONTENT = 'main-content';
 
 const setTabindex = function (event) {
   // NB: we know because of the selector we're delegating to below that the
   // href already begins with '#'
-  const id = this.getAttribute('href').slice(1);
-  const target = document.getElementById(id);
+  const id = this.getAttribute('href');
+  const target = document.getElementById((id === '#') ? MAINCONTENT : id.slice(1));
+
   if (target) {
+    event.preventDefault();
+    window.location.hash = target.id;
+
     target.setAttribute('tabindex', 0);
     target.addEventListener('blur', once(event => {
       target.setAttribute('tabindex', -1);

--- a/src/js/components/skipnav.js
+++ b/src/js/components/skipnav.js
@@ -14,10 +14,9 @@ const setTabindex = function (event) {
   const target = document.getElementById((id === '#') ? MAINCONTENT : id.slice(1));
 
   if (target) {
-    event.preventDefault();
-    window.location.hash = target.id;
-
+    target.style.outline = '0';
     target.setAttribute('tabindex', 0);
+    target.focus();
     target.addEventListener('blur', once(event => {
       target.setAttribute('tabindex', -1);
     }));


### PR DESCRIPTION
This enables the `Return to top` link to set the focus on the main content area so that tabbing does not skip back to the footer links.

It is backwards compatible so if the return to top link is set to `#` (which it is in all of our documentation), it will override that and instead set it to `#main-content` (if it exists). If folks have manually set the link to target a different element, it should still also work as it did before, but will also reset the focus to the specified target.

This addresses https://github.com/uswds/uswds/issues/2321

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-return-top)