### PR TITLE
Fix header mega menu HTML validation 

### DIFF
--- a/src/components/08-navigation/_nav-primary.njk
+++ b/src/components/08-navigation/_nav-primary.njk
@@ -8,7 +8,7 @@
     <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="{{ nav.id_prefix }}{{ link.id }}">
       <span>{{ link.text }}</span>
     </button>
-    <ul id="{{ nav.id_prefix }}{{ link.id }}" class="usa-nav-submenu{% if nav.mega %} usa-megamenu usa-grid-full{% endif %}">
+    <{% if nav.mega %}div{% else %}ul{% endif %} id="{{ nav.id_prefix }}{{ link.id }}" class="usa-nav-submenu{% if nav.mega %} usa-megamenu usa-grid-full{% endif %}">
       {%- if nav.id_prefix == "basic-" or nav.id_prefix == "extended-" -%}
         {%- for child in link.links -%}
           {%- if loop.index < 4 -%}
@@ -20,15 +20,17 @@
       {%- else -%}
         {%- for group in link.links | batch(3) -%}
           <div class="usa-megamenu-col">
-            {%- for child in group -%}
-              <li>
-                <a href="{{ child.href }}">{{ child.text }}</a>
-              </li>
-            {%- endfor -%}
+            <ul>
+              {%- for child in group -%}
+                <li>
+                  <a href="{{ child.href }}">{{ child.text }}</a>
+                </li>
+              {%- endfor -%}
+            </ul>
           </div>
         {%- endfor -%}
       {%- endif -%}
-    </ul>
+    </{% if nav.mega %}div{% else %}ul{% endif %}>
     {%- else -%}
     <a class="usa-nav-link{% if link.current %} usa-current{% endif %}" href="{{ link.href }}">
       <span>{{ link.text }}</span>


### PR DESCRIPTION
This changes the mega menu from a single list that was broken up by divs into multiple lists.

An enhancement of this would be to add headings above the lists. However, we'd need to come up with a design for how those headings would look on mobile.

Fixes #2634.