### PR TITLE
[app] unnest h4 from li element in footer

### DIFF
--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -5,42 +5,42 @@
   <div class="usa-footer-primary-section">
     <div class="usa-grid">
       <nav class="usa-footer-nav usa-width-two-thirds">
-        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-          <li class="usa-footer-primary-link">
-            <h4>Topic</h4>
-          </li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-        </ul>
-        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-          <li class="usa-footer-primary-link">
-            <h4>Topic</h4>
-          </li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-        </ul>
-        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-          <li class="usa-footer-primary-link">
-            <h4>Topic</h4>
-          </li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-        </ul>
-        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-          <li class="usa-footer-primary-link">
-            <h4>Topic</h4>
-          </li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-        </ul>
+        <section class="usa-width-one-fourth">
+          <h4 class="usa-footer-primary-link">Topic</h4>
+          <ul class="usa-unstyled-list usa-footer-primary-content">
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          </ul>
+        </section>
+        <section class="usa-width-one-fourth">
+          <h4 class="usa-footer-primary-link">Topic</h4>
+          <ul class="usa-unstyled-list  usa-footer-primary-content">
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          </ul>
+        </section>
+        <section class="usa-width-one-fourth">
+          <h4 class="usa-footer-primary-link">Topic</h4>
+          <ul class="usa-unstyled-list usa-footer-primary-content">
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          </ul>
+        </section>
+        <section class="usa-width-one-fourth">
+          <h4 class="usa-footer-primary-link">Topic</h4>
+          <ul class="usa-unstyled-list usa-footer-primary-content">
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+          </ul>
+        </section>
       </nav>
 
       <div class="usa-sign_up-block usa-width-one-third">

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -28,7 +28,7 @@
   }
 
   .usa-footer-primary-link ~ li a,
-  .usa-footer-secondary-link {
+  .usa-footer-secondary-link a {
     text-decoration: none;
   }
 }
@@ -285,6 +285,12 @@ li.usa-footer-primary-content {
 }
 
 .usa-footer-big {
+  .usa-footer-nav {
+    .usa-footer-primary-link, .usa-footer-primary-link > * {
+      margin-bottom: 0;
+    }
+  }
+
   .usa-footer-contact_info {
     display: block;
 


### PR DESCRIPTION
## Un-nest h4 element from li

## Description

Header elements cant be children of `ul`s, this PR promotes the heading in a footer nav to be a sibling of the `ul`.

## Additional information

I had to make some minor CSS additions to get the nav to display consistently


[PREVIEW 😎 ](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/ab-1659/components/preview/footer--big.html)

Fixes #1659 
