### PR TITLE
Add a typeset() mixin

### DIFF
--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -1,17 +1,3 @@
-@import 'at-media';
-@import 'content-size';
-@import 'focus';
-@import 'font-smoothing';
-@import 'icon';
-@import 'layout-grid';
-@import 'screen-reader';
-@import 'sidenav';
-@import 'typography';
-@import 'unstyled-list';
-
-// object mixins
-@import 'add-list-reset';
-
 // utility mixins
 @import 'utilities/align-items';
 @import 'utilities/background-color';
@@ -57,3 +43,18 @@
 @import 'utilities/white-space';
 @import 'utilities/width';
 @import 'utilities/z-index';
+
+// object mixins
+@import 'add-list-reset';
+
+// general mixins
+@import 'at-media';
+@import 'content-size';
+@import 'focus';
+@import 'font-smoothing';
+@import 'icon';
+@import 'layout-grid';
+@import 'screen-reader';
+@import 'sidenav';
+@import 'typography';
+@import 'unstyled-list';

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -35,3 +35,19 @@
   line-height: $base-line-height;
   text-transform: uppercase;
 }
+
+/*
+----------------------------------------
+typeset()
+----------------------------------------
+Sets:
+- family
+- size
+- line-height
+----------------------------------------
+*/
+
+@mixin typeset($family, $scale, $line-height) {
+  @include u-font($family, $scale);
+  @include u-line-height($family, $line-height);
+}


### PR DESCRIPTION
This adds a simple mixin that combines a couple of our utility mixins. Just something to help developer UX and prevent redundancy.

```
@include typeset([family], [scale], [line height])
``` 

is the equivalent of 

```
@include u-font([family], [scale]);
@include u-line-height([family], [line-height])
```