### PR TITLE
Use hidden attribute and expand by default with no js

### DIFF
--- a/spec/1.x/accordion.spec.js
+++ b/spec/1.x/accordion.spec.js
@@ -10,7 +10,7 @@ const TEMPLATE = fs.readFileSync(
 
 const CONTROLS = 'aria-controls';
 const EXPANDED = 'aria-expanded';
-const HIDDEN = 'aria-hidden';
+const HIDDEN = 'hidden';
 
 describe('1.x accordion component', function () {
 
@@ -57,8 +57,8 @@ describe('1.x accordion component', function () {
       assert.equal(button.getAttribute(EXPANDED), 'true');
     });
 
-    it('toggles "aria-hidden" to false', function () {
-      assert.equal(content.getAttribute(HIDDEN), 'false');
+    it('toggles "hidden" off', function () {
+      assert(content.hasAttribute(HIDDEN) != 'true');
     });
   });
 
@@ -72,8 +72,8 @@ describe('1.x accordion component', function () {
       assert.equal(button.getAttribute(EXPANDED), 'false');
     });
 
-    it('toggles "aria-hidden" to true', function () {
-      assert.equal(content.getAttribute(HIDDEN), 'true');
+    it('toggles "hidden" on', function () {
+      assert(content.hasAttribute(HIDDEN));
     });
   });
 
@@ -84,20 +84,20 @@ describe('1.x accordion component', function () {
       const content = document.getElementById(
         button.getAttribute(CONTROLS)
       );
-      assert.equal(content.getAttribute(HIDDEN), 'true');
+      assert(content.hasAttribute(HIDDEN));
     });
   });
 
   it('can show buttons', function () {
     accordion.show(button);
     assert.equal(button.getAttribute(EXPANDED), 'true');
-    assert.equal(content.getAttribute(HIDDEN), 'false');
+    assert(content.getAttribute(HIDDEN) != 'true');
   });
 
   it('can hide buttons', function () {
     accordion.hide(button);
     assert.equal(button.getAttribute(EXPANDED), 'false');
-    assert.equal(content.getAttribute(HIDDEN), 'true');
+    assert(content.hasAttribute(HIDDEN));
   });
 
 });

--- a/spec/unit/accordion/accordion.spec.js
+++ b/spec/unit/accordion/accordion.spec.js
@@ -8,7 +8,7 @@ const TEMPLATE = fs.readFileSync(__dirname + '/template.html');
 // `aria` prefixed attributes
 const EXPANDED = 'aria-expanded';
 const CONTROLS = 'aria-controls';
-const HIDDEN   = 'aria-hidden';
+const HIDDEN   = 'hidden';
 const MULTISELECTABLE = 'aria-multiselectable';
 
 describe('accordion behavior', function () {
@@ -55,8 +55,8 @@ describe('accordion behavior', function () {
         assert.equal(button.getAttribute(EXPANDED), 'true');
       });
 
-      it('toggles content aria-hidden="false"', function () {
-        assert.equal(content.getAttribute(HIDDEN), 'false');
+      it('toggles content "hidden" off', function () {
+        assert(content.hasAttribute(HIDDEN) != 'true');
       });
     });
 
@@ -70,8 +70,8 @@ describe('accordion behavior', function () {
         assert.equal(button.getAttribute(EXPANDED), 'false');
       });
 
-      it('toggles content aria-hidden="true"', function () {
-        assert.equal(content.getAttribute(HIDDEN), 'true');
+      it('toggles content "hidden" on', function () {
+        assert(content.hasAttribute(HIDDEN));
       });
     });
   });
