### PR TITLE
Improvements to grid and gap

### DIFF
--- a/src/stylesheets/core/_layout-grid.scss
+++ b/src/stylesheets/core/_layout-grid.scss
@@ -9,7 +9,7 @@ $grid-global: '';
 
 // basic container
 .#{$namespace-grid}container {
-  $props: append-important($grid-global, desktop);
+  $props: append-important($grid-global, $theme-grid-container-max-width);
   @include grid-container($props);
 }
 

--- a/src/stylesheets/core/_layout-grid.scss
+++ b/src/stylesheets/core/_layout-grid.scss
@@ -145,6 +145,10 @@ $grid-global: '';
     @include grid-offset($props);
   }
 }
+.#{$namespace-grid}offset-none {
+  $props: append-important($grid-global, none);
+  @include grid-offset($props);
+}
 
 // responsive offsets
 @each $mq-key, $mq-value in $uswds-breakpoints {

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -360,3 +360,19 @@ Column gap
 $theme-column-gap-small: 2px !default;
 $theme-column-gap:       2 !default;
 $theme-column-gap-large: 3 !default;
+
+/*
+----------------------------------------
+Grid container max-width
+----------------------------------------
+mobile
+mobile-lg
+tablet
+tablet-lg
+desktop
+desktop-lg
+widescreen
+----------------------------------------
+*/
+
+$theme-grid-container-max-width: desktop !default;

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -97,7 +97,7 @@ $uswds-spacing:(
 
 $uswds-column-gaps: (
   '2px':      2px,
-  '05':     '05',
+  .5:       '05',
   1:        1,
   3:        3,
   4:        4,

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -2,7 +2,7 @@
 @mixin grid-container($props...) {
   @if length($props) == 0 {
     @include u-margin-x(auto);
-    @include u-maxw(desktop);
+    @include u-maxw($theme-grid-container-max-width);
   }
   @else {
     $props: nth($props, 1);
@@ -39,8 +39,11 @@
     @if map-has-key($project-column-gaps, $gap) {
       $gap: map-get($project-column-gaps, $gap);
     }
+    @elseif map-has-key($uswds-column-gaps, $gap) {
+      $gap: map-get($uswds-column-gaps, $gap);
+    }
     @include u-margin-x(append-important($props, unquote("#{$neg-prefix}-#{calc-gap-offset($gap)}")));
-    > * {
+    > [class*='grid-col'] {
       @include u-padding-x(append-important($props, calc-gap-offset($gap)));
     }
   }

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -84,7 +84,11 @@
 @mixin grid-offset($props...) {
   $props: unpack($props);
   $offset: smart-quote(nth($props, 1));
-  @if not map-has-key($uswds-layout-grid-widths, $offset) {
+  @if $offset == 'none' {
+    $width: append-important($props, 0);
+    @include u-margin-left(override, $width);
+  }
+  @elseif not map-has-key($uswds-layout-grid-widths, $offset) {
     @error "#{$offset} is not a valid layout grid width. Valid width are #{map-keys($uswds-layout-grid-widths)}";
   }
   @else {

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -364,3 +364,19 @@ Column gap
 $theme-column-gap-small: 2px;
 $theme-column-gap:       2;
 $theme-column-gap-large: 3;
+
+/*
+----------------------------------------
+Grid container max-width
+----------------------------------------
+mobile
+mobile-lg
+tablet
+tablet-lg
+desktop
+desktop-lg
+widescreen
+----------------------------------------
+*/
+
+$theme-grid-container-max-width: desktop;


### PR DESCRIPTION
- Add `$theme-grid-container-max-width` variable to set default container max width
- Fix `grid-gap()` to allow `.5`
-  Scope gap padding to `grid-col*` classed items
- Allow `grid-offset(none)` and `.grid-offset-none`