### PR TITLE
Utility package refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # ignore Node-specific files and directories
 node_modules/
 npm-debug.log*
+.gz
 
 # code coverage
 coverage/

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -105,7 +105,7 @@ Leaves bools as is
   @if type-of($value) == 'number' {
     @return inspect($value);
   }
-  @elseif type-of($value) == 'string' {
+  @elseif type-of($value) == 'string' or type-of($value) == 'color'{
     @return quote($value);
   }
   @else {
@@ -417,7 +417,8 @@ variable that is, itself, a list
     @return false;
   }
   @elseif length($props) == 1 {
-    @return map-get($uswds-colors, $props);
+    $props: smart-quote(nth($props, 1));
+    @return map-get($uswds-colors, smart-quote(nth($props, 1)));
   }
   @elseif length($props) == 2 {
     @return map-deep-get(

--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -471,7 +471,6 @@ $uswds-properties: (
       map-get($uswds-spacing, smaller),
       map-get($uswds-spacing, small),
       map-get($uswds-spacing, medium),
-      map-get($uswds-spacing-em, small),
       map-get($partial-values, zero-zero)
     ),
     extended: (),

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -76,15 +76,15 @@ used by utilities or layout grid
 */
 
 $theme-output-breakpoints: (
-  'card':            false,   // 160px
-  'card-plus':       false,   // 240px
-  'mobile':          false,   // 320px
-  'mobile-plus':     true,    // 480px
-  'tablet':          true,    // 640px
-  'tablet-plus':     false,   // 800px
-  'desktop':         true,    // 1040px
-  'desktop-plus':    false,   // 1200px
-  'widescreen':      false,   // 1400px
+  'card':             false,   // 160px
+  'card-lg':          false,   // 240px
+  'mobile':           false,   // 320px
+  'mobile-lg':        true,    // 480px
+  'tablet':           true,    // 640px
+  'tablet-lg':        false,   // 800px
+  'desktop':          true,    // 1040px
+  'desktop-lg':       false,   // 1200px
+  'widescreen':       false,   // 1400px
 ) !default;
 
 /*
@@ -232,13 +232,13 @@ Palette colors
 ----------------------------------------
 */
 
-$theme-color-neutral:             black !default;
-$theme-color-neutral-lightest:    white !default;
-$theme-color-neutral-lighter:     $theme-color-neutral, 5 !default;
-$theme-color-neutral-light:       $theme-color-neutral, 50 !default;
-$theme-color-neutral-base:        $theme-color-neutral, 80 !default;
-$theme-color-neutral-dark:        $theme-color-neutral, 90 !default;
-$theme-color-neutral-darker:      false !default;
+$theme-color-gray:                black !default;
+$theme-color-gray-lightest:       white !default;
+$theme-color-gray-lighter:        $theme-color-gray, 5 !default;
+$theme-color-gray-light:          $theme-color-gray, 50 !default;
+$theme-color-gray-base:           $theme-color-gray, 80 !default;
+$theme-color-gray-dark:           $theme-color-gray, 90 !default;
+$theme-color-gray-darker:         false !default;
 
 $theme-color-primary:             blue !default;
 $theme-color-primary-lighter:     $theme-color-primary, 10 !default;

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -19,15 +19,15 @@ $uswds-namespace: (
   ),
   'grid': (
     namespace:  'g-',
-    output:     true,
+    output:     false,
   ),
   'object': (
     namespace:  'o-',
-    output:     true,
+    output:     false,
   ),
   'utility': (
     namespace:  'u-',
-    output:     true,
+    output:     false,
   ),
 ) !default;
 

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -115,9 +115,9 @@ Units
 
 $uswds-spacing-em: (
  small: (
-   '0p5em':  .5em,
+   '05em':  .5em,
    '1em':        1em,
-   '1p5em':  1.5em,
+   '105em':  1.5em,
    '2em':        2em,
  ),
 );

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -261,13 +261,13 @@ $project-font-weights: (
 );
 
 $project-colors: (
-  neutral: (
-    lightest: get-uswds-color($theme-color-neutral-lightest),
-    lighter:  get-uswds-color($theme-color-neutral-lighter),
-    light:    get-uswds-color($theme-color-neutral-light),
-    base:     get-uswds-color($theme-color-neutral-base),
-    dark:     get-uswds-color($theme-color-neutral-dark),
-    darker:   get-uswds-color($theme-color-neutral-darker),
+  gray: (
+    lightest: get-uswds-color($theme-color-gray-lightest),
+    lighter:  get-uswds-color($theme-color-gray-lighter),
+    light:    get-uswds-color($theme-color-gray-light),
+    base:     get-uswds-color($theme-color-gray-base),
+    dark:     get-uswds-color($theme-color-gray-dark),
+    darker:   get-uswds-color($theme-color-gray-darker),
   ),
   primary: (
     lighter: get-uswds-color($theme-color-primary-lighter),
@@ -394,11 +394,12 @@ Color palettes
 */
 
 $color-palette-theme: (
-  'neutral-lighter':    get-uswds-color($theme-color-neutral-lighter),
-  'neutral-light':      get-uswds-color($theme-color-neutral-light),
-  'neutral':            get-uswds-color($theme-color-neutral-base),
-  'neutral-dark':       get-uswds-color($theme-color-neutral-dark),
-  'neutral-darker':     get-uswds-color($theme-color-neutral-darker),
+  'gray-lightest':      get-uswds-color($theme-color-gray-lightest),
+  'gray-lighter':       get-uswds-color($theme-color-gray-lighter),
+  'gray-light':         get-uswds-color($theme-color-gray-light),
+  'gray':               get-uswds-color($theme-color-gray-base),
+  'gray-dark':          get-uswds-color($theme-color-gray-dark),
+  'gray-darker':        get-uswds-color($theme-color-gray-darker),
   'primary-lighter':    get-uswds-color($theme-color-primary-lighter),
   'primary-light':      get-uswds-color($theme-color-primary-light),
   'primary':            get-uswds-color($theme-color-primary-base),

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -30,15 +30,15 @@ $uswds-namespace: (
   ),
   'grid': (
     namespace:  'g-',
-    output:     true,
+    output:     false,
   ),
   'object': (
     namespace:  'o-',
-    output:     true,
+    output:     false,
   ),
   'utility': (
     namespace:  'u-',
-    output:     true,
+    output:     false,
   ),
 );
 

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -243,13 +243,13 @@ Palette colors
 ----------------------------------------
 */
 
-$theme-color-neutral:             black;
-$theme-color-neutral-lightest:    white;
-$theme-color-neutral-lighter:     $theme-color-neutral, 5;
-$theme-color-neutral-light:       $theme-color-neutral, 50;
-$theme-color-neutral-base:        $theme-color-neutral, 80;
-$theme-color-neutral-dark:        $theme-color-neutral, 90;
-$theme-color-neutral-darker:      false;
+$theme-color-base:             black;
+$theme-color-base-lightest:    white;
+$theme-color-base-lighter:     $theme-color-base, 5;
+$theme-color-base-light:       $theme-color-base, 50;
+$theme-color-base-base:        $theme-color-base, 80;
+$theme-color-base-dark:        $theme-color-base, 90;
+$theme-color-base-darker:      false;
 
 $theme-color-primary:             blue;
 $theme-color-primary-lighter:     $theme-color-primary, 10;

--- a/src/stylesheets/project/_uswds-project-utilities-settings.scss
+++ b/src/stylesheets/project/_uswds-project-utilities-settings.scss
@@ -11,14 +11,12 @@ USWDS UTILITIES SETTINGS
 ----------------------------------------
 */
 
-$utilities-use-namespace:     true ;
 $utilities-use-important:     false;
-
-$output-all-utilities:        false;
+$output-all-utilities:        true;
 
 /*
 ----------------------------------------
-global colors
+Global colors
 ----------------------------------------
 The following plugins will be added to
 - background-color
@@ -30,41 +28,24 @@ The following plugins will be added to
 
 $global-color-plugins: (
   'plugin-color-palette-theme',
-  'plugin-color-black-all',
-  'plugin-color-palette-basic'
+  'plugin-color-palette-basic',
+  'plugin-color-black-all'
 );
 
 /*
-========================================
-.align-items
+----------------------------------------
+Settings
 ----------------------------------------
 */
 
 $align-items-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$align-items-plugins: (
-  /*
-  */
-  'plugin-standard-align-items'
-);
-
-$align-items-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.background-color
-----------------------------------------
-*/
 
 $background-color-settings: (
   output:       true,
@@ -75,126 +56,32 @@ $background-color-settings: (
   visited:      false
 );
 
-$background-color-plugins: (
-  /*
-  'plugin-color-[color]'
-  'plugin-color-[color]-light'
-  'plugin-color-[color]-medium'
-  'plugin-color-[color]-dark'
-  'plugin-color-[color]-light-vivid'
-  'plugin-color-[color]-medium-vivid'
-  'plugin-color-[color]-dark-vivid'
-  'plugin-color-[color]-standard'
-  'plugin-color-[color]-vivid'
-  'plugin-color-palette-status'
-  'plugin-standard-background-color',
-  */
-);
-
-$background-color-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.border (width and solid)
-----------------------------------------
-*/
-
 $border-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
 
-$border-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border',
-);
-
-$border-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.border-color
-----------------------------------------
-*/
-
 $border-color-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        true,
   visited:      false
 );
 
-$border-color-plugins: (
-  /*
-  'plugin-color-[color]'
-  'plugin-color-[color]-light'
-  'plugin-color-[color]-medium'
-  'plugin-color-[color]-dark'
-  'plugin-color-[color]-light-vivid'
-  'plugin-color-[color]-medium-vivid'
-  'plugin-color-[color]-dark-vivid'
-  'plugin-color-[color]-standard'
-  'plugin-color-[color]-vivid'
-  'plugin-color-palette-status'
-  'plugin-standard-border-color'
-  */
-);
-
-$border-color-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.border-radius
-----------------------------------------
-*/
-
 $border-radius-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$border-radius-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border-radius'
-);
-
-$border-radius-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.border-style
-----------------------------------------
-*/
 
 $border-style-settings: (
   output:       true,
@@ -205,24 +92,16 @@ $border-style-settings: (
   visited:      false
 );
 
-$border-style-plugins: (
-  /*
-  */
-  'plugin-standard-border-style'
-);
-
-$border-style-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.border-width
-----------------------------------------
-*/
-
 $border-width-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        true,
+  visited:      false
+);
+
+$bottom-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -230,88 +109,15 @@ $border-width-settings: (
   hover:        false,
   visited:      false
 );
-
-$border-width-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border-width',
-);
-
-$border-width-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.bottom
-----------------------------------------
-*/
-
-$bottom-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
-$bottom-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-bottom',
-);
-
-$bottom-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.box-shadow
-----------------------------------------
-*/
 
 $box-shadow-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
-
-$box-shadow-plugins: (
-  /*
-  */
-  'plugin-standard-box-shadow'
-);
-
-$box-shadow-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.circle
-----------------------------------------
-*/
 
 $circle-settings: (
   output:       true,
@@ -322,31 +128,6 @@ $circle-settings: (
   visited:      false
 );
 
-$circle-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  */
-  'plugin-standard-circle',
-);
-
-$circle-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.clearfix
-----------------------------------------
-*/
-
 $clearfix-settings: (
   output:       true,
   responsive:   false,
@@ -355,12 +136,6 @@ $clearfix-settings: (
   hover:        false,
   visited:      false
 );
-
-/*
-========================================
-.color
-----------------------------------------
-*/
 
 $color-settings: (
   output:       true,
@@ -371,34 +146,16 @@ $color-settings: (
   visited:      false
 );
 
-$color-plugins: (
-  /*
-  'plugin-[color]'
-  'plugin-[color]-light'
-  'plugin-[color]-medium'
-  'plugin-[color]-dark'
-  'plugin-[color]-light-vivid'
-  'plugin-[color]-medium-vivid'
-  'plugin-[color]-dark-vivid'
-  'plugin-[color]-standard'
-  'plugin-[color]-vivid'
-  'plugin-palette-status'
-  'plugin-standard-color'
-  */
-);
-
-$color-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.display
-----------------------------------------
-*/
-
 $display-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+);
+
+$flex-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -407,94 +164,23 @@ $display-settings: (
   visited:      false
 );
 
-$display-plugins: (
-  /*
-  */
-  'plugin-standard-display'
-);
-
-$display-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.flex
-----------------------------------------
-*/
-
-$flex-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
-$flex-plugins: (
-  /*
-  */
-  'plugin-standard-flex'
-);
-
-$flex-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.flex-direction
-----------------------------------------
-*/
-
 $flex-direction-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$flex-direction-plugins: (
-  'plugin-standard-flex-direction'
-);
-
-$flex-direction-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.flex-wrap
-----------------------------------------
-*/
 
 $flex-wrap-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$flex-wrap-plugins: (
-  'plugin-standard-flex-wrap'
-);
-
-$flex-wrap-manual-values: (
-);
-
-/*
-========================================
-.float
-----------------------------------------
-*/
 
 $float-settings: (
   output:       true,
@@ -505,56 +191,14 @@ $float-settings: (
   visited:      false
 );
 
-$float-plugins: (
-  'plugin-standard-float'
-);
-
-$float-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.font
-----------------------------------------
-*/
-
 $font-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$font-plugins: (
-  /*
-  'plugin-font-theme-mono-all'
-  'plugin-font-theme-sans-all'
-  'plugin-font-theme-serif-all'
-  'plugin-font-uswds-all'
-  'plugin-system-[family]-small'
-  'plugin-system-[family]-medium'
-  'plugin-system-[family]-large'
-  'plugin-system-[family]-xlarge'
-  'plugin-system-[family]-all'
-  */
-  'plugin-font-theme-all',
-  'plugin-font-theme-roles-all'
-);
-
-$font-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.font-family
-----------------------------------------
-*/
 
 $font-family-settings: (
   output:       true,
@@ -565,48 +209,14 @@ $font-family-settings: (
   visited:      false
 );
 
-$font-family-plugins: (
-  /*
-  */
-  'plugin-standard-font-family'
-);
-
-$font-family-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.font-feature-settings
-----------------------------------------
-*/
-
 $font-feature-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$font-feature-plugins: (
-  /*
-  */
-  'plugin-standard-font-feature-settings'
-);
-
-$font-feature-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.font-style
-----------------------------------------
-*/
 
 $font-style-settings: (
   output:       true,
@@ -617,20 +227,16 @@ $font-style-settings: (
   visited:      false
 );
 
-$font-style-plugins: (
-  'plugin-standard-font-style'
-);
-
-$font-style-manual-values: (
-);
-
-/*
-========================================
-.font-weight
-----------------------------------------
-*/
-
 $font-weight-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+);
+
+$height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -639,132 +245,23 @@ $font-weight-settings: (
   visited:      false
 );
 
-$font-weight-plugins: (
-  /*
-  'plugin-font-weights-numeric'
-  */
-  'plugin-standard-font-weight'
-);
-
-$font-weight-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.height
-----------------------------------------
-*/
-
-$height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
-$height-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  */
-  'plugin-standard-height'
-);
-
-$height-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.justify-content
-----------------------------------------
-*/
-
 $justify-content-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$justify-content-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-justify-content'
-);
-
-$justify-content-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.left
-----------------------------------------
-*/
 
 $left-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$left-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-left'
-);
-
-$left-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.letter-spacing
-----------------------------------------
-*/
 
 $letter-spacing-settings: (
   output:       true,
@@ -775,48 +272,14 @@ $letter-spacing-settings: (
   visited:      false
 );
 
-$letter-spacing-plugins: (
-  /*
-  */
-  'plugin-standard-letter-spacing'
-);
-
-$letter-spacing-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.line-height
-----------------------------------------
-*/
-
 $line-height-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$line-height-plugins: (
-  /*
-  */
-  'plugin-standard-line-height'
-);
-
-$line-height-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.list-reset
-----------------------------------------
-*/
 
 $list-reset-settings: (
   output:       true,
@@ -827,13 +290,16 @@ $list-reset-settings: (
   visited:      false
 );
 
-/*
-========================================
-.margin
-----------------------------------------
-*/
-
 $margin-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+);
+
+$max-height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -841,74 +307,6 @@ $margin-settings: (
   hover:        false,
   visited:      false
 );
-
-$margin-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller',
-  'plugin-spacing-uswds-smaller-negative',
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-negative',
-  'plugin-spacing-units-ch',
-  'plugin-spacing-units-ch-negative',
-  'plugin-spacing-units-em'
-  */
-  'plugin-standard-margin'
-);
-
-$margin-manual-values: (
-  /*
-  */
-);
-
-$margin-vertical-plugins: (
-  'plugin-standard-margin-vertical'
-);
-
-$margin-vertical-manual-values: (
-);
-
-$margin-horizontal-plugins: (
-  'plugin-standard-margin-horizontal'
-);
-
-$margin-horizontal-manual-values: (
-);
-
-/*
-========================================
-.max-height
-----------------------------------------
-*/
-
-$max-height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
-$max-height-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller'
-  */
-  'plugin-standard-max-height'
-);
-
-$max-height-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.max-width
-----------------------------------------
-*/
 
 $max-width-settings: (
   output:       true,
@@ -919,26 +317,16 @@ $max-width-settings: (
   visited:      false
 );
 
-$max-width-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-breakpoints'
-  */
-  'plugin-standard-max-width'
-);
-
-$max-width-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.measure
-----------------------------------------
-*/
-
 $measure-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+);
