### PR TITLE
Escape parentheses in showcase link

### DIFF
--- a/docs/WHO_IS_USING_USWDS.md
+++ b/docs/WHO_IS_USING_USWDS.md
@@ -90,7 +90,7 @@ Below are a list of websites and applications currently using the U.S. Web Desig
 - [National Archives and Records Administration](https://archives.gov)
 - [National Archives Museum](https://museum.archives.gov/)
 - [National Institute of Health](https://www.nih.gov/)
-- [The National Flood Insurance Program (FloodSmart)](https://www.floodsmart.gov/)
+- [The National Flood Insurance Program \(FloodSmart\)](https://www.floodsmart.gov/)
 - [National Library of Medicine Customer Support](https://support.nlm.nih.gov)
 - [Navy 6th Fleet](http://www.c6f.navy.mil/)
 - [NYC School Finder](http://schoolfinder.nyc.gov/)


### PR DESCRIPTION
This link is appearing as a table on docs site: https://designsystem.digital.gov/getting-started/showcase/all/