### PR TITLE
Don't uglify JS code during development

### DIFF
--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -31,9 +31,13 @@ gulp.task(task, function (done) {
     .pipe(gulp.dest('dist/js'));
 
   stream
-    .pipe(sourcemaps.init({ loadMaps: true }))
-    .pipe(uglify())
-    .on('error', gutil.log)
+    .pipe(sourcemaps.init({ loadMaps: true }));
+
+  if (process.env.NODE_ENV !== 'development') {
+    stream.pipe(uglify());
+  }
+
+  stream.on('error', gutil.log)
     .pipe(rename({
       suffix: '.min',
     }))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "fractal start --sync",
     "test": "gulp eslint typecheck stylelint test",
     "version": "gulp build release",
-    "watch": "nswatch"
+    "watch": "NODE_ENV=development nswatch"
   },
   "watch": {
     "src/stylesheets/{components,core,elements,}/*.scss": "build:css",


### PR DESCRIPTION
## Skip JS uglification when developing

## Description

Its difficult to diagnose issues when debuggers are stripped and code
is obfuscated. I almost always comment out the code form our build script when working on changes to the JS, this makes this automatic.
