### PR TITLE
Hide date autocomplete icons on Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5621,7 +5621,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -5926,6 +5927,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6114,7 +6116,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6342,6 +6345,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -1,18 +1,20 @@
-<fieldset>
-  <legend>Date of birth</legend>
-  <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
-  <div class="usa-date-of-birth">
-    <div class="usa-form-group usa-form-group-month">
-      <label for="date_of_birth_1">Month</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">
+<form>
+  <fieldset>
+    <legend>Date of birth</legend>
+    <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
+    <div class="usa-date-of-birth">
+      <div class="usa-form-group usa-form-group-month">
+        <label for="date_of_birth_1">Month</label>
+        <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">
+      </div>
+      <div class="usa-form-group usa-form-group-day">
+        <label for="date_of_birth_2">Day</label>
+        <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="number" min="1" max="31" value="">
+      </div>
+      <div class="usa-form-group usa-form-group-year">
+        <label for="date_of_birth_3">Year</label>
+        <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" type="number" min="1900" max="2000" value="">
+      </div>
     </div>
-    <div class="usa-form-group usa-form-group-day">
-      <label for="date_of_birth_2">Day</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="number" min="1" max="31" value="">
-    </div>
-    <div class="usa-form-group usa-form-group-year">
-      <label for="date_of_birth_3">Year</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" type="number" min="1900" max="2000" value="">
-    </div>
-  </div>
-</fieldset>
+  </fieldset>
+</form>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -351,8 +351,7 @@ legend {
   [type=number] {
     -moz-appearance: textfield;
 
-    &::-webkit-inner-spin-button,
-    &::-webkit-outer-spin-button {
+    &::-webkit-inner-spin-button {
       appearance: none;
       margin: 0;
     }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -353,7 +353,6 @@ legend {
 
     &::-webkit-inner-spin-button {
       appearance: none;
-      margin: 0;
     }
   }
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -351,7 +351,8 @@ legend {
   [type=number] {
     -moz-appearance: textfield;
 
-    &::-webkit-inner-spin-button {
+    &::-webkit-inner-spin-button,
+    &::-webkit-contacts-auto-fill-button {
       appearance: none;
     }
   }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -348,14 +348,14 @@ legend {
     margin-top: 0;
   }
 
-  [type=number]::-webkit-inner-spin-button,
-  [type=number]::-webkit-outer-spin-button {
-    appearance: none;
-    margin: 0;
-  }
-
   [type=number] {
     -moz-appearance: textfield;
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      appearance: none;
+      margin: 0;
+    }
   }
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -343,7 +343,7 @@ legend {
 
 // Memorable dates
 
-.usa-date-of-birth {
+.usa-date-of-birth { /* stylelint-disable-line */
   label {
     margin-top: 0;
   }
@@ -357,7 +357,7 @@ legend {
 
     &::-webkit-contacts-auto-fill-button {
       visibility: hidden;
-      display: none !important;
+      display: none !important; /* stylelint-disable-line declaration-no-important */
       pointer-events: none;
       height: 0;
       width: 0;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -351,9 +351,17 @@ legend {
   [type=number] {
     -moz-appearance: textfield;
 
-    &::-webkit-inner-spin-button,
-    &::-webkit-contacts-auto-fill-button {
+    &::-webkit-inner-spin-button {
       appearance: none;
+    }
+
+    &::-webkit-contacts-auto-fill-button {
+      visibility: hidden;
+      display: none !important;
+      pointer-events: none;
+      height: 0;
+      width: 0;
+      margin: 0;
     }
   }
 }


### PR DESCRIPTION
This hides the autocomplete icons from appearing in Safari when you click on a field.

To test, you'd need to go to a computer where you have a Safari "My card" in your contacts with your birthdate (my personal machine in this case), and click on the field.

This also cleans up the SCSS of the date field component by nesting it better and removing some code that didn't do anything - was based on an older CSS Tricks article which I assume that Chrome may have changed how it displays auto-populate icons, so made it unnecessary.

I initially tried a simple `appearance: none` but it was not strong enough bc Safari's user agent adds a `display: none !important`, so I based the code on this: https://jrnv.nl/hiding-safaris-contact-auto-fill-when-autocomplete-is-turned-off-c415b2257df8

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/hide-date-autocomplete/components/preview/date-input.html)

Fixes #1972.