+
+$min-height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -947,353 +335,95 @@ $measure-settings: (
   visited:      false
 );
 
-$measure-plugins: (
-  /*
-  */
-  'plugin-standard-measure'
-);
-
-$measure-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.min-height
-----------------------------------------
-*/
-
-$min-height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
-
-$min-height-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-min-height'
-);
-
-$min-height-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.min-width
-----------------------------------------
-*/
-
 $min-width-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$min-width-plugins: (
-  /*
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller-negative',
-  'plugin-spacing-units-em',
-  'plugin-spacing-units-ch'
-  'plugin-spacing-units-percentage'
-  */
-  'plugin-standard-min-width'
-);
-
-$min-width-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.opacity
-----------------------------------------
-*/
 
 $opacity-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$opacity-plugins: (
-  /*
-  */
-  'plugin-standard-opacity'
-);
-
-$opacity-manual-values: (
-  /*
-  '0':            '0',
-  '01':           '0.1',
-  '02':           '0.2',
-  '03':           '0.3',
-  '04':           '0.4',
-  '05':           '0.5',
-  '06':           '0.6',
-  '07':           '0.7',
-  '08':           '0.8',
-  '09':           '0.9',
-  '1':            '1',
-  */
-);
-
-/*
-========================================
-.order
-----------------------------------------
-*/
 
 $order-settings: (
-  output:       false,
-  responsive:   false,
+  output:       true,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$order-plugins: (
-  /*
-  */
-  'plugin-standard-order'
-);
-
-$order-manual-values: (
-  /*
-  0:            0,
-  1:            1,
-  2:            2,
-  3:            3,
-  4:            4,
-  5:            5,
-  6:            6,
-  7:            7,
-  8:            8,
-  9:            9,
-  10:           10,
-  11:           11,
-  */
-  first:        '-1',
-  last:         '99'
-);
-
-/*
-========================================
-.outline
-----------------------------------------
-*/
 
 $outline-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$outline-plugins: (
-  /*
-  */
-  'plugin-standard-outline'
-);
-
-$outline-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.outline-color
-----------------------------------------
-*/
 
 $outline-color-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$outline-color-plugins: (
-  /*
-  */
-  'plugin-standard-outline-color'
-);
-
-$outline-color-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.overflow
-----------------------------------------
-*/
 
 $overflow-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$overflow-plugins: (
-  /*
-  */
-  'plugin-standard-overflow'
-);
-
-$overflow-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.padding
-----------------------------------------
-*/
 
 $padding-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$padding-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller',
-  */
-  'plugin-standard-padding'
-);
-
-$padding-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.position
-----------------------------------------
-*/
 
 $position-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$position-plugins: (
-  /*
-  */
-  'plugin-standard-position'
-);
-
-$position-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.right
-----------------------------------------
-*/
 
 $right-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$right-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-right'
