### PR TITLE
[ci] test filtering out pull requests from ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
           command: |
             ls -agolf dist/
             codeclimate-test-reporter < coverage/lcov.info
-    branches:
-      ignore:
-        - /pull\/.*/
+          branches:
+            ignore:
+              - /pull\/.*/
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
           command: |
             ls -agolf dist/
             codeclimate-test-reporter < coverage/lcov.info
+    branches:
+      ignore:
+        - /pull\/.*/
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,10 @@ jobs:
       - run:
           name: Checking build
           command: |
-            ls -agolf dist/
-            codeclimate-test-reporter < coverage/lcov.info
-          branches:
-            ignore:
-              - /pull\/.*/
+            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -lt 0 ]]; then
+              ls -agolf dist/
+              codeclimate-test-reporter < coverage/lcov.info
+            fi
 
   deploy:
     docker:


### PR DESCRIPTION
## Filter PR branches from CI

The env variables specific to this project are not available when building from a forked branch, causing those builds to fail

## Description

Check for branches prefixed with `pull/`, which should indicate a PR originating from a fork of this repo. Hopefully this resolves build failures on those branches