### PR TITLE
Generalize date input 

### DIFF
--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -1,7 +1,7 @@
 <fieldset>
   <legend>Date of birth</legend>
   <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
-  <div class="usa-date-of-birth">
+  <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group-month">
       <label for="date_of_birth_1">Month</label>
       <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -338,7 +338,7 @@ legend {
 
 // Memorable dates
 
-.usa-date-of-birth {
+.usa-memorable-date {
   label {
     margin-top: 0;
   }


### PR DESCRIPTION
Change the date of birth class name to memorable date to make it more generalized.

This is going into `release-2.0` bc changing the class name is a breaking change.

Fixes #1920.