### PR TITLE
Add specific JS bundling guidance to examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ that uses the `package.json` in each directory to:
 
 ## General
 
-If you `require('uswds')` in your bundled JS, you will get the minified ES5 browser bundle. (**This might be a problem if the `uswds` JS API becomes public, because it may not export.**) If you're handling ES5 conversion already or using a tool that does it automatically, you can work around this in two ways:
+If you `require('uswds')` in your bundled JS, you will get the minified ES5 browser bundle. If you're handling ES5 conversion already or using a tool that does it automatically, you can work around this in two ways:
 
 1. Import the specific entry point with `require('uswds/src/js/start')`.
 1. Configure your bundler to read the entry point from the `jsnext:main` field instead of `main`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,3 +19,10 @@ that uses the `package.json` in each directory to:
 [Node.js]: https://nodejs.org/en/about/
 [npm]: https://docs.npmjs.com/getting-started/what-is-npm
 [scripts]: https://docs.npmjs.com/misc/scripts
+
+## General
+
+If you `require('uswds')` in your bundled JS, you will get the minified ES5 browser bundle. (**This might be a problem if the `uswds` JS API becomes public, because it may not export.**) If you're handling ES5 conversion already or using a tool that does it automatically, you can work around this in two ways:
+
+1. Import the specific entry point with `require('uswds/src/js/start')`.
+1. Configure your bundler to read the entry point from the `jsnext:main` field instead of `main`.

--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -45,3 +45,9 @@ for more information.
 [source map]: https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
 [uglifyjs]: https://github.com/mishoo/UglifyJS2
 [uglifyify]: https://github.com/hughsk/uglifyify
+
+### JS bundling guidance
+- You don't need to use `babelify` if you're just using `require('uswds')`, because our ["main" field](https://github.com/18F/web-design-standards/blob/develop/package.json#L5) points to the built distribution.
+- If you wish to import uswds submodules directly with browserify,
+ such as `require('uswds/src/js/components/accordion')`, you should use `babelify` as a global transform.
+- If you're using `babelify` (or another Babel-powered browserify transform) already, you can access the ES2015 entry point directly with `require('uswds/src/js/start')`. **Note that you must either use the transform globally, or tell it _not_ to exclude scripts in `node_modules`.**

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -28,3 +28,7 @@ for more information.
 [es2015]: https://babeljs.io/learn-es2015/
 [npm]: https://docs.npmjs.com/getting-started/what-is-npm
 [source map]: https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
+
+### JS bundling guidance
+- Because webpack 2 understands ES2015 natively, it's safe to use one of the above techniques import the original sources.
+- As of this writing, it's not possible to take advantage of [tree shaking](https://webpack.js.org/guides/tree-shaking/) because the Standards source JavaScript doesn't use the `import`/`export` module syntax.


### PR DESCRIPTION
Adds the guidance in their respective locations.

Fixes #1951.