### PR TITLE
Fix radio and checkbox left alignment

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -196,15 +196,18 @@ legend {
 [type=checkbox] + label::before,
 [type=radio] + label::before {
   background: $color-white;
-  border-radius: $checkbox-border-radius;
-  box-shadow: 0 0 0 1px $color-gray-medium;
   content: '\a0';
   display: inline-block;
+  text-indent: 0.15em;
+  vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
+}
+
+[type=checkbox] + label::before {
+  border-radius: $checkbox-border-radius;
+  box-shadow: 0 0 0 1px $color-gray-medium;
   height: $spacing-medium;
   line-height: $spacing-medium;
   margin-right: 0.6em;
-  text-indent: 0.15em;
-  vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
   width: $spacing-medium;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -207,6 +207,7 @@ legend {
   box-shadow: 0 0 0 1px $color-gray-medium;
   height: $spacing-medium;
   line-height: $spacing-medium;
+  margin-left: 1px;
   margin-right: 0.6em;
   width: $spacing-medium;
 }
@@ -216,6 +217,7 @@ legend {
   box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $color-gray-medium;
   height: 1.4rem; // Size overrides to account for shape + checked styling
   line-height: 1.4rem;
+  margin-left: 3px;
   margin-right: 0.75em;
   width: 1.4rem;
 }


### PR DESCRIPTION
The radio and checkboxes are not flush left bc of the box-shadow being used that makes it extend out. This fixes that. This also moves some of the combined radio and checkbox CSS that only apply to checkbox into it's own section rather than combined and overriden in the radio code below to make it clearer which code applies to which input.

<img width="626" alt="screen shot 2018-07-17 at 11 48 06 am" src="https://user-images.githubusercontent.com/5249443/42839528-d90a0e3c-89b8-11e8-9eae-8fcd0903861c.png">
<img width="546" alt="screen shot 2018-07-17 at 11 50 09 am" src="https://user-images.githubusercontent.com/5249443/42839531-db59498c-89b8-11e8-9ba8-2cf3c4ce3558.png">

[😎 Preview: checkboxes](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-radio-alignment/components/detail/checkboxes.html)

[😎 Preview: radio buttons](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-radio-alignment/components/detail/radio-buttons.html)

Fixes: #1881.