### PR TITLE
Add default `hover:` output to some color utilities

### DIFF
--- a/src/stylesheets/project/_uswds-project-utilities-settings.scss
+++ b/src/stylesheets/project/_uswds-project-utilities-settings.scss
@@ -54,7 +54,7 @@ $background-color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 
@@ -120,7 +120,7 @@ $border-color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 
@@ -352,7 +352,7 @@ $color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 

--- a/src/stylesheets/utilities/_utilities-settings.scss
+++ b/src/stylesheets/utilities/_utilities-settings.scss
@@ -63,7 +63,7 @@ $background-color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
 
@@ -128,7 +128,7 @@ $border-color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
 
@@ -359,7 +359,7 @@ $color-settings: (
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
 


### PR DESCRIPTION
Added default `hover:` output to 
- `background-color`
- `border-color`
- `color`