### PR TITLE
Output utilities with `noValue` values properly

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -1270,7 +1270,10 @@ through all possible variants
       $v: null;
       $mv: null;
       $val-props: ();
+      $no-value: false;
       $mq: null;
+      $no-modifier: false;
+      $debug-flag: false;
 
       $b: map-get($utility, base);
 
@@ -1314,6 +1317,11 @@ through all possible variants
             map-get($val-value, 'content'),
             $val-value
           );
+
+          @if $val-slug == ''
+            or smart-quote($val-slug) == 'noValue' {
+            $no-value: true;
+          }
 
           // Add any appended values...
 
@@ -1393,12 +1401,13 @@ through all possible variants
 
               // if the value is noValue ('')
 
-              } @else if $val-slug == ''
-                or smart-quote($val-slug) == 'noValue' {
+            } @else if $no-value {
 
                   // selector is the base only
 
                   $selector: $b;
+                  @debug 'it me! #{$utility-name} selector:#{$selector}';
+                  $debug-flag: true;
 
               } @else {
 
@@ -1415,18 +1424,20 @@ through all possible variants
 
             @else {
 
-              // Join into selector $mv.
-
-              $mv: $mod-key + '-' + $v;
+              $mv: if(
+                $no-value,
+                $mod-key,
+                $mod-key + '-' + $v
+              );
 
               // Once we have $mv, test for $b
               // and build the selector as before.
 
-              @if $b == null {
-                $selector: $mv;
-              } @else {
-                $selector: $b + '-' + $mv;
-              }
+              $selector: if(
+                $b == null,
+                $mv,
+                $b + '-' + $mv
+              );
             }
 
             // finished setting modifier vars
@@ -1439,6 +1450,10 @@ through all possible variants
             // https://www.youtube.com/watch?v=R3Igz5SfBCE
 
             @include render-utility($utility, $selector, $property, $value, $val-value);
+
+            @if $debug-flag {
+              @debug 'UTILITY: #{$utility}, SELECTOR: #{$selector}, PROPERTY: #{$property}, VALUE: #{$value}, VAL-VALUE: #{$val-value}';
+            }
 
           } // end the modifier loop
         } // end the null value conditional

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -591,7 +591,6 @@ variable that is, itself, a list
   }
 
   @if not map-has-key($uswds-required-colors, $color-family) {
-    @debug '#{$color-family}';
     @error 'USWDS colors require a grade. '
          + 'Exceptions: #{map-keys($uswds-required-colors)}';
   }
@@ -1272,8 +1271,6 @@ through all possible variants
       $val-props: ();
       $no-value: false;
       $mq: null;
-      $no-modifier: false;
-      $debug-flag: false;
 
       $b: map-get($utility, base);
 
@@ -1406,9 +1403,6 @@ through all possible variants
                   // selector is the base only
 
                   $selector: $b;
-                  @debug 'it me! #{$utility-name} selector:#{$selector}';
-                  $debug-flag: true;
-
               } @else {
 
                 // otherwise, selctor is joined with a hyphen.
@@ -1450,10 +1444,6 @@ through all possible variants
             // https://www.youtube.com/watch?v=R3Igz5SfBCE
 
             @include render-utility($utility, $selector, $property, $value, $val-value);
-
-            @if $debug-flag {
-              @debug 'UTILITY: #{$utility}, SELECTOR: #{$selector}, PROPERTY: #{$property}, VALUE: #{$value}, VAL-VALUE: #{$val-value}';
-            }
 
           } // end the modifier loop
         } // end the null value conditional

--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -57,7 +57,7 @@ $uswds-properties: (
       map-get($uswds-spacing, small),
       map-get($partial-values, zero-zero),
       (
-        noValue: 1px,
+        'noValue': 1px,
       )
     ),
     extended: (),

--- a/src/stylesheets/utilities/rules/clearfix.scss
+++ b/src/stylesheets/utilities/rules/clearfix.scss
@@ -19,7 +19,7 @@ $u-clearfix: (
     modifiers: null,
     values: (
       reset: (
-        slug: noValue,
+        slug: 'noValue',
         isReadable: false,
         content: 'both',
         extend: (


### PR DESCRIPTION
I'd introduced an error where `noValue` utilities like `border-left` (which should result in `border-left: 1px`) outputted as `border-left-noValue`. This fixes that!

Now, we should see no instances of the `noValue` string in our compiled css, and the border utilities that don't have an explicit value (like `border-left` vs `border-left-1px`) should output [as documented](https://v2.designsystem.digital.gov/utilities/border/)