### PR TITLE
Use 2.0 palette on tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -671,7 +671,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "2.1.0",
@@ -2694,7 +2694,7 @@
     "chrome-launcher": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.3.2.tgz",
-      "integrity": "sha512-Bd8hDNE05dP5mJ+LDhEQv+98PPab/5hEYmRicCHaYJCth4LRo8qneh/BxC9X6d3IxF5taxgFmxNO7PXsmukpnQ==",
+      "integrity": "sha1-w6ieQO0kYombrICUF8TXxFHV3gU=",
       "dev": true,
       "requires": {
         "@types/core-js": "^0.9.41",
@@ -2734,7 +2734,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -7025,7 +7025,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7170,7 +7170,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -9917,7 +9917,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -11376,7 +11376,7 @@
     "matches-selector": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
-      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
+      "integrity": "sha1-0YFOfo9D5p0irDPJr3J9yITs8So="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -11634,7 +11634,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12279,7 +12279,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -12331,7 +12331,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -12745,7 +12745,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -14431,7 +14431,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "requires": {
         "asap": "~2.0.3"
@@ -15414,7 +15414,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "scss-tokenizer": {
@@ -15656,7 +15656,7 @@
     },
     "should-equal": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
       "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
       "dev": true,
       "requires": {
@@ -15731,7 +15731,7 @@
     "sinon": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
-      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
       "dev": true,
       "requires": {
         "diff": "^3.1.0",

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -1122,7 +1122,6 @@ $site-margins:                  units($theme-site-margins) !default;
 $site-margins-mobile:           units($theme-site-margins-mobile) !default;
 $article-max-width:             600px !default;
 $input-max-width:               46rem !default;
-$label-border-radius:           2px !default;
 $checkbox-border-radius:        2px !default;
 $border-radius:                 3px !default;
 $button-border-radius:          5px !default;

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -1,11 +1,11 @@
 .usa-tag {
   @include u-bg('base-dark');
-  @include u-color('white');
   @include u-font('sans', '2xs');
   @include u-margin-right(0.5);
   @include u-padding-x(1);
   @include u-padding-y(1px);
   @include u-radius('sm');
+  @include u-text('white');
   text-transform: uppercase;
 
   &:only-of-type {

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -14,5 +14,5 @@
 
 .usa-tag-big {
   @include u-padding-x(1);
-  @include u-font('sans', 'xs');
+  @include u-font('sans', $theme-base-font-size);
 }

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -5,8 +5,7 @@
   @include u-padding-x(1);
   @include u-padding-y(1px);
   @include u-radius('sm');
-  @include u-text('white');
-  text-transform: uppercase;
+  @include u-text('white', 'uppercase');
 
   &:only-of-type {
     margin-right: 0;

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -1,10 +1,11 @@
 .usa-tag {
-  background-color: $color-gray;
-  border-radius: $label-border-radius;
-  color: $color-white;
-  font-size: $h5-font-size;
-  margin-right: 0.5rem;
-  padding: 0.1rem 0.7rem;
+  @include u-bg('base-dark');
+  @include u-color('white');
+  @include u-font('sans', '2xs');
+  @include u-margin-right(0.5);
+  @include u-padding-x(1);
+  @include u-padding-y(1px);
+  @include u-radius('sm');
   text-transform: uppercase;
 
   &:only-of-type {
@@ -13,7 +14,6 @@
 }
 
 .usa-tag-big {
-  font-size: $base-font-size;
-  padding-left: 0.9rem;
-  padding-right: 0.9rem;
+  @include u-padding-x(1);
+  @include u-font('sans', 'xs');
 }


### PR DESCRIPTION
Removed the `$label-border-radius` variable bc I don't think it's needed.

Note:
The [docs](https://v2.designsystem.digital.gov/utilities/color/#utility-mixins) still say text color is done with `@include u-text('white');` but it should be `@include u-color('white');`.

## Preview
- [Default tags](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-tags-v2/components/detail/labels--default.html)
- [Big tags](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-tags-v2/components/detail/labels--big)

Part of #2660.