### PR TITLE
Use px for utility media queries until we can determine what's wrong with em

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -625,7 +625,7 @@ is false. Warn if it is.
       @return unquote($value);
     }
     @else {
-      @return $value;      
+      @return $value;
     }
   }
   @else {
@@ -1197,10 +1197,12 @@ loop
 
   @each $media-key, $media-value in $our-breakpoints {
     $mq: unquote($media-key);
-    $media-value-em: grid-to-base-em($media-value);
+    // TODO: not working properly
+    // $media-value-em: grid-to-base-em($media-value);
+    $media-value-px: rem-to-px($media-value);
 
     @if map-get($theme-output-breakpoints, $media-key) {
-      @media (min-width: #{$media-value-em}) {
+      @media (min-width: #{$media-value-px}) {
         .#{$mq}\:#{ns($this-type)}#{$selector} {
           @if map-has-key($val-props, extend) {
             @each $ext-prop, $ext-value in map-get($val-props, extend) {


### PR DESCRIPTION
This change should render the utility media queries with px values instead of em. Something about our 10px base isn't playing well with the em-based media query (I don't know why — the em keeps referencing 16px and I don't know where that value is coming from).

