### PR TITLE
Update skipnav to use 2.0 palette

### DIFF
--- a/src/stylesheets/components/_skipnav.scss
+++ b/src/stylesheets/components/_skipnav.scss
@@ -1,17 +1,15 @@
 .usa-skipnav {
   background: transparent;
-  color: $color-base;
   left: 0;
-  padding: 1rem 1.5rem;
+  padding: units(1) units(2);
   position: absolute;
-  top: -4.2rem;
+  top: -3.8rem; // skipnav link height
   transition: all 0.2s ease-in-out;
   z-index: 100;
 
   &:focus {
-    background: $color-white;
+    background: color('white');
     left: 0;
-    outline: 0;
     position: absolute;
     top: 0;
     transition: all 0.2s ease-in-out;

--- a/src/stylesheets/components/_skipnav.scss
+++ b/src/stylesheets/components/_skipnav.scss
@@ -5,7 +5,7 @@
   position: absolute;
   top: -3.8rem; // skipnav link height
   transition: all 0.2s ease-in-out;
-  z-index: 100;
+  z-index: z-index(100);
 
   &:focus {
     background: color('white');


### PR DESCRIPTION
- Removed the black text for the link so it uses standard link color.
- Removed outline zero so focus appears

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-skipnav-v2/components/preview/layout--landing.html) - hit <kbd>Tab</kbd>

Part of #2660 