### PR TITLE
Add required colors to all color mixins

### DIFF
--- a/src/stylesheets/core/mixins/utilities/_border.scss
+++ b/src/stylesheets/core/mixins/utilities/_border.scss
@@ -7,6 +7,9 @@ $border-utilities: (
     map-deep-get($uswds-properties, border-style, standard),
     map-deep-get($uswds-properties, border-style, extended)
   ),
+  color: map-collect(
+    $uswds-required-colors
+  ),
 );
 
 @mixin border-n($side, $value...) {
@@ -20,6 +23,23 @@ $border-utilities: (
     $match: false;
     @if $value == false {
       @error "You've added a border color that does not exist or is set to false.";
+    }
+    @elseif map-has-key($uswds-required-colors, $this-value) {
+      $match: true;
+      @if $side == n {
+        border-color: color($this-value)#{$important};
+      }
+      @elseif $side == x {
+        border-left-color: color($this-value)#{$important};
+        border-right-color: color($this-value)#{$important};
+      }
+      @elseif $side == y {
+        border-bottom-color: color($this-value)#{$important};
+        border-top-color: color($this-value)#{$important};
+      }
+      @else {
+        border-#{$side}-color: color($this-value)#{$important};
+      }
     }
     @elseif type-of($this-value) == 'color' {
       $match: true;

--- a/src/stylesheets/core/mixins/utilities/_outline.scss
+++ b/src/stylesheets/core/mixins/utilities/_outline.scss
@@ -14,6 +14,10 @@
       $match: true;
       outline-color: $this-value#{$important};
     }
+    @elseif map-has-key($uswds-required-colors, $this-value) {
+      $match: true;
+      outline-color: color($this-value)#{$important};
+    }
     @elseif type-of($this-value) == 'number' {
       $converted-value: number-to-value($this-value);
       $widths: map-deep-get($uswds-properties, outline, standard);

--- a/src/stylesheets/core/mixins/utilities/_text-decoration.scss
+++ b/src/stylesheets/core/mixins/utilities/_text-decoration.scss
@@ -9,8 +9,9 @@
   @each $this-value in $value {
     @if type-of($this-value) == 'color' {
       text-decoration-color: $this-value#{$important};
-    }
-    @else {
+    } @elseif map-has-key($uswds-required-colors, $this-value) {
+      text-decoration-color: color($this-value)#{$important};
+    } @else {
       text-decoration: get-uswds-value(text-decoration, $value...)#{$important};
     }
   }

--- a/src/stylesheets/core/mixins/utilities/_text.scss
+++ b/src/stylesheets/core/mixins/utilities/_text.scss
@@ -33,6 +33,9 @@ $text-utililies: (
     map-deep-get($uswds-properties, white-space, standard),
     map-deep-get($uswds-properties, white-space, extended)
   ),
+  color: map-collect(
+    $uswds-required-colors
+  ),
 );
 
 @mixin u-text($value...) {


### PR DESCRIPTION
 Adds `'transparent'`, `'black'`, and `'white'` to the valid values accepted by the color mixins:
- u-text()
- u-bg()
- u-border()
- u-outline()
- u-outline-color()
- u-text-decoration()
- u-underline()