### PR TITLE
Make extended header search open by default

### DIFF
--- a/src/components/08-navigation/_nav-secondary.njk
+++ b/src/components/08-navigation/_nav-secondary.njk
@@ -1,13 +1,5 @@
 <div class="usa-nav-secondary">
-  {% if nav.search %}
-    {% render '@search--header', {search: nav.search, search_js: true, id_prefix: id_prefix} %}
-  {% endif %}
   <ul class="usa-unstyled-list usa-nav-secondary-links">
-    {% if nav.search %}
-    <li class="js-search-button-container">
-      <button class="usa-header-search-button js-search-button">Search</button>
-    </li>
-    {% endif %}
     {% for link in nav.links %}
     <li>
       <a href="{{ link.href }}"{% if link.current %} class="usa-current"{% endif %}>
@@ -16,4 +8,7 @@
     </li>
     {% endfor %}
   </ul>
+  {% if nav.search %}
+    {% render '@search--header', {search: nav.search, search_js: false, id_prefix: id_prefix} %}
+  {% endif %}
 </div>

--- a/src/components/08-navigation/nav-secondary.config.yml
+++ b/src/components/08-navigation/nav-secondary.config.yml
@@ -7,3 +7,4 @@ context:
     links:
       - text: Secondary priority link
       - text: Easy to comprehend
+      - text: Utility link

--- a/src/components/08-navigation/nav-secondary.config.yml
+++ b/src/components/08-navigation/nav-secondary.config.yml
@@ -7,4 +7,3 @@ context:
     links:
       - text: Secondary priority link
       - text: Easy to comprehend
-      - text: Utility link

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -25,7 +25,7 @@ $z-index-nav:     9000;
   .usa-search {
     @include media($nav-width) {
       float: right;
-      max-width: 72ch;
+      max-width: 30em;
     }
   }
 }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -25,7 +25,7 @@ $z-index-nav:     9000;
   .usa-search {
     @include media($nav-width) {
       float: right;
-      max-width: 27em; // max-width of 27 letters
+      max-width: $search-min-width;
     }
   }
 }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -25,7 +25,7 @@ $z-index-nav:     9000;
   .usa-search {
     @include media($nav-width) {
       float: right;
-      max-width: 30em;
+      max-width: 27em; // max-width of 27 letters
     }
   }
 }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -25,7 +25,7 @@ $z-index-nav:     9000;
   .usa-search {
     @include media($nav-width) {
       float: right;
-      max-width: $search-min-width;
+      max-width: calc(#{$search-min-width} + #{$usa-btn-small-width});
     }
   }
 }

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -25,7 +25,7 @@ $z-index-nav:     9000;
   .usa-search {
     @include media($nav-width) {
       float: right;
-      max-width: 21.5rem;
+      max-width: 72ch;
     }
   }
 }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -323,8 +323,9 @@
 
   @include media($nav-width) {
     bottom: calc(5rem + 16px); // XXX magic number, 16px from bottom
+    font-size: $small-font-size;
     margin-top: units(1);
-    min-width: 381px; // XXX magic number, to keep search filled when list disappears
+    min-width: 30em; // max-width of 30 letters
     position: absolute;
     right: $site-margins;
   }
@@ -346,6 +347,7 @@
   margin-top: 2.4rem;
 
   @include media($nav-width) {
+    float: right;
     margin-bottom: units(0.5);
     margin-top: 0;
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -322,10 +322,11 @@
   margin-top: 1.5rem;
 
   @include media($nav-width) {
-    margin-top: 0;
+    bottom: 66px; // XXX magic number, 16px from bottom
+    margin-top: 16px;
+    min-width: 381px; // XXX magic number, to keep search filled when list disappears
     position: absolute;
     right: $site-margins;
-    top: -5.7rem; // XXX magic number
   }
 
   .usa-search {
@@ -335,8 +336,8 @@
     @include media($nav-width) {
       @include u-margin-bottom(0);
       @include u-margin-left(0);
-      @include u-margin-top(-0.9rem);
-      float: left;
+      @include u-margin-top(0);
+      width: 100%;
     }
   }
 }
