### PR TITLE
Add switch to respect user font size settings

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -4,6 +4,22 @@ Functions
 ----------------------------------------
 */
 
+// The following vars need to be set
+// here, before the rest of the system
+// variables are set
+
+$root-font-size: if(
+  $theme-respect-user-font-size,
+  100%,
+  $theme-root-font-size
+);
+
+$root-font-size-equiv: if(
+  $theme-respect-user-font-size,
+  16px,
+  $theme-root-font-size
+);
+
 /*
 ========================================
 General-purpose functions
@@ -344,27 +360,6 @@ Append `!important` to a list
 
 /*
 ----------------------------------------
-root-to-px()
-----------------------------------------
-Outputs the size as the original px
-or 16px if the root is set to 100%
-----------------------------------------
-*/
-
-@function root-to-px($size) {
-  @if $size == 100% {
-    @return 16px;
-  }
-
-  @if not unit($size) == 'px' {
-    @error "``$theme-root-font-size` needs to be in px or 100%.";
-  }
-
-  @return $size;
-}
-
-/*
-----------------------------------------
 grid-units()
 ----------------------------------------
 Converts a spacing unit multiple into
@@ -373,7 +368,7 @@ the desired final units (currently rem)
 */
 
 @function grid-units($unit) {
-  $grid-to-rem: strip-unit($uswds-spacing-grid-base) * $unit / strip-unit(root-to-px($theme-root-font-size)) * 1rem;
+  $grid-to-rem: ($uswds-spacing-grid-base * $unit) / $root-font-size-equiv * 1rem;
 
   @return $grid-to-rem;
 }
@@ -386,24 +381,31 @@ Converts a value in rem to a value in px
 ----------------------------------------
 */
 
