### PR TITLE
[UI component]: Adding best-practice ruleset and fix for heading-level error

### DIFF
--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -14,12 +14,22 @@ const AXE_CONTEXT = JSON.stringify({
 });
 
 const AXE_OPTIONS = JSON.stringify({
+  runOnly: {
+    type: 'tag',
+    values: [ 'section508', 'wcag2a', 'wcag2aa', 'best-practice' ],
+  },
   rules: {
     // Not all our examples need "skip to main content" links, so
     // ignore that rule.
     'bypass': { enabled: false },
     // Nor do all our examples need main landmarks...
     'landmark-one-main': { enabled: false },
+    // Not all content will be in a landmark region
+    'region': { enabled: false },
+    // Not all examples have skip-link as a first element
+    'skip-link': { enabled: false },
+    // Links can have an href '#' here
+    'href-no-hash': { enabled: false },
   },
 });
 

--- a/src/components/01-type/typesetting.njk
+++ b/src/components/01-type/typesetting.njk
@@ -1,7 +1,7 @@
 <div class="usa-grid">
   <h6 class="usa-heading-alt">Alignment</h6>
   <div class="alignment-example">
-    <h4>The Grand Canyon</h4>
+    <h5>The Grand Canyon</h5>
     <p>Grand Canyon National Park is the United States' 15th oldest national park. Named a UNESCO World Heritage Site in 1979, the park is located in Arizona.</p>
   </div>
 


### PR DESCRIPTION
## Description

Adding best-practice ruleset and  exceptions to axe test script. Conversation in the USWDS public Slack channel asked about best-practice rules showing up in axe web browser plugin, but not on automated test runs. I added a `runOnly` object to the axe-tester.js configuration object that adds best-practice rules as defined by Deque.

I changed the first `<h4>Grand Canyon</h4>` to `<h5>Grand Canyon</h5>` to fix 2 best-practices errors calling out heading order. This felt like a better approach than trying to add an exception to the axe-tester.js, as I felt letting users know of a heading order issue was a good thing. 

Deque `axe-core` list of rules, including best practices:
https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md