### PR TITLE
Add a `u-font()` mixin that combines both font-size and font-family

### DIFF
--- a/src/stylesheets/core/mixins/utilities/_font.scss
+++ b/src/stylesheets/core/mixins/utilities/_font.scss
@@ -6,7 +6,7 @@ Get a font-family stack
 ----------------------------------------
 */
 
-@mixin u-family($family) {
+@mixin u-font-family($family) {
   $our-family: smart-quote($family);
   @if not map-has-key($project-font-stacks, $our-family){
     @error "#{$our-family} is not a valid font family. Valid values: #{map-keys($project-font-stacks)}";
@@ -29,7 +29,7 @@ system scale or project scale
 ----------------------------------------
 */
 
-@mixin u-size($family, $scale) {
+@mixin u-font-size($family, $scale) {
   $our-family: smart-quote($family);
   $our-scale: smart-quote($scale);
   @if not map-has-key($project-cap-heights, $our-family) {

--- a/src/stylesheets/core/mixins/utilities/_font.scss
+++ b/src/stylesheets/core/mixins/utilities/_font.scss
@@ -49,3 +49,37 @@ system scale or project scale
     }
   }
 }
+
+/*
+----------------------------------------
+font()
+----------------------------------------
+Get a font-family stack
+AND
+Get a normalized font-size in rem from
+a family and a type size in either
+system scale or project scale
+----------------------------------------
+*/
+
+@mixin u-font($family, $scale) {
+  $our-family: smart-quote($family);
+  $our-scale: smart-quote($scale);
+  @if not map-has-key($project-cap-heights, $our-family) {
+    @error "#{$our-family} is not a valid font family. Valid values: #{map-keys($project-cap-heights)}";
+  }
+  @elseif not map-get($all-type-scale, $our-scale) {
+    @error "`#{$our-scale}` is not a valid font scale. Valid values: #{map-keys($all-type-scale)}";
+  }
+  @else {
+    $this-cap: map-get($project-cap-heights, $our-family);
+    $this-scale: map-get($all-type-scale, $our-scale);
+    @if $this-scale and $this-cap {
+      font-family: map-get($project-font-stacks, $our-family);
+      font-size: type-scale($this-cap, $this-scale);
+    }
+    @else {
+      @error "The scale `#{$our-scale}` is disabled in your project's theme settings. Set its value to `true` to use this family.";
+    }
+  }
+}

--- a/src/stylesheets/utilities/rules/font-family.scss
+++ b/src/stylesheets/utilities/rules/font-family.scss
@@ -24,7 +24,7 @@ example:
 
 $u-font-family: (
   font-family: (
-    base: 'family',
+    base: 'font-family',
     modifiers: null,
     values: map-collect(
       get-plugins($font-family-plugins),

--- a/src/stylesheets/utilities/rules/font.scss
+++ b/src/stylesheets/utilities/rules/font.scss
@@ -28,7 +28,7 @@ example:
 
 $u-font: (
   font: (
-    base: 'size',
+    base: 'font',
     modifiers: null,
     values: map-collect(
       get-plugins($font-plugins),


### PR DESCRIPTION
We can now set just font size with `size()`, just family with `family()`, or both with `font()`