### PR TITLE
Fix h6 heading margins

### DIFF
--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -66,16 +66,13 @@ h1,
 h2,
 h3,
 h4,
-h5 {
+h5,
+h6 {
   clear: both;
   font-family: $font-serif;
   line-height: $heading-line-height;
   margin-bottom: .5em;
   margin-top: 1.5em;
-}
-
-h6 {
-  font-family: $font-sans;
 }
 
 h1 {
@@ -100,6 +97,7 @@ h5 {
 
 h6 {
   @include h6();
+  font-family: $font-sans;
 }
 
 // Remove user agent styles

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -71,7 +71,7 @@ h6 {
   clear: both;
   font-family: $font-serif;
   line-height: $heading-line-height;
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
   margin-top: 1.5em;
 }
 


### PR DESCRIPTION
The h6's are missing the proper margins (as well as the `clear: both` CSS rule) and defaults to browser defaults (too large).

## Before 
<img width="280" alt="screen shot 2018-05-31 at 3 10 39 pm" src="https://user-images.githubusercontent.com/5249443/40811096-cd89a44e-64e4-11e8-86a9-fa07475272a9.png">

## After
<img width="255" alt="screen shot 2018-05-31 at 3 09 55 pm" src="https://user-images.githubusercontent.com/5249443/40811099-d098cafc-64e4-11e8-8fcd-68c7b7619c2a.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-h6/components/detail/typesetting.html)