### PR TITLE
Make form error more robust

### DIFF
--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -2,7 +2,7 @@
   <fieldset>
     <legend>Date of birth</legend>
     <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
-    <div class="usa-date-of-birth">
+    <div class="usa-memorable-date">
       <div class="usa-form-group usa-form-group-month">
         <label for="date_of_birth_1">Month</label>
         <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">

--- a/src/components/07-form/controls/text-input.njk
+++ b/src/components/07-form/controls/text-input.njk
@@ -5,10 +5,10 @@
   <label for="input-focus">Text input focused</label>
   <input class="usa-focus" id="input-focus" name="input-focus" type="text">
 
-  <div class="usa-input-error">
+  <div class="usa-form-group-error">
     <label class="usa-input-error-label" for="input-error">Text input error</label>
     <span class="usa-input-error-message" id="input-error-message" role="alert">Helpful error message</span>
-    <input id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
+    <input class="usa-input-error" id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
   </div>
 
   <label for="input-success">Text input success</label>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -44,9 +44,7 @@ select {
 .usa-form-group-error {
   border-left: 4px solid $color-secondary-dark;
   margin-top: 3rem;
-  padding-bottom: 0.8rem;
   padding-left: 1.5rem;
-  padding-top: 0.8rem;
   position: relative;
   right: 1.9rem;
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -41,7 +41,7 @@ select {
 }
 /* stylelint-enable */
 
-.usa-input-error {
+.usa-form-group-error {
   border-left: 4px solid $color-secondary-dark;
   margin-top: 3rem;
   padding-bottom: 0.8rem;
@@ -49,32 +49,17 @@ select {
   padding-top: 0.8rem;
   position: relative;
   right: 1.9rem;
+}
 
-  input,
-  textarea,
-  select {
-    border: 3px solid $color-secondary-dark;
-    width: calc(100% + 1.9rem); // 1.5rem left padding + 4px border from input error spacing
-  }
-
-  label {
-    margin-top: 0;
-  }
-
-  .usa-input-inline {
-    border: $input-border-width solid $color-gray;
-    width: inherit;
-  }
-
-  .usa-input-inline-error {
-    border: 3px solid $color-secondary-dark;
-  }
+.usa-input-error {
+  border: 3px solid $color-secondary-dark;
 }
 
 .usa-input-error-label {
   display: block;
   font-size: $base-font-size;
   font-weight: $font-bold;
+  margin-top: 0;
 }
 
 .usa-input-error-message {


### PR DESCRIPTION
- Changes `usa-input-error` to `usa-form-group-error` to make it more applicable.
- De-nests input element tags inside the error message CSS into `usa-input-error`
- Slight design changes to be more in line with [GOV.UK design updates](https://design-system.service.gov.uk/components/error-message/) including removing extra padding from on error line.
- Saved over `usa-memorable-date` in 0d5a6d5c552608bc182a35efeba7d9942f7ea5fa so this fixes that.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-date-error/components/preview/text-input.html)

Refs #2304.