### PR TITLE
Update global switch to use a mixin instead of an extend

### DIFF
--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -92,7 +92,7 @@ body {
   }
 }
 
-%theme-content-styles {
+@mixin usa-content-styles {
   @include usa-typography-base-styles;
   @include usa-headings-styles;
   @include usa-list-styles;
@@ -103,10 +103,10 @@ body {
 @mixin theme-content-styles {
   @if $theme-content-styles == 'scoped' {
     .usa-prose {
-      @extend %theme-content-styles;
+      @include usa-content-styles;
     }
   } @else if $theme-content-styles == 'global' {
-    @extend %theme-content-styles;
+    @include usa-content-styles;
   } @else {
     // Default nothing if it’s neither
   }


### PR DESCRIPTION
When integrating on the uswds site, this only works as a `@mixin` not an `@extend` so changing this.