### PR TITLE
Output grid prefix and object prefix, but not for simple objects

### DIFF
--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -24,11 +24,11 @@ $theme-namespace: (
   ),
   'grid': (
     namespace:  'grid-',
-    output:     false,
+    output:     true,
   ),
   'object': (
     namespace:  'add-',
-    output:     false,
+    output:     true,
   ),
   'utility': (
     namespace:  'u-',

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -28,11 +28,11 @@ $theme-namespace: (
   ),
   'grid': (
     namespace:  'grid-',
-    output:     false,
+    output:     true,
   ),
   'object': (
     namespace:  'add-',
-    output:     false,
+    output:     true,
   ),
   'utility': (
     namespace:  'u-',
@@ -233,7 +233,7 @@ $theme-font-weight-normal:        400;
 $theme-font-weight-medium:        false;
 $theme-font-weight-semibold:      false;
 $theme-font-weight-bold:          700;
-$theme-font-weight-black:         false;
+$theme-font-weight-heavy:         false;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/utilities/rules/circle.scss
+++ b/src/stylesheets/utilities/rules/circle.scss
@@ -30,6 +30,6 @@ $u-circle: (
     extend: (
       'border-radius': '50%',
     ),
-    type: 'object',
+    type: 'utility',
   )
 )

--- a/src/stylesheets/utilities/rules/clearfix.scss
+++ b/src/stylesheets/utilities/rules/clearfix.scss
@@ -30,6 +30,6 @@ $u-clearfix: (
     ),
     settings: $clearfix-settings,
     property: 'clear',
-    type: 'object',
+    type: 'utility',
   )
 );

--- a/src/stylesheets/utilities/rules/square.scss
+++ b/src/stylesheets/utilities/rules/square.scss
@@ -28,6 +28,6 @@ $u-square: (
     ),
     settings: $square-settings,
     property: '',
-    type: 'object',
+    type: 'utility',
   )
 )


### PR DESCRIPTION
This activates the `grid-` prefix for grid utilities to help distinguish them and bring them in line with their mixin pairs. And it does the same for the object `add-` prefix. Notably, `circle` and `square` have been demoted from object to simple utility (for now!).

It also updates the project settings file, which was getting a little out of date.

 