### PR TITLE
Update font size theme vars to use current token names

### DIFF
--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -252,15 +252,15 @@ values from the USWDS system type scale
 ----------------------------------------
 */
 
-$theme-type-scale-3xs:         1 !default;
+$theme-type-scale-3xs:      1 !default;
 $theme-type-scale-2xs:      3 !default;
 $theme-type-scale-xs:       5 !default;
-$theme-type-scale-sm:         6 !default;
-$theme-type-scale-md:          7 !default;
-$theme-type-scale-lg:         10 !default;
-$theme-type-scale-xl:        12 !default;
-$theme-type-scale-2xl:       14 !default;
-$theme-type-scale-3xl:          16 !default;
+$theme-type-scale-sm:       6 !default;
+$theme-type-scale-md:       7 !default;
+$theme-type-scale-lg:       10 !default;
+$theme-type-scale-xl:       12 !default;
+$theme-type-scale-2xl:      14 !default;
+$theme-type-scale-3xl:      16 !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/core/_settings.scss
+++ b/src/stylesheets/core/_settings.scss
@@ -252,15 +252,15 @@ values from the USWDS system type scale
 ----------------------------------------
 */
 
-$theme-type-scale-micro:         1 !default;
-$theme-type-scale-smallest:      3 !default;
-$theme-type-scale-smaller:       5 !default;
-$theme-type-scale-small:         6 !default;
-$theme-type-scale-base:          7 !default;
-$theme-type-scale-large:         10 !default;
-$theme-type-scale-larger:        12 !default;
-$theme-type-scale-largest:       14 !default;
-$theme-type-scale-mega:          16 !default;
+$theme-type-scale-3xs:         1 !default;
+$theme-type-scale-2xs:      3 !default;
+$theme-type-scale-xs:       5 !default;
+$theme-type-scale-sm:         6 !default;
+$theme-type-scale-md:          7 !default;
+$theme-type-scale-lg:         10 !default;
+$theme-type-scale-xl:        12 !default;
+$theme-type-scale-2xl:       14 !default;
+$theme-type-scale-3xl:          16 !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -419,15 +419,15 @@ Build the project type scale map
 */
 
 $project-type-scale: (
-  '3xs': system-type-scale($theme-type-scale-micro),
-  '2xs': system-type-scale($theme-type-scale-smallest),
-  'xs': system-type-scale($theme-type-scale-smaller),
-  'sm': system-type-scale($theme-type-scale-small),
-  'md': system-type-scale($theme-type-scale-base),
-  'lg': system-type-scale($theme-type-scale-large),
-  'xl': system-type-scale($theme-type-scale-larger),
-  '2xl': system-type-scale($theme-type-scale-largest),
-  '3xl': system-type-scale($theme-type-scale-mega),
+  '3xs': system-type-scale($theme-type-scale-3xs),
+  '2xs': system-type-scale($theme-type-scale-2xs),
+  'xs': system-type-scale($theme-type-scale-xs),
+  'sm': system-type-scale($theme-type-scale-sm),
+  'md': system-type-scale($theme-type-scale-md),
+  'lg': system-type-scale($theme-type-scale-lg),
+  'xl': system-type-scale($theme-type-scale-xl),
+  '2xl': system-type-scale($theme-type-scale-2xl),
+  '3xl': system-type-scale($theme-type-scale-3xl),
 );
 
 $all-type-scale: map-collect(

--- a/src/stylesheets/project/_uswds-project-settings.scss
+++ b/src/stylesheets/project/_uswds-project-settings.scss
@@ -256,15 +256,15 @@ values from the USWDS system type scale
 ----------------------------------------
 */
 
-$theme-type-scale-micro:         1;
-$theme-type-scale-smallest:      3;
-$theme-type-scale-smaller:       5;
-$theme-type-scale-small:         6;
-$theme-type-scale-base:          7;
-$theme-type-scale-large:         10;
-$theme-type-scale-larger:        12;
-$theme-type-scale-largest:       14;
-$theme-type-scale-mega:          16;
+$theme-type-scale-3xs:  1;
+$theme-type-scale-2xs:  3;
+$theme-type-scale-xs:   5;
+$theme-type-scale-sm:   6;
+$theme-type-scale-md:   7;
+$theme-type-scale-lg:   10;
+$theme-type-scale-xl:   12;
+$theme-type-scale-2xl:  14;
+$theme-type-scale-3xl:  16;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
Note: this change will temporarily break `uswds-site`. Once this is merged, we can update the var names in `uswds-site` and all will be well again.