### PR TITLE
Fix line height and grid gap

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -336,7 +336,7 @@ a family and a line-height scale unit
   @else {
     $this-cap: map-get($project-cap-heights, $family);
     $this-line-height: map-get($uswds-line-height, $scale);
-    $normalized-line-height: ($this-cap / $uswds-base-cap-height) * $this-line-height;
+    $normalized-line-height:  $this-line-height / ($uswds-base-cap-height / $this-cap);
     @return $normalized-line-height;
   }
 };

--- a/src/stylesheets/core/_layout-grid.scss
+++ b/src/stylesheets/core/_layout-grid.scss
@@ -71,7 +71,7 @@ $grid-namespace-prefix: 'g-';
           }
         }
         @if $theme-column-gap-small {
-          &.#{$mq-key}\:#{$grid-namespace-prefix}gap-small {
+          &.#{$mq-key}\:#{$grid-namespace-prefix}gap-sm {
             @include u-margin-x(#{$neg-prefix}-#{calc-gap-offset($theme-column-gap-small)});
             > [class*='#{$grid-namespace-prefix}col'] {
               @include u-padding-x(calc-gap-offset($theme-column-gap-small));
@@ -79,7 +79,7 @@ $grid-namespace-prefix: 'g-';
           }
         }
         @if $theme-column-gap-large {
-          &.#{$mq-key}\:#{$grid-namespace-prefix}gap-large {
+          &.#{$mq-key}\:#{$grid-namespace-prefix}gap-lg {
             @include u-margin-x(#{$neg-prefix}-#{calc-gap-offset($theme-column-gap-large)});
             > [class*='#{$grid-namespace-prefix}col'] {
               @include u-padding-x(calc-gap-offset($theme-column-gap-large));

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -237,7 +237,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-mono'], .font-family-mono { font-family: $font-stack-mono; }
+  [class*='#{$namespace-prefix}mono'], .font-family-mono { font-family: $font-stack-mono; }
 }
 
 @if $theme-font-sans {
@@ -246,7 +246,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-sans'], .font-family-sans { font-family: $font-stack-sans; }
+  [class*='#{$namespace-prefix}sans'], .font-family-sans { font-family: $font-stack-sans; }
 }
 
 @if $theme-font-serif {
@@ -255,7 +255,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-serif'], .font-family-serif { font-family: $font-stack-serif; }
+  [class*='#{$namespace-prefix}serif'], .font-family-serif { font-family: $font-stack-serif; }
 }
 
 @if $theme-font-cond {
@@ -264,7 +264,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-cond'], .font-family-cond { font-family: $font-stack-cond; }
+  [class*='#{$namespace-prefix}cond'], .font-family-cond { font-family: $font-stack-cond; }
 }
 
 @if $theme-font-heading {
@@ -273,7 +273,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-heading'], .font-family-heading { font-family: $font-stack-heading; }
+  [class*='#{$namespace-prefix}heading'], .font-family-heading { font-family: $font-stack-heading; }
 }
 
 @if $theme-font-body {
@@ -282,7 +282,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-body'], .font-family-body { font-family: $font-stack-body; }
+  [class*='#{$namespace-prefix}body'], .font-family-body { font-family: $font-stack-body; }
 }
 
 @if $theme-font-code {
@@ -291,7 +291,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-code'], .font-family-code { font-family: $font-stack-code; }
+  [class*='#{$namespace-prefix}code'], .font-family-code { font-family: $font-stack-code; }
 }
 
 @if $theme-font-alt {
@@ -300,7 +300,7 @@ namespace var set in utilities-settings?
   @if $utilities-use-namespace {
     $namespace-prefix: map-get($uswds-namespace, 'utility');
   }
-  [class*='#{$namespace-prefix}font-alt'], .font-family-alt { font-family: $font-stack-alt; }
+  [class*='#{$namespace-prefix}alt'], .font-family-alt { font-family: $font-stack-alt; }
 }
 
 $project-font-weights: (


### PR DESCRIPTION
- Use a better line height calculation
- Target fonts using the new naming system
- Use `sm` and `lg` as grid gap modifiers