### PR TITLE
Simplify default color options

### DIFF
--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -256,10 +256,12 @@ $theme-color-primary-dark:        'blue-warm', 70, vivid !default;
 $theme-color-primary-darker:      'blue-warm', 80, vivid !default;
 
 $theme-color-secondary-family:    'red' !default;
+$theme-color-secondary-lighter:   false !default;
 $theme-color-secondary-light:     $theme-color-secondary-family, 50 !default;
 $theme-color-secondary:           $theme-color-secondary-family, 60 !default;
 $theme-color-secondary-vivid:     $theme-color-secondary-family, 50, vivid !default;
 $theme-color-secondary-dark:      $theme-color-secondary-family, 80 !default;
+$theme-color-secondary-darker:    false !default;
 
 $theme-color-accent-warm-family:  'orange' !default;
 $theme-color-accent-warm:         $theme-color-accent-warm-family, 30, vivid !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -323,10 +323,12 @@ $project-colors: (
     'darker':  get-uswds-color($theme-color-primary-darker),
   ),
   'secondary': (
+    'lighter':  get-uswds-color($theme-color-secondary-lighter),
     'light':   get-uswds-color($theme-color-secondary-light),
     'default': get-uswds-color($theme-color-secondary),
     'vivid':   get-uswds-color($theme-color-secondary-vivid),
     'dark':    get-uswds-color($theme-color-secondary-dark),
+    'darker':  get-uswds-color($theme-color-secondary-darker),
   ),
   'accent-warm': (
     'default': get-uswds-color($theme-color-accent-warm),

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -233,7 +233,7 @@ $theme-font-weight-normal:        400;
 $theme-font-weight-medium:        false;
 $theme-font-weight-semibold:      false;
 $theme-font-weight-bold:          700;
-$theme-font-weight-black:         false;
+$theme-font-weight-heavy:         false;
 
 /*
 ----------------------------------------
@@ -260,10 +260,12 @@ $theme-color-primary-dark:        'blue-warm', 70, vivid;
 $theme-color-primary-darker:      'blue-warm', 80, vivid;
 
 $theme-color-secondary-family:    'red';
+$theme-color-secondary-lighter:   false;
 $theme-color-secondary-light:     $theme-color-secondary-family, 50;
 $theme-color-secondary:           $theme-color-secondary-family, 60;
 $theme-color-secondary-vivid:     $theme-color-secondary-family, 50, vivid;
 $theme-color-secondary-dark:      $theme-color-secondary-family, 80;
+$theme-color-secondary-darker:    false;
 
 $theme-color-accent-warm-family:  'orange';
 $theme-color-accent-warm:         $theme-color-accent-warm-family, 30, vivid;

--- a/src/stylesheets/utilities/_utilities-settings.scss
+++ b/src/stylesheets/utilities/_utilities-settings.scss
@@ -29,7 +29,7 @@ The following plugins will be added to
 $global-color-plugins: (
   'plugin-color-palette-theme',
   'plugin-color-palette-basic',
-  'plugin-color-gray-all'
+  'plugin-color-palette-grayscale'
 ) !default;
 
 /*

--- a/src/stylesheets/utilities/plugins/colors/palettes/_palette-plugins.scss
+++ b/src/stylesheets/utilities/plugins/colors/palettes/_palette-plugins.scss
@@ -42,11 +42,18 @@ $color-palette-state: (
   'disabled':           get-uswds-color($theme-color-disabled),
 );
 
-$color-palette-grayscale: $uswds-gray;
+$color-palette-grayscale: (
+  'gray-5':    get-uswds-color('gray', 5),
+  'gray-10':   get-uswds-color('gray', 10),
+  'gray-30':   get-uswds-color('gray', 30),
+  'gray-50':   get-uswds-color('gray', 50),
+  'gray-70':   get-uswds-color('gray', 70),
+  'gray-90':   get-uswds-color('gray', 90),
+);
 
 $plugin-palettes: (
   'plugin-color-palette-theme':     $color-palette-theme,
-  'plugin-color-palette-grayscale': $plugin-color-gray-all,
+  'plugin-color-palette-grayscale': $color-palette-grayscale,
   'plugin-color-palette-required':  $uswds-required-colors,
   'plugin-color-palette-state':     $color-palette-state,
   'plugin-color-palette-basic':     $uswds-basic-colors,


### PR DESCRIPTION
This sets the default grayscale palette to a more restricted palette that only uses gray 5, 10, 30, 50, 70, and 90 (in addition to black and white).

It also adds a `darker` and `lighter` option to the `secondary` family, but sets the defaults as false.