### PR TITLE
Use `heavy` instead of `black` in font weight

### DIFF
--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -222,7 +222,7 @@ $uswds-properties: (
       'medium': $theme-font-weight-medium,
       'semibold': $theme-font-weight-semibold,
       'bold': bold,
-      'black': $theme-font-weight-black,
+      'heavy': $theme-font-weight-heavy,
     ),
     extended: (
       100: 100,

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -229,7 +229,7 @@ $theme-font-weight-normal:        400 !default;
 $theme-font-weight-medium:        false !default;
 $theme-font-weight-semibold:      false !default;
 $theme-font-weight-bold:          700 !default;
-$theme-font-weight-black:         false !default;
+$theme-font-weight-heavy:         false !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -301,7 +301,7 @@ $project-font-weights: (
   'medium':     $theme-font-weight-medium,
   'semibold':   $theme-font-weight-semibold,
   'bold':       $theme-font-weight-bold,
-  'black':      $theme-font-weight-black,
+  'heavy':      $theme-font-weight-heavy,
 );
 
 $project-colors: (


### PR DESCRIPTION
This prevents a conflict with the color `black` in a utility like `text-black`