### PR TITLE
[app] use object.keys over .values

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -15,8 +15,11 @@ uswds.components = components;
 
 domready(() => {
   const target = document.body;
-
-  Object.values(components).forEach(behavior => behavior.on(target));
+  Object.keys(components)
+    .forEach((key) => {
+      const behavior = components[key];
+      behavior.on(target);
+    });
 });
 
 module.exports = uswds;


### PR DESCRIPTION
## Use Object.keys over .values

## Description

`Object.values` is not supported in any of the numbered IE versions we support. Uses `.keys` and `.forEach` instead.

Fixes #2637
