### PR TITLE
Change banner parent container div to section element

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -1,4 +1,4 @@
-<div class="usa-banner">
+<section class="usa-banner">
   <div class="usa-accordion">
     <header class="usa-banner-header">
       <div class="usa-grid usa-banner-inner">
@@ -33,4 +33,4 @@
       </div>
     </div>
   </div>
-</div>
+</section>


### PR DESCRIPTION
Currently, there's a `header` element within the banner parent container `div`, and this needs to be inside a sectioning element to be conformant. This ensures the markup is conformant to HTML standards. 

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-gov-banner/components/detail/banner.html)

Feedback:
>But `header` tags, per the 5.1 spec, “can only contain a header or footer if they are themselves contained within sectioning content.” (https://www.w3.org/TR/html51/sections.html#example-6f9fce34) As these `header` tags are not contained within `article`, `aside`, `nav`, or `section`, this use seems to be non-conforming (and is causing my tests to yell at me).