-);
-
-$right-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.square
-----------------------------------------
-*/
 
 $square-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$square-plugins: (
-  /*
-  */
-  'plugin-standard-square'
-);
-
-$square-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.text-align
-----------------------------------------
-*/
 
 $text-align-settings: (
   output:       true,
@@ -1304,101 +434,32 @@ $text-align-settings: (
   visited:      false
 );
 
-$text-align-plugins: (
-  /*
-  */
-  'plugin-standard-text-align'
-);
-
-$text-align-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.text-decoration
-----------------------------------------
-*/
-
 $text-decoration-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
-
-$text-decoration-plugins: (
-  /*
-  */
-  'plugin-standard-text-decoration'
-);
-
-$text-decoration-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.text-decoration-color
-----------------------------------------
-*/
 
 $text-decoration-color-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 );
 
-$text-decoration-color-plugins: (
-  /*
-  'plugin-color-palette-grayscale'
-  'plugin-standard-text-decoration-color'
-  */
-);
-
-$text-decoration-color-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.text-indent
-----------------------------------------
-*/
-
 $text-indent-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$text-indent-plugins: (
-  /*
-  */
-  'plugin-standard-text-indent'
-);
-
-$text-indent-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.text-transform
-----------------------------------------
-*/
 
 $text-transform-settings: (
   output:       true,
@@ -1409,114 +470,35 @@ $text-transform-settings: (
   visited:      false
 );
 
-$text-transform-plugins: (
-  /*
-  */
-  'plugin-standard-text-transform'
-);
-
-$text-transform-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.top
-----------------------------------------
-*/
-
 $top-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$top-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-top'
-);
-
-$top-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.vertical-align
-----------------------------------------
-*/
 
 $vertical-align-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$vertical-align-plugins: (
-  /*
-  */
-  'plugin-standard-vertical-align'
-);
-
-$vertical-align-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.white-space
-----------------------------------------
-*/
 
 $whitespace-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 );
