### PR TITLE
[WIP] Fix units conversion error

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -789,20 +789,15 @@ calculated variables
 ----------------------------------------
 */
 
-$theme-site-margins: units($theme-site-margins);
-$theme-site-margins-mobile: units($theme-site-margins-mobile);
-$theme-nav-width: units($theme-nav-width);
-$theme-site-max-width: units($theme-site-max-width);
-
 $text-width-sm: 60ch;
 
 $text-max-width:                66ch !default; // 66 characters per line
 $text-narrow-width:             40ch !default;
 $text-wide-width:               72ch !default;
 $lead-max-width:                77rem !default;
-$site-max-width:                $theme-site-max-width;
-$site-margins:                  $theme-site-margins;
-$site-margins-mobile:           $theme-site-margins-mobile;
+$site-max-width:                1040px !default;
+$site-margins:                  units($theme-site-margins) !default;
+$site-margins-mobile:           units($theme-site-margins-mobile) !default;
 $article-max-width:             600px !default;
 $input-max-width:               46rem !default;
 $label-border-radius:           2px !default;

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -17,6 +17,33 @@ PROJECT THEME SETTINGS
 
 /*
 ----------------------------------------
+Basic styles
+----------------------------------------
+Sets the default typography styles for
+paragraph text and links
+
+Accepts true or false
+----------------------------------------
+*/
+
+$theme-global-styles-basic: true;
+
+/*
+----------------------------------------
+Content styles
+----------------------------------------
+Sets the default typography styles for
+paragraph text, links, headings, lists,
+and tables
+
+Accepts global, scoped, or none
+----------------------------------------
+*/
+
+$theme-content-styles: 'scoped';
+
+/*
+----------------------------------------
 Namespace
 ----------------------------------------
 */
@@ -46,6 +73,8 @@ Root font size
 ----------------------------------------
 Sets the font size of the html root
 for rem calculations
+
+Accepts [n]px or 100%
 ----------------------------------------
 */
 
@@ -380,3 +409,65 @@ widescreen
 */
 
 $theme-grid-container-max-width: desktop;
+
+/*
+----------------------------------------
+New stuff from variables
+----------------------------------------
+Type scale tokens
+----------------------------------------
+micro:      10px
+1:          12px
+2:          13px
+3:          14px
+4:          15px
+5:          16px
+6:          17px
+7:          18px
+8:          20px
+9:          22px
+10:         24px
+11:         28px
+12:         32px
+13:         36px
+14:         40px
+15:         48px
+16:         56px
+17:         64px
+18:         80px
+19:         120px
+20:         140px
+----------------------------------------
+Line height tokens
+----------------------------------------
+1:    1
+2:    1.15
+3:    1.35
+4:    1.5
+5:    1.62
+6:    1.75
+----------------------------------------
+*/
+
+$theme-base-font-size:      6; // was 1.7rem
+$theme-small-font-size:     3; // was 1.4rem
+$theme-lead-font-size:      8; // was 2rem
+$theme-title-font-size:     15; // was 5.2rem
+$theme-h1-font-size:        14; // was 4rem
+$theme-h2-font-size:        11; // was 3rem
+$theme-h3-font-size:        8; // was 2rem
+$theme-h4-font-size:        6; // was 1.7rem
+$theme-h5-font-size:        4; // was 1.5rem
+$theme-h6-font-size:        2; // was 1.3rem
+$theme-base-line-height:    4; // was 1.5
+$theme-heading-line-height: 3; // was 1.3
+$theme-lead-line-height:    6; // was 1.7
+
+$theme-site-margins:        4; // was 3rem
+$theme-site-margins-mobile: 2; // was 1.5rem
+
+$theme-nav-width:           'desktop'; // was 951px
+$theme-site-max-width:      'desktop'; // was 1040px
+
+$theme-font-weight-normal:         400;
+$theme-font-weight-bold:           700;


### PR DESCRIPTION
The following code was an unnecessary technique to try and make these settings vars more "useful" in our code. They are set with numeric tokens, like `4` and this would convert those tokens into rem units (like `3.2rem`) to make something like `padding-left: $theme-site-margins` possible, instead of  `padding-left: units($theme-site-margins)`. 

This worked well in the normal repo, but threw an error when the sass was added via packages in `uswds-site`.

```scss
$theme-site-margins: units($theme-site-margins);	
$theme-site-margins-mobile: units($theme-site-margins-mobile);	
$theme-nav-width: units($theme-nav-width);	
$theme-site-max-width: units($theme-site-max-width);
```