### PR TITLE
Update spacing function

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -692,14 +692,11 @@ the desired final units (currently rem)
 */
 
 @function spacing($value) {
-  @if map-has-key($project-spacing-standard, quote($value)) {
-    @if map-get($project-spacing-standard, quote($value)) == false {
-      @warn "Spacing unit `#{$value}` has been disabled in your theme settings. It will output as `false`.";
-    }
-    @return map-get($project-spacing-standard, quote($value));
-  }
-  @elseif $value == false {
+  @if $value == false {
     @return false;
+  }
+  @elseif map-has-key($project-spacing-standard, quote($value)) {
+    @return map-get($project-spacing-standard, quote($value));
   }
   @elseif not unitless($value) {
     @warn "`#{$value}` is not a standard USWDS unit. This is OK, but consider using a standard spacing unit instead.";


### PR DESCRIPTION
Looks like you can't run `quote()` on a string that is a boolean like `false`.  For now, moving the check to see if the value is false to the beginning of the conditional statement so it does not accidentally get passed through.

Fixes https://github.com/uswds/uswds/issues/2429