### PR TITLE
Fix link path to npm script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ node_modules/uswds/
 
 Since you are already using `npm`, the U.S. Web Design System team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
 
-[Link to `npm` scripts example in `uswds-site`](https://github.com/uswds/uswds-site/blob/master/package.json#L4)
+[Link to `npm` scripts example in `uswds-site`](https://github.com/uswds/uswds-site/blob/master/package.json#L28)
 
 [Link to gulpfile.js example in `uswds-site`](https://github.com/uswds/uswds-site/blob/master/gulpfile.js)
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ node_modules/uswds/
 
 Since you are already using `npm`, the U.S. Web Design System team recommends leveraging the ability to write custom scripts. Here are some links to how we do this with our docs website using `npm` + [`gulp`](http://gulpjs.com/):
 
-[Link to `npm` scripts example in `uswds-site`](https://github.com/uswds/uswds-site/blob/develop/package.json#L4)
+[Link to `npm` scripts example in `uswds-site`](https://github.com/uswds/uswds-site/blob/master/package.json#L4)
 
-[Link to gulpfile.js example in `uswds-site`](https://github.com/uswds/uswds-site/blob/develop/gulpfile.js)
+[Link to gulpfile.js example in `uswds-site`](https://github.com/uswds/uswds-site/blob/master/gulpfile.js)
 
 #### Sass
 


### PR DESCRIPTION
We don't have a `develop` branch anymore on the uswds-site, this changes it to the `master` branch.

Though I don't know what line 4 in https://github.com/uswds/uswds-site/blob/master/package.json#L4 is intended to link to. That file has likely changed.