@@ -86,10 +86,10 @@ describe('accordion behavior', function () {
       second.click();
       // first button and section should be collapsed
       assert.equal(button.getAttribute(EXPANDED), 'false');
-      assert.equal(content.getAttribute(HIDDEN), 'true');
+      assert(content.hasAttribute(HIDDEN));
       // second should be expanded
       assert.equal(second.getAttribute(EXPANDED), 'true');
-      assert.equal(target.getAttribute(HIDDEN), 'false');
+      assert(target.getAttribute(HIDDEN) != 'true');
     });
 
     it('keeps multiple sections open with aria-multiselectable="true"', function () {
@@ -103,10 +103,10 @@ describe('accordion behavior', function () {
       button.click();
 
       assert.equal(button.getAttribute(EXPANDED), 'true');
-      assert.equal(content.getAttribute(HIDDEN), 'false');
+      assert(content.hasAttribute(HIDDEN) != 'true');
       // second should be expanded
       assert.equal(second.getAttribute(EXPANDED), 'true');
-      assert.equal(target.getAttribute(HIDDEN), 'false');
+      assert(content.hasAttribute(HIDDEN) != 'true');
     });
 
 

--- a/spec/unit/banner/banner.spec.js
+++ b/spec/unit/banner/banner.spec.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const TEMPLATE = fs.readFileSync(__dirname + '/template.html');
 const EXPANDED = 'aria-expanded';
 const EXPANDED_CLASS = 'usa-banner-header-expanded';
-const HIDDEN = 'aria-hidden';
+const HIDDEN = 'hidden';
 
 describe('banner', function () {
   const body = document.body;
@@ -34,14 +34,14 @@ describe('banner', function () {
   it('initializes closed', function () {
     assert.equal(header.classList.contains(EXPANDED_CLASS), false);
     assert.equal(button.getAttribute(EXPANDED), 'false');
-    assert.equal(content.getAttribute(HIDDEN), 'true');
+    assert(content.hasAttribute(HIDDEN));
   });
 
   it('opens when you click the button', function () {
     button.click();
     assert.equal(header.classList.contains(EXPANDED_CLASS), true);
     assert.equal(button.getAttribute(EXPANDED), 'true');
-    assert.equal(content.getAttribute(HIDDEN), 'false');
+    assert(content.hasAttribute(HIDDEN) != 'false');
   });
 
   it('closes when you click the button again', function () {
@@ -49,7 +49,7 @@ describe('banner', function () {
     button.click();
     assert.equal(header.classList.contains(EXPANDED_CLASS), false);
     assert.equal(button.getAttribute(EXPANDED), 'false');
-    assert.equal(content.getAttribute(HIDDEN), 'true');
+    assert(content.hasAttribute(HIDDEN));
   });
 
 });

--- a/src/js/utils/toggle.js
+++ b/src/js/utils/toggle.js
@@ -1,7 +1,7 @@
 'use strict';
 const EXPANDED = 'aria-expanded';
 const CONTROLS = 'aria-controls';
-const HIDDEN = 'aria-hidden';
+const HIDDEN = 'hidden';
 
 module.exports = (button, expanded) => {
 
@@ -18,6 +18,6 @@ module.exports = (button, expanded) => {
     );
   }
 
-  controls.setAttribute(HIDDEN, !expanded);
+  expanded ? controls.removeAttribute(HIDDEN, '') : controls.setAttribute(HIDDEN, '');
   return expanded;
 };

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -72,12 +72,6 @@ $v-padding: $spacing-md-small;
   > :last-child {
     margin-bottom: 0;
   }
-
-  &:not([aria-hidden]) {
-    @include sr-only();
-  }
-
-  @include accessibly-hidden();
 }
 
 .usa-accordion-button {

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -77,6 +77,10 @@
       width: 2rem;
     }
   }
+
+  &:not(.usa-banner-header-expanded) + .usa-banner-content {
+    display: none;
+  }
 }
 
 .usa-banner-header-expanded {

--- a/src/stylesheets/core/_utilities.scss
+++ b/src/stylesheets/core/_utilities.scss
@@ -68,13 +68,6 @@
   @include sr-only();
 }
 
-// Aria hidden helper
-@mixin accessibly-hidden() {
-  &[aria-hidden=true] {
-    display: none;
-  }
-}
-
 // Unstyled list helper
 @mixin unstyled-list() {
   @include margin(0 null);


### PR DESCRIPTION
This addresses the remaining items in https://github.com/uswds/uswds/pull/2360#issuecomment-366375618 - accordions now use `hidden` instead of `aria-hidden`, the `accessibly-hidden` mixin has been removed, and accordions should default to being open in browsers without JS.

There was one complication with this, the top gov't banner uses the accordion, so it was also wanting to default to open without JS so I added some additional CSS to prevent that.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-more-accordion)