-
-$whitespace-plugins: (
-  /*
-  */
-  'plugin-standard-white-space'
-);
-
-$whitespace-manual-values: (
-  /*
-  */
-);
-
-/*
-========================================
-.width
-----------------------------------------
-*/
 
 $width-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
@@ -1524,45 +506,286 @@ $width-settings: (
   visited:      false
 );
 
-$width-plugins: (
-  /*
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller',
-  'plugin-spacing-units-em',
-  'plugin-spacing-units-ch'
-  'plugin-spacing-units-percentage'
-  */
-  'plugin-standard-width'
-);
-
-$width-manual-values: (
-  /*
-  100ct:        '100%'
-  */
+$z-index-settings: (
+  output:       true,
+  responsive:   false,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
 );
 
 /*
-========================================
-.z-index
+----------------------------------------
+Values
 ----------------------------------------
 */
 
-$z-index-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-);
+// .align-items
 
-$z-index-plugins: (
+$align-items-plugins: ( 'plugin-standard-align-items' );
+$align-items-manual-values: ();
+
+// .background-color
+
+$background-color-plugins: ();
+$background-color-manual-values: ();
+
+// .border
+
+$border-plugins: ( 'plugin-standard-border' );
+$border-manual-values: ();
+
+// .border-color
+
+$border-color-plugins: ();
+$border-color-manual-values: ();
+
+// .border-radius
+
+$border-radius-plugins: ( 'plugin-standard-border-radius' );
+$border-radius-manual-values: ();
+
+// .border-style
+
+$border-style-plugins: ( 'plugin-standard-border-style' );
+$border-style-manual-values: ();
+
+// .border-width
+
+$border-width-plugins: ( 'plugin-standard-border-width' );
+$border-width-manual-values: ();
+
+// .bottom
+
+$bottom-plugins: ( 'plugin-standard-bottom' );
+
+$bottom-manual-values: ();
+
+// .box-shadow
+
+$box-shadow-plugins: (
   /*
   */
-  'plugin-standard-z-index'
+  'plugin-standard-box-shadow'
 );
 
-$z-index-manual-values: (
-  /*
-  */
+$box-shadow-manual-values: ();
+
+// .circle
+
+$circle-plugins: ( 'plugin-standard-circle' );
+$circle-manual-values: ();
+
+// .color
+
+$color-plugins: ();
+$color-manual-values: ();
+
+// .display
+
+$display-plugins: ( 'plugin-standard-display' );
+$display-manual-values: ();
+
+// .flex
+
+$flex-plugins: ( 'plugin-standard-flex' );
+$flex-manual-values: ();
+
+// .flex-direction
+
+$flex-direction-plugins: ( 'plugin-standard-flex-direction' );
+$flex-direction-manual-values: ();
+
+// .flex-wrap
+
+$flex-wrap-plugins: ( 'plugin-standard-flex-wrap' );
+$flex-wrap-manual-values: ();
+
+// .float
+
+$float-plugins: ( 'plugin-standard-float' );
+$float-manual-values: ();
+
+// .font
+
+$font-plugins: (
+  'plugin-font-theme-all',
+  'plugin-font-theme-roles-all'
 );
+$font-manual-values: ();
+
+// .font-family
+
+$font-family-plugins: ( 'plugin-standard-font-family' );
+$font-family-manual-values: ();
+
+// .font-feature-settings
+
+$font-feature-plugins: ( 'plugin-standard-font-feature-settings' );
+$font-feature-manual-values: ();
+
+// .font-style
+
+$font-style-plugins: ( 'plugin-standard-font-style' );
+$font-style-manual-values: ();
+
+// .font-weight
+
+$font-weight-plugins: ( 'plugin-standard-font-weight' );
+$font-weight-manual-values: ();
+
+// .height
+
+$height-plugins: ( 'plugin-standard-height' );
+$height-manual-values: ();
+
+// .justify-content
+
+$justify-content-plugins: ( 'plugin-standard-justify-content' );
+$justify-content-manual-values: ();
+
+// .left
+
+$left-plugins: ( 'plugin-standard-left' );
+$left-manual-values: ();
+
+// .letter-spacing
+
+$letter-spacing-plugins: ( 'plugin-standard-letter-spacing' );
+$letter-spacing-manual-values: ();
+
+// .line-height
+
+$line-height-plugins: ( 'plugin-standard-line-height' );
+$line-height-manual-values: ();
+
+// .margin
+
+$margin-plugins: ( 'plugin-standard-margin' );
+$margin-manual-values: ();
+$margin-vertical-plugins: ( 'plugin-standard-margin-vertical' );
+$margin-vertical-manual-values: ();
+$margin-horizontal-plugins: ( 'plugin-standard-margin-horizontal' );
+$margin-horizontal-manual-values: ();
+
+// .max-height
+
+$max-height-plugins: ( 'plugin-standard-max-height' );
+$max-height-manual-values: ();
+
+// .max-width
+
+$max-width-plugins: ( 'plugin-standard-max-width' );
+$max-width-manual-values: ();
+
+// .measure
+
+$measure-plugins: ( 'plugin-standard-measure' );
+$measure-manual-values: ();
+
+// .min-height
+
+$min-height-plugins: ( 'plugin-standard-min-height' );
+$min-height-manual-values: ();
+
+// .min-width
+
+$min-width-plugins: ( 'plugin-standard-min-width' );
+$min-width-manual-values: ();
+
+// .opacity
+
+$opacity-plugins: ( 'plugin-standard-opacity' );
+$opacity-manual-values: ();
+
+// .order
+
+$order-plugins: ( 'plugin-standard-order' );
+$order-manual-values: ();
+
+// .outline
+
+$outline-plugins: ( 'plugin-standard-outline' );
+$outline-manual-values: ();
+
+// .outline-color
+
+$outline-color-plugins: ( 'plugin-standard-outline-color' );
+$outline-color-manual-values: ();
+
+// .overflow
+
+$overflow-plugins: ( 'plugin-standard-overflow' );
+$overflow-manual-values: ();
+
+// .padding
+
+$padding-plugins: ( 'plugin-standard-padding' );
+$padding-manual-values: ();
+
+// .position
+
+$position-plugins: ( 'plugin-standard-position' );
+$position-manual-values: ();
+
+// .right
+
+$right-plugins: ( 'plugin-standard-right' );
+$right-manual-values: ();
+
+// .square
+
+$square-plugins: ( 'plugin-standard-square' );
+$square-manual-values: ();
+
+// .text-align
+
+$text-align-plugins: ( 'plugin-standard-text-align' );
+$text-align-manual-values: ();
+
+// .text-decoration
+
+$text-decoration-plugins: ( 'plugin-standard-text-decoration' );
+$text-decoration-manual-values: ();
+
+// .text-decoration-color
+
+$text-decoration-color-plugins: ();
+$text-decoration-color-manual-values: ();
+
+// .text-indent
+
+$text-indent-plugins: ( 'plugin-standard-text-indent' );
+$text-indent-manual-values: ();
+
+// .text-transform
+
+$text-transform-plugins: ( 'plugin-standard-text-transform' );
+$text-transform-manual-values: ();
+
+// .top
+
+
+$top-plugins: ( 'plugin-standard-top' );
+$top-manual-values: ();
+
+// .vertical-align
+
+$vertical-align-plugins: ( 'plugin-standard-vertical-align' );
+$vertical-align-manual-values: ();
+
+// .white-space
+
+$whitespace-plugins: ( 'plugin-standard-white-space' );
+$whitespace-manual-values: ();
+
+// .width
+
+$width-plugins: ( 'plugin-standard-width' );
+$width-manual-values: ();
+
+// .z-index
+
+$z-index-plugins: ( 'plugin-standard-z-index' );
+$z-index-manual-values: ();

--- a/src/stylesheets/utilities/_utilities-settings.scss
+++ b/src/stylesheets/utilities/_utilities-settings.scss
@@ -1,15 +1,22 @@
 /*
+* * * * * ==============================
+* * * * * ==============================
+* * * * * ==============================
+* * * * * ==============================
 ========================================
+========================================
+========================================
+----------------------------------------
 USWDS UTILITIES SETTINGS
 ----------------------------------------
 */
 
 $utilities-use-important:     false !default;
-$output-all-utilities:        false !default;
+$output-all-utilities:        true !default;
 
 /*
 ----------------------------------------
-global colors
+Global colors
 ----------------------------------------
 The following plugins will be added to
 - background-color
@@ -21,41 +28,24 @@ The following plugins will be added to
 
 $global-color-plugins: (
   'plugin-color-palette-theme',
-  'plugin-color-black-all',
-  'plugin-color-palette-basic'
+  'plugin-color-palette-basic',
+  'plugin-color-black-all'
 ) !default;
 
 /*
-========================================
-.align-items
+----------------------------------------
+Settings
 ----------------------------------------
 */
 
 $align-items-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$align-items-plugins: (
-  /*
-  */
-  'plugin-standard-align-items'
-) !default;
-
-$align-items-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.background-color
-----------------------------------------
-*/
 
 $background-color-settings: (
   output:       true,
@@ -66,126 +56,32 @@ $background-color-settings: (
   visited:      false
 ) !default;
 
-$background-color-plugins: (
-  /*
-  'plugin-color-[color]'
-  'plugin-color-[color]-light'
-  'plugin-color-[color]-medium'
-  'plugin-color-[color]-dark'
-  'plugin-color-[color]-light-vivid'
-  'plugin-color-[color]-medium-vivid'
-  'plugin-color-[color]-dark-vivid'
-  'plugin-color-[color]-standard'
-  'plugin-color-[color]-vivid'
-  'plugin-color-palette-status'
-  'plugin-standard-background-color',
-  */
-) !default;
-
-$background-color-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.border (width and solid)
-----------------------------------------
-*/
-
 $border-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
 
-$border-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border',
-) !default;
-
-$border-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.border-color
-----------------------------------------
-*/
-
 $border-color-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        true,
   visited:      false
 ) !default;
 
-$border-color-plugins: (
-  /*
-  'plugin-color-[color]'
-  'plugin-color-[color]-light'
-  'plugin-color-[color]-medium'
-  'plugin-color-[color]-dark'
-  'plugin-color-[color]-light-vivid'
-  'plugin-color-[color]-medium-vivid'
-  'plugin-color-[color]-dark-vivid'
-  'plugin-color-[color]-standard'
-  'plugin-color-[color]-vivid'
-  'plugin-color-palette-status'
-  'plugin-standard-border-color'
-  */
-) !default;
-
-$border-color-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.border-radius
-----------------------------------------
-*/
-
 $border-radius-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$border-radius-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border-radius'
-) !default;
-
-$border-radius-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.border-style
-----------------------------------------
-*/
 
 $border-style-settings: (
   output:       true,
@@ -196,24 +92,16 @@ $border-style-settings: (
   visited:      false
 ) !default;
 
-$border-style-plugins: (
-  /*
-  */
-  'plugin-standard-border-style'
-) !default;
-
-$border-style-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.border-width
-----------------------------------------
-*/
-
 $border-width-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        true,
+  visited:      false
+) !default;
+
+$bottom-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -221,88 +109,15 @@ $border-width-settings: (
   hover:        false,
   visited:      false
 ) !default;
