### PR TITLE
Remove redundant rules, re-color inverse buttons

### DIFF
--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -99,19 +99,19 @@ $button-stroke: inset 0 0 0 2px;
   &.usa-button-secondary-inverse,
   &.usa-button-outline-inverse {    // Outline inverse to be deprecated in 2.0
     background: transparent;
-    box-shadow: $button-stroke color('white');
-    color: color('white');
+    box-shadow: $button-stroke color('base-lighter');
+    color: color('base-lighter');
 
     &:hover,
     &.usa-button-hover {
-      box-shadow: $button-stroke color('base-lighter');
-      color: color('base-lighter');
+      box-shadow: $button-stroke color('base-lightest');
+      color: color('base-lightest');
     }
 
     &:active,
     &.usa-button-active {
-      box-shadow: $button-stroke color('base-light');
-      color: color('base-lighter');
+      box-shadow: $button-stroke color('white');
+      color: color('white');
     }
   }
 
@@ -172,9 +172,7 @@ $button-stroke: inset 0 0 0 2px;
 .usa-button-secondary:disabled,
 .usa-button-secondary-inverse:disabled,
 .usa-button-outline-inverse:disabled {   // Outline inverse to be deprecated in 2.0
-  box-shadow: $button-stroke color('disabled');
   pointer-events: none;
-  color: color('disabled');
 
   &:hover,
   &.usa-button-hover,
@@ -187,16 +185,21 @@ $button-stroke: inset 0 0 0 2px;
   }
 }
 
-html .usa-button-secondary-disabled,          // Deprecated
+html .usa-button-secondary-disabled, // Deprecated
+.usa-button-secondary-disabled, // Deprecated
 .usa-button-secondary:disabled {
   background-color: color('white');
+  box-shadow: $button-stroke color('disabled');
+  color: color('disabled');
 }
 
-html .usa-button-secondary-inverse-disabled,  // Deprecated
-.usa-button-secondary-inverse:disabled {
+html .usa-button-secondary-inverse-disabled, // Deprecated
+.usa-button-secondary-inverse-disabled,  // Deprecated
+.usa-button-secondary-inverse:disabled,
+.usa-button-outline-inverse:disabled {   // Outline inverse to be deprecated in 2.0
   background-color: transparent;
-  color: color('disabled');
-  box-shadow: $button-stroke color('disabled');
+  box-shadow: $button-stroke color('base');
+  color: color('base');
 }
 
 @mixin button-unstyled {


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-buttons-v2/components/detail/buttons--secondary-inverse.html)

This cleans up button styles a bit more to remove redundant rules and improve the performance of inverse buttons:

- remove a couple duplicative/redundant rules
- makes the hover state the higher contrast state (like with regular buttons)
- makes the disabled state less bright