### PR TITLE
[UIComponent] use element.hidden on search form

### DIFF
--- a/spec/1.x/search.spec.js
+++ b/spec/1.x/search.spec.js
@@ -7,7 +7,7 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, '../unit/search/template.html'),
 );
 
-const isVisuallyHidden = el => el.classList.contains('usa-sr-only');
+const isVisuallyHidden = el => el.hidden;
 
 describe('search toggle', () => {
   let button;

--- a/spec/unit/search/search.spec.js
+++ b/spec/unit/search/search.spec.js
@@ -4,9 +4,8 @@ const path = require('path');
 const search = require('../../../src/js/components/search');
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, 'template.html'));
-const VISUALLY_HIDDEN = 'usa-sr-only';
 
-const isVisuallyHidden = el => el.classList.contains(VISUALLY_HIDDEN);
+const isVisuallyHidden = el => el.hidden;
 
 describe('search toggle', () => {
   const { body } = document;

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -6,13 +6,11 @@ const behavior = require('../utils/behavior');
 const select = require('../utils/select');
 
 const { CLICK } = require('../events');
-const { prefix: PREFIX } = require('../config');
 
 const BUTTON = '.js-search-button';
 const FORM = '.js-search-form';
 const INPUT = '[type=search]';
 const CONTEXT = 'header'; // XXX
-const VISUALLY_HIDDEN = `${PREFIX}-sr-only`;
 
 let lastButton;
 
@@ -30,8 +28,10 @@ const toggleSearch = (button, active) => {
     throw new Error(`No ${FORM} found for search toggle in ${CONTEXT}!`);
   }
 
-  button.hidden = active; // eslint-disable-line no-param-reassign
-  form.classList.toggle(VISUALLY_HIDDEN, !active);
+  /* eslint-disable no-param-reassign */
+  button.hidden = active;
+  form.hidden = !active;
+  /* eslint-enable*/
 
   if (!active) {
     return;


### PR DESCRIPTION
## Fix tab behavior on extended header

## Description

Previously, we hid the search form in the extended header using a
screen reader only class. This led to users being able to tab through
the invisible form fields, which was confusing

## Additional information

Fixes #2601 

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/ab-2601/components/detail/header--extended.html)
