### PR TITLE
Add USWDS version number to Fractal

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -13,7 +13,7 @@ const context = {
   },
 };
 
-fractal.set('project.title', 'U.S. Web Design System');
+fractal.set('project.title', `U.S. Web Design System (v${pkg.version})`);
 
 const components = fractal.components;
 components.set('ext', '.njk');


### PR DESCRIPTION
Sometimes when deploying new versions it's not easy to tell if the Fractal component library has been updated to the latest version as expected. This adds the version number to the title of the Fractal site so it is clear what underlying `uswds` package is being used.

Fixes https://github.com/uswds/uswds/issues/2445

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/bh-fractal-version)