### PR TITLE
Update paragraph text spacing so adjacent sibling gets top margin

### DIFF
--- a/src/components/01-type/type-spacing.njk
+++ b/src/components/01-type/type-spacing.njk
@@ -3,11 +3,12 @@
     <div class="usa-width-one-half">
       <h1>Heading 1</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+      <div class="height-5 width-auto bg-secondary-lighter"></div>
     </div>
     <div class="usa-width-one-half">
       <h2>Heading 2</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
-      <h3>Heading 3 adoiasjdoi</h3>
+      <h3>Heading 3</h3>
     </div>
   </div>
   <div class="usa-grid bg-base-light">

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -11,6 +11,10 @@ body {
   line-height: $base-line-height;
   margin-bottom: 0;
   margin-top: 1em;
+
+  + * {
+    margin-top: 1em;
+  }
 }
 
 %usa-link {


### PR DESCRIPTION
Adds top margin to adjacent sibling selector of paragraph text to ensure proper spacing. This still ensures that we can have sections with no unwanted margins added.

Fixes #2705.