@@ -345,7 +346,7 @@
   margin-top: 2.4rem;
 
   @include media($nav-width) {
-    float: left;
+    margin-bottom: 4px;
     margin-top: 0;
   }
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -325,7 +325,7 @@
     bottom: calc(5rem + 16px); // XXX magic number, 16px from bottom
     font-size: $small-font-size;
     margin-top: units(1);
-    min-width: 30em; // max-width of 30 letters
+    min-width: 27em; // max-width of 27 letters
     position: absolute;
     right: $site-margins;
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -325,7 +325,7 @@
     bottom: calc(5rem + 16px); // XXX magic number, 16px from bottom
     font-size: $small-font-size;
     margin-top: units(1);
-    min-width: $search-min-width;
+    min-width: calc(#{$search-min-width} + #{$usa-btn-small-width});
     position: absolute;
     right: $site-margins;
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -322,8 +322,8 @@
   margin-top: 1.5rem;
 
   @include media($nav-width) {
-    bottom: 66px; // XXX magic number, 16px from bottom
-    margin-top: 16px;
+    bottom: calc(5rem + 16px); // XXX magic number, 16px from bottom
+    margin-top: units(1);
     min-width: 381px; // XXX magic number, to keep search filled when list disappears
     position: absolute;
     right: $site-margins;
@@ -346,7 +346,7 @@
   margin-top: 2.4rem;
 
   @include media($nav-width) {
-    margin-bottom: 4px;
+    margin-bottom: units(0.5);
     margin-top: 0;
   }
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -325,7 +325,7 @@
     bottom: calc(5rem + 16px); // XXX magic number, 16px from bottom
     font-size: $small-font-size;
     margin-top: units(1);
-    min-width: 27em; // max-width of 27 letters
+    min-width: $search-min-width;
     position: absolute;
     right: $site-margins;
   }

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -1,4 +1,4 @@
-$usa-btn-small-width:   4.5rem;
+// $usa-btn-small-width is in core/variables.scss
 $usa-btn-medium-width:  8.5rem;
 $usa-btn-big-width:     11.6rem;
 

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -774,7 +774,8 @@ $focus-outline:                 units(0.5) solid $color-focus !default;
 $focus-spacing:                 0 !default;
 $nav-width:                     951px !default;
 $sidenav-current-border-width:  0.4rem !default; // must be in rem for math
-$search-min-width:              27em !default; // minimum width of 27 letters for comfortable search bar
+$usa-btn-small-width:           4.5rem;
+$search-min-width:              27ch; // minimum width of 27 letters for comfortable search bar
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface Guidelines
 $hit-area: 4.4rem !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -774,6 +774,7 @@ $focus-outline:                 units(0.5) solid $color-focus !default;
 $focus-spacing:                 0 !default;
 $nav-width:                     951px !default;
 $sidenav-current-border-width:  0.4rem !default; // must be in rem for math
+$search-min-width:              27em !default; // minimum width of 27 letters for comfortable search bar
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface Guidelines
 $hit-area: 4.4rem !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -775,7 +775,7 @@ $focus-spacing:                 0 !default;
 $nav-width:                     951px !default;
 $sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 $usa-btn-small-width:           4.5rem;
-$search-min-width:              27ch; // minimum width of 27 letters for comfortable search bar
+$search-min-width:              27ch; // minimum length of 27 letters for typical search query
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface Guidelines
 $hit-area: 4.4rem !default;


### PR DESCRIPTION
- Puts secondary (utility) links above search
- Allows you to remove secondary links or search w/o effecting layout
- Makes search 27 letters wide as recommended on the [search bar page](https://designsystem.digital.gov/components/search-bar/).

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-extended-header-search/components/preview/header--extended.html)

Fixes #1640.