### PR TITLE
Fix footer class naming inconsistency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8994,13 +8994,14 @@
       "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "requires": {
         "inherits": "^2.0.1",
+        "isarray": "^2.0.4",
         "stream-splicer": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA=="
         }
       }
     },

--- a/spec/unit/footer/template.html
+++ b/spec/unit/footer/template.html
@@ -54,7 +54,7 @@
     </div>
   </div>
 
-  <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
+  <div class="usa-footer-secondary-section usa-footer-big-secondary-section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
         <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="Logo image">

--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -54,7 +54,7 @@
     </div>
   </div>
 
-  <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
+  <div class="usa-footer-secondary-section usa-footer-big-secondary-section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
         <img class="usa-footer-big-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">

--- a/src/components/10-footer/footer--slim.njk
+++ b/src/components/10-footer/footer--slim.njk
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <div class="usa-footer-secondary_section">
+  <div class="usa-footer-secondary-section">
     <div class="usa-grid">
       <div class="usa-footer-logo">
         <img class="usa-footer-slim-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">

--- a/src/components/10-footer/footer.config.yml
+++ b/src/components/10-footer/footer.config.yml
@@ -1,5 +1,5 @@
 label: Footer
-status: wip
+status: ready
 
 variants:
   - name: default

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="usa-footer-secondary_section">
+  <div class="usa-footer-secondary-section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
         <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -255,7 +255,7 @@ li.usa-footer-primary-content {
   }
 }
 
-.usa-footer-secondary_section {
+.usa-footer-secondary-section {
   background-color: $color-gray-lighter;
   padding-bottom: $spacing-medium;
   padding-top: $spacing-medium;


### PR DESCRIPTION
Changes the class `usa-footer-secondary_section` to `usa-footer-secondary-section` to follow what we use in `usa-footer-primary-section`. 

I was originally going to suggest we go with `usa-footer-section-secondary` and `usa-footer-section-primary` but then found we have a lot of additional CSS classes following the `usa-footer-primary-*` pattern and would rather not change that many class names.

I'm not sure how the unit tests work but realized we have the footer template appearing manually in `spec/unit/footer/template.html` and wasn't sure if it should be pulling it in from a source file so we don't have to keep an additional file up-to-date.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-footer-naming/components/detail/footer--default.html)

Fixes #1505.