### PR TITLE
Remove submit button block display and extra styling

### DIFF
--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -2,7 +2,6 @@ $usa-form-width: 32rem;
 
 [type=submit],
 [type=submit] {
-  display: block;
   margin-bottom: 1.5em;
   margin-top: 2.5rem;
 

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -1,20 +1,8 @@
 $usa-form-width: 32rem;
 
-[type=submit],
-[type=submit] {
-  margin-bottom: 1.5em;
-  margin-top: 2.5rem;
-
-  @include media($medium-screen) {
-    padding-left: 2.7em;
-    padding-right: 2.7em;
-    width: auto;
-  }
-}
-
 [name=password],
 [name=confirmPassword] {
-  margin-bottom: 1.1rem;
+  margin-bottom: 1rem;
 }
 
 fieldset {


### PR DESCRIPTION
This removes the `display: block` from submit buttons. While doing this I also realized we likely don't need any of the added styles so removed them.

**A few things I found in this work:**
1. The sketch file has two different font size for "show password" (17px) and "show my typing" (15px) toggles. Since they function in the same way should they be the same sizes? The code has them at 15px.
2. This code removes the extra padding on the submit button, leading to a less wide Sign in button. Is it too short this way? We can add a min-width of 134px on the submit buttons bc the extra padding is not desired on buttons that are already wide from longer text.

Fixes #2409.
