### PR TITLE
Fix typography spacing - take 2

### DIFF
--- a/src/components/01-type/type-spacing.njk
+++ b/src/components/01-type/type-spacing.njk
@@ -1,0 +1,58 @@
+<div class="usa-prose">
+  <div class="usa-grid">
+    <div class="usa-width-one-half">
+      <h1>Heading 1</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+    <div class="usa-width-one-half">
+      <h2>Heading 2</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+      <h3>Heading 3 adoiasjdoi</h3>
+    </div>
+  </div>
+  <div class="usa-grid bg-base-light">
+    <div class="usa-width-one-half">
+      <h3>Heading 3</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie.</p>
+      <p>Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+    <div class="usa-width-one-half">
+      <h3>Heading 3</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+  </div>
+  <div class="usa-grid">
+    <div class="usa-width-one-half">
+      <p><b>Paragraph text inside a grid column (usa-width-one-half):</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+  </div>
+  <div class="usa-grid">
+    <p><b>Paragraph text inside a grid:</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+  </div>
+  <div class="usa-grid">
+    <ul>
+      <li>Unordered list item</li>
+      <li>Unordered list item</li>
+      <li>Unordered list item</li>
+    </ul>
+    <p>Lorem ipsum dolor sit amet</p>
+  </div>
+  <div class="usa-section usa-section-dark">
+    <div class="usa-grid">
+      <h2>Heading 2 in a dark section</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+  </div>
+  <div class="usa-section">
+    <div class="usa-grid">
+      <h2>Heading 2 in a section</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+    </div>
+  </div>
+</div>
+
+<style>
+  .wrapper {
+    max-width: 100%;
+  }
+</style>

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -9,7 +9,7 @@ body {
 
 %usa-paragraph {
   line-height: $base-line-height;
-  margin-bottom: 1em;
+  margin-bottom: 0;
   margin-top: 1em;
 }
 
@@ -36,6 +36,10 @@ body {
   font-family: $font-serif;
   line-height: $heading-line-height;
   margin-bottom: 0.5em;
+  margin-top: 0;
+}
+
+* + %usa-heading {
   margin-top: 1.5em;
 }
 
@@ -242,52 +246,4 @@ dfn {
 .usa-text-small {
   font-size: $h6-font-size;
   margin-top: 0;
-}
-
-// Removes top margin from first child and bottom margin from last child on
-// elements when they are within those layout elements.
-.usa-section,
-.usa-grid,
-.usa-grid-full {
-  > :first-child {
-    margin-top: 0;
-  }
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-}
-
-.usa-width-one-whole,
-.usa-width-one-half,
-.usa-width-one-third,
-.usa-width-two-thirds,
-.usa-width-one-fourth,
-.usa-width-three-fourths,
-.usa-width-one-sixth,
-.usa-width-five-sixths,
-.usa-width-one-twelfth {
-  &:first-child {
-    > :first-child {
-      margin-top: 0;
-    }
-  }
-
-  > :first-child {
-    @include media($medium-screen) {
-      margin-top: 0;
-    }
-  }
-
-  &:last-child {
-    > :last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  > :last-child {
-    @include media($medium-screen) {
-      margin-bottom: 0;
-    }
-  }
 }


### PR DESCRIPTION
Updates our typography spacing rules to ensure content consistently displays proper margins in different scenarios (from simple layouts to complex grids). We expect folks to adjust margins as needed to sections in their project.

## Changes include
- Uni-directional margins on paragraph text (top margin)
- Applies top margins to headings that follow other elements using the `* + %usa-heading` selector. This is scoped to the the `theme-content-styles` mixin which is set in a user's settings file to be scoped or global.
- Removes previous code that removed top margins from the first element and bottom margins from the last element in `usa-section` and `usa-grid` and grid items

TODO
- [x] Check page templates and components to make sure it looks OK and we didn't cause any unintended issues
- [ ] When the review is complete, should we remove the added test page: [Type spacing](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-typography-spacing-2/components/detail/type-spacing.html)?

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-typography-spacing-2/components/detail/type-spacing.html)

## Sample page
![127 0 0 1_3000_components_preview_type-spacing 1](https://user-images.githubusercontent.com/5249443/44490560-7312c700-a613-11e8-84b3-378515ee8be6.png)

Supercedes #2343.

Fixes: #2215.

