### PR TITLE
Update paragraph margins

### DIFF
--- a/src/components/01-type/type-spacing.njk
+++ b/src/components/01-type/type-spacing.njk
@@ -11,32 +11,33 @@
       <h3>Heading 3</h3>
     </div>
   </div>
-  <div class="usa-grid bg-base-light">
+  <div class="usa-grid bg-base-lighter">
     <div class="usa-width-one-half">
       <h3>Heading 3</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie.</p>
       <p>Quisque tincidunt posuere ligula, ut dictum quam.</p>
     </div>
     <div class="usa-width-one-half">
-      <h3>Heading 3</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
     </div>
   </div>
   <div class="usa-grid">
     <div class="usa-width-one-half">
       <p><b>Paragraph text inside a grid column (usa-width-one-half):</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
+      <p>Another paragraph within the same section</p>
     </div>
   </div>
-  <div class="usa-grid">
+  <div class="usa-grid bg-base-lighter">
     <p><b>Paragraph text inside a grid:</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sodales eros a diam fermentum, id pulvinar lacus tincidunt. Ut varius ipsum at ex maximus molestie. Quisque tincidunt posuere ligula, ut dictum quam.</p>
-  </div>
-  <div class="usa-grid">
     <ul>
       <li>Unordered list item</li>
       <li>Unordered list item</li>
       <li>Unordered list item</li>
     </ul>
     <p>Lorem ipsum dolor sit amet</p>
+  </div>
+  <div class="usa-grid">
+
   </div>
   <div class="usa-section usa-section-dark">
     <div class="usa-grid">

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -10,7 +10,11 @@ body {
 %usa-paragraph {
   line-height: $base-line-height;
   margin-bottom: 0;
-  margin-top: 1em;
+  margin-top: 0;
+
+  * + & {
+    margin-top: 1em;
+  }
 
   + * {
     margin-top: 1em;


### PR DESCRIPTION
Makes an adjustment to how we apply margins to paragraph text, so it only applies a top margin to `p` after something else, the first p will not have top margins. This is similar to how the headings work.

Refs #2705.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-paragraph-margins/components/detail/type-spacing.html)