-@function rem-to-px($value) {
-  $rem-to-px: strip-unit($value) * root-to-px($theme-root-font-size);
-
-  @return $rem-to-px;
+@function rem-to-px($value-in-rem) {
+  @if unit($value-in-rem) == 'rem' {
+    $rem-to-px: ($value-in-rem / 1rem) * $root-font-size-equiv;
+    @return $rem-to-px;
+  }
+  @if unit($value-in-rem) != 'px' {
+    @error 'This value must be in either px or rem';
+  }
+  @return $value-in-rem;
 }
 
 /*
 ----------------------------------------
-grid-to-base-em()
+rem-to-user-em()
 ----------------------------------------
-Converts a value in px to a value in em
+Converts a value in rem to a value in
+[user-settings] em for use in media
+queries
 ----------------------------------------
 */
 
-@function grid-to-base-em($grid-in-rem) {
-  $grid-to-base-em: strip-unit($grid-in-rem) * 1em;
+@function rem-to-user-em($grid-in-rem) {
+  $rem-to-user-em: ($grid-in-rem / 1rem) * 1em;
 
-  @return $grid-to-base-em;
+  @return $rem-to-user-em;
 }
 
 /*
@@ -438,8 +440,7 @@ Converts a value in px to a value in rem
   @if not $pixels {
     @return false;
   }
-
-  $px-to-rem: strip-unit($pixels) / strip-unit(root-to-px($theme-root-font-size)) * 1rem;
+  $px-to-rem: ($pixels / $root-font-size-equiv) * 1rem;
 
   @return $px-to-rem;
 }
@@ -458,7 +459,7 @@ to a set target
     @return false;
   }
 
-  $this-scale: $uswds-base-cap-height * strip-unit($scale) / $cap-height;
+  $this-scale: $uswds-base-cap-height * strip-unit($scale) / $cap-height * 1px;
 
   @return px-to-rem($this-scale);
 

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -67,12 +67,34 @@ $theme-namespace: (
 ----------------------------------------
 Root font size
 ----------------------------------------
-Sets the font size of the html root
-for rem calculations
+Setting $theme-respect-user-font-size to
+true sets the root font size to 100% and
+uses ems for media queries
+----------------------------------------
+$theme-root-font-size only applies when
+$theme-respect-user-font-size is set to
+false.
 
-Accepts [n]px or 100%
+This will set the root font size
+as a specific px value and use px values
+for media queries.
+
+Accepts true or false
 ----------------------------------------
 */
+
+$theme-respect-user-font-size: false !default;
+
+
+// $theme-root-font-size only applies when
+// $theme-respect-user-font-size is set to
+// false.
+
+// This will set the root font size
+// as a specific px value and use px values
+// for media queries.
+
+// Accepts values in px
 
 $theme-root-font-size: 10px !default;
 

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -166,33 +166,33 @@ defined in the system:
 $theme-font-definitions: (
   /*
   font-new: (
-    name: "Font Display Name",
-    dir: "folder-name", // relative to settings.$theme-font-path
+    name: 'Font Display Name',
+    dir: 'folder-name', // relative to settings.$theme-font-path
     stack: $font-stack-system,
     system-font: false,
-    cap-height: "364px", // height of a 500px `N` in Sketch
+    cap-height: '364px', // height of a 500px `N` in Sketch
     variable-font: false,
     roman: (
-      100: "Filename-without-extension", // or false
-      200: "Filename-without-extension", // or false
-      300: "Filename-without-extension", // or false
-      400: "Filename-without-extension", // or false
-      500: "Filename-without-extension", // or false
-      600: "Filename-without-extension", // or false
-      700: "Filename-without-extension", // or false
-      800: "Filename-without-extension", // or false
-      900: "Filename-without-extension", // or false
+      100: 'Filename-without-extension', // or false
+      200: 'Filename-without-extension', // or false
+      300: 'Filename-without-extension', // or false
+      400: 'Filename-without-extension', // or false
+      500: 'Filename-without-extension', // or false
+      600: 'Filename-without-extension', // or false
+      700: 'Filename-without-extension', // or false
+      800: 'Filename-without-extension', // or false
+      900: 'Filename-without-extension', // or false
     ),
     italic: (
-      100: "Filename-without-extension", // or false
-      200: "Filename-without-extension", // or false
-      300: "Filename-without-extension", // or false
-      400: "Filename-without-extension", // or false
-      500: "Filename-without-extension", // or false
-      600: "Filename-without-extension", // or false
-      700: "Filename-without-extension", // or false
-      800: "Filename-without-extension", // or false
-      900: "Filename-without-extension", // or false
+      100: 'Filename-without-extension', // or false
+      200: 'Filename-without-extension', // or false
+      300: 'Filename-without-extension', // or false
+      400: 'Filename-without-extension', // or false
+      500: 'Filename-without-extension', // or false
+      600: 'Filename-without-extension', // or false
+      700: 'Filename-without-extension', // or false
+      800: 'Filename-without-extension', // or false
+      900: 'Filename-without-extension', // or false
     ),
   ),
   */

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -85,7 +85,6 @@ Accepts true or false
 
 $theme-respect-user-font-size: false !default;
 
-
 // $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
 // false.

--- a/src/stylesheets/core/mixins/_at-media.scss
+++ b/src/stylesheets/core/mixins/_at-media.scss
@@ -4,9 +4,11 @@
   $quoted-bp: quote($bp);
   $our-breakpoints: map-deep-get($uswds-properties, breakpoints, standard);
   @if map-has-key($our-breakpoints, $quoted-bp){
-    // for some reason em isn't working??
-    // $bp: grid-to-base-em(map-get($our-breakpoints, $quoted-bp));
-    $bp: rem-to-px(map-get($our-breakpoints, $quoted-bp));
+    @if $theme-respect-user-font-size {
+      $bp: rem-to-user-em(map-get($our-breakpoints, $quoted-bp));
+    } @else {
+      $bp: rem-to-px(map-get($our-breakpoints, $quoted-bp));
+    }
   }
   @else {
     @warn "`#{$bp}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}";

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -1,6 +1,6 @@
 html {
   font-family: $font-sans;
-  font-size: $theme-root-font-size;
+  font-size: $root-font-size;
 }
 
 body {

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -71,12 +71,34 @@ $theme-namespace: (
 ----------------------------------------
 Root font size
 ----------------------------------------
-Sets the font size of the html root
-for rem calculations
+Setting $theme-respect-user-font-size to
+true sets the root font size to 100% and
+uses ems for media queries
+----------------------------------------
+$theme-root-font-size only applies when
+$theme-respect-user-font-size is set to
+false.
 
-Accepts [n]px or 100%
+This will set the root font size
+as a specific px value and use px values
+for media queries.
+
+Accepts true or false
 ----------------------------------------
 */
+
+$theme-respect-user-font-size: false;
+
+
+// $theme-root-font-size only applies when
+// $theme-respect-user-font-size is set to
+// false.
+
+// This will set the root font size
+// as a specific px value and use px values
+// for media queries.
+
+// Accepts values in px
 
 $theme-root-font-size: 10px;
 
@@ -149,33 +171,33 @@ defined in the system:
 $theme-font-definitions: (
   /*
   font-new: (
-    name: 'Font Display Name',
-    dir: 'folder-name', // relative to settings.$theme-font-path
+    name: "Font Display Name",
+    dir: "folder-name", // relative to settings.$theme-font-path
     stack: $font-stack-system,
     system-font: false,
-    cap-height: '364px', // height of a 500px `N` in Sketch
+    cap-height: "364px", // height of a 500px `N` in Sketch
     variable-font: false,
     roman: (
-      100: 'Filename-without-extension', // or false
-      200: 'Filename-without-extension', // or false
-      300: 'Filename-without-extension', // or false
-      400: 'Filename-without-extension', // or false
-      500: 'Filename-without-extension', // or false
-      600: 'Filename-without-extension', // or false
-      700: 'Filename-without-extension', // or false
-      800: 'Filename-without-extension', // or false
-      900: 'Filename-without-extension', // or false
+      100: "Filename-without-extension", // or false
+      200: "Filename-without-extension", // or false
+      300: "Filename-without-extension", // or false
+      400: "Filename-without-extension", // or false
+      500: "Filename-without-extension", // or false
+      600: "Filename-without-extension", // or false
+      700: "Filename-without-extension", // or false
+      800: "Filename-without-extension", // or false
+      900: "Filename-without-extension", // or false
     ),
     italic: (
-      100: 'Filename-without-extension', // or false
-      200: 'Filename-without-extension', // or false
-      300: 'Filename-without-extension', // or false
-      400: 'Filename-without-extension', // or false
-      500: 'Filename-without-extension', // or false
-      600: 'Filename-without-extension', // or false
-      700: 'Filename-without-extension', // or false
-      800: 'Filename-without-extension', // or false
-      900: 'Filename-without-extension', // or false
+      100: "Filename-without-extension", // or false
+      200: "Filename-without-extension", // or false
+      300: "Filename-without-extension", // or false
+      400: "Filename-without-extension", // or false
+      500: "Filename-without-extension", // or false
+      600: "Filename-without-extension", // or false
+      700: "Filename-without-extension", // or false
+      800: "Filename-without-extension", // or false
+      900: "Filename-without-extension", // or false
     ),
   ),
   */

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -89,7 +89,6 @@ Accepts true or false
 
 $theme-respect-user-font-size: false;
 
-
 // $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
 // false.

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -170,33 +170,33 @@ defined in the system:
 $theme-font-definitions: (
   /*
   font-new: (
-    name: "Font Display Name",
-    dir: "folder-name", // relative to settings.$theme-font-path
+    name: 'Font Display Name',
+    dir: 'folder-name', // relative to settings.$theme-font-path
     stack: $font-stack-system,
     system-font: false,
-    cap-height: "364px", // height of a 500px `N` in Sketch
+    cap-height: '364px', // height of a 500px `N` in Sketch
     variable-font: false,
     roman: (
-      100: "Filename-without-extension", // or false
-      200: "Filename-without-extension", // or false
-      300: "Filename-without-extension", // or false
-      400: "Filename-without-extension", // or false
-      500: "Filename-without-extension", // or false
-      600: "Filename-without-extension", // or false
-      700: "Filename-without-extension", // or false
-      800: "Filename-without-extension", // or false
-      900: "Filename-without-extension", // or false
+      100: 'Filename-without-extension', // or false
+      200: 'Filename-without-extension', // or false
+      300: 'Filename-without-extension', // or false
+      400: 'Filename-without-extension', // or false
+      500: 'Filename-without-extension', // or false
+      600: 'Filename-without-extension', // or false
+      700: 'Filename-without-extension', // or false
+      800: 'Filename-without-extension', // or false
+      900: 'Filename-without-extension', // or false
     ),
     italic: (
-      100: "Filename-without-extension", // or false
-      200: "Filename-without-extension", // or false
-      300: "Filename-without-extension", // or false
-      400: "Filename-without-extension", // or false
-      500: "Filename-without-extension", // or false
-      600: "Filename-without-extension", // or false
-      700: "Filename-without-extension", // or false
-      800: "Filename-without-extension", // or false
-      900: "Filename-without-extension", // or false
+      100: 'Filename-without-extension', // or false
+      200: 'Filename-without-extension', // or false
+      300: 'Filename-without-extension', // or false
+      400: 'Filename-without-extension', // or false
+      500: 'Filename-without-extension', // or false
+      600: 'Filename-without-extension', // or false
+      700: 'Filename-without-extension', // or false
+      800: 'Filename-without-extension', // or false
+      900: 'Filename-without-extension', // or false
     ),
   ),
   */


### PR DESCRIPTION
The changes we've made and are making for USWDS 2.0 allows us to do something previously impossible: respect users' browser font size settings.

This PR adds a new boolean variable to theme settings: `$theme-respect-user-font-size`.  When set to `true` the system does a few things:
- Sets the font size of the `html` element to `100%`
- Uses `em` values for media queries (for media queries, `em` is a multiplier of the user's browser default font size)

When set to `false` the system acts as it does now:
- Sets the font size of the `html` to the value of `$theme-root-font-size`
- Uses `px` values for media queries

- - -

Currently, I've left the value of `$theme-respect-user-font-size` as `false` because our components are not all rebuilt with the new tokens. They'll all tend to get _really_ big if this is set to `true` right now. However, once the system is rebuilt in the new tokens (as the banner is now), we should set our system default to `true` — and our components will scale related to the user's settings, _which is the expected behavior_. Our mobile-first, responsive components will be well suited to this change.

**Examples**
Medium font size set in Chrome:

<img width="1013" alt="screen shot 2018-08-14 at 3 05 43 pm" src="https://user-images.githubusercontent.com/11464021/44121112-9352ed9c-9fd3-11e8-991e-6676814bbbb0.png">

- - -

Large font size set in Chrome:

<img width="1056" alt="screen shot 2018-08-14 at 3 01 53 pm" src="https://user-images.githubusercontent.com/11464021/44120992-1019aaf6-9fd3-11e8-9bd0-48dad960a230.png">
(The discrepancy in widths between the header and the content above is due to the old grid still using a px value as its max-width)

- - -

In the 1.0 system, these components would appear the same size regardless of the user settings. The `false` setting above would preserve this behavior, which might be the appropriate setting for some USWDS projects.

