### PR TITLE
Fix bugs in italic font builder

### DIFF
--- a/src/stylesheets/core/_font-definitions.scss
+++ b/src/stylesheets/core/_font-definitions.scss
@@ -124,7 +124,7 @@ $uswds-font-definitions: (
       100: false,
       200: false,
       300: false,
-      400: 'sourcesanspro-bold-webfont',
+      400: 'sourcesanspro-italic-webfont',
       500: false,
       600: false,
       700: false,

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -1495,11 +1495,9 @@ through all possible variants
     }
 
     @if $italic {
-      @debug 'it me! italic! #{$font-name}';
       @each $weight, $filename in $italic {
         @each $key, $outputweight in $these-weights {
           @if $outputweight == $weight and $filename {
-            @debug 'found an valid italic! #{$font-name}: #{$filename}';
             @include font-face(
               '#{$font-name}',
               '#{$theme-font-path}/#{$dir}/#{$filename}',

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -1473,41 +1473,40 @@ through all possible variants
   @if $this-font-face and map-deep-get($all-font-definitions, $this-font-face, generate) {
     $this-font: map-get($all-font-definitions, $this-font-face);
     $this-font-system: map-get($this-font, system-font);
+    $font-name: map-get($this-font, name);
+    $roman: map-get($this-font, roman);
+    $italic: map-get($this-font, italic);
+    $dir: map-get($this-font, dir);
 
-    @if $this-font-system == false {
-      $font-name: map-get($this-font, name);
-      $roman: map-get($this-font, roman);
-      $italic: map-get($this-font, italic);
-      $dir: map-get($this-font, dir);
-
-      @if $roman {
-        @each $weight, $filename in $roman {
-          @each $key, $outputweight in $these-weights {
-            @if $outputweight == $weight and $filename {
-              @include font-face(
-                '#{$font-name}',
-                '#{$theme-font-path}/#{$dir}/#{$filename}',
-                #{$weight},
-                normal,
-                $file-formats: eot woff2 woff ttf
-              );
-            }
+    @if $roman {
+      @each $weight, $filename in $roman {
+        @each $key, $outputweight in $these-weights {
+          @if $outputweight == $weight and $filename {
+            @include font-face(
+              '#{$font-name}',
+              '#{$theme-font-path}/#{$dir}/#{$filename}',
+              #{$weight},
+              normal,
+              $file-formats: eot woff2 woff ttf
+            );
           }
         }
       }
+    }
 
-      @if $italic {
-        @each $weight, $filename in $italic {
-          @each $outputweight in $these-weights {
-            @if $outputweight == $weight and $filename {
-              @include font-face(
-                '#{$font-name}',
-                '#{$theme-font-path}/#{$dir}/#{$filename}',
-                #{$weight},
-                italic,
-                $file-formats: eot woff2 woff ttf
-              );
-            }
+    @if $italic {
+      @debug 'it me! italic! #{$font-name}';
+      @each $weight, $filename in $italic {
+        @each $key, $outputweight in $these-weights {
+          @if $outputweight == $weight and $filename {
+            @debug 'found an valid italic! #{$font-name}: #{$filename}';
+            @include font-face(
+              '#{$font-name}',
+              '#{$theme-font-path}/#{$dir}/#{$filename}',
+              #{$weight},
+              italic,
+              $file-formats: eot woff2 woff ttf
+            );
           }
         }
       }


### PR DESCRIPTION
- Remove unnecessary `@if` in font builder mixin
- Use proper filename for source sans pro italic
- Use proper map keys for italic weights loop