### PR TITLE
Remove duplicate css

### DIFF
--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -36,9 +36,8 @@
 }
 
 .usa-banner-inner {
-  @include outer-container();
+  @include outer-container($site-max-width);
   @include padding(null $site-margins-mobile);
-  max-width: $site-max-width;
 
   @include media($nav-width) {
     @include padding(null $site-margins);

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -154,11 +154,10 @@ $z-index-nav:     9000;
 
   .usa-navbar {
     @include media($nav-width) {
-      @include outer-container();
+      @include outer-container($site-max-width);
       @include padding(null $site-margins);
       display: block;
       height: auto;
-      max-width: $site-max-width;
     }
   }
 
@@ -173,10 +172,9 @@ $z-index-nav:     9000;
 
   .usa-nav-inner {
     @include media($nav-width) {
-      @include outer-container();
+      @include outer-container($site-max-width);
       @include padding(null $site-margins null 1.5rem);
       margin-top: -1px;
-      max-width: $site-max-width;
       position: relative;
     }
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -44,9 +44,8 @@
 
 .usa-nav-container {
   @include media($nav-width) {
-    @include outer-container();
+    @include outer-container($site-max-width);
     @include padding(null $site-margins);
-    max-width: $site-max-width;
   }
 }
 

--- a/src/stylesheets/core/_grid.scss
+++ b/src/stylesheets/core/_grid.scss
@@ -1,8 +1,7 @@
 // Grid container
 .usa-grid,
 .usa-grid-full {
-  @include outer-container();
-  max-width: $site-max-width;
+  @include outer-container($site-max-width);
 }
 
 .usa-grid {

--- a/src/stylesheets/core/_variables-vendor.scss
+++ b/src/stylesheets/core/_variables-vendor.scss
@@ -9,5 +9,4 @@
 ///   *, *::after, *::before {
 ///     box-sizing: inherit;
 ///   }
-
 $border-box-sizing: false;

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -1,6 +1,7 @@
 /*! uswds @version */
 
 // Vendor -------------- //
+@import 'vendor/variables';
 @import 'lib/bourbon';
 @import 'lib/neat';
 @import 'lib/normalize';

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -1,7 +1,7 @@
 /*! uswds @version */
 
 // Vendor -------------- //
-@import 'vendor/variables';
+@import 'core/variables-vendor';
 @import 'lib/bourbon';
 @import 'lib/neat';
 @import 'lib/normalize';

--- a/src/stylesheets/vendor/_variables.scss
+++ b/src/stylesheets/vendor/_variables.scss
@@ -1,0 +1,13 @@
+/// When set to true, it sets the box-sizing property of all elements to `border-box`. Set with a `!global` flag.
+///
+/// @type Bool
+///
+/// @example css - CSS Output
+///   html {
+///     box-sizing: border-box; }
+///
+///   *, *::after, *::before {
+///     box-sizing: inherit;
+///   }
+
+$border-box-sizing: false;


### PR DESCRIPTION
This removes the duplicate css identified in https://github.com/uswds/uswds/issues/2361

The `box-sizing` at the top of the compiled  stylesheet was being brought in by Bourbon Neat, so in order to remove it the `$border-box-sizing` has to be set to false. I created a vendor variables partial in order to set that before Bourbon in added. The alternative would be to continue to rely on Bourbon Neat, and remove the duplicate code from `core/_base.scss` but it seems more flexible for us to be able to control those rules vs it being injected by an a third party library.

Bourbon Neat also sets a default `$max-width` that is used with the `outer-container` mixin, which is why we were having to specify a second `max-width` with `$site-max-width` to override it. The `outer-container` actually takes the max-width as an argument though, so I updated all the occurrences of it to pass in `$site-max-width` which makes adding the second max-width unnecessary.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-duplicate-css)