### PR TITLE
Revise default grid features

### DIFF
--- a/src/stylesheets/core/_layout-grid.scss
+++ b/src/stylesheets/core/_layout-grid.scss
@@ -42,8 +42,7 @@ $namespace-grid: ns('grid');
 
   // ...that includes column gaps
   &.#{$namespace-grid}gap {
-    $props: append-important($grid-global, md);
-    @include grid-gap($props);
+    @include grid-gap-responsive;
   }
   @each $gap-key, $gap-val in map-deep-get($system-properties, gap, standard){
     &.#{$namespace-grid}gap-#{$gap-key} {
@@ -56,22 +55,10 @@ $namespace-grid: ns('grid');
   @each $mq-key, $mq-value in $system-breakpoints {
     @if map-get($theme-utility-breakpoints, $mq-key) {
       @include at-media($mq-key) {
-        &.#{$mq-key}\:#{$namespace-grid}gap {
-          @include grid-gap;
-        }
-        @if $theme-column-gap-sm {
-          &.#{$mq-key}\:#{$namespace-grid}gap-sm {
-            @include grid-gap('sm');
-          }
-        }
-        @if $theme-column-gap-md {
-          &.#{$mq-key}\:#{$namespace-grid}gap-md {
-            @include grid-gap('md');
-          }
-        }
-        @if $theme-column-gap-lg {
-          &.#{$mq-key}\:#{$namespace-grid}gap-lg {
-            @include grid-gap('lg');
+        @each $gap-key, $gap-val in map-deep-get($system-properties, gap, standard){
+          &.#{$mq-key}\:#{$namespace-grid}gap-#{$gap-key} {
+            $props: append-important($grid-global, $gap-key);
+            @include grid-gap($props);
           }
         }
       }

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -11,7 +11,7 @@
     @include u-maxw($props);
   }
   @include u-padding-x($theme-site-margins-mobile);
-  @include at-media('desktop'){
+  @include at-media('desktop') {
     @include u-padding-x($theme-site-margins);
   }
 }
@@ -49,7 +49,7 @@
     @include u-padding-x(calc-gap-offset($gap-mobile));
   }
 
-  @include at-media('desktop'){
+  @include at-media('desktop') {
     @include u-margin-x( unquote('#{$neg-prefix}-#{calc-gap-offset($gap-desktop)}'));
 
     > [class*='grid-col'] {

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -10,6 +10,10 @@
     @include u-margin-x($margin-x);
     @include u-maxw($props);
   }
+  @include u-padding-x($theme-site-margins-mobile);
+  @include at-media('desktop'){
+    @include u-padding-x($theme-site-margins);
+  }
 }
 
 @mixin grid-row($props...) {

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -23,31 +23,67 @@
   @include u-flex($flex);
 }
 
-@mixin grid-gap($props...) {
-  $props: unpack($props);
-  $gap: if(
-    length($props) == 0,
-    $theme-column-gap-md,
-    smart-quote(nth($props, 1))
+@mixin grid-gap-responsive {
+  $gap-mobile: if(
+    map-has-key($system-column-gaps, $theme-column-gap-mobile),
+    map-get($system-column-gaps, $theme-column-gap-mobile),
+    'error'
+  );
+  $gap-desktop: if(
+    map-has-key($system-column-gaps, $theme-column-gap-desktop),
+    map-get($system-column-gaps, $theme-column-gap-desktop),
+    'error'
   );
 
-  @if $gap == 0 {
-    @include u-margin-x(append-important($props, 0));
+  @if $gap-mobile == 'error' {
+    @error '$theme-column-gap-mobile is not set to a valid column gap width.';
+  }
 
-    > * {
-      @include u-padding-y(append-important($props, 0));
+  @if $gap-desktop == 'error' {
+    @error '$theme-column-gap-desktop is not set to a valid column gap width.';
+  }
+
+  @include u-margin-x( unquote('#{$neg-prefix}-#{calc-gap-offset($gap-mobile)}'));
+
+  > [class*='grid-col'] {
+    @include u-padding-x(calc-gap-offset($gap-mobile));
+  }
+
+  @include at-media('desktop'){
+    @include u-margin-x( unquote('#{$neg-prefix}-#{calc-gap-offset($gap-desktop)}'));
+
+    > [class*='grid-col'] {
+      @include u-padding-x(calc-gap-offset($gap-desktop));
     }
   }
+}
+
+@mixin grid-gap($props...) {
+  $props: unpack($props);
+  @if length($props) == 0 {
+    @error 'grid-gap() needs a valid grid gap.';
+  }
+
   @else {
-    @if map-has-key($project-column-gaps, $gap) {
-      $gap: map-get($project-column-gaps, $gap);
+    $gap: smart-quote(nth($props, 1));
+    @if $gap == 0 {
+      @include u-margin-x(append-important($props, 0));
+
+      > * {
+        @include u-padding-y(append-important($props, 0));
+      }
     }
-    @else if map-has-key($system-column-gaps, $gap) {
-      $gap: map-get($system-column-gaps, $gap);
-    }
-    @include u-margin-x(append-important($props, unquote('#{$neg-prefix}-#{calc-gap-offset($gap)}')));
-    > [class*='grid-col'] {
-      @include u-padding-x(append-important($props, calc-gap-offset($gap)));
+    @else {
+      @if map-has-key($project-column-gaps, $gap) {
+        $gap: map-get($project-column-gaps, $gap);
+      }
+      @else if map-has-key($system-column-gaps, $gap) {
+        $gap: map-get($system-column-gaps, $gap);
+      }
+      @include u-margin-x(append-important($props, unquote('#{$neg-prefix}-#{calc-gap-offset($gap)}')));
+      > [class*='grid-col'] {
+        @include u-padding-x(append-important($props, calc-gap-offset($gap)));
+      }
     }
   }
 }

--- a/src/stylesheets/settings/_settings-spacing.scss
+++ b/src/stylesheets/settings/_settings-spacing.scss
@@ -56,6 +56,10 @@ $theme-column-gap-sm: 2px !default;
 $theme-column-gap-md: 2 !default;
 $theme-column-gap-lg: 3 !default;
 
+// These determine the responsive gap sizes set with .grid-gap
+$theme-column-gap-mobile:  2 !default;
+$theme-column-gap-desktop: 4 !default;
+
 /*
 ----------------------------------------
 Grid container max-width

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -67,7 +67,3 @@ Output all USWDS
 @import 'utilities/rules/package';
 @include render-utilities-in($utilities-package);
 @import 'core/layout-grid';
-
-.foo {
-  @include grid-container;
-}

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -67,3 +67,7 @@ Output all USWDS
 @import 'utilities/rules/package';
 @include render-utilities-in($utilities-package);
 @import 'core/layout-grid';
+
+.foo {
+  @include grid-container;
+}


### PR DESCRIPTION
- `grid-gap` now provides a responsive gap with the value of `$theme-column-gap-mobile` up until desktop width and `$theme-column-gap-desktop` at desktop and above
- all other `grid-gap-[modifier]` utilities act as before
- `grid-container` now has padding-x of `$theme-site-margins-mobile` up until desktop width and `$theme-site-margins` thereafter