### PR TITLE
Remove margin in nav inner to fix Firefox zooming bug

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -174,7 +174,6 @@ $z-index-nav:     9000;
     @include media($nav-width) {
       @include outer-container($site-max-width);
       @include padding(null $site-margins null 1.5rem);
-      margin-top: -1px;
       position: relative;
     }
   }


### PR DESCRIPTION
Remove extra -1px margin in nav inner to fix Firefox zooming bug.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/remove-nav-margin/components/preview/header--extended.html)

Fixes #2631.