-
-$border-width-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-border-width',
-) !default;
-
-$border-width-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.bottom
-----------------------------------------
-*/
-
-$bottom-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
-
-$bottom-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-bottom',
-) !default;
-
-$bottom-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.box-shadow
-----------------------------------------
-*/
 
 $box-shadow-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
-
-$box-shadow-plugins: (
-  /*
-  */
-  'plugin-standard-box-shadow'
-) !default;
-
-$box-shadow-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.circle
-----------------------------------------
-*/
 
 $circle-settings: (
   output:       true,
@@ -313,31 +128,6 @@ $circle-settings: (
   visited:      false
 ) !default;
 
-$circle-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  */
-  'plugin-standard-circle',
-) !default;
-
-$circle-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.clearfix
-----------------------------------------
-*/
-
 $clearfix-settings: (
   output:       true,
   responsive:   false,
@@ -346,12 +136,6 @@ $clearfix-settings: (
   hover:        false,
   visited:      false
 ) !default;
-
-/*
-========================================
-.color
-----------------------------------------
-*/
 
 $color-settings: (
   output:       true,
@@ -362,34 +146,16 @@ $color-settings: (
   visited:      false
 ) !default;
 
-$color-plugins: (
-  /*
-  'plugin-[color]'
-  'plugin-[color]-light'
-  'plugin-[color]-medium'
-  'plugin-[color]-dark'
-  'plugin-[color]-light-vivid'
-  'plugin-[color]-medium-vivid'
-  'plugin-[color]-dark-vivid'
-  'plugin-[color]-standard'
-  'plugin-[color]-vivid'
-  'plugin-palette-status'
-  'plugin-standard-color'
-  */
-) !default;
-
-$color-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.display
-----------------------------------------
-*/
-
 $display-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+) !default;
+
+$flex-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -398,94 +164,23 @@ $display-settings: (
   visited:      false
 ) !default;
 
-$display-plugins: (
-  /*
-  */
-  'plugin-standard-display'
-) !default;
-
-$display-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.flex
-----------------------------------------
-*/
-
-$flex-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
-
-$flex-plugins: (
-  /*
-  */
-  'plugin-standard-flex'
-) !default;
-
-$flex-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.flex-direction
-----------------------------------------
-*/
-
 $flex-direction-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$flex-direction-plugins: (
-  'plugin-standard-flex-direction'
-) !default;
-
-$flex-direction-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.flex-wrap
-----------------------------------------
-*/
 
 $flex-wrap-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$flex-wrap-plugins: (
-  'plugin-standard-flex-wrap'
-) !default;
-
-$flex-wrap-manual-values: (
-) !default;
-
-/*
-========================================
-.float
-----------------------------------------
-*/
 
 $float-settings: (
   output:       true,
@@ -496,56 +191,14 @@ $float-settings: (
   visited:      false
 ) !default;
 
-$float-plugins: (
-  'plugin-standard-float'
-) !default;
-
-$float-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.font
-----------------------------------------
-*/
-
 $font-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$font-plugins: (
-  /*
-  'plugin-font-theme-mono-all'
-  'plugin-font-theme-sans-all'
-  'plugin-font-theme-serif-all'
-  'plugin-font-uswds-all'
-  'plugin-system-[family]-small'
-  'plugin-system-[family]-medium'
-  'plugin-system-[family]-large'
-  'plugin-system-[family]-xlarge'
-  'plugin-system-[family]-all'
-  */
-  'plugin-font-theme-all',
-  'plugin-font-theme-roles-all'
-) !default;
-
-$font-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.font-family
-----------------------------------------
-*/
 
 $font-family-settings: (
   output:       true,
@@ -556,48 +209,14 @@ $font-family-settings: (
   visited:      false
 ) !default;
 
-$font-family-plugins: (
-  /*
-  */
-  'plugin-standard-font-family'
-) !default;
-
-$font-family-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.font-feature-settings
-----------------------------------------
-*/
-
 $font-feature-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$font-feature-plugins: (
-  /*
-  */
-  'plugin-standard-font-feature-settings'
-) !default;
-
-$font-feature-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.font-style
-----------------------------------------
-*/
 
 $font-style-settings: (
   output:       true,
@@ -608,20 +227,16 @@ $font-style-settings: (
   visited:      false
 ) !default;
 
-$font-style-plugins: (
-  'plugin-standard-font-style'
-) !default;
-
-$font-style-manual-values: (
-) !default;
-
-/*
-========================================
-.font-weight
-----------------------------------------
-*/
-
 $font-weight-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+) !default;
+
+$height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -630,132 +245,23 @@ $font-weight-settings: (
   visited:      false
 ) !default;
 
-$font-weight-plugins: (
-  /*
-  'plugin-font-weights-numeric'
-  */
-  'plugin-standard-font-weight'
-) !default;
-
-$font-weight-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.height
-----------------------------------------
-*/
-
-$height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
-
-$height-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  */
-  'plugin-standard-height'
-) !default;
-
-$height-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.justify-content
-----------------------------------------
-*/
-
 $justify-content-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$justify-content-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-justify-content'
-) !default;
-
-$justify-content-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.left
-----------------------------------------
-*/
 
 $left-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$left-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-left'
-) !default;
-
-$left-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.letter-spacing
-----------------------------------------
-*/
 
 $letter-spacing-settings: (
   output:       true,
@@ -766,48 +272,14 @@ $letter-spacing-settings: (
   visited:      false
 ) !default;
 
-$letter-spacing-plugins: (
-  /*
-  */
-  'plugin-standard-letter-spacing'
-) !default;
-
-$letter-spacing-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.line-height
-----------------------------------------
-*/
-
 $line-height-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$line-height-plugins: (
-  /*
-  */
-  'plugin-standard-line-height'
-) !default;
-
-$line-height-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.list-reset
-----------------------------------------
-*/
 
 $list-reset-settings: (
   output:       true,
@@ -818,13 +290,16 @@ $list-reset-settings: (
   visited:      false
 ) !default;
 
-/*
-========================================
-.margin
-----------------------------------------
-*/
-
 $margin-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+) !default;
+
+$max-height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -832,74 +307,6 @@ $margin-settings: (
   hover:        false,
   visited:      false
 ) !default;
-
-$margin-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller',
-  'plugin-spacing-uswds-smaller-negative',
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-negative',
-  'plugin-spacing-units-ch',
-  'plugin-spacing-units-ch-negative',
-  'plugin-spacing-units-em'
-  */
-  'plugin-standard-margin'
-) !default;
-
-$margin-manual-values: (
-  /*
-  */
-) !default;
-
-$margin-vertical-plugins: (
-  'plugin-standard-margin-vertical'
-) !default;
-
-$margin-vertical-manual-values: (
-) !default;
-
-$margin-horizontal-plugins: (
-  'plugin-standard-margin-horizontal'
-) !default;
-
-$margin-horizontal-manual-values: (
-) !default;
-
-/*
-========================================
-.max-height
-----------------------------------------
-*/
-
-$max-height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
-
-$max-height-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller'
-  */
-  'plugin-standard-max-height'
-) !default;
-
-$max-height-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.max-width
-----------------------------------------
-*/
 
 $max-width-settings: (
   output:       true,
@@ -910,26 +317,16 @@ $max-width-settings: (
   visited:      false
 ) !default;
 
-$max-width-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-breakpoints'
-  */
-  'plugin-standard-max-width'
-) !default;
-
-$max-width-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.measure
-----------------------------------------
-*/
-
 $measure-settings: (
+  output:       true,
+  responsive:   true,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
+) !default;
+
+$min-height-settings: (
   output:       true,
   responsive:   false,
   active:       false,
@@ -938,353 +335,95 @@ $measure-settings: (
   visited:      false
 ) !default;
 
-$measure-plugins: (
-  /*
-  */
-  'plugin-standard-measure'
-) !default;
-
-$measure-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.min-height
-----------------------------------------
-*/
-
-$min-height-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
-
-$min-height-plugins: (
-  /*
-  'plugin-spacing-units-percentage',
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  */
-  'plugin-standard-min-height'
-) !default;
-
-$min-height-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.min-width
-----------------------------------------
-*/
-
 $min-width-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$min-width-plugins: (
-  /*
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller-negative',
-  'plugin-spacing-units-em',
-  'plugin-spacing-units-ch'
-  'plugin-spacing-units-percentage'
-  */
-  'plugin-standard-min-width'
-) !default;
-
-$min-width-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.opacity
-----------------------------------------
-*/
 
 $opacity-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$opacity-plugins: (
-  /*
-  */
-  'plugin-standard-opacity'
-) !default;
-
-$opacity-manual-values: (
-  /*
-  '0':            '0',
-  '01':           '0.1',
-  '02':           '0.2',
-  '03':           '0.3',
-  '04':           '0.4',
-  '05':           '0.5',
-  '06':           '0.6',
-  '07':           '0.7',
-  '08':           '0.8',
-  '09':           '0.9',
-  '1':            '1',
-  */
-) !default;
-
-/*
-========================================
-.order
-----------------------------------------
-*/
 
 $order-settings: (
-  output:       false,
-  responsive:   false,
+  output:       true,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$order-plugins: (
-  /*
-  */
-  'plugin-standard-order'
-) !default;
-
-$order-manual-values: (
-  /*
-  0:            0,
-  1:            1,
-  2:            2,
-  3:            3,
-  4:            4,
-  5:            5,
-  6:            6,
-  7:            7,
-  8:            8,
-  9:            9,
-  10:           10,
-  11:           11,
-  */
-  first:        '-1',
-  last:         '99'
-) !default;
-
-/*
-========================================
-.outline
-----------------------------------------
-*/
 
 $outline-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$outline-plugins: (
-  /*
-  */
-  'plugin-standard-outline'
-) !default;
-
-$outline-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.outline-color
-----------------------------------------
-*/
 
 $outline-color-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$outline-color-plugins: (
-  /*
-  */
-  'plugin-standard-outline-color'
-) !default;
-
-$outline-color-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.overflow
-----------------------------------------
-*/
 
 $overflow-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$overflow-plugins: (
-  /*
-  */
-  'plugin-standard-overflow'
-) !default;
-
-$overflow-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.padding
-----------------------------------------
-*/
 
 $padding-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$padding-plugins: (
-  /*
-  'plugin-spacing-uswds-smaller',
-  */
-  'plugin-standard-padding'
-) !default;
-
-$padding-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.position
-----------------------------------------
-*/
 
 $position-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$position-plugins: (
-  /*
-  */
-  'plugin-standard-position'
-) !default;
-
-$position-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.right
-----------------------------------------
-*/
 
 $right-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$right-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-right'
-) !default;
-
-$right-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.square
-----------------------------------------
-*/
 
 $square-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$square-plugins: (
-  /*
-  */
-  'plugin-standard-square'
-) !default;
-
-$square-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.text-align
-----------------------------------------
-*/
 
 $text-align-settings: (
   output:       true,
@@ -1295,101 +434,32 @@ $text-align-settings: (
   visited:      false
 ) !default;
 
-$text-align-plugins: (
-  /*
-  */
-  'plugin-standard-text-align'
-) !default;
-
-$text-align-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.text-decoration
-----------------------------------------
-*/
-
 $text-decoration-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
-
-$text-decoration-plugins: (
-  /*
-  */
-  'plugin-standard-text-decoration'
-) !default;
-
-$text-decoration-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.text-decoration-color
-----------------------------------------
-*/
 
 $text-decoration-color-settings: (
   output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
-  hover:        false,
+  hover:        true,
   visited:      false
 ) !default;
 
-$text-decoration-color-plugins: (
-  /*
-  'plugin-color-palette-grayscale'
-  'plugin-standard-text-decoration-color'
-  */
-) !default;
-
-$text-decoration-color-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.text-indent
-----------------------------------------
-*/
-
 $text-indent-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$text-indent-plugins: (
-  /*
-  */
-  'plugin-standard-text-indent'
-) !default;
-
-$text-indent-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.text-transform
-----------------------------------------
-*/
 
 $text-transform-settings: (
   output:       true,
@@ -1400,114 +470,35 @@ $text-transform-settings: (
   visited:      false
 ) !default;
 
-$text-transform-plugins: (
-  /*
-  */
-  'plugin-standard-text-transform'
-) !default;
-
-$text-transform-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.top
-----------------------------------------
-*/
-
 $top-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$top-plugins: (
-  /*
-  'plugin-spacing-uswds-small'
-  'plugin-spacing-uswds-medium'
-  'plugin-spacing-uswds-large'
-  'plugin-spacing-uswds-xlarge'
-  'plugin-spacing-uswds-all'
-  'plugin-spacing-uswds-smaller-negative'
-  'plugin-spacing-uswds-medium-negative'
-  'plugin-spacing-uswds-negative'
-  'plugin-spacing-units-percentage'
-  'plugin-spacing-uswds-smaller'
-  'plugin-spacing-uswds-smaller-negative'
-  */
-  'plugin-standard-top'
-) !default;
-
-$top-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.vertical-align
-----------------------------------------
-*/
 
 $vertical-align-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$vertical-align-plugins: (
-  /*
-  */
-  'plugin-standard-vertical-align'
-) !default;
-
-$vertical-align-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.white-space
-----------------------------------------
-*/
 
 $whitespace-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
   hover:        false,
   visited:      false
 ) !default;
-
-$whitespace-plugins: (
-  /*
-  */
-  'plugin-standard-white-space'
-) !default;
-
-$whitespace-manual-values: (
-  /*
-  */
-) !default;
-
-/*
-========================================
-.width
-----------------------------------------
-*/
 
 $width-settings: (
-  output:       false,
+  output:       true,
   responsive:   false,
   active:       false,
   focus:        false,
@@ -1515,45 +506,286 @@ $width-settings: (
   visited:      false
 ) !default;
 
-$width-plugins: (
-  /*
-  'plugin-spacing-uswds-all',
-  'plugin-spacing-uswds-smaller',
-  'plugin-spacing-units-em',
-  'plugin-spacing-units-ch'
-  'plugin-spacing-units-percentage'
-  */
-  'plugin-standard-width'
-) !default;
-
-$width-manual-values: (
-  /*
-  100ct:        '100%'
-  */
+$z-index-settings: (
+  output:       true,
+  responsive:   false,
+  active:       false,
+  focus:        false,
+  hover:        false,
+  visited:      false
 ) !default;
 
 /*
-========================================
-.z-index
+----------------------------------------
+Values
 ----------------------------------------
 */
 
-$z-index-settings: (
-  output:       false,
-  responsive:   false,
-  active:       false,
-  focus:        false,
-  hover:        false,
-  visited:      false
-) !default;
+// .align-items
 
-$z-index-plugins: (
+$align-items-plugins: ( 'plugin-standard-align-items' ) !default;
+$align-items-manual-values: () !default;
+
+// .background-color
+
+$background-color-plugins: () !default;
+$background-color-manual-values: () !default;
+
+// .border
+
+$border-plugins: ( 'plugin-standard-border' ) !default;
+$border-manual-values: () !default;
+
+// .border-color
+
+$border-color-plugins: () !default;
+$border-color-manual-values: () !default;
+
+// .border-radius
+
+$border-radius-plugins: ( 'plugin-standard-border-radius' ) !default;
+$border-radius-manual-values: () !default;
+
+// .border-style
+
+$border-style-plugins: ( 'plugin-standard-border-style' ) !default;
+$border-style-manual-values: () !default;
+
+// .border-width
+
+$border-width-plugins: ( 'plugin-standard-border-width' ) !default;
+$border-width-manual-values: () !default;
+
+// .bottom
+
+$bottom-plugins: ( 'plugin-standard-bottom' ) !default;
+
+$bottom-manual-values: () !default;
+
+// .box-shadow
+
+$box-shadow-plugins: (
   /*
   */
-  'plugin-standard-z-index'
+  'plugin-standard-box-shadow'
 ) !default;
 
-$z-index-manual-values: (
-  /*
-  */
+$box-shadow-manual-values: () !default;
+
+// .circle
+
+$circle-plugins: ( 'plugin-standard-circle' ) !default;
+$circle-manual-values: () !default;
+
+// .color
+
+$color-plugins: () !default;
+$color-manual-values: () !default;
+
+// .display
+
+$display-plugins: ( 'plugin-standard-display' ) !default;
+$display-manual-values: () !default;
+
+// .flex
+
+$flex-plugins: ( 'plugin-standard-flex' ) !default;
+$flex-manual-values: () !default;
+
+// .flex-direction
+
+$flex-direction-plugins: ( 'plugin-standard-flex-direction' ) !default;
+$flex-direction-manual-values: () !default;
+
+// .flex-wrap
+
+$flex-wrap-plugins: ( 'plugin-standard-flex-wrap' ) !default;
+$flex-wrap-manual-values: () !default;
+
+// .float
+
+$float-plugins: ( 'plugin-standard-float' ) !default;
+$float-manual-values: () !default;
+
+// .font
+
+$font-plugins: (
+  'plugin-font-theme-all',
+  'plugin-font-theme-roles-all'
 ) !default;
+$font-manual-values: () !default;
+
+// .font-family
+
+$font-family-plugins: ( 'plugin-standard-font-family' ) !default;
+$font-family-manual-values: () !default;
+
+// .font-feature-settings
+
+$font-feature-plugins: ( 'plugin-standard-font-feature-settings' ) !default;
+$font-feature-manual-values: () !default;
+
+// .font-style
+
+$font-style-plugins: ( 'plugin-standard-font-style' ) !default;
+$font-style-manual-values: () !default;
+
+// .font-weight
+
+$font-weight-plugins: ( 'plugin-standard-font-weight' ) !default;
+$font-weight-manual-values: () !default;
+
+// .height
+
+$height-plugins: ( 'plugin-standard-height' ) !default;
+$height-manual-values: () !default;
+
+// .justify-content
+
+$justify-content-plugins: ( 'plugin-standard-justify-content' ) !default;
+$justify-content-manual-values: () !default;
+
+// .left
+
+$left-plugins: ( 'plugin-standard-left' ) !default;
+$left-manual-values: () !default;
+
+// .letter-spacing
+
+$letter-spacing-plugins: ( 'plugin-standard-letter-spacing' ) !default;
+$letter-spacing-manual-values: () !default;
+
+// .line-height
+
+$line-height-plugins: ( 'plugin-standard-line-height' ) !default;
+$line-height-manual-values: () !default;
+
+// .margin
+
+$margin-plugins: ( 'plugin-standard-margin' ) !default;
+$margin-manual-values: () !default;
+$margin-vertical-plugins: ( 'plugin-standard-margin-vertical' ) !default;
+$margin-vertical-manual-values: () !default;
+$margin-horizontal-plugins: ( 'plugin-standard-margin-horizontal' ) !default;
+$margin-horizontal-manual-values: () !default;
+
+// .max-height
+
+$max-height-plugins: ( 'plugin-standard-max-height' ) !default;
+$max-height-manual-values: () !default;
+
+// .max-width
+
+$max-width-plugins: ( 'plugin-standard-max-width' ) !default;
+$max-width-manual-values: () !default;
+
+// .measure
+
+$measure-plugins: ( 'plugin-standard-measure' ) !default;
+$measure-manual-values: () !default;
+
+// .min-height
+
+$min-height-plugins: ( 'plugin-standard-min-height' ) !default;
+$min-height-manual-values: () !default;
+
+// .min-width
+
+$min-width-plugins: ( 'plugin-standard-min-width' ) !default;
+$min-width-manual-values: () !default;
+
+// .opacity
+
+$opacity-plugins: ( 'plugin-standard-opacity' ) !default;
+$opacity-manual-values: () !default;
+
+// .order
+
+$order-plugins: ( 'plugin-standard-order' ) !default;
+$order-manual-values: () !default;
+
+// .outline
+
+$outline-plugins: ( 'plugin-standard-outline' ) !default;
+$outline-manual-values: () !default;
+
+// .outline-color
+
+$outline-color-plugins: ( 'plugin-standard-outline-color' ) !default;
+$outline-color-manual-values: () !default;
+
+// .overflow
+
+$overflow-plugins: ( 'plugin-standard-overflow' ) !default;
+$overflow-manual-values: () !default;
+
+// .padding
+
+$padding-plugins: ( 'plugin-standard-padding' ) !default;
+$padding-manual-values: () !default;
+
+// .position
+
+$position-plugins: ( 'plugin-standard-position' ) !default;
+$position-manual-values: () !default;
+
+// .right
+
+$right-plugins: ( 'plugin-standard-right' ) !default;
+$right-manual-values: () !default;
+
+// .square
+
+$square-plugins: ( 'plugin-standard-square' ) !default;
+$square-manual-values: () !default;
+
+// .text-align
+
+$text-align-plugins: ( 'plugin-standard-text-align' ) !default;
+$text-align-manual-values: () !default;
+
+// .text-decoration
+
+$text-decoration-plugins: ( 'plugin-standard-text-decoration' ) !default;
+$text-decoration-manual-values: () !default;
+
+// .text-decoration-color
+
+$text-decoration-color-plugins: () !default;
+$text-decoration-color-manual-values: () !default;
+
+// .text-indent
+
+$text-indent-plugins: ( 'plugin-standard-text-indent' ) !default;
+$text-indent-manual-values: () !default;
+
+// .text-transform
+
+$text-transform-plugins: ( 'plugin-standard-text-transform' ) !default;
+$text-transform-manual-values: () !default;
+
+// .top
+
+
+$top-plugins: ( 'plugin-standard-top' ) !default;
+$top-manual-values: () !default;
+
+// .vertical-align
+
+$vertical-align-plugins: ( 'plugin-standard-vertical-align' ) !default;
+$vertical-align-manual-values: () !default;
+
+// .white-space
+
+$whitespace-plugins: ( 'plugin-standard-white-space' ) !default;
+$whitespace-manual-values: () !default;
+
+// .width
+
+$width-plugins: ( 'plugin-standard-width' ) !default;
+$width-manual-values: () !default;
+
+// .z-index
+
+$z-index-plugins: ( 'plugin-standard-z-index' ) !default;
+$z-index-manual-values: () !default;

--- a/src/stylesheets/utilities/rules/outline-color.scss
+++ b/src/stylesheets/utilities/rules/outline-color.scss
@@ -20,7 +20,7 @@ $outline-color: (
     modifiers: null,
     values: map-collect(
       get-plugins($outline-color-plugins),
-      /*get-plugins($global-color-plugins),*/
+      get-plugins($global-color-plugins),
       $outline-color-manual-values
     ),
     settings: $outline-color-settings,


### PR DESCRIPTION
- Don't namespace utilities or layout grid
- Fix smart-quote() to quote named colors
- Remove small ems from padding properties
- Use `-lg` prefix on responsive names
- Use `gray` instead of `neutral` in project theme palette
- Use `05` half naming in em values
- Reorganize utility settings
- Use global colors in outline color
- Aim for ~20 KB gzipped utility package