### PR TITLE
Add gulp build to Federalist npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:js": "gulp javascript",
     "cover": "istanbul cover --config config/istanbul.yml gulp cover",
     "cracks": "cracks --paths package.json,spec",
-    "federalist": "npm install --only=dev && fractal build",
+    "federalist": "npm install --only=dev && gulp build && fractal build",
     "mocha": "mocha --opts spec/mocha.opts",
     "prepare": "gulp build",
     "preversion": "npm test",


### PR DESCRIPTION
Federalist script needs `gulp build` in order to have the minified CSS available for the Fractal site.

[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-missing-styles/components/detail/buttons--default.html)