### PR TITLE
Update typography to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "watch": "NODE_ENV=development nswatch"
   },
   "watch": {
-    "src/stylesheets/{components,core,elements,utilities,}/*.scss": "build:css",
+    "src/stylesheets/{components,core,elements,utilities,settings,}/*.scss": "build:css",
     "src/stylesheets/uswds.scss": "build:css",
     "src/js/**/*.js": "build:js"
   },

--- a/src/components/01-type/fonts.njk
+++ b/src/components/01-type/fonts.njk
@@ -1,5 +1,5 @@
 {% for face in typefaces %}
-<section id="{{ face.id }}" class="usa-grid">
+<section id="{{ face.id }}" class="usa-section usa-grid">
   <h4 class="usa-heading-alt">{{ face.name }} (<tt>.usa-{{ face.id }}</tt>)</h4>
 
   <div class="usa-grid-full">

--- a/src/components/01-type/type.config.yml
+++ b/src/components/01-type/type.config.yml
@@ -1,2 +1,2 @@
 label: Typography
-preview: '@uswds-framed'
+preview: '@uswds-content'

--- a/src/components/04-tables/tables.config.yml
+++ b/src/components/04-tables/tables.config.yml
@@ -1,0 +1,2 @@
+label: Tables
+preview: '@uswds-framed'

--- a/src/components/07-form/controls/checkboxes.njk
+++ b/src/components/07-form/controls/checkboxes.njk
@@ -1,21 +1,23 @@
-<fieldset class="usa-fieldset-inputs usa-sans">
-  <legend class="usa-sr-only">Historical figures 1</legend>
-  <ul class="usa-unstyled-list">
-    <li>
-      <input class="usa-checkbox-input" id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
-      <label class="usa-checkbox-label" for="truth">Sojourner Truth</label>
-    </li>
-    <li>
-      <input class="usa-checkbox-input" id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
-      <label class="usa-checkbox-label" for="douglass">Frederick Douglass</label>
-    </li>
-    <li>
-      <input class="usa-checkbox-input" id="washington" type="checkbox" name="historical-figures-1" value="washington">
-      <label class="usa-checkbox-label" for="washington">Booker T. Washington</label>
-    </li>
-    <li>
-      <input class="usa-checkbox-input" id="carver" type="checkbox" name="historical-figures-1" disabled>
-      <label class="usa-checkbox-label" for="carver">George Washington Carver</label>
-    </li>
-  </ul>
-</fieldset>
+<form class="usa-form">
+  <fieldset class="usa-fieldset-inputs">
+    <legend class="usa-sr-only">Historical figures 1</legend>
+    <ul class="usa-unstyled-list">
+      <li>
+        <input class="usa-checkbox-input" id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
+        <label class="usa-checkbox-label" for="truth">Sojourner Truth</label>
+      </li>
+      <li>
+        <input class="usa-checkbox-input" id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
+        <label class="usa-checkbox-label" for="douglass">Frederick Douglass</label>
+      </li>
+      <li>
+        <input class="usa-checkbox-input" id="washington" type="checkbox" name="historical-figures-1" value="washington">
+        <label class="usa-checkbox-label" for="washington">Booker T. Washington</label>
+      </li>
+      <li>
+        <input class="usa-checkbox-input" id="carver" type="checkbox" name="historical-figures-1" disabled>
+        <label class="usa-checkbox-label" for="carver">George Washington Carver</label>
+      </li>
+    </ul>
+  </fieldset>
+</form>

--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -1,5 +1,5 @@
-<form>
-  <fieldset>
+<form class="usa-form">
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend">Date of birth</legend>
     <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
     <div class="usa-memorable-date">

--- a/src/components/07-form/controls/radio-buttons.njk
+++ b/src/components/07-form/controls/radio-buttons.njk
@@ -1,17 +1,19 @@
-<fieldset class="usa-fieldset-inputs usa-sans">
-  <legend class="usa-sr-only">Historical figures 2</legend>
-  <ul class="usa-unstyled-list">
-    <li>
-      <input class="usa-radio-input" id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
-      <label class="usa-radio-label" for="stanton">Elizabeth Cady Stanton</label>
-    </li>
-    <li>
-      <input class="usa-radio-input" id="anthony" type="radio" name="historical-figures-2" value="anthony">
-      <label class="usa-radio-label" for="anthony">Susan B. Anthony</label>
-    </li>
-    <li>
-      <input class="usa-radio-input" id="tubman" type="radio" name="historical-figures-2" value="tubman">
-      <label class="usa-radio-label" for="tubman">Harriet Tubman</label>
-    </li>
-  </ul>
-</fieldset>
+<form class="usa-form">
+  <fieldset class="usa-fieldset-inputs">
+    <legend class="usa-sr-only">Historical figures 2</legend>
+    <ul class="usa-unstyled-list">
+      <li>
+        <input class="usa-radio-input" id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
+        <label class="usa-radio-label" for="stanton">Elizabeth Cady Stanton</label>
+      </li>
+      <li>
+        <input class="usa-radio-input" id="anthony" type="radio" name="historical-figures-2" value="anthony">
+        <label class="usa-radio-label" for="anthony">Susan B. Anthony</label>
+      </li>
+      <li>
+        <input class="usa-radio-input" id="tubman" type="radio" name="historical-figures-2" value="tubman">
+        <label class="usa-radio-label" for="tubman">Harriet Tubman</label>
+      </li>
+    </ul>
+  </fieldset>
+</form>

--- a/src/components/07-form/controls/range-input.njk
+++ b/src/components/07-form/controls/range-input.njk
@@ -1,2 +1,4 @@
-<label class="usa-label" for="range-slider">Range slider</label>
-<input id="range-slider" class="usa-range" type="range" min="0" max="100" step="10" value="20">
+<form class="usa-form">
+  <label class="usa-label" for="range-slider">Range slider</label>
+  <input id="range-slider" class="usa-range" type="range" min="0" max="100" step="10" value="20">
+</form>

--- a/src/components/07-form/controls/text-input.njk
+++ b/src/components/07-form/controls/text-input.njk
@@ -1,4 +1,4 @@
-<form>
+<form class="usa-form">
   <label class="usa-label" for="input-type-text">Text input label</label>
   <input class="usa-input" id="input-type-text" name="input-type-text" type="text">
 

--- a/src/components/07-form/controls/validation.njk
+++ b/src/components/07-form/controls/validation.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <fieldset>
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-drop_text">Enter a code</legend>
     <div class="usa-alert usa-alert-info">
       <div class="usa-alert-body">

--- a/src/components/07-form/templates/address-form.njk
+++ b/src/components/07-form/templates/address-form.njk
@@ -1,5 +1,5 @@
 <form class="usa-form-large">
-  <fieldset>
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend">Mailing address</legend>
     <label class="usa-label" for="mailing-address-1">Street address 1</label>
     <input class="usa-input" id="mailing-address-1" name="mailing-address-1" type="text">

--- a/src/components/07-form/templates/address-form.njk
+++ b/src/components/07-form/templates/address-form.njk
@@ -1,4 +1,4 @@
-<form class="usa-form-large">
+<form class="usa-form">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Mailing address</legend>
     <label class="usa-label" for="mailing-address-1">Street address 1</label>

--- a/src/components/07-form/templates/address-form.njk
+++ b/src/components/07-form/templates/address-form.njk
@@ -1,4 +1,4 @@
-<form class="usa-form">
+<form class="usa-form-large">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Mailing address</legend>
     <label class="usa-label" for="mailing-address-1">Street address 1</label>

--- a/src/components/07-form/templates/name-form.njk
+++ b/src/components/07-form/templates/name-form.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <fieldset>
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend">Name</legend>
     <label class="usa-label" for="title">Title <span class="usa-input-label-helper">(optional)</span></label>
     <input class="usa-input usa-input-tiny" id="title" name="title" type="text">

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -1,7 +1,7 @@
 <form class="usa-form">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-drop_text">Reset password</legend>
-    <span class="usa-serif">Please enter your new password</span>
+    <span>Please enter your new password</span>
 
     <div class="usa-alert usa-alert-info">
       <div class="usa-alert-body">

--- a/src/components/07-form/templates/password-reset-form.njk
+++ b/src/components/07-form/templates/password-reset-form.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <fieldset>
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-drop_text">Reset password</legend>
     <span class="usa-serif">Please enter your new password</span>
 

--- a/src/components/07-form/templates/sign-in-form.njk
+++ b/src/components/07-form/templates/sign-in-form.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <fieldset>
+  <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-drop_text">Sign in</legend>
     <span>or <a href="javascript:void(0);">create an account</a></span>
 

--- a/src/components/_uswds-content.njk
+++ b/src/components/_uswds-content.njk
@@ -1,7 +1,7 @@
 {% extends '_uswds.njk' %}
 {% block body %}
   <div class="usa-grid" style="padding: 2em">
-    <div class="usa-width-one-whole">
+    <div class="usa-width-one-whole usa-prose">
       {{ yield }}
     </div>
   </div>

--- a/src/components/grid/grid.config.yml
+++ b/src/components/grid/grid.config.yml
@@ -1,5 +1,6 @@
 label: Grid
 status: ready
+preview: '@uswds-content'
 
 variants:
   - name: default

--- a/src/components/test/kitchen-sink.njk
+++ b/src/components/test/kitchen-sink.njk
@@ -11,7 +11,7 @@
       {% render '@sidenav', {sidenav: sidenav} %}
     </aside>
 
-    <div class="usa-width-three-fourths usa-layout-docs-main_content">
+    <div class="usa-width-three-fourths usa-layout-docs-main_content usa-prose">
       <h1>{{ page.title }}</h1>
 
       <p class="usa-font-lead">{{ page.lead }}</p>

--- a/src/components/test/multi-column-checkboxes.njk
+++ b/src/components/test/multi-column-checkboxes.njk
@@ -1,5 +1,5 @@
 <main class="usa-grid usa-section">
