### PR TITLE
Filter prerelease logic on release-2.0 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,4 +83,4 @@ workflows:
             - build
           filters:
             branches:
-              only: /^.+-alpha(\.[0-9]{1})?/
+              only: release-2.0


### PR DESCRIPTION
## Filter prerelease job on release-2.0

## Description

Try and execute the prerelease build and push to npm on the `release-2.0` branch, instead of a feature branch.
