### PR TITLE
Accept named values in units() fn

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -978,6 +978,15 @@ the desired final units (currently rem)
   @if type-of($value) == 'list' and length($value) == 1 {
     $value: nth($value, 1);
   }
+  @if type-of($value) == 'string' {
+    $value: smart-quote($value);
+    @if map-has-key($project-spacing-named, $value) {
+      @return map-get($project-spacing-standard, $value);
+    }
+    @else {
+      @error "`#{$value}` is not a valid named spacing unit. Valid named spacing unit values: #{map-keys($project-spacing-named)}";
+    }
+  }
   @if type-of($value) == 'number' and unitless($value) {
     @return grid-units($value);
   }
@@ -991,10 +1000,6 @@ the desired final units (currently rem)
     }
     @elseif $value == false {
       @return false;
-    }
-    @elseif type-of($value) == 'number' and not unitless($value) {
-      @warn "`#{$value}` is not a standard USWDS unit. This is OK, but consider using a standard spacing unit instead.";
-      @return $value;
     }
     @else {
       @error "`#{$value}` is not a valid spacing unit. Valid spacing unit values: #{map-keys($project-spacing-standard)}";

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -52,6 +52,12 @@ $project-spacing-standard: map-collect(
   map-get($uswds-spacing, special)
 );
 
+$project-spacing-named: map-collect(
+  map-get($uswds-spacing, large),
+  map-get($uswds-spacing, larger),
+  map-get($uswds-spacing, largest)
+);
+
 $spacing-to-token: (
   '0':           0,
   '1':           '1px',

--- a/src/stylesheets/core/mixins/utilities/_padding.scss
+++ b/src/stylesheets/core/mixins/utilities/_padding.scss
@@ -8,18 +8,18 @@
     $important: ' !important';
   }
   @if $side == all {
-    padding: units($value...)#{$important};
+    padding: get-uswds-value(padding, $value...)#{$important};
   }
   @elseif $side == x {
-    padding-left: units($value...)#{$important};
-    padding-right: units($value...)#{$important};
+    padding-left: get-uswds-value(padding, $value...)#{$important};
+    padding-right: get-uswds-value(padding, $value...)#{$important};
   }
   @elseif $side == y {
-    padding-bottom: units($value...)#{$important};
-    padding-top: units($value...)#{$important};
+    padding-bottom: get-uswds-value(padding, $value...)#{$important};
+    padding-top: get-uswds-value(padding, $value...)#{$important};
   }
   @else {
-    padding-#{$side}: units($value...)#{$important};
+    padding-#{$side}: get-uswds-value(padding, $value...)#{$important};
   }
 }
 


### PR DESCRIPTION
- Now the `units()` function can accept the USWDS named spacing values, like `units(card)` or units(`mobile-lg`)`
- Rewrite `u-padding()` mixin to use `get-uswds-value()` not `units()` fn

