### PR TITLE
Update media block to use 2.0 system palette

### DIFF
--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,4 +1,4 @@
-@mixin media-block-img($margin-right: 1rem) {
+@mixin media-block-img($margin-right: units(1)) {
   float: left;
   margin-right: $margin-right;
 }


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-media-block-v2/components/detail/graphic-list) 

Comment out the custom graphic list margin to see the default margin:
<img width="982" alt="screen shot 2018-09-10 at 11 55 11 am" src="https://user-images.githubusercontent.com/5249443/45318138-d8f6be00-b4f0-11e8-9387-aebfedc91c2c.png">