-  <fieldset class="usa-fieldset-inputs usa-sans">
+  <fieldset class="usa-fieldset-inputs">
     <legend class="usa-sr-only">Historical figures 1</legend>
     <div class="usa-width-one-third">
       <input id="washington" type="checkbox" name="historical-figures-1" value="washington">

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -15,7 +15,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 // scss-lint:disable PropertyCount
 @mixin accordion-button-styles {
   @include button-unstyled;
-  @include typeset-default($theme-accordion-font-family);
+  @include typeset-default($theme-font-family-accordion);
 
   background-color: color('base-lightest');
   background-image: url('#{$theme-image-path}/minus.png');
@@ -61,7 +61,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 .usa-accordion-bordered {
   @include accordion-list-styles;
   @include accordion-nested-list;
-  @include typeset-default($theme-accordion-font-family);
+  @include typeset-default($theme-font-family-accordion);
 
   + .usa-accordion,
   + .usa-accordion-bordered {
@@ -83,7 +83,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 }
 
 .usa-accordion-heading {
-  @include typeset($theme-accordion-font-family, $theme-base-font-size, 1);
+  @include typeset($theme-font-family-accordion, $theme-font-size-base, 1);
   margin: 0;
 
   &:not(:first-child) {

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -1,7 +1,6 @@
 // Variables
 
 $accordion-border: units(0.5) solid color('base-lightest');
-$accordion-font-family: 'sans' !default;
 
 // Accordion Styles
 
@@ -16,6 +15,7 @@ $accordion-font-family: 'sans' !default;
 // scss-lint:disable PropertyCount
 @mixin accordion-button-styles {
   @include button-unstyled;
+  @include typeset-default($theme-accordion-font-family);
 
   background-color: color('base-lightest');
   background-image: url('#{$theme-image-path}/minus.png');
@@ -26,7 +26,6 @@ $accordion-font-family: 'sans' !default;
   color: color('ink');
   cursor: pointer;
   display: inline-block;
-  font-family: font-family($accordion-font-family);
   font-weight: font-weight('bold');
   margin: 0;
   padding: units(2) units(2.5) * 2 + units(2) units(2) units(2.5);
@@ -62,6 +61,7 @@ $accordion-font-family: 'sans' !default;
 .usa-accordion-bordered {
   @include accordion-list-styles;
   @include accordion-nested-list;
+  @include typeset-default($theme-accordion-font-family);
 
   + .usa-accordion,
   + .usa-accordion-bordered {
@@ -83,7 +83,7 @@ $accordion-font-family: 'sans' !default;
 }
 
 .usa-accordion-heading {
-  @include typeset($accordion-font-family, $theme-base-font-size, 1);
+  @include typeset($theme-accordion-font-family, $theme-base-font-size, 1);
   margin: 0;
 
   &:not(:first-child) {

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -15,7 +15,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 // scss-lint:disable PropertyCount
 @mixin accordion-button-styles {
   @include button-unstyled;
-  @include typeset-default($theme-font-family-accordion);
+  @include typeset($theme-font-family-accordion);
 
   background-color: color('base-lightest');
   background-image: url('#{$theme-image-path}/minus.png');
@@ -61,7 +61,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 .usa-accordion-bordered {
   @include accordion-list-styles;
   @include accordion-nested-list;
-  @include typeset-default($theme-font-family-accordion);
+  @include typeset($theme-font-family-accordion);
 
   + .usa-accordion,
   + .usa-accordion-bordered {

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -15,7 +15,6 @@ $accordion-border: units(0.5) solid color('base-lightest');
 // scss-lint:disable PropertyCount
 @mixin accordion-button-styles {
   @include button-unstyled;
-  @include typeset($theme-font-family-accordion);
 
   background-color: color('base-lightest');
   background-image: url('#{$theme-image-path}/minus.png');

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -25,7 +25,7 @@ $left-padding: $h-padding + $bar-size;
 $icon-size: units(4);
 
 .usa-alert {
-  @include typeset-default($theme-font-family-alerts);
+  @include typeset($theme-font-family-alerts);
 
   background-color: $color-gray-lightest;
   background-position: $h-padding $h-padding;

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -83,7 +83,7 @@ $icon-size: units(4);
 }
 
 .usa-alert-heading {
-  @extend %usa-heading;
+  @include typeset-h3;
   margin-top: 0;
   margin-bottom: 0;
 }

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -25,7 +25,7 @@ $left-padding: $h-padding + $bar-size;
 $icon-size: units(4);
 
 .usa-alert {
-  @include typeset-default($theme-alerts-font-family);
+  @include typeset-default($theme-font-family-alerts);
 
   background-color: $color-gray-lightest;
   background-position: $h-padding $h-padding;

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -37,6 +37,10 @@ $icon-size: units(4);
   padding-top: $h-padding;
   position: relative;
 
+  * + & {
+    margin-top: units(2);
+  }
+
   &::before {
     background-color: color('gray-40');
     content: '';

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -25,6 +25,8 @@ $left-padding: $h-padding + $bar-size;
 $icon-size: units(4);
 
 .usa-alert {
+  @include typeset-default;
+
   background-color: $color-gray-lightest;
   background-position: $h-padding $h-padding;
   background-repeat: no-repeat;
@@ -89,9 +91,7 @@ $icon-size: units(4);
 }
 
 .usa-alert-text {
-  font-family: font-family('sans');
-  margin-bottom: 0;
-  margin-top: 0;
+  @include u-margin-y(0);
 }
 
 .usa-alert-text:only-child {

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -25,7 +25,7 @@ $left-padding: $h-padding + $bar-size;
 $icon-size: units(4);
 
 .usa-alert {
-  @include typeset-default;
+  @include typeset-default($theme-alerts-font-family);
 
   background-color: $color-gray-lightest;
   background-position: $h-padding $h-padding;

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -1,13 +1,11 @@
-$banner-font-family: 'sans';
-
 .usa-banner {
+  @include typeset-default($theme-banner-font-family);
   @include u-bg('base-lightest');
-  @include u-font-family($banner-font-family);
   @include u-padding-bottom(1);
   @include u-position('relative');
 
   @include at-media('mobile-lg') {
-    @include u-font-size($banner-font-family, $theme-h6-font-size);
+    @include u-font-size($theme-banner-font-family, $theme-h6-font-size);
     @include u-padding-bottom(0);
   }
 }
@@ -29,9 +27,6 @@ $banner-font-family: 'sans';
   }
 
   p {
-    @include u-font-size($banner-font-family, $theme-h5-font-size);
-    @include u-line-height($banner-font-family, $theme-base-line-height);
-
     &:first-child {
       @include u-margin-top(1);
 
@@ -58,14 +53,14 @@ $banner-font-family: 'sans';
 
 .usa-banner-header {
   @include u-padding-y(0.5);
-  @include u-font-size($banner-font-family, 1);
+  @include u-font-size($theme-banner-font-family, 1);
 
   @include at-media('mobile-lg') {
     @include u-padding-y(2px);
   }
 
   p {
-    @include u-line-height($banner-font-family, 1);
+    @include u-line-height($theme-banner-font-family, 1);
     @include u-margin-bottom(0);
     @include u-margin-top(2px);
     display: block;
@@ -91,13 +86,12 @@ $banner-font-family: 'sans';
 }
 
 .usa-banner-header-expanded {
-  @include u-font-size($banner-font-family, $theme-h5-font-size);
   border-bottom: 1px solid color('base-lighter');
   min-height: units(7);
   padding-right: units(4);
 
   @include at-media('mobile-lg') {
-    @include u-font-size($banner-font-family, 1);
+    @include u-font-size($theme-banner-font-family, 1);
     border-bottom: none;
     display: block;
     min-height: 0;
@@ -121,11 +115,11 @@ $banner-font-family: 'sans';
   }
 
   p {
-    @include u-line-height($banner-font-family, $theme-heading-line-height);
+    @include u-line-height($theme-banner-font-family, $theme-heading-line-height);
     vertical-align: top;
 
     @include at-media('mobile-lg') {
-      @include u-line-height($banner-font-family, $theme-base-line-height);
+      @include u-line-height($theme-banner-font-family, $theme-base-line-height);
       vertical-align: middle;
     }
   }
@@ -133,8 +127,8 @@ $banner-font-family: 'sans';
 
 .usa-banner-button {
   @include button-unstyled;
-  @include u-font-size($banner-font-family, 1);
-  @include u-line-height($banner-font-family, 1);
+  @include u-font-size($theme-banner-font-family, 1);
+  @include u-line-height($theme-banner-font-family, 1);
   @include u-padding-top(1.5);
   @include u-padding-left(6);
   background-position-x: right;

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -1,5 +1,5 @@
 .usa-banner {
-  @include typeset-default($theme-font-family-banner);
+  @include typeset($theme-font-family-banner);
   @include u-bg('base-lightest');
   @include u-padding-bottom(1);
   @include u-position('relative');

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -1,11 +1,11 @@
 .usa-banner {
-  @include typeset-default($theme-banner-font-family);
+  @include typeset-default($theme-font-family-banner);
   @include u-bg('base-lightest');
   @include u-padding-bottom(1);
   @include u-position('relative');
 
   @include at-media('mobile-lg') {
-    @include u-font-size($theme-banner-font-family, $theme-h6-font-size);
+    @include u-font-size($theme-font-family-banner, $theme-font-size-h6);
     @include u-padding-bottom(0);
   }
 }
@@ -53,14 +53,14 @@
 
 .usa-banner-header {
   @include u-padding-y(0.5);
-  @include u-font-size($theme-banner-font-family, 1);
+  @include u-font-size($theme-font-family-banner, 1);
 
   @include at-media('mobile-lg') {
     @include u-padding-y(2px);
   }
 
   p {
-    @include u-line-height($theme-banner-font-family, 1);
+    @include u-line-height($theme-font-family-banner, 1);
     @include u-margin-bottom(0);
     @include u-margin-top(2px);
     display: block;
@@ -91,7 +91,7 @@
   padding-right: units(4);
 
   @include at-media('mobile-lg') {
-    @include u-font-size($theme-banner-font-family, 1);
+    @include u-font-size($theme-font-family-banner, 1);
     border-bottom: none;
     display: block;
     min-height: 0;
@@ -115,11 +115,11 @@
   }
 
   p {
-    @include u-line-height($theme-banner-font-family, $theme-heading-line-height);
+    @include u-line-height($theme-font-family-banner, $theme-line-height-heading);
     vertical-align: top;
 
     @include at-media('mobile-lg') {
-      @include u-line-height($theme-banner-font-family, $theme-base-line-height);
+      @include u-line-height($theme-font-family-banner, $theme-line-height-base);
       vertical-align: middle;
     }
   }
@@ -127,8 +127,8 @@
 
 .usa-banner-button {
   @include button-unstyled;
-  @include u-font-size($theme-banner-font-family, 1);
-  @include u-line-height($theme-banner-font-family, 1);
+  @include u-font-size($theme-font-family-banner, 1);
+  @include u-line-height($theme-font-family-banner, 1);
   @include u-padding-top(1.5);
   @include u-padding-left(6);
   background-position-x: right;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,4 +1,6 @@
 .usa-footer {
+  @include typeset-default($theme-footer-font-family);
+
   .usa-unstyled-list {
     display: block;
   }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,5 +1,5 @@
 .usa-footer {
-  @include typeset-default($theme-footer-font-family);
+  @include typeset-default($theme-font-family-footer);
 
   .usa-unstyled-list {
     display: block;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,5 +1,5 @@
 .usa-footer {
-  @include typeset-default($theme-font-family-footer);
+  @include typeset($theme-font-family-footer);
 
   .usa-unstyled-list {
     display: block;

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -11,13 +11,13 @@ Functions
 $root-font-size: if(
   $theme-respect-user-font-size,
   100%,
-  $theme-root-font-size
+  $theme-font-size-root
 );
 
 $root-font-size-equiv: if(
   $theme-respect-user-font-size,
   16px,
-  $theme-root-font-size
+  $theme-font-size-root
 );
 
 /*

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -1018,7 +1018,7 @@ settings
 
 // Removing the !default from $em-base so we are not inheriting that value from Bourbon.
 
-$em-base:             $theme-root-font-size;
+$em-base:             $theme-font-size-root;
 $base-font-size:      1.7rem !default;
 $small-font-size:     1.4rem !default;
 $lead-font-size:      2rem !default;

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -173,6 +173,7 @@ $font-stack-serif:    false;
 $font-stack-mono:     false;
 $font-stack-cond:     false;
 
+$font-stack-ui:       false;
 $font-stack-heading:  false;
 $font-stack-body:     false;
 $font-stack-code:     false;
@@ -228,6 +229,19 @@ $font-stack-alt:      false;
     'stack'
   );
   $font-stack-cond: $font-stack-cond + unquote('');
+}
+
+@if $theme-font-ui {
+  $font-stack-ui: map-deep-get(
+    $all-font-definitions,
+    $theme-font-ui,
+    'name'
+  ), map-deep-get(
+    $all-font-definitions,
+    $theme-font-ui,
+    'stack'
+  );
+  $font-stack-ui: $font-stack-ui + unquote('');
 }
 
 @if $theme-font-heading {
@@ -287,6 +301,7 @@ $project-font-stacks:(
   'sans':     $font-stack-sans,
   'serif':    $font-stack-serif,
   'cond':     $font-stack-cond,
+  'ui':       $font-stack-ui,
   'heading':  $font-stack-heading,
   'body':     $font-stack-body,
   'code':     $font-stack-code,
@@ -330,6 +345,10 @@ $if-important: '';
 
 @if $theme-font-cond {
   [class*='#{ns('utility')}font-cond-'] { font-family: $font-stack-cond#{$if-important}; }
+}
+
+@if $theme-font-ui {
+  [class*='#{ns('utility')}font-ui-'] { font-family: $font-stack-ui#{$if-important}; }
 }
 
 @if $theme-font-heading {
@@ -644,6 +663,7 @@ $project-cap-heights:(
   'sans':     cap-height($theme-font-sans),
   'serif':    cap-height($theme-font-serif),
   'cond':     cap-height($theme-font-cond),
+  'ui':       cap-height($theme-font-ui),
   'heading':  cap-height($theme-font-heading),
   'body':     cap-height($theme-font-body),
   'code':     cap-height($theme-font-code),
@@ -771,6 +791,36 @@ $scale-cond-17: scale('cond', 17, force);
 $scale-cond-18: scale('cond', 18, force);
 $scale-cond-19: scale('cond', 19, force);
 $scale-cond-20: scale('cond', 20, force);
+$scale-ui-3xs: scale('ui', '3xs', force);
+$scale-ui-2xs: scale('ui', '2xs', force);
+$scale-ui-xs: scale('ui', 'xs', force);
+$scale-ui-sm: scale('ui', 'sm', force);
+$scale-ui-md: scale('ui', 'md', force);
+$scale-ui-lg: scale('ui', 'lg', force);
+$scale-ui-xl: scale('ui', 'xl', force);
+$scale-ui-2xl: scale('ui', '2xl', force);
+$scale-ui-3xl: scale('ui', '3xl', force);
+$scale-ui-micro: scale('ui', 'micro', force);
+$scale-ui-1: scale('ui', 1, force);
+$scale-ui-2: scale('ui', 2, force);
+$scale-ui-3: scale('ui', 3, force);
+$scale-ui-4: scale('ui', 4, force);
+$scale-ui-5: scale('ui', 5, force);
+$scale-ui-6: scale('ui', 6, force);
+$scale-ui-7: scale('ui', 7, force);
+$scale-ui-8: scale('ui', 8, force);
+$scale-ui-9: scale('ui', 9, force);
+$scale-ui-10: scale('ui', 10, force);
+$scale-ui-11: scale('ui', 11, force);
+$scale-ui-12: scale('ui', 12, force);
+$scale-ui-13: scale('ui', 13, force);
+$scale-ui-14: scale('ui', 14, force);
+$scale-ui-15: scale('ui', 15, force);
+$scale-ui-16: scale('ui', 16, force);
+$scale-ui-17: scale('ui', 17, force);
+$scale-ui-18: scale('ui', 18, force);
+$scale-ui-19: scale('ui', 19, force);
+$scale-ui-20: scale('ui', 20, force);
 $scale-heading-3xs: scale('heading', '3xs', force);
 $scale-heading-2xs: scale('heading', '2xs', force);
 $scale-heading-xs: scale('heading', 'xs', force);

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -161,12 +161,13 @@ Sets:
 
 @mixin h6 {
   @include typeset(
-    'alt',
+    'body',
     $theme-h6-font-size,
     $theme-heading-line-height
   );
 
   font-weight: fw($theme-font-weight-normal);
+  letter-spacing: ls('ls-1');
   text-transform: uppercase;
 }
 

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -14,11 +14,11 @@ Sets:
   @include u-line-height($family, $line-height);
 }
 
-@mixin typeset-default($family: #{$theme-base-font-family}) {
+@mixin typeset-default($family: #{$theme-font-family-base}) {
   @include typeset(
     $family,
-    $theme-base-font-size,
-    $theme-base-line-height
+    $theme-font-size-base,
+    $theme-line-height-base
   );
 }
 
@@ -35,12 +35,12 @@ Sets:
 // typeset element mixins
 @mixin typeset-p {
   line-height: line-height(
-    $theme-base-font-family,
-    $theme-base-line-height
+    $theme-font-family-base,
+    $theme-line-height-base
   );
   margin-bottom: 0;
   margin-top: 0;
-  max-width: measure($theme-text-max-width);
+  max-width: measure($theme-measure-text);
 
   * + & {
     margin-top: 1em;
@@ -72,8 +72,8 @@ Sets:
 @mixin title {
   @include typeset(
     'heading',
-    $theme-title-font-size,
-    $theme-heading-line-height
+    $theme-font-size-title,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -87,8 +87,8 @@ Sets:
 @mixin h1 {
   @include typeset(
     'heading',
-    $theme-h1-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h1,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -102,8 +102,8 @@ Sets:
 @mixin h2 {
   @include typeset(
     'heading',
-    $theme-h2-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h2,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -117,8 +117,8 @@ Sets:
 @mixin h3 {
   @include typeset(
     'heading',
-    $theme-h3-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h3,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -132,8 +132,8 @@ Sets:
 @mixin h4 {
   @include typeset(
     'heading',
-    $theme-h4-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h4,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -147,8 +147,8 @@ Sets:
 @mixin h5 {
   @include typeset(
     'heading',
-    $theme-h5-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h5,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-bold);
@@ -162,8 +162,8 @@ Sets:
 @mixin h6 {
   @include typeset(
     'body',
-    $theme-h6-font-size,
-    $theme-heading-line-height
+    $theme-font-size-h6,
+    $theme-line-height-heading
   );
 
   font-weight: fw($theme-font-weight-normal);

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -9,17 +9,12 @@ Sets:
 ----------------------------------------
 */
 
-@mixin typeset($family, $scale, $line-height) {
+@mixin typeset(
+  $family: $theme-font-family-base,
+  $scale: $theme-font-size-base,
+  $line-height: $theme-line-height-base) {
   @include u-font($family, $scale);
   @include u-line-height($family, $line-height);
-}
-
-@mixin typeset-default($family: #{$theme-font-family-base}) {
-  @include typeset(
-    $family,
-    $theme-font-size-base,
-    $theme-line-height-base
-  );
 }
 
 @mixin typeset-heading {

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -14,7 +14,7 @@ Sets:
   @include u-line-height($family, $line-height);
 }
 
-@mixin typeset-default($family) {
+@mixin typeset-default($family: #{$theme-base-font-family}) {
   @include typeset(
     $family,
     $theme-base-font-size,

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -1,41 +1,3 @@
-// Heading mixins
-@mixin title {
-  font-size: $title-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h1 {
-  font-size: $h1-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h2 {
-  font-size: $h2-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h3 {
-  font-size: $h3-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h4 {
-  font-size: $h4-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h5 {
-  font-size: $h5-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h6 {
-  font-size: $h6-font-size;
-  font-weight: $font-normal;
-  line-height: $base-line-height;
-  text-transform: uppercase;
-}
-
 /*
 ----------------------------------------
 typeset()
@@ -50,4 +12,165 @@ Sets:
 @mixin typeset($family, $scale, $line-height) {
   @include u-font($family, $scale);
   @include u-line-height($family, $line-height);
+}
+
+@mixin typeset-default($family) {
+  @include typeset(
+    $family,
+    $theme-base-font-size,
+    $theme-base-line-height
+  );
+}
+
+@mixin typeset-heading {
+  clear: both;
+  margin-bottom: 0.5em;
+  margin-top: 0;
+
+  * + & {
+    margin-top: 1.5em;
+  }
+}
+
+// typeset element mixins
+@mixin typeset-p {
+  line-height: line-height(
+    $theme-base-font-family,
+    $theme-base-line-height
+  );
+  margin-bottom: 0;
+  margin-top: 0;
+  max-width: measure($theme-text-max-width);
+
+  * + & {
+    margin-top: 1em;
+  }
+
+  + * {
+    margin-top: 1em;
+  }
+}
+
+@mixin typeset-link {
+  color: color('primary');
+  text-decoration: underline;
+
+  &:hover,
+  &:active {
+    color: color('primary-darker');
+  }
+
+  &:focus {
+    @include focus;
+  }
+
+  &:visited {
+    color: $color-visited;
+  }
+}
+
+@mixin title {
+  @include typeset(
+    'heading',
+    $theme-title-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-title {
+  @include typeset-heading;
+  @include title;
+}
+
+@mixin h1 {
+  @include typeset(
+    'heading',
+    $theme-h1-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-h1 {
+  @include typeset-heading;
+  @include h1;
+}
+
+@mixin h2 {
+  @include typeset(
+    'heading',
+    $theme-h2-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-h2 {
+  @include typeset-heading;
+  @include h2;
+}
+
+@mixin h3 {
+  @include typeset(
+    'heading',
+    $theme-h3-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-h3 {
+  @include typeset-heading;
+  @include h3;
+}
+
+@mixin h4 {
+  @include typeset(
+    'heading',
+    $theme-h4-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-h4 {
+  @include typeset-heading;
+  @include h4;
+}
+
+@mixin h5 {
+  @include typeset(
+    'heading',
+    $theme-h5-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-bold);
+}
+
+@mixin typeset-h5 {
+  @include typeset-heading;
+  @include h5;
+}
+
+@mixin h6 {
+  @include typeset(
+    'alt',
+    $theme-h6-font-size,
+    $theme-heading-line-height
+  );
+
+  font-weight: fw($theme-font-weight-normal);
+  text-transform: uppercase;
+}
+
+@mixin typeset-h6 {
+  @include typeset-heading;
+  @include h6;
 }

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -12,7 +12,23 @@ Sets:
 @mixin typeset(
   $family: $theme-font-family-base,
   $scale: $theme-font-size-base,
-  $line-height: $theme-line-height-base) {
+  $line-height: $theme-line-height-base
+) {
+  $family: if(
+    $family == null,
+    $theme-font-family-base,
+    $family
+  );
+  $scale: if(
+    $scale == null,
+    $theme-font-size-base,
+    $scale
+  );
+  $line-height: if(
+    $line-height == null,
+    $theme-line-height-base,
+    $line-height
+  );
   @include u-font($family, $scale);
   @include u-line-height($family, $line-height);
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -85,22 +85,6 @@ $input-height: floor($input-height-exact * 10) / 10;
   font-weight: $theme-font-weight-bold;
 }
 
-// Deprecated: Some screen readers can't read CSS content.
-// Will be removed in 2.0.
-// TODO: remove?
-.usa-input-required:after {
-  color: color('error-dark');
-  content: ' (*required)';
-}
-
-// Deprecated: Some screen readers can't read CSS content.
-// Will be removed in 2.0.
-// TODO: remove?
-.usa-input-optional:after {
-  color: color('base');
-  content: ' (optional)';
-}
-
 .usa-input-label-helper {
   color: color('base');
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -1,14 +1,14 @@
 // scss-lint:disable QualifyingElement, PropertyCount
 
-$input-font-size: scale($theme-font-family-input, $theme-font-size-base);
-$input-line-height: lh($theme-font-family-input, $theme-line-height-input); // was 1.3
+$input-font-size-calc: scale($theme-font-family-input, $theme-font-size-base);
+$input-line-height-calc: lh($theme-font-family-input, $theme-line-height-input); // was 1.3
 $input-border-width: px-to-rem(1px); // Using rem instead of px so function uses same units
 $input-padding-vertical: units(1);
 
 // input heights will vary by browser and type
 // if height not explicitly set
 $input-height-exact: (
-  (scale($theme-font-family-input, $theme-font-size-base) * $input-line-height) +
+  ($input-font-size-calc * $input-line-height-calc) +
   ($input-padding-vertical * 2) +
   ($input-border-width * 2)
 );
@@ -18,14 +18,12 @@ $input-height-exact: (
 $input-height: floor($input-height-exact * 10) / 10;
 
 // Block form elements
-/* stylelint-disable selector-no-qualifying-type */
-
 .usa-form,
 // with a more consistent use of .usa-form
 // the following should be unnecessary
 .usa-form-large,
-.usa-fieldset-inputs,
 .usa-fieldset,
+.usa-fieldset-inputs,
 .usa-input,
 .usa-textarea,
 .usa-select,
@@ -58,7 +56,6 @@ $input-height: floor($input-height-exact * 10) / 10;
     @include u-border(2px, 'success');
   }
 }
-/* stylelint-enable */
 
 .usa-form-group-error {
   @include u-border-left(0.5, 'error');
@@ -74,7 +71,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 
 .usa-input-error-label {
   display: block;
-  font-size: $input-font-size;
+  font-size: $input-font-size-calc;
   font-weight: $theme-font-weight-bold;
   margin-top: 0;
 }
@@ -83,12 +80,13 @@ $input-height: floor($input-height-exact * 10) / 10;
   @include u-padding-y(0.5);
   color: color('error');
   display: block;
-  font-size: $input-font-size;
+  font-size: $input-font-size-calc;
   font-weight: $theme-font-weight-bold;
 }
 
 // Deprecated: Some screen readers can't read CSS content.
 // Will be removed in 2.0.
+// TODO: remove?
 .usa-input-required:after {
   color: color('error-dark');
   content: ' (*required)';
@@ -96,6 +94,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 
 // Deprecated: Some screen readers can't read CSS content.
 // Will be removed in 2.0.
+// TODO: remove?
 .usa-input-optional:after {
   color: color('base');
   content: ' (optional)';
@@ -110,8 +109,8 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-label {
-  @include typeset($theme-font-family-input, $theme-font-size-base, 2);
   display: block;
+  line-height: line-ehight($theme-font-family-input, 2);
   margin-top: units(3);
   max-width: $input-max-width;
 }
@@ -151,6 +150,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 .usa-legend {
   font-size: scale($theme-font-family-input, $theme-font-size-h2);
   font-weight: $theme-font-weight-bold;
+  line-height: line-height($theme-font-family-input, 2);
 }
 
 .usa-fieldset-inputs {
@@ -201,7 +201,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-checkbox-label::before {
-  border-radius: $checkbox-border-radius;
+  border-radius: radius($theme-border-radius-checkbox);
   box-shadow: 0 0 0 2px color('base');
   height: units($theme-spacing-md);
   line-height: units($theme-spacing-md);

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -21,6 +21,9 @@ $input-height: floor($input-height-exact * 10) / 10;
 /* stylelint-disable selector-no-qualifying-type */
 
 .usa-form,
+// with a more consistent use of .usa-form
+// the following should be unnecessary
+.usa-form-large,
 .usa-fieldset-inputs,
 .usa-fieldset,
 .usa-input,

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -49,7 +49,7 @@ $input-height: floor($input-height-exact * 10) / 10;
   color: color('ink'); // standardize on firefox
   display: block;
   height: $input-height;
-  margin: units(0.5) 0;
+  margin: units(1) 0;
   max-width: $input-max-width;
   padding: $input-padding-vertical units(1);
   width: 100%;
@@ -112,7 +112,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 .usa-label {
   @include typeset($theme-input-font-family, $theme-base-font-size, 2);
   display: block;
-  margin-top: units(4);
+  margin-top: units(3);
   max-width: $input-max-width;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -111,7 +111,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 
 .usa-label {
   display: block;
-  line-height: line-ehight($theme-font-family-input, 2);
+  line-height: line-height($theme-font-family-input, 2);
   margin-top: units(3);
   max-width: $input-max-width;
 }

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -1,14 +1,14 @@
 // scss-lint:disable QualifyingElement, PropertyCount
 
-$input-font-size: scale($theme-input-font-family, $theme-base-font-size);
-$input-line-height: lh($theme-input-font-family, $theme-input-line-height); // was 1.3
+$input-font-size: scale($theme-font-family-input, $theme-font-size-base);
+$input-line-height: lh($theme-font-family-input, $theme-line-height-input); // was 1.3
 $input-border-width: px-to-rem(1px); // Using rem instead of px so function uses same units
 $input-padding-vertical: units(1);
 
 // input heights will vary by browser and type
 // if height not explicitly set
 $input-height-exact: (
-  (scale($theme-input-font-family, $theme-base-font-size) * $input-line-height) +
+  (scale($theme-font-family-input, $theme-font-size-base) * $input-line-height) +
   ($input-padding-vertical * 2) +
   ($input-border-width * 2)
 );
@@ -32,9 +32,9 @@ $input-height: floor($input-height-exact * 10) / 10;
 .usa-range,
 .usa-form-hint {
   @include typeset(
-    $theme-input-font-family,
-    $theme-base-font-size,
-    $theme-input-line-height
+    $theme-font-family-input,
+    $theme-font-size-base,
+    $theme-line-height-input
   );
 }
 
@@ -110,7 +110,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-label {
-  @include typeset($theme-input-font-family, $theme-base-font-size, 2);
+  @include typeset($theme-font-family-input, $theme-font-size-base, 2);
   display: block;
   margin-top: units(3);
   max-width: $input-max-width;
@@ -149,7 +149,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-legend {
-  font-size: scale($theme-input-font-family, $theme-h2-font-size);
+  font-size: scale($theme-font-family-input, $theme-font-size-h2);
   font-weight: $theme-font-weight-bold;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -1,15 +1,14 @@
 // scss-lint:disable QualifyingElement, PropertyCount
 
-$input-font-family: 'sans' !default;
-$input-font-size: scale($input-font-family, $theme-base-font-size);
-$input-line-height: lh($input-font-family, 3); // was 1.3
+$input-font-size: scale($theme-input-font-family, $theme-base-font-size);
+$input-line-height: lh($theme-input-font-family, $theme-input-line-height); // was 1.3
 $input-border-width: px-to-rem(1px); // Using rem instead of px so function uses same units
 $input-padding-vertical: units(1);
 
 // input heights will vary by browser and type
 // if height not explicitly set
 $input-height-exact: (
-  (scale($input-font-family, $theme-base-font-size) * $input-line-height) +
+  (scale($theme-input-font-family, $theme-base-font-size) * $input-line-height) +
   ($input-padding-vertical * 2) +
   ($input-border-width * 2)
 );
@@ -21,19 +20,32 @@ $input-height: floor($input-height-exact * 10) / 10;
 // Block form elements
 /* stylelint-disable selector-no-qualifying-type */
 
+.usa-form,
+.usa-fieldset-inputs,
+.usa-fieldset,
+.usa-input,
+.usa-textarea,
+.usa-select,
+.usa-range,
+.usa-form-hint {
+  @include typeset(
+    $theme-input-font-family,
+    $theme-base-font-size,
+    $theme-input-line-height
+  );
+}
+
 .usa-input,
 .usa-textarea,
 .usa-select,
 .usa-range {
   @include u-border(1px, 'base-dark');
-  @include u-font($input-font-family, $theme-base-font-size);
   appearance: none;
   border-radius: 0;
   box-sizing: border-box;
   color: color('ink'); // standardize on firefox
   display: block;
   height: $input-height;
-  line-height: $input-line-height;
   margin: units(0.5) 0;
   max-width: $input-max-width;
   padding: $input-padding-vertical units(1);
@@ -95,7 +107,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-label {
-  @include typeset($input-font-family, $theme-base-font-size, 2);
+  @include typeset($theme-input-font-family, $theme-base-font-size, 2);
   display: block;
   margin-top: units(4);
   max-width: $input-max-width;
@@ -134,7 +146,7 @@ $input-height: floor($input-height-exact * 10) / 10;
 }
 
 .usa-legend {
-  font-size: scale($input-font-family, $theme-h2-font-size);
+  font-size: scale($theme-input-font-family, $theme-h2-font-size);
   font-weight: $theme-font-weight-bold;
 }
 
@@ -148,7 +160,6 @@ $input-height: floor($input-height-exact * 10) / 10;
 
 .usa-form-hint {
   color: color('base');
-  font-family: font-family($input-font-family);
   margin-bottom: 0;
 }
 

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -49,7 +49,7 @@ $input-height: floor($input-height-exact * 10) / 10;
   color: color('ink'); // standardize on firefox
   display: block;
   height: $input-height;
-  margin: units(1) 0;
+  margin-top: units(1);
   max-width: $input-max-width;
   padding: $input-padding-vertical units(1);
   width: 100%;

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -1,4 +1,5 @@
 %usa-table {
+  @include typeset-default;
   border-spacing: 0;
   margin: units(2.5) 0;
 

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -1,5 +1,5 @@
 %usa-table {
-  @include typeset-default;
+  @include typeset;
   border-spacing: 0;
   margin: units(2.5) 0;
 

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -1,5 +1,5 @@
 .usa-tag {
-  @include u-font('sans', '2xs');
+  @include u-font('ui', '2xs');
   @include u-text('white', 'uppercase');
   background-color: color('base-dark');
   border-radius: radius('sm');
@@ -13,5 +13,5 @@
 
 .usa-tag-big {
   @include u-padding-x(1);
-  @include u-font('sans', $theme-font-size-base);
+  @include u-font('ui', $theme-font-size-base);
 }

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -13,5 +13,5 @@
 
 .usa-tag-big {
   @include u-padding-x(1);
-  @include u-font('sans', $theme-base-font-size);
+  @include u-font('sans', $theme-font-size-base);
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -198,6 +198,7 @@ dfn {
 }
 
 // TODO: How should we keep or adapt these?
+// Strong candidates for deprecation
 .usa-text-small {
   font-size: $h6-font-size;
   margin-top: 0;
@@ -211,6 +212,7 @@ dfn {
     font-family: $font-sans;
   }
 
+  // TODO: This is an unexpected effect of .usa-sans
   a {
     border-bottom: none;
     font-weight: $font-bold;

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -1,59 +1,19 @@
 html {
-  font-family: font-family($theme-font-default);
+  font-family: font-family($theme-base-font-family);
   font-size: $root-font-size;
 }
 
-%usa-paragraph {
-  line-height: $base-line-height;
-  margin-bottom: 0;
-  margin-top: 0;
-
-  * + & {
-    margin-top: 1em;
-  }
-
-  + * {
-    margin-top: 1em;
-  }
-}
-
-%usa-link {
-  color: color('primary');
-  text-decoration: underline;
-
-  &:hover,
-  &:active {
-    color: color('primary-darker');
-  }
-
-  &:focus {
-    @include focus;
-  }
-
-  &:visited {
-    color: $color-visited;
-  }
-}
-
 %usa-heading {
-  clear: both;
-  font-family: $font-serif;
-  line-height: $heading-line-height;
-  margin-bottom: 0.5em;
-  margin-top: 0;
-}
-
-* + %usa-heading {
-  margin-top: 1.5em;
+  @include typeset-heading
 }
 
 @mixin usa-typography-base-styles {
   p {
-    @extend %usa-paragraph;
+    @include typeset-p;
   }
 
   a {
-    @extend %usa-link;
+    @include typeset-link;
   }
 }
 
@@ -89,7 +49,6 @@ html {
 
   h6 {
     @include h6;
-    font-family: $font-sans;
   }
 }
 
@@ -105,6 +64,10 @@ html {
   @include usa-headings-styles;
   @include usa-list-styles;
   @include usa-table-styles;
+}
+
+.usa-prose {
+  @include typeset-default($theme-base-font-family);
 }
 
 /* stylelint-disable block-closing-brace-newline-after, at-rule-empty-line-before */
@@ -127,11 +90,11 @@ html {
 @include theme-content-styles;
 
 .usa-paragraph {
-  @extend %usa-paragraph;
+  @include typeset-p;
 }
 
 .usa-link {
-  @extend %usa-link;
+  @include typeset-link;
 }
 
 @mixin external-link($external-link, $external-link-hover) {
@@ -143,7 +106,7 @@ html {
     display: inline-block;
     height: 0.65em;
     margin-bottom: -1px;
-    margin-left: 4px;
+    margin-left: units(0.5);
     width: 0.65em;
   }
 
@@ -180,12 +143,58 @@ dfn {
   p,
   ul:not(.usa-accordion):not(.usa-accordion-bordered),
   ol:not(.usa-accordion):not(.usa-accordion-bordered) {
-    max-width: $text-max-width;
+    max-width: measure($theme-text-max-width);
   }
 }
 
 .usa-content-list {
-  max-width: $text-max-width;
+  max-width: measure($theme-text-max-width);
+}
+
+.usa-display {
+  @include typeset-h3;
+  margin-bottom: 0;
+
+  @include media($small-screen) {
+    @include typeset-h1;
+  }
+
+  @include media($medium-screen) {
+    @include typeset-title;
+  }
+}
+
+.usa-font-lead {
+  @include typeset(
+    $theme-lead-font-family,
+    $theme-lead-font-size,
+    $theme-lead-line-height
+  );
+  font-weight: $theme-font-weight-normal;
+  max-width: measure($theme-lead-max-width);
+}
+
+.usa-background-dark {
+  background-color: color('base-darker');
+
+  p,
+  span {
+    color: color('white');
+  }
+
+  a {
+    color: color('base-lighter');
+
+    &:hover {
+      color: color('white');
+    }
+  }
+}
+
+// TODO: How should we keep or adapt these?
+.usa-text-small {
+  font-size: $h6-font-size;
+  margin-top: 0;
 }
 
 .usa-sans {
@@ -209,47 +218,4 @@ dfn {
   span {
     font-family: $font-serif;
   }
-}
-
-.usa-display {
-  @include h3;
-  margin-bottom: 0;
-
-  @include media($small-screen) {
-    @include h1;
-  }
-
-  @include media($medium-screen) {
-    @include title;
-  }
-}
-
-.usa-font-lead {
-  font-family: $font-serif;
-  font-size: $lead-font-size;
-  font-weight: $font-normal;
-  line-height: $lead-line-height;
-  max-width: $lead-max-width;
-}
-
-.usa-background-dark {
-  background-color: $color-gray-dark;
-
-  p,
-  span {
-    color: $color-white;
-  }
-
-  a {
-    color: $color-gray-lighter;
-
-    &:hover {
-      color: $color-white;
-    }
-  }
-}
-
-.usa-text-small {
-  font-size: $h6-font-size;
-  margin-top: 0;
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -10,7 +10,7 @@ html {
 }
 
 %usa-heading {
-  @include typeset-heading
+  @include typeset-heading;
 }
 
 @mixin usa-typography-base-styles {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -1,5 +1,5 @@
 html {
-  font-family: font-family($theme-base-font-family);
+  font-family: font-family($theme-font-family-base);
   font-size: $root-font-size;
 }
 
@@ -73,7 +73,7 @@ html {
 }
 
 .usa-prose {
-  @include typeset-default($theme-prose-font-family);
+  @include typeset-default($theme-font-family-prose);
 }
 
 /* stylelint-disable block-closing-brace-newline-after, at-rule-empty-line-before */
@@ -149,12 +149,12 @@ dfn {
   p,
   ul:not(.usa-accordion):not(.usa-accordion-bordered),
   ol:not(.usa-accordion):not(.usa-accordion-bordered) {
-    max-width: measure($theme-text-max-width);
+    max-width: measure($theme-measure-text);
   }
 }
 
 .usa-content-list {
-  max-width: measure($theme-text-max-width);
+  max-width: measure($theme-measure-text);
 }
 
 .usa-display {
@@ -172,12 +172,12 @@ dfn {
 
 .usa-font-lead {
   @include typeset(
-    $theme-lead-font-family,
-    $theme-lead-font-size,
-    $theme-lead-line-height
+    $theme-font-family-lead,
+    $theme-font-size-lead,
+    $theme-line-height-lead
   );
   font-weight: $theme-font-weight-normal;
-  max-width: measure($theme-lead-max-width);
+  max-width: measure($theme-measure-lead);
 }
 
 .usa-background-dark {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -196,34 +196,3 @@ dfn {
     }
   }
 }
-
-// TODO: How should we keep or adapt these?
-// Strong candidates for deprecation
-.usa-text-small {
-  font-size: $h6-font-size;
-  margin-top: 0;
-}
-
-.usa-sans {
-  p,
-  a,
-  li,
-  span {
-    font-family: $font-sans;
-  }
-
-  // TODO: This is an unexpected effect of .usa-sans
-  a {
-    border-bottom: none;
-    font-weight: $font-bold;
-  }
-}
-
-.usa-serif {
-  p,
-  a,
-  li,
-  span {
-    font-family: $font-serif;
-  }
-}

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -3,6 +3,12 @@ html {
   font-size: $root-font-size;
 }
 
+@if $theme-style-body-element {
+  body {
+    @include typeset-default;
+  }
+}
+
 %usa-heading {
   @include typeset-heading
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -67,7 +67,7 @@ html {
 }
 
 .usa-prose {
-  @include typeset-default($theme-base-font-family);
+  @include typeset-default($theme-prose-font-family);
 }
 
 /* stylelint-disable block-closing-brace-newline-after, at-rule-empty-line-before */

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -5,7 +5,7 @@ html {
 
 @if $theme-style-body-element {
   body {
-    @include typeset-default;
+    @include typeset;
   }
 }
 
@@ -73,7 +73,7 @@ html {
 }
 
 .usa-prose {
-  @include typeset-default($theme-font-family-prose);
+  @include typeset($theme-font-family-prose);
 }
 
 /* stylelint-disable block-closing-brace-newline-after, at-rule-empty-line-before */

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -161,11 +161,11 @@ dfn {
   @include typeset-h3;
   margin-bottom: 0;
 
-  @include media($small-screen) {
+  @include at-media('mobile-lg') {
     @include typeset-h1;
   }
 
-  @include media($medium-screen) {
+  @include at-media('tablet') {
     @include typeset-title;
   }
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -1,10 +1,6 @@
 html {
-  font-family: $font-sans;
+  font-family: font-family($theme-font-default);
   font-size: $root-font-size;
-}
-
-body {
-  font-size: $base-font-size;
 }
 
 %usa-paragraph {
@@ -22,12 +18,12 @@ body {
 }
 
 %usa-link {
-  color: $color-primary;
+  color: color('primary');
   text-decoration: underline;
 
   &:hover,
   &:active {
-    color: $color-primary-darker;
+    color: color('primary-darker');
   }
 
   &:focus {

--- a/src/stylesheets/settings/_settings-spacing.scss
+++ b/src/stylesheets/settings/_settings-spacing.scss
@@ -35,6 +35,8 @@ $theme-border-radius-sm:       2px !default;
 $theme-border-radius-md:       0.5 !default;
 $theme-border-radius-lg:       1 !default;
 
+$theme-border-radius-checkbox: 'sm' !default;
+
 /*
 ----------------------------------------
 Column gap

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -310,7 +310,7 @@ $theme-lead-max-width:             5 !default;
 
 /*
 ----------------------------------------
-Component font families
+Component default font families
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -282,7 +282,7 @@ $theme-base-font-size:             'sm' !default; // was 1.7rem
 $theme-base-line-height:           5 !default; // was 1.5
 
 // If true, explicitly style the <body> element with the base styles
-$theme-style-body-element:         true !default;
+$theme-style-body-element:         false !default;
 
 // Font sizes
 $theme-small-font-size:            '2xs' !default; // was 1.4rem

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -276,12 +276,12 @@ none:    none
 ----------------------------------------
 */
 
-// Base settings are the defaults for components
+// Base settings are the equivalent of setting the <body> element
 $theme-base-font-family:           'body' !default;
 $theme-base-font-size:             'sm' !default; // was 1.7rem
 $theme-base-line-height:           5 !default; // was 1.5
 
-// Sizes
+// Font sizes
 $theme-small-font-size:            '2xs' !default; // was 1.4rem
 $theme-lead-font-size:             'lg' !default; // was 2rem
 $theme-title-font-size:            '3xl' !default; // was 5.2rem
@@ -312,12 +312,11 @@ $theme-lead-max-width:             5 !default;
 ----------------------------------------
 Component font families
 ----------------------------------------
-Components will take the base font
-settings unless these variables
-are set.
-----------------------------------------
 */
 
-$theme-input-font-family:       'ui' !default;
-$theme-lead-font-family:        'heading' !default;
-$theme-accordion-font-family:   $theme-base-font-family !default;
+$theme-accordion-font-family:      'body' !default;
+$theme-banner-font-family:         'ui' !default;
+$theme-alerts-font-family:         'ui' !default;
+$theme-input-font-family:          'ui' !default;
+$theme-lead-font-family:           'heading' !default;
+$theme-prose-font-family:          'body' !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -181,22 +181,6 @@ $theme-font-alt:      $theme-font-sans !default;
 
 /*
 ----------------------------------------
-Default font family
-----------------------------------------
-Set the font family of the html element
-from the fonts in use:
-
-$theme-font-sans
-$theme-font-serif
-$theme-font-mono
-$theme-font-cond
-----------------------------------------
-*/
-
-$theme-font-default: $theme-font-sans !default;
-
-/*
-----------------------------------------
 Type scale
 ----------------------------------------
 Define your project's type scale using
@@ -237,6 +221,8 @@ $theme-font-weight-heavy:         false !default;
 
 /*
 ----------------------------------------
+Defaults
+----------------------------------------
 Type scale tokens
 ----------------------------------------
 micro:      10px
@@ -270,9 +256,30 @@ Line height tokens
 5:    1.62
 6:    1.75
 ----------------------------------------
+Font family tokens
+----------------------------------------
+'sans'
+'serif'
+'mono'
+'cond'
+----------------------------------------
+Max-width tokens
+----------------------------------------
+1:       40ch
+2:       60ch
+3:       66ch
+4:       72ch
+5:       77ch
+none:    none
+----------------------------------------
 */
 
+// Base settings are the defaults for components
+$theme-base-font-family:           'sans' !default;
 $theme-base-font-size:             'sm' !default; // was 1.7rem
+$theme-base-line-height:           5 !default; // was 1.5
+
+// Sizes
 $theme-small-font-size:            '2xs' !default; // was 1.4rem
 $theme-lead-font-size:             'lg' !default; // was 2rem
 $theme-title-font-size:            '3xl' !default; // was 5.2rem
@@ -282,8 +289,29 @@ $theme-h3-font-size:               'lg' !default; // was 2rem
 $theme-h4-font-size:               'sm' !default; // was 1.7rem
 $theme-h5-font-size:               'xs' !default; // was 1.5rem
 $theme-h6-font-size:               '3xs' !default; // was 1.3rem
-$theme-base-line-height:           4 !default; // was 1.5
+
+// Line heights
 $theme-heading-line-height:        3 !default; // was 1.3
 $theme-lead-line-height:           6 !default; // was 1.7
 $theme-font-weight-normal:         400 !default;
 $theme-font-weight-bold:           700 !default;
+
+// Max widths
+$theme-text-narrow-width:          1 !default;
+$theme-text-max-width:             3 !default;
+$theme-text-wide-width:            4 !default;
+$theme-lead-max-width:             5 !default;
+
+
+/*
+----------------------------------------
+Component font families
+----------------------------------------
+Components will take the base font
+settings unless these variables
+are set.
+----------------------------------------
+*/
+
+$theme-lead-font-family: 'heading' !default;
+$theme-accordion-font-family: $theme-base-font-family !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -281,6 +281,9 @@ $theme-base-font-family:           'body' !default;
 $theme-base-font-size:             'sm' !default; // was 1.7rem
 $theme-base-line-height:           5 !default; // was 1.5
 
+// If true, explicitly style the <body> element with the base styles
+$theme-style-body-element:         true !default;
+
 // Font sizes
 $theme-small-font-size:            '2xs' !default; // was 1.4rem
 $theme-lead-font-size:             'lg' !default; // was 2rem

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -293,6 +293,9 @@ $theme-h6-font-size:               '3xs' !default; // was 1.3rem
 // Line heights
 $theme-heading-line-height:        3 !default; // was 1.3
 $theme-lead-line-height:           6 !default; // was 1.7
+$theme-input-line-height:          3 !default; // was 1.7
+
+// Font weights
 $theme-font-weight-normal:         400 !default;
 $theme-font-weight-bold:           700 !default;
 
@@ -313,5 +316,6 @@ are set.
 ----------------------------------------
 */
 
+$theme-input-font-family: 'sans' !default;
 $theme-lead-font-family: 'heading' !default;
 $theme-accordion-font-family: $theme-base-font-family !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -310,7 +310,6 @@ $theme-measure-text:               3 !default;
 $theme-measure-text-wide:          4 !default;
 $theme-measure-lead:               5 !default;
 
-
 /*
 ----------------------------------------
 Component default font families

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -315,8 +315,9 @@ Component font families
 */
 
 $theme-accordion-font-family:      'body' !default;
-$theme-banner-font-family:         'ui' !default;
 $theme-alerts-font-family:         'ui' !default;
+$theme-banner-font-family:         'ui' !default;
+$theme-footer-font-family:         'body' !default;
 $theme-input-font-family:          'ui' !default;
 $theme-lead-font-family:           'heading' !default;
 $theme-prose-font-family:          'body' !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -19,7 +19,7 @@ Setting $theme-respect-user-font-size to
 true sets the root font size to 100% and
 uses ems for media queries
 ----------------------------------------
-$theme-root-font-size only applies when
+$theme-font-size-root only applies when
 $theme-respect-user-font-size is set to
 false.
 
@@ -33,7 +33,7 @@ Accepts true or false
 
 $theme-respect-user-font-size: false !default;
 
-// $theme-root-font-size only applies when
+// $theme-font-size-root only applies when
 // $theme-respect-user-font-size is set to
 // false.
 
@@ -43,7 +43,7 @@ $theme-respect-user-font-size: false !default;
 
 // Accepts values in px
 
-$theme-root-font-size: 10px !default;
+$theme-font-size-root: 10px !default;
 
 /*
 ----------------------------------------
@@ -265,7 +265,7 @@ Font family tokens
 'code'
 'alt'
 ----------------------------------------
-Max-width tokens
+Measure (max-width) tokens
 ----------------------------------------
 1:       40ch
 2:       60ch
@@ -277,38 +277,38 @@ none:    none
 */
 
 // Base settings are the equivalent of setting the <body> element
-$theme-base-font-family:           'body' !default;
-$theme-base-font-size:             'sm' !default; // was 1.7rem
-$theme-base-line-height:           5 !default; // was 1.5
+$theme-font-family-base:           'body' !default;
+$theme-font-size-base:             'sm' !default; // was 1.7rem
+$theme-line-height-base:           5 !default; // was 1.5
 
 // If true, explicitly style the <body> element with the base styles
 $theme-style-body-element:         false !default;
 
 // Font sizes
-$theme-small-font-size:            '2xs' !default; // was 1.4rem
-$theme-lead-font-size:             'lg' !default; // was 2rem
-$theme-title-font-size:            '3xl' !default; // was 5.2rem
-$theme-h1-font-size:               '2xl' !default; // was 4rem
-$theme-h2-font-size:               'xl' !default; // was 3rem
-$theme-h3-font-size:               'lg' !default; // was 2rem
-$theme-h4-font-size:               'sm' !default; // was 1.7rem
-$theme-h5-font-size:               'xs' !default; // was 1.5rem
-$theme-h6-font-size:               '3xs' !default; // was 1.3rem
+$theme-font-size-small:            '2xs' !default; // was 1.4rem
+$theme-font-size-lead:             'lg' !default; // was 2rem
+$theme-font-size-title:            '3xl' !default; // was 5.2rem
+$theme-font-size-h1:               '2xl' !default; // was 4rem
+$theme-font-size-h2:               'xl' !default; // was 3rem
+$theme-font-size-h3:               'lg' !default; // was 2rem
+$theme-font-size-h4:               'sm' !default; // was 1.7rem
+$theme-font-size-h5:               'xs' !default; // was 1.5rem
+$theme-font-size-h6:               '3xs' !default; // was 1.3rem
 
 // Line heights
-$theme-heading-line-height:        3 !default; // was 1.3
-$theme-lead-line-height:           6 !default; // was 1.7
-$theme-input-line-height:          3 !default; // was 1.7
+$theme-line-height-heading:        3 !default; // was 1.3
+$theme-line-height-lead:           6 !default; // was 1.7
+$theme-line-height-input:          3 !default; // was 1.7
 
 // Font weights
 $theme-font-weight-normal:         400 !default;
 $theme-font-weight-bold:           700 !default;
 
-// Max widths
-$theme-text-narrow-width:          1 !default;
-$theme-text-max-width:             3 !default;
-$theme-text-wide-width:            4 !default;
-$theme-lead-max-width:             5 !default;
+// Measure (max-width)
+$theme-measure-text-narrow:        1 !default;
+$theme-measure-text:               3 !default;
+$theme-measure-text-wide:          4 !default;
+$theme-measure-lead:               5 !default;
 
 
 /*
@@ -317,10 +317,10 @@ Component default font families
 ----------------------------------------
 */
 
-$theme-accordion-font-family:      'body' !default;
-$theme-alerts-font-family:         'ui' !default;
-$theme-banner-font-family:         'ui' !default;
-$theme-footer-font-family:         'body' !default;
-$theme-input-font-family:          'ui' !default;
-$theme-lead-font-family:           'heading' !default;
-$theme-prose-font-family:          'body' !default;
+$theme-font-family-accordion:      'body' !default;
+$theme-font-family-alerts:         'ui' !default;
+$theme-font-family-banner:         'ui' !default;
+$theme-font-family-footer:         'body' !default;
+$theme-font-family-input:          'ui' !default;
+$theme-font-family-lead:           'heading' !default;
+$theme-font-family-prose:          'body' !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -181,6 +181,22 @@ $theme-font-alt:      $theme-font-sans !default;
 
 /*
 ----------------------------------------
+Default font family
+----------------------------------------
+Set the font family of the html element
+from the fonts in use:
+
+$theme-font-sans
+$theme-font-serif
+$theme-font-mono
+$theme-font-cond
+----------------------------------------
+*/
+
+$theme-font-default: $theme-font-sans !default;
+
+/*
+----------------------------------------
 Type scale
 ----------------------------------------
 Define your project's type scale using

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -164,7 +164,7 @@ $theme-font-cond:   false !default;
 ----------------------------------------
 Fonts by role
 ----------------------------------------
-Set the heading, body, code, and alt
+Set the ui, heading, body, code, and alt
 faces for your project from
 
 $theme-font-sans
@@ -174,10 +174,11 @@ $theme-font-cond
 ----------------------------------------
 */
 
+$theme-font-ui:       $theme-font-sans !default;
 $theme-font-heading:  $theme-font-serif !default;
-$theme-font-body:     $theme-font-serif !default;
+$theme-font-body:     $theme-font-sans !default;
 $theme-font-code:     $theme-font-mono !default;
-$theme-font-alt:      $theme-font-sans !default;
+$theme-font-alt:      $theme-font-serif !default;
 
 /*
 ----------------------------------------
@@ -258,10 +259,11 @@ Line height tokens
 ----------------------------------------
 Font family tokens
 ----------------------------------------
-'sans'
-'serif'
-'mono'
-'cond'
+'ui'
+'heading'
+'body'
+'code'
+'alt'
 ----------------------------------------
 Max-width tokens
 ----------------------------------------
@@ -275,7 +277,7 @@ none:    none
 */
 
 // Base settings are the defaults for components
-$theme-base-font-family:           'sans' !default;
+$theme-base-font-family:           'body' !default;
 $theme-base-font-size:             'sm' !default; // was 1.7rem
 $theme-base-line-height:           5 !default; // was 1.5
 
@@ -316,6 +318,6 @@ are set.
 ----------------------------------------
 */
 
-$theme-input-font-family: 'sans' !default;
-$theme-lead-font-family: 'heading' !default;
-$theme-accordion-font-family: $theme-base-font-family !default;
+$theme-input-font-family:       'ui' !default;
+$theme-lead-font-family:        'heading' !default;
+$theme-accordion-font-family:   $theme-base-font-family !default;

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -315,8 +315,9 @@ Component font families
 */
 
 $theme-accordion-font-family:      'body';
-$theme-banner-font-family:         'ui';
 $theme-alerts-font-family:         'ui';
+$theme-banner-font-family:         'ui';
+$theme-footer-font-family:         'body';
 $theme-input-font-family:          'ui';
 $theme-lead-font-family:           'heading';
 $theme-prose-font-family:          'body';

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -164,7 +164,7 @@ $theme-font-cond:   false;
 ----------------------------------------
 Fonts by role
 ----------------------------------------
-Set the heading, body, code, and alt
+Set the ui, heading, body, code, and alt
 faces for your project from
 
 $theme-font-sans
@@ -174,10 +174,11 @@ $theme-font-cond
 ----------------------------------------
 */
 
+$theme-font-ui:       $theme-font-sans;
 $theme-font-heading:  $theme-font-serif;
-$theme-font-body:     $theme-font-serif;
+$theme-font-body:     $theme-font-sans;
 $theme-font-code:     $theme-font-mono;
-$theme-font-alt:      $theme-font-sans;
+$theme-font-alt:      $theme-font-serif;
 
 /*
 ----------------------------------------
@@ -221,6 +222,8 @@ $theme-font-weight-heavy:         false;
 
 /*
 ----------------------------------------
+Defaults
+----------------------------------------
 Type scale tokens
 ----------------------------------------
 micro:      10px
@@ -254,9 +257,31 @@ Line height tokens
 5:    1.62
 6:    1.75
 ----------------------------------------
+Font family tokens
+----------------------------------------
+'ui'
+'heading'
+'body'
+'code'
+'alt'
+----------------------------------------
+Max-width tokens
+----------------------------------------
+1:       40ch
+2:       60ch
+3:       66ch
+4:       72ch
+5:       77ch
+none:    none
+----------------------------------------
 */
 
+// Base settings are the equivalent of setting the <body> element
+$theme-base-font-family:           'body';
 $theme-base-font-size:             'sm'; // was 1.7rem
+$theme-base-line-height:           5; // was 1.5
+
+// Font sizes
 $theme-small-font-size:            '2xs'; // was 1.4rem
 $theme-lead-font-size:             'lg'; // was 2rem
 $theme-title-font-size:            '3xl'; // was 5.2rem
@@ -266,8 +291,32 @@ $theme-h3-font-size:               'lg'; // was 2rem
 $theme-h4-font-size:               'sm'; // was 1.7rem
 $theme-h5-font-size:               'xs'; // was 1.5rem
 $theme-h6-font-size:               '3xs'; // was 1.3rem
-$theme-base-line-height:           4; // was 1.5
+
+// Line heights
 $theme-heading-line-height:        3; // was 1.3
 $theme-lead-line-height:           6; // was 1.7
+$theme-input-line-height:          3; // was 1.7
+
+// Font weights
 $theme-font-weight-normal:         400;
 $theme-font-weight-bold:           700;
+
+// Max widths
+$theme-text-narrow-width:          1;
+$theme-text-max-width:             3;
+$theme-text-wide-width:            4;
+$theme-lead-max-width:             5;
+
+
+/*
+----------------------------------------
+Component font families
+----------------------------------------
+*/
+
+$theme-accordion-font-family:      'body';
+$theme-banner-font-family:         'ui';
+$theme-alerts-font-family:         'ui';
+$theme-input-font-family:          'ui';
+$theme-lead-font-family:           'heading';
+$theme-prose-font-family:          'body';

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -281,6 +281,9 @@ $theme-base-font-family:           'body';
 $theme-base-font-size:             'sm'; // was 1.7rem
 $theme-base-line-height:           5; // was 1.5
 
+// If true, explicitly style the <body> element with the base styles
+$theme-style-body-element:         false;
+
 // Font sizes
 $theme-small-font-size:            '2xs'; // was 1.4rem
 $theme-lead-font-size:             'lg'; // was 2rem

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -19,7 +19,7 @@ Setting $theme-respect-user-font-size to
 true sets the root font size to 100% and
 uses ems for media queries
 ----------------------------------------
-$theme-root-font-size only applies when
+$theme-font-size-root only applies when
 $theme-respect-user-font-size is set to
 false.
 
@@ -33,7 +33,7 @@ Accepts true or false
 
 $theme-respect-user-font-size: false;
 
-// $theme-root-font-size only applies when
+// $theme-font-size-root only applies when
 // $theme-respect-user-font-size is set to
 // false.
 
@@ -43,7 +43,7 @@ $theme-respect-user-font-size: false;
 
 // Accepts values in px
 
-$theme-root-font-size: 10px;
+$theme-font-size-root: 10px;
 
 /*
 ----------------------------------------
@@ -265,7 +265,7 @@ Font family tokens
 'code'
 'alt'
 ----------------------------------------
-Max-width tokens
+Measure (max-width) tokens
 ----------------------------------------
 1:       40ch
 2:       60ch
@@ -277,39 +277,38 @@ none:    none
 */
 
 // Base settings are the equivalent of setting the <body> element
-$theme-base-font-family:           'body';
-$theme-base-font-size:             'sm'; // was 1.7rem
-$theme-base-line-height:           5; // was 1.5
+$theme-font-family-base:           'body';
+$theme-font-size-base:             'sm'; // was 1.7rem
+$theme-line-height-base:           5; // was 1.5
 
 // If true, explicitly style the <body> element with the base styles
 $theme-style-body-element:         false;
 
 // Font sizes
-$theme-small-font-size:            '2xs'; // was 1.4rem
-$theme-lead-font-size:             'lg'; // was 2rem
-$theme-title-font-size:            '3xl'; // was 5.2rem
-$theme-h1-font-size:               '2xl'; // was 4rem
-$theme-h2-font-size:               'xl'; // was 3rem
-$theme-h3-font-size:               'lg'; // was 2rem
-$theme-h4-font-size:               'sm'; // was 1.7rem
-$theme-h5-font-size:               'xs'; // was 1.5rem
-$theme-h6-font-size:               '3xs'; // was 1.3rem
+$theme-font-size-small:            '2xs'; // was 1.4rem
+$theme-font-size-lead:             'lg'; // was 2rem
+$theme-font-size-title:            '3xl'; // was 5.2rem
+$theme-font-size-h1:               '2xl'; // was 4rem
+$theme-font-size-h2:               'xl'; // was 3rem
+$theme-font-size-h3:               'lg'; // was 2rem
+$theme-font-size-h4:               'sm'; // was 1.7rem
+$theme-font-size-h5:               'xs'; // was 1.5rem
+$theme-font-size-h6:               '3xs'; // was 1.3rem
 
 // Line heights
-$theme-heading-line-height:        3; // was 1.3
-$theme-lead-line-height:           6; // was 1.7
-$theme-input-line-height:          3; // was 1.7
+$theme-line-height-heading:        3; // was 1.3
+$theme-line-height-lead:           6; // was 1.7
+$theme-line-height-input:          3; // was 1.7
 
 // Font weights
 $theme-font-weight-normal:         400;
 $theme-font-weight-bold:           700;
 
-// Max widths
-$theme-text-narrow-width:          1;
-$theme-text-max-width:             3;
-$theme-text-wide-width:            4;
-$theme-lead-max-width:             5;
-
+// Measure (max-width)
+$theme-measure-text-narrow:        1;
+$theme-measure-text:               3;
+$theme-measure-text-wide:          4;
+$theme-measure-lead:               5;
 
 /*
 ----------------------------------------
@@ -317,10 +316,10 @@ Component default font families
 ----------------------------------------
 */
 
-$theme-accordion-font-family:      'body';
-$theme-alerts-font-family:         'ui';
-$theme-banner-font-family:         'ui';
-$theme-footer-font-family:         'body';
-$theme-input-font-family:          'ui';
-$theme-lead-font-family:           'heading';
-$theme-prose-font-family:          'body';
+$theme-font-family-accordion:      'body';
+$theme-font-family-alerts:         'ui';
+$theme-font-family-banner:         'ui';
+$theme-font-family-footer:         'body';
+$theme-font-family-input:          'ui';
+$theme-font-family-lead:           'heading';
+$theme-font-family-prose:          'body';

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -310,7 +310,7 @@ $theme-lead-max-width:             5;
 
 /*
 ----------------------------------------
-Component font families
+Component default font families
 ----------------------------------------
 */
 

--- a/src/stylesheets/utilities/palettes/_font-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_font-palettes.scss
@@ -10,6 +10,7 @@ utilities
 
 $palette-font-misc:(
   'palette-font-stack-roles': (
+    ui:       #{$font-stack-ui},
     heading:  #{$font-stack-heading},
     body:     #{$font-stack-body},
     code:     #{$font-stack-code},
@@ -473,6 +474,112 @@ $palette-font-theme-code:(
   'palette-font-theme-code-all': $palette-font-theme-code-all,
 );
 
+$palette-font-theme-ui-3xs: (
+  ui-3xs: (
+    slug: 'ui-3xs',
+    isReadable: true,
+    content: utility-font(ui, 3xs),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-2xs: (
+  ui-2xs: (
+    slug: 'ui-2xs',
+    isReadable: true,
+    content: utility-font(ui, 2xs),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-xs: (
+  ui-xs: (
+    slug: 'ui-xs',
+    isReadable: true,
+    content: utility-font(ui, xs),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-sm: (
+  ui-sm: (
+    slug: 'ui-sm',
+    isReadable: true,
+    content: utility-font(ui, sm),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-md: (
+  ui-md: (
+    slug: 'ui-md',
+    isReadable: true,
+    content: utility-font(ui, md),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-lg: (
+  ui-lg: (
+    slug: 'ui-lg',
+    isReadable: true,
+    content: utility-font(ui, lg),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-xl: (
+  ui-xl: (
+    slug: 'ui-xl',
+    isReadable: true,
+    content: utility-font(ui, xl),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-2xl: (
+  ui-2xl: (
+    slug: 'ui-2xl',
+    isReadable: true,
+    content: utility-font(ui, 2xl),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-3xl: (
+  ui-3xl: (
+    slug: 'ui-3xl',
+    isReadable: true,
+    content: utility-font(ui, 3xl),
+    dependency: $theme-font-ui,
+  ),
+);
+
+$palette-font-theme-ui-all: map-collect(
+  $palette-font-theme-ui-3xs,
+  $palette-font-theme-ui-2xs,
+  $palette-font-theme-ui-xs,
+  $palette-font-theme-ui-sm,
+  $palette-font-theme-ui-md,
+  $palette-font-theme-ui-lg,
+  $palette-font-theme-ui-xl,
+  $palette-font-theme-ui-2xl,
+  $palette-font-theme-ui-3xl
+);
+
+$palette-font-theme-ui:(
+  'palette-font-theme-ui-3xs': $palette-font-theme-ui-3xs,
+  'palette-font-theme-ui-2xs': $palette-font-theme-ui-2xs,
+  'palette-font-theme-ui-xs': $palette-font-theme-ui-xs,
+  'palette-font-theme-ui-sm': $palette-font-theme-ui-sm,
+  'palette-font-theme-ui-md': $palette-font-theme-ui-md,
+  'palette-font-theme-ui-lg': $palette-font-theme-ui-lg,
+  'palette-font-theme-ui-xl': $palette-font-theme-ui-xl,
+  'palette-font-theme-ui-2xl': $palette-font-theme-ui-2xl,
+  'palette-font-theme-ui-3xl': $palette-font-theme-ui-3xl,
+  'palette-font-theme-ui-all': $palette-font-theme-ui-all,
+);
+
 $palette-font-theme-heading-3xs: (
   heading-3xs: (
     slug: 'heading-3xs',
@@ -794,6 +901,7 @@ $palette-font-theme-alt:(
 $palette-font-theme-roles-all:(
   'palette-font-theme-roles-all': map-collect(
     $palette-font-theme-code-all,
+    $palette-font-theme-ui-all,
     $palette-font-theme-heading-all,
     $palette-font-theme-body-all,
     $palette-font-theme-alt-all


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-typograhy-v2/)

- - -

This PR adds a bit of functionality and a little overhead to our component Sass.

Specifically, it removes default styling from the `<body>` element to keep our components as modular as possible — and gives the option to add it back with a feature flag.

```sass
// _settings-typography.scss

// Base settings are the equivalent of setting the <body> element
$theme-font-family-base:           'body' !default;
$theme-font-size-base:             'sm' !default; // was 1.7rem
$theme-line-height-base:           5 !default; // was 1.5

// If true, explicitly style the <body> element with the base styles
$theme-style-body-element:         false !default;
```

Our components should display properly regardless of `<body>` styling. To achieve this, we need to explicitly set typesetting at the component level with the `typeset()` mixin.

```sass
.usa-component {
  @include typeset;
  ...
}

// compiles as

.usa-component {
  font-family: font-family($theme-font-family-base);
  font-size: scale($theme-font-family-base, $theme-font-size-base);
  line-height: line-height($theme-font-family-base, $theme-line-height-base);
}
```

`typeset()` also accepts 1-3 tokens as arguments: `[font-family]`, `[scale]`,  and `[line-height]`. By default, those arguments are set to `$theme-font-family-base`, `$theme-font-size-base`, and `$theme-line-height-base`.  If an argument is explicitly `null`, that argument will get the default. 

```
typeset('sans')        == typeset('sans', $theme-font-size-base, $theme-line-height-base)
typeset('sans', 'xs')  == typeset('sans', 'xs', $theme-line-height-base)
typeset(null, null, 2) == typeset($theme-font-family-base, $theme-font-size-base, 2)
```

We can also set explicit font families for our components in `settings-typography`:

```sass
$theme-font-family-accordion:      'body' !default;
$theme-font-family-alerts:         'ui' !default;
$theme-font-family-banner:         'ui' !default;
$theme-font-family-footer:         'body' !default;
$theme-font-family-input:          'ui' !default;
$theme-font-family-lead:           'heading' !default;
$theme-font-family-prose:          'body' !default;
```

Then use that variable as the family arg in `typeset()`, like `typeset($theme-font-family-banner)`.

_Your component will probably appear very small until you do this!_

- - -

To apply default `p`, `a`, `h1-h6` styles to a class, use the `typeset-[element]` mixin (one exception: use `typeset-link` not `typeset-a`):

```sass
.usa-component-title {
  @include typeset-h3;
}

.usa-component-description {
  @include typeset-p;

  a {
    @include typeset-link;
  }
}

```

- - -

This PR also adds `ui` as one of the role-based font families.
- `ui`
- `heading`
- `body`
- `code`
- `alt`