### PR TITLE
Packaging: Support node-sass npm importers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "main": "dist/js/uswds.min.js",
   "jsnext:main": "src/js/start.js",
+  "style": "dist/css/uswds.min.css",
+  "sass": "src/stylesheets/uswds.scss",
   "scripts": {
     "build": "gulp build",
     "build:css": "gulp sass",


### PR DESCRIPTION
Add "sass" and "styles" attributes to package.json so the entry points are discoverable by node-sass importers.

## Description

`node-sass` supports custom importers, such as [`node-sass-package-importer`](https://github.com/maoberlehner/node-sass-magic-importer), which will import packages relative to a local `node_modules` directory. This PR adds the metadata necessary for the importer to determine what the SASS and CSS entry points of the npm package are.

## Additional information
For example, here is Bootstrap's usage of these attributes: https://github.com/twbs/bootstrap/blob/v4-dev/package.json#L74-L75

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
