### PR TITLE
Update footer to v2

### DIFF
--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -1,89 +1,123 @@
 <footer class="usa-footer usa-footer-big" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
+  <div class="grid-container usa-footer-return-to-top">
     <a href="#">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
-    <div class="usa-grid">
-      <nav class="usa-footer-nav usa-width-two-thirds">
-        <section class="usa-width-one-fourth usa-footer-primary-content usa-footer-collapsible">
-          <h4 class="usa-footer-primary-link">Topic</h4>
-          <ul class="usa-unstyled-list">
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-        </section>
-        <section class="usa-width-one-fourth usa-footer-primary-content usa-footer-collapsible">
-          <h4 class="usa-footer-primary-link">Topic</h4>
-          <ul class="usa-unstyled-list">
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-        </section>
-        <section class="usa-width-one-fourth usa-footer-primary-content usa-footer-collapsible">
-          <h4 class="usa-footer-primary-link">Topic</h4>
-          <ul class="usa-unstyled-list">
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-        </section>
-        <section class="usa-width-one-fourth usa-footer-primary-content usa-footer-collapsible">
-          <h4 class="usa-footer-primary-link">Topic</h4>
-          <ul class="usa-unstyled-list">
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-            <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-        </section>
-      </nav>
-
-      <div class="usa-sign_up-block usa-width-one-third">
-        <h3 class="usa-sign_up-header">Sign up</h3>
-
-        <label class="usa-label" for="email" id="">Your email address</label>
-        <input class="usa-input" id="email" name="email" type="email">
-
-        <button class="usa-button" type="submit">Sign up</button>
+    <div class="grid-container">
+      <div class="grid-row">
+        <div class="mobile-lg:grid-col-8">
+          <nav class="usa-footer-nav">
+            <div class="row">
+              <div class="mobile-lg:grid-col">
+                <section class="usa-footer-primary-content usa-footer-collapsible">
+                  <h4 class="usa-footer-primary-link">Topic</h4>
+                  <ul class="usa-unstyled-list">
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's a bit longer than most of the others</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                  </ul>
+                </section>
+              </div>
+              <div class="mobile-lg:grid-col">
+                <section class="usa-footer-primary-content usa-footer-collapsible">
+                  <h4 class="usa-footer-primary-link">Topic</h4>
+                  <ul class="usa-unstyled-list">
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link that's pretty long</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                  </ul>
+                </section>
+              </div>
+              <div class="mobile-lg:grid-col">
+                <section class="usa-footer-primary-content usa-footer-collapsible">
+                  <h4 class="usa-footer-primary-link">Topic</h4>
+                  <ul class="usa-unstyled-list">
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                  </ul>
+                </section>
+              </div>
+              <div class="mobile-lg:grid-col">
+                <section class="usa-footer-primary-content usa-footer-collapsible">
+                  <h4 class="usa-footer-primary-link">Topic</h4>
+                  <ul class="usa-unstyled-list">
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                    <li class="usa-footer-secondary-link"><a href="javascript:void(0);">Secondary link</a></li>
+                  </ul>
+                </section>
+              </div>
+            </div>
+          </nav>
+        </div>
+        <div class="mobile-lg:grid-col-4">
+          <div class="usa-sign_up-block">
+            <h3 class="usa-sign_up-header">Sign up</h3>
+            <form class="usa-form">
+              <label class="usa-label" for="email" id="">Your email address</label>
+              <input class="usa-input" id="email" name="email" type="email">
+              <button class="usa-button" type="submit">Sign up</button>
+            </form>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-
-  <div class="usa-footer-secondary-section usa-footer-big-secondary-section">
-    <div class="usa-grid">
-      <div class="usa-footer-logo usa-width-one-half">
-        <img class="usa-footer-big-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
-        <h3 class="usa-footer-big-logo-heading">Name of Agency</h3>
-      </div>
-      <div class="usa-footer-contact-links usa-width-one-half">
-        <a class="usa-link-facebook" href="javascript:void(0);">
-          <span>Facebook</span>
-        </a>
-        <a class="usa-link-twitter" href="javascript:void(0);">
-          <span>Twitter</span>
-        </a>
-        <a class="usa-link-youtube" href="javascript:void(0);">
-          <span>YouTube</span>
-        </a>
-        <a class="usa-link-rss" href="javascript:void(0);">
-          <span>RSS</span>
-        </a>
-        <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-        <address>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p>
-              <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
-            </p>
+  <div class="usa-footer-secondary-section">
+    <div class="grid-container">
+      <div class="grid-row grid-gap">
+        <div class="usa-footer-logo grid-row mobile-lg:grid-col-6 mobile-lg:grid-gap-2">
+          <div class="mobile-lg:grid-col-auto">
+            <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
           </div>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
+          <div class="mobile-lg:grid-col-auto">
+            <h3 class="usa-footer-logo-heading">Name of Agency</h3>
           </div>
-        </address>
+        </div>
+        <div class="usa-footer-contact-links mobile-lg:grid-col-6">
+          <div class="usa-footer-social-links grid-row grid-gap-1">
+            <div class="grid-col-auto">
+              <a class="usa-link-facebook" href="javascript:void(0);">
+                <span>Facebook</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-twitter" href="javascript:void(0);">
+                <span>Twitter</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-youtube" href="javascript:void(0);">
+                <span>YouTube</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-rss" href="javascript:void(0);">
+                <span>RSS</span>
+              </a>
+            </div>
+          </div>
+          <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+          <address class="usa-footer-address">
+            <div class="grid-row grid-gap mobile-lg:flex-justify-end">
+              <div class="grid-col-auto">
+                <div class="usa-footer-contact_info">
+                  <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
+                </div>
+              </div>
+              <div class="grid-col-auto">
+                <div class="usa-footer-contact_info">
+                  <a href="mailto:info@agency.gov">info@agency.gov</a>
+                </div>
+              </div>
+            </div>
+          </address>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -4,11 +4,11 @@
   </div>
   <div class="usa-footer-primary-section">
     <div class="grid-container">
-      <div class="grid-row">
-        <div class="mobile-lg:grid-col-8">
+      <div class="grid-row grid-gap">
+        <div class="tablet:grid-col-8">
           <nav class="usa-footer-nav">
-            <div class="row">
-              <div class="mobile-lg:grid-col">
+            <div class="grid-row grid-gap-4">
+              <div class="mobile-lg:grid-col-6">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -19,7 +19,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col">
+              <div class="mobile-lg:grid-col-6">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -30,7 +30,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col">
+              <div class="mobile-lg:grid-col-6">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -41,7 +41,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col">
+              <div class="mobile-lg:grid-col-6">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -55,7 +55,7 @@
             </div>
           </nav>
         </div>
-        <div class="mobile-lg:grid-col-4">
+        <div class="tablet:grid-col-4">
           <div class="usa-sign_up-block">
             <h3 class="usa-sign_up-header">Sign up</h3>
             <form class="usa-form">

--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -8,7 +8,7 @@
         <div class="tablet:grid-col-8">
           <nav class="usa-footer-nav">
             <div class="grid-row grid-gap-4">
-              <div class="mobile-lg:grid-col-6">
+              <div class="mobile-lg:grid-col-6 desktop:grid-col-3">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -19,7 +19,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col-6">
+              <div class="mobile-lg:grid-col-6 desktop:grid-col-3">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -30,7 +30,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col-6">
+              <div class="mobile-lg:grid-col-6 desktop:grid-col-3">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">
@@ -41,7 +41,7 @@
                   </ul>
                 </section>
               </div>
-              <div class="mobile-lg:grid-col-6">
+              <div class="mobile-lg:grid-col-6 desktop:grid-col-3">
                 <section class="usa-footer-primary-content usa-footer-collapsible">
                   <h4 class="usa-footer-primary-link">Topic</h4>
                   <ul class="usa-unstyled-list">

--- a/src/components/10-footer/footer--slim.njk
+++ b/src/components/10-footer/footer--slim.njk
@@ -1,45 +1,54 @@
 <footer class="usa-footer usa-footer-slim" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
-    <a href="javascript:void(0);">Return to top</a>
+  <div class="grid-container usa-footer-return-to-top">
+    <a href="#">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
-    <div class="usa-grid">
-      <nav class="usa-footer-nav usa-width-two-thirds">
-        <ul class="usa-unstyled-list">
-          <li class="usa-width-one-fourth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-fourth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-fourth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-fourth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-        </ul>
-      </nav>
-      <address>
-        <div class="usa-width-one-third">
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p>
-              <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
-            </p>
+    <div class="grid-row grid-row maxw-desktop margin-x-auto desktop:padding-x-4">
+      <div class="mobile-lg:grid-col-8">
+        <nav class="usa-footer-nav">
+          <ul class="add-list-reset grid-row grid-gap">
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+            <li class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div class="mobile-lg:grid-col-4">
+        <address class="usa-footer-address">
+          <div class="grid-row grid-gap mobile-lg:grid-gap-0">
+            <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+              <div class="usa-footer-contact_info">
+                <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
+              </div>
+            </div>
+            <div class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto">
+              <div class="usa-footer-contact_info">
+                <a href="mailto:info@agency.gov">info@agency.gov</a>
+              </div>
+            </div>
           </div>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
-          </div>
-        </div>
-      </address>
+        </address>
+      </div>
     </div>
   </div>
-
   <div class="usa-footer-secondary-section">
-    <div class="usa-grid">
-      <div class="usa-footer-logo">
-        <img class="usa-footer-slim-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
-        <h3 class="usa-footer-slim-logo-heading">Name of Agency</h3>
+    <div class="grid-container">
+      <div class="usa-footer-logo grid-row grid-gap-2">
+        <div class="grid-col-auto">
+          <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
+        </div>
+        <div class="grid-col-auto">
+          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -59,14 +59,18 @@
             </div>
           </div>
           <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-          <address class="usa-footer-address grid-row grid-gap">
-            <div class="usa-footer-contact_info grid-col-auto">
-              <p>
-                <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
-              </p>
-            </div>
-            <div class="usa-footer-contact_info grid-col-auto">
-              <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
+          <address class="usa-footer-address">
+            <div class="grid-row grid-gap mobile-lg:flex-justify-end">
+              <div class="grid-col-auto">
+                <div class="usa-footer-contact_info">
+                  <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
+                </div>
+              </div>
+              <div class="grid-col-auto">
+                <div class="usa-footer-contact_info">
+                  <a href="mailto:info@agency.gov">info@agency.gov</a>
+                </div>
+              </div>
             </div>
           </address>
         </div>

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -27,9 +27,13 @@
   <div class="usa-footer-secondary-section">
     <div class="grid-container">
       <div class="grid-row grid-gap">
-        <div class="usa-footer-logo mobile-lg:grid-col-6">
-          <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
-          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+        <div class="usa-footer-logo grid-row mobile-lg:grid-col-6 mobile-lg:grid-gap-2">
+          <div class="mobile-lg:grid-col-auto">
+            <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
+          </div>
+          <div class="mobile-lg:grid-col-auto">
+            <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+          </div>
         </div>
         <div class="usa-footer-contact-links mobile-lg:grid-col-6">
           <div class="usa-footer-social-links grid-row grid-gap-1">
@@ -56,12 +60,12 @@
           </div>
           <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
           <address class="usa-footer-address grid-row grid-gap">
-            <div class="usa-footer-primary-content usa-footer-contact_info grid-col-auto">
+            <div class="usa-footer-contact_info grid-col-auto">
               <p>
                 <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
               </p>
             </div>
-            <div class="usa-footer-primary-content usa-footer-contact_info grid-col-auto">
+            <div class="usa-footer-contact_info grid-col-auto">
               <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
             </div>
           </address>

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -1,29 +1,27 @@
 <footer class="usa-footer usa-footer-medium" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
+  <div class="grid-container usa-footer-return-to-top">
     <a href="#">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
-    <div class="usa-grid">
-      <nav class="usa-footer-nav">
-        <ul class="usa-unstyled-list">
-          <li class="usa-width-one-sixth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-sixth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-sixth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-sixth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-          <li class="usa-width-one-sixth usa-footer-primary-content">
-            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <nav class="usa-footer-nav margin-x-auto padding-x-0 mobile-lg:padding-x-2 desktop:padding-x-4">
+      <ul class="add-list-reset grid-row grid-gap">
+        <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
+          <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+        </li>
+        <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
+          <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+        </li>
+        <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
+          <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+        </li>
+        <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
+          <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+        </li>
+        <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
+          <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+        </li>
+      </ul>
+    </nav>
   </div>
 
   <div class="usa-footer-secondary-section">

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -3,7 +3,7 @@
     <a href="#">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
-    <nav class="usa-footer-nav margin-x-auto padding-x-0 mobile-lg:padding-x-2 desktop:padding-x-4">
+    <nav class="usa-footer-nav">
       <ul class="add-list-reset grid-row grid-gap">
         <li class="mobile-lg:grid-col-4 desktop:grid-col-2 usa-footer-primary-content">
           <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
@@ -25,35 +25,47 @@
   </div>
 
   <div class="usa-footer-secondary-section">
-    <div class="usa-grid">
-      <div class="usa-footer-logo usa-width-one-half">
-        <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
-        <h3 class="usa-footer-logo-heading">Name of Agency</h3>
-      </div>
-      <div class="usa-footer-contact-links usa-width-one-half">
-        <a class="usa-link-facebook" href="javascript:void(0);">
-          <span>Facebook</span>
-        </a>
-        <a class="usa-link-twitter" href="javascript:void(0);">
-          <span>Twitter</span>
-        </a>
-        <a class="usa-link-youtube" href="javascript:void(0);">
-          <span>YouTube</span>
-        </a>
-        <a class="usa-link-rss" href="javascript:void(0);">
-          <span>RSS</span>
-        </a>
-        <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-        <address>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p>
-              <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
-            </p>
+    <div class="grid-container">
+      <div class="grid-row grid-gap">
+        <div class="usa-footer-logo mobile-lg:grid-col-6">
+          <img class="usa-footer-logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
+          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+        </div>
+        <div class="usa-footer-contact-links mobile-lg:grid-col-6">
+          <div class="usa-footer-social-links grid-row grid-gap-1">
+            <div class="grid-col-auto">
+              <a class="usa-link-facebook" href="javascript:void(0);">
+                <span>Facebook</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-twitter" href="javascript:void(0);">
+                <span>Twitter</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-youtube" href="javascript:void(0);">
+                <span>YouTube</span>
+              </a>
+            </div>
+            <div class="grid-col-auto">
+              <a class="usa-link-rss" href="javascript:void(0);">
+                <span>RSS</span>
+              </a>
+            </div>
           </div>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
-          </div>
-        </address>
+          <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+          <address class="usa-footer-address grid-row grid-gap">
+            <div class="usa-footer-primary-content usa-footer-contact_info grid-col-auto">
+              <p>
+                <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
+              </p>
+            </div>
+            <div class="usa-footer-primary-content usa-footer-contact_info grid-col-auto">
+              <p><a href="mailto:info@agency.gov">info@agency.gov</a></p>
+            </div>
+          </address>
+        </div>
       </div>
     </div>
   </div>

--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -10,7 +10,7 @@ const NAV = `${SCOPE} nav`;
 const BUTTON = `${NAV} .${PREFIX}-footer-primary-link`;
 const COLLAPSIBLE = `.${PREFIX}-footer-collapsible`;
 
-const HIDE_MAX_WIDTH = 600;
+const HIDE_MAX_WIDTH = 480;
 const DEBOUNCE_RATE = 180;
 
 function showPanel() {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -14,7 +14,7 @@
     padding-top: $spacing-medium;
     text-decoration: none;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       border-top: none;
     }
 
@@ -22,7 +22,7 @@
       cursor: pointer;
       text-decoration: underline;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         cursor: auto;
         text-decoration: none;
       }
@@ -60,7 +60,7 @@
     padding-left: 1.5rem;
     padding-right: 2.5rem;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-left: 0;
       padding-right: 0;
     }
@@ -68,14 +68,14 @@
     li {
       margin-left: 1rem;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         margin-left: 0;
       }
     }
   }
 
   .usa-grid-full {
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-left: 2.5rem;
       padding-right: 2.5rem;
     }
@@ -87,7 +87,7 @@
     p {
       margin: 0 $spacing-small 0 0;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         margin: 0 0 0 $spacing-small;
       }
     }
@@ -96,7 +96,7 @@
   .usa-footer-contact-heading {
     margin-top: 0;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       margin-top: $spacing-x-small;
       margin-bottom: $spacing-x-small;
     }
@@ -105,7 +105,7 @@
   .usa-footer-logo {
     padding: $spacing-small 0;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding: $spacing-medium 0;
     }
   }
@@ -119,20 +119,20 @@
     > .usa-grid {
       padding: 0;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         padding-left: $spacing-large;
         padding-right: $spacing-large;
       }
     }
 
     .usa-footer-primary-content {
-      @include media($large-screen) {
+      @include at-media('desktop') {
         margin-right: 5%;
         width: inherit;
       }
 
       &:last-child {
-        @include media($large-screen) {
+        @include at-media('desktop') {
           margin-right: 0;
         }
       }
@@ -140,7 +140,7 @@
   }
 
   .usa-footer-nav ul {
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       align-items: center;
     }
   }
@@ -153,13 +153,13 @@
     }
 
     .usa-footer-primary-content {
-      @include media($large-screen) {
+      @include at-media('desktop') {
         margin-right: 5%;
         width: inherit;
       }
 
       &:last-child {
-        @include media($large-screen) {
+        @include at-media('desktop') {
           margin-right: 0;
         }
       }
@@ -175,13 +175,13 @@
     > .usa-grid {
       padding: 0;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         padding-left: $spacing-large;
         padding-right: $spacing-large;
       }
     }
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-bottom: 0;
       padding-top: 0;
 
@@ -193,20 +193,20 @@
 
   .usa-footer-contact_info {
     > * {
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         margin: 0;
       }
     }
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       @include u-padding-y($spacing-md-small);
     }
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       width: 100%;
     }
 
-    @include media($large-screen) {
+    @include at-media('desktop') {
       @include span-columns(6);
     }
   }
@@ -218,14 +218,14 @@ li.usa-footer-primary-content,
 li.usa-footer-primary-content {
   border-top: 1px solid $color-gray-light;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     border: none;
   }
 
   &:last-child {
     border-bottom: 1px solid $color-gray-light;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       border-bottom: none;
     }
   }
@@ -237,7 +237,7 @@ li.usa-footer-primary-content {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     float: right;
     padding: 0;
   }
@@ -268,14 +268,14 @@ li.usa-footer-primary-content {
 }
 
 .usa-footer-big-secondary-section {
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     padding-top: $spacing-medium;
     padding-bottom: $spacing-medium;
   }
 }
 
 .usa-footer-contact-links {
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     text-align: right;
   }
 }
@@ -290,14 +290,14 @@ li.usa-footer-primary-content {
   .usa-footer-collapsible {
     border-top: 1px solid $color-gray-light;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       border-top: none;
     }
 
     &:last-child {
       border-bottom: 1px solid $color-gray-light;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         border-bottom: none;
       }
     }
@@ -317,7 +317,7 @@ li.usa-footer-primary-content {
         cursor: pointer;
         display: block;
 
-        @include media($medium-screen) {
+        @include at-media('mobile-lg') {
           background: none;
           padding-left: 0;
         }
@@ -334,7 +334,7 @@ li.usa-footer-primary-content {
       margin-left: 0;
       padding-left: 3.5rem;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         background: none;
         margin-bottom: .8rem;
         padding-bottom: 0;
@@ -353,14 +353,14 @@ li.usa-footer-primary-content {
     p {
       margin: 0 $spacing-small 0 0;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         margin: $spacing-x-small 0 0 $spacing-small;
       }
     }
   }
 
   .usa-footer-contact-links {
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-top: $spacing-medium;
     }
   }
@@ -368,13 +368,13 @@ li.usa-footer-primary-content {
   .usa-footer-logo {
     padding: $spacing-small 0;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding: $spacing-medium 0;
     }
   }
 
   .usa-footer-primary-section {
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-bottom: 4rem;
       padding-top: 3rem;
     }
@@ -382,7 +382,7 @@ li.usa-footer-primary-content {
     > .usa-grid {
       padding: 0;
 
-      @include media($medium-screen) {
+      @include at-media('mobile-lg') {
         padding-left: $spacing-large;
         padding-right: $spacing-large;
       }
@@ -395,7 +395,7 @@ li.usa-footer-primary-content {
       li {
         margin-left: $spacing-md-small;
 
-        @include media($medium-screen) {
+        @include at-media('mobile-lg') {
           margin-left: 0;
         }
       }
@@ -409,7 +409,7 @@ li.usa-footer-primary-content {
   ul {
     padding-bottom: 2.4rem;
 
-    @include media($medium-screen) {
+    @include at-media('mobile-lg') {
       padding-bottom: 0;
     }
 
@@ -427,7 +427,7 @@ li.usa-footer-primary-content {
 }
 
 .usa-sign_up-header {
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     margin: 0;
     padding: 2rem 0;
   }
@@ -436,7 +436,7 @@ li.usa-footer-primary-content {
 .usa-footer-logo-img {
   max-width: 8rem;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     float: left;
   }
 }
@@ -454,7 +454,7 @@ li.usa-footer-primary-content {
   display: block;
   margin-top: $spacing-small;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     display: inline-block;
     margin-top: $spacing-large;
     padding-left: $spacing-md-small;
@@ -464,7 +464,7 @@ li.usa-footer-primary-content {
 .usa-footer-big-logo-heading {
   margin-top: $spacing-md-small;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     margin-top: $spacing-medium;
   }
 }
@@ -478,7 +478,7 @@ li.usa-footer-primary-content {
 .usa-footer-contact-heading {
   margin-top: 0;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     margin-top: 1rem;
   }
 }
@@ -503,7 +503,7 @@ li.usa-footer-primary-content {
   text-align: center;
   width: $hit-area;
 
-  @include media($medium-screen) {
+  @include at-media('mobile-lg') {
     @include u-margin-left($spacing-x-small);
     @include u-margin-right(0);
     @include u-margin-top(0);

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -105,7 +105,7 @@
   }
 
   .usa-button {
-    margin-top: units(1.5)
+    margin-top: units(1.5);
   }
 }
 
@@ -310,7 +310,7 @@
     }
 
     .usa-unstyled-list {
-      @include u-padding-x($theme-site-margins-mobile)
+      @include u-padding-x($theme-site-margins-mobile);
       padding-bottom: units(2.5);
 
       @include at-media('mobile-lg') {
@@ -319,7 +319,7 @@
     }
   }
 
-  .usa-footer-secondary-link  {
+  .usa-footer-secondary-link {
     line-height: line-height($theme-font-family-footer, 2);
     margin: 0;
     padding: 0;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -92,14 +92,7 @@
   padding-bottom: units(4);
   padding-top: units(3);
 
-  .usa-label {
-    margin-top: units(1.5);
-  }
-
-  * + .usa-label {
-    margin-top: units(1.5);
-  }
-
+  .usa-label,
   .usa-button {
     margin-top: units(1.5);
   }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -261,33 +261,24 @@
 
   .usa-footer-primary-link {
     @include h4;
-    @include u-margin-y(0);
+    background-image: url('#{$theme-image-path}/arrow-down.png');
+    background-image: url('#{$theme-image-path}/arrow-down.svg');
+    background-position: units(2) center;
+    background-repeat: no-repeat;
+    background-size: units(1.5);
     line-height: line-height('heading', 2);
-    text-decoration: none;
+    margin: 0;
+    padding-left: units(4);
 
     @include at-media('mobile-lg') {
       @include u-padding-y(0);
+      background: none;
+      margin-bottom: units(1);
+      padding-left: 0;
     }
   }
 
   .usa-footer-collapsible {
-    .usa-footer-primary-link {
-      background-image: url('#{$theme-image-path}/arrow-down.png');
-      background-image: url('#{$theme-image-path}/arrow-down.svg');
-      background-position: units(2) center;
-      background-repeat: no-repeat;
-      background-size: units(1.5);
-      margin-bottom: 0;
-      margin-left: 0;
-      padding-left: units(4);
-
-      @include at-media('mobile-lg') {
-        background: none;
-        margin-bottom: units(1);
-        padding-left: 0;
-      }
-    }
-
     &.hidden {
       .usa-unstyled-list {
         display: none;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -29,7 +29,6 @@
   background-color: color('base-lightest');
 }
 
-// TODO: usage in big footer? i don't get it yet.
 .usa-footer-primary-content {
   line-height: line-height($theme-font-family-footer, 2);
 
@@ -50,8 +49,6 @@
 
   @include at-media('mobile-lg') {
     @include u-padding-x(0);
-    // TODO: where is this border coming from? necessary?
-    border-top: none;
   }
 
   &:hover {
@@ -108,7 +105,6 @@
   }
 }
 
-// TODO: all these styles needed?
 .usa-sign_up-header {
   @include h3;
   margin: 0;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -291,11 +291,6 @@
     &.hidden {
       .usa-unstyled-list {
         display: none;
-
-        // TODO: Kludge until js is fixed
-        @include at-media('mobile-lg') {
-          display: block;
-        }
       }
 
       .usa-footer-primary-link {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -47,7 +47,7 @@
 .usa-footer-primary-link {
   @include u-padding-x($theme-site-margins-mobile);
   @include u-padding-y(2);
-  @include u-text('ink', 'no-underline', 'bold')
+  @include u-text('ink', 'no-underline', 'bold');
   display: block;
 
   @include at-media('mobile-lg') {
@@ -287,30 +287,12 @@
 // Medium footer styles
 
 .usa-footer-medium {
-
   .usa-footer-contact-heading {
     margin-top: 0;
 
     @include at-media('mobile-lg') {
       margin-top: units(0.5);
       margin-bottom: units(0.5);
-    }
-  }
-
-  .usa-footer-primary-section {
-    > .usa-grid {
-      padding: 0;
-
-      @include at-media('mobile-lg') {
-        padding-left: units(4);
-        padding-right: units(4);
-      }
-    }
-  }
-
-  .usa-footer-nav ul {
-    @include at-media('mobile-lg') {
-      align-items: center;
     }
   }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -31,13 +31,13 @@
 
 .usa-footer-primary-content {
   line-height: line-height($theme-font-family-footer, 2);
+}
 
-  li {
-    margin-left: units(1);
-
-    @include at-media('mobile-lg') {
-      margin-left: 0;
-    }
+.usa-footer-primary-link a,
+.usa-footer-secondary-link a {
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
   }
 }
 
@@ -54,26 +54,20 @@
   &:hover {
     cursor: pointer;
     text-decoration: underline;
-
-    @include at-media('mobile-lg') {
-      cursor: auto;
-      text-decoration: none;
-    }
   }
-}
-
-.usa-footer-primary-link a,
-.usa-footer-secondary-link a {
-  text-decoration: none;
 }
 
 .usa-footer-secondary-link {
   line-height: line-height($theme-font-family-footer, 2);
-  margin: 0;
+  margin: 0 0 0 units(1);
   padding: 0;
 
   & + .usa-footer-secondary-link {
     padding-top: units(2);
+  }
+
+  @include at-media('mobile-lg') {
+    margin-left: 0;
   }
 }
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -3,10 +3,6 @@
 .usa-footer {
   @include typeset($theme-font-family-footer);
   overflow: hidden;
-
-  .usa-unstyled-list {
-    display: block;
-  }
 }
 
 .usa-footer-return-to-top {
@@ -14,6 +10,7 @@
   line-height: line-height($theme-font-family-footer, 1);
 }
 
+// TODO: can I use a regular grid-container and then use neg margin at mobile to make it all work? code would be cleaner and more consistent.
 .usa-footer-nav {
   @include u-margin-x('auto');
   @include u-padding-x(0);
@@ -31,7 +28,7 @@
   background-color: color('base-lightest');
 }
 
-// TODO: usage
+// TODO: usage in big footer? i don't get it yet.
 .usa-footer-primary-content {
   line-height: line-height($theme-font-family-footer, 2);
 
@@ -52,6 +49,7 @@
 
   @include at-media('mobile-lg') {
     @include u-padding-x(0);
+    // TODO: where is this border coming from? necessary?
     border-top: none;
   }
 
@@ -91,6 +89,7 @@
     border: none;
   }
 
+  // TODO: necessary? Is there a cleaner way to do this?
   &:last-child {
     border-bottom: 1px solid color('base-light');
 
@@ -100,6 +99,7 @@
   }
 }
 
+// TODO: what is this? preview?
 .usa-sign_up-block {
   @include u-padding-y(2);
   padding-bottom: units(5);
@@ -125,20 +125,21 @@
 }
 
 .usa-footer-secondary-section {
+  @include u-padding-y(2.5);
   background-color: color('base-lighter');
-  padding-bottom: units(2.5);
-  padding-top: units(2.5);
 
   a {
     color: color('ink');
   }
 }
 
+// TODO: all these styles needed?
 .usa-footer-topic {
   margin: 0;
   padding: units(2) 0;
 }
 
+// TODO: all these styles needed?
 .usa-sign_up-header {
   @include at-media('mobile-lg') {
     margin: 0;
@@ -148,7 +149,6 @@
 
 .usa-footer-logo {
   @include u-margin-y(1);
-
   @include at-media('mobile-lg') {
     @include u-margin-y(0);
     @include u-flex('align-center');
@@ -157,10 +157,6 @@
 
 .usa-footer-logo-img {
   max-width: units(10);
-
-  @include at-media('mobile-lg') {
-    float: left;
-  }
 }
 
 .usa-footer-logo-heading {
@@ -213,8 +209,6 @@
   background-color: color('black-transparent-10');
   display: inline-block;
   height: $hit-area;
-  position: relative;
-  text-align: center;
   width: $hit-area;
 
   span {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,46 +1,82 @@
+// General footer styles
+
 .usa-footer {
   @include typeset($theme-font-family-footer);
+  overflow: hidden;
 
   .usa-unstyled-list {
     display: block;
   }
+}
 
-  .usa-footer-primary-link {
-    color: $color-base;
-    display: block;
-    font-weight: $font-bold;
-    margin-top: 0;
-    padding-bottom: $spacing-medium;
-    padding-top: $spacing-medium;
-    text-decoration: none;
+.usa-footer-return-to-top {
+  @include u-padding-y(2.5);
+  line-height: line-height($theme-font-family-footer, 1);
+}
+
+.usa-footer-nav {
+  @include u-margin-x('auto');
+  @include u-padding-x(0);
+  max-width: units('desktop');
+
+  @include at-media('mobile-lg') {
+    @include u-padding-x($theme-site-margins-mobile);
+  }
+  @include at-media('desktop') {
+    @include u-padding-x($theme-site-margins);
+  }
+}
+
+.usa-footer-primary-section {
+  background-color: color('base-lightest');
+}
+
+// TODO: usage
+.usa-footer-primary-content {
+  line-height: line-height($theme-font-family-footer, 2);
+
+  li {
+    margin-left: units(1);
 
     @include at-media('mobile-lg') {
-      border-top: none;
-    }
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-
-      @include at-media('mobile-lg') {
-        cursor: auto;
-        text-decoration: none;
-      }
+      margin-left: 0;
     }
   }
+}
 
-  .usa-footer-primary-link ~ li a,
-  .usa-footer-secondary-link a {
-    text-decoration: none;
+.usa-footer-primary-link {
+  @include u-padding-x($theme-site-margins-mobile);
+  @include u-padding-y(2.5);
+  @include u-text('ink', 'no-underline', 'bold')
+  display: block;
+  margin-top: 0;
+
+  @include at-media('mobile-lg') {
+    @include u-padding-x(0);
+    border-top: none;
   }
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+
+    @include at-media('mobile-lg') {
+      cursor: auto;
+      text-decoration: none;
+    }
+  }
+}
+
+.usa-footer-primary-link ~ li a,
+.usa-footer-secondary-link a {
+  text-decoration: none;
 }
 
 .usa-footer-contact_info {
   display: inline-block;
 
   a {
-    color: $color-base;
-    text-decoration: none;
+    @include u-text('ink', 'no-underline');
   }
 
   &:hover {
@@ -48,182 +84,18 @@
   }
 }
 
-.usa-footer-return-to-top {
-  padding-bottom: $spacing-medium;
-  padding-top: $spacing-medium;
-}
-
-.usa-footer-primary-section {
-  background-color: $color-gray-lightest;
-
-  .usa-footer-primary-content {
-    padding-left: 1.5rem;
-    padding-right: 2.5rem;
-
-    @include at-media('mobile-lg') {
-      padding-left: 0;
-      padding-right: 0;
-    }
-
-    li {
-      margin-left: 1rem;
-
-      @include at-media('mobile-lg') {
-        margin-left: 0;
-      }
-    }
-  }
-
-  .usa-grid-full {
-    @include at-media('mobile-lg') {
-      padding-left: 2.5rem;
-      padding-right: 2.5rem;
-    }
-  }
-}
-
-.usa-footer-medium {
-  .usa-footer-contact_info {
-    p {
-      margin: 0 $spacing-small 0 0;
-
-      @include at-media('mobile-lg') {
-        margin: 0 0 0 $spacing-small;
-      }
-    }
-  }
-
-  .usa-footer-contact-heading {
-    margin-top: 0;
-
-    @include at-media('mobile-lg') {
-      margin-top: $spacing-x-small;
-      margin-bottom: $spacing-x-small;
-    }
-  }
-
-  .usa-footer-logo {
-    padding: $spacing-small 0;
-
-    @include at-media('mobile-lg') {
-      padding: $spacing-medium 0;
-    }
-  }
-
-  .usa-footer-primary-link {
-    padding-bottom: $spacing-md-small;
-    padding-top: $spacing-md-small;
-  }
-
-  .usa-footer-primary-section {
-    > .usa-grid {
-      padding: 0;
-
-      @include at-media('mobile-lg') {
-        padding-left: $spacing-large;
-        padding-right: $spacing-large;
-      }
-    }
-
-    .usa-footer-primary-content {
-      @include at-media('desktop') {
-        margin-right: 5%;
-        width: inherit;
-      }
-
-      &:last-child {
-        @include at-media('desktop') {
-          margin-right: 0;
-        }
-      }
-    }
-  }
-
-  .usa-footer-nav ul {
-    @include at-media('mobile-lg') {
-      align-items: center;
-    }
-  }
-}
-
-.usa-footer-slim {
-  .usa-footer-nav {
-    a {
-      display: block;
-    }
-
-    .usa-footer-primary-content {
-      @include at-media('desktop') {
-        margin-right: 5%;
-        width: inherit;
-      }
-
-      &:last-child {
-        @include at-media('desktop') {
-          margin-right: 0;
-        }
-      }
-    }
-  }
-
-  .usa-footer-primary-link {
-    padding-bottom: $spacing-md-small;
-    padding-top: $spacing-md-small;
-  }
-
-  .usa-footer-primary-section {
-    > .usa-grid {
-      padding: 0;
-
-      @include at-media('mobile-lg') {
-        padding-left: $spacing-large;
-        padding-right: $spacing-large;
-      }
-    }
-
-    @include at-media('mobile-lg') {
-      padding-bottom: 0;
-      padding-top: 0;
-
-      .usa-grid-full {
-        align-items: center;
-      }
-    }
-  }
-
-  .usa-footer-contact_info {
-    > * {
-      @include at-media('mobile-lg') {
-        margin: 0;
-      }
-    }
-
-    @include at-media('mobile-lg') {
-      @include u-padding-y($spacing-md-small);
-    }
-
-    @include at-media('mobile-lg') {
-      width: 100%;
-    }
-
-    @include at-media('desktop') {
-      @include span-columns(6);
-    }
-  }
-}
-
 /* stylelint-disable selector-no-qualifying-type */
 ul.usa-footer-primary-content,
 li.usa-footer-primary-content,
 li.usa-footer-primary-content {
-  border-top: 1px solid $color-gray-light;
+  border-top: 1px solid color('base-light');
 
   @include at-media('mobile-lg') {
     border: none;
   }
 
   &:last-child {
-    border-bottom: 1px solid $color-gray-light;
+    border-bottom: 1px solid color('base-light');
 
     @include at-media('mobile-lg') {
       border-bottom: none;
@@ -258,19 +130,19 @@ li.usa-footer-primary-content {
 }
 
 .usa-footer-secondary-section {
-  background-color: $color-gray-lighter;
-  padding-bottom: $spacing-medium;
-  padding-top: $spacing-medium;
+  background-color: color('base-lighter');
+  padding-bottom: units(2.5);
+  padding-top: units(2.5);
 
   a {
-    color: $color-base;
+    color: color('ink');
   }
 }
 
 .usa-footer-big-secondary-section {
   @include at-media('mobile-lg') {
-    padding-top: $spacing-medium;
-    padding-bottom: $spacing-medium;
+    padding-top: units(2.5);
+    padding-bottom: units(2.5);
   }
 }
 
@@ -280,22 +152,212 @@ li.usa-footer-primary-content {
   }
 }
 
-.usa-social-links {
-  a {
-    text-decoration: none;
+.usa-footer-contact-heading {
+  @include typeset-h3;
+  margin-top: 0;
+
+  @include at-media('mobile-lg') {
+    margin-top: 1rem;
   }
 }
 
+.usa-footer-social-links {
+  line-height: line-height($theme-font-family-footer, 1);
+  padding-bottom: units(1);
+
+  a {
+    text-decoration: none;
+  }
+
+  @include at-media('mobile-lg') {
+    @include u-flex('justify-end');
+  }
+}
+
+.usa-social_link {
+  $background-height: units(4); // Height of icon within hit area.
+  // Link hit target is 44 x 44 pixels following
+  // Apple iOS Human Interface Guidelines.
+  $hit-area: 4.4rem;
+
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: auto $background-height;
+  background-color: color('black-transparent-10');
+  display: inline-block;
+  height: $hit-area;
+  position: relative;
+  text-align: center;
+  width: $hit-area;
+
+  span {
+    @include sr-only();
+  }
+}
+
+.usa-link-facebook {
+  @extend .usa-social_link;
+  background-image: url('#{$theme-image-path}/social-icons/png/facebook25.png');
+  background-image: url('#{$theme-image-path}/social-icons/svg/facebook25.svg');
+}
+
+.usa-link-twitter {
+  @extend .usa-social_link;
+  background-image: url('#{$theme-image-path}/social-icons/png/twitter16.png');
+  background-image: url('#{$theme-image-path}/social-icons/svg/twitter16.svg');
+}
+
+.usa-link-youtube {
+  @extend .usa-social_link;
+  background-image: url('#{$theme-image-path}/social-icons/png/youtube15.png');
+  background-image: url('#{$theme-image-path}/social-icons/svg/youtube15.svg');
+}
+
+.usa-link-rss {
+  @extend .usa-social_link;
+  background-image: url('#{$theme-image-path}/social-icons/png/rss25.png');
+  background-image: url('#{$theme-image-path}/social-icons/svg/rss25.svg');
+}
+
+.usa-footer-address {
+  @include at-media('mobile-lg') {
+    @include u-flex('justify-end');
+  }
+}
+
+// Slim footer styles
+
+.usa-footer-slim {
+  .usa-footer-nav {
+    a {
+      display: block;
+    }
+
+    .usa-footer-primary-content {
+      @include at-media('desktop') {
+        margin-right: 5%;
+        width: inherit;
+      }
+
+      &:last-child {
+        @include at-media('desktop') {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+
+  .usa-footer-primary-link {
+    padding-bottom: units(2);
+    padding-top: units(2);
+  }
+
+  .usa-footer-primary-section {
+    > .usa-grid {
+      padding: 0;
+
+      @include at-media('mobile-lg') {
+        padding-left: units(4);
+        padding-right: units(4);
+      }
+    }
+
+    @include at-media('mobile-lg') {
+      padding-bottom: 0;
+      padding-top: 0;
+
+      .usa-grid-full {
+        align-items: center;
+      }
+    }
+  }
+
+  .usa-footer-contact_info {
+    > * {
+      @include at-media('mobile-lg') {
+        margin: 0;
+      }
+    }
+
+    @include at-media('mobile-lg') {
+      @include u-padding-y(units(2));
+    }
+
+    @include at-media('mobile-lg') {
+      width: 100%;
+    }
+
+    @include at-media('desktop') {
+      @include span-columns(6);
+    }
+  }
+}
+
+// Medium footer styles
+
+.usa-footer-medium {
+  .usa-footer-contact_info {
+    p {
+      margin: 0 units(1) 0 0;
+
+      @include at-media('mobile-lg') {
+        margin: 0 0 0 units(1);
+      }
+    }
+  }
+
+  .usa-footer-contact-heading {
+    margin-top: 0;
+
+    @include at-media('mobile-lg') {
+      margin-top: units(0.5);
+      margin-bottom: units(0.5);
+    }
+  }
+
+  .usa-footer-logo {
+    padding: units(1) 0;
+
+    @include at-media('mobile-lg') {
+      padding: units(2.5) 0;
+    }
+  }
+
+  .usa-footer-primary-link {
+    padding-bottom: units(2);
+    padding-top: units(2);
+  }
+
+  .usa-footer-primary-section {
+    > .usa-grid {
+      padding: 0;
+
+      @include at-media('mobile-lg') {
+        padding-left: units(4);
+        padding-right: units(4);
+      }
+    }
+  }
+
+  .usa-footer-nav ul {
+    @include at-media('mobile-lg') {
+      align-items: center;
+    }
+  }
+}
+
+// Big footer styles
+
 .usa-footer-big {
   .usa-footer-collapsible {
-    border-top: 1px solid $color-gray-light;
+    border-top: 1px solid color('base-light');
 
     @include at-media('mobile-lg') {
       border-top: none;
     }
 
     &:last-child {
-      border-bottom: 1px solid $color-gray-light;
+      border-bottom: 1px solid color('base-light');
 
       @include at-media('mobile-lg') {
         border-bottom: none;
@@ -351,25 +413,25 @@ li.usa-footer-primary-content {
     display: block;
 
     p {
-      margin: 0 $spacing-small 0 0;
+      margin: 0 units(1) 0 0;
 
       @include at-media('mobile-lg') {
-        margin: $spacing-x-small 0 0 $spacing-small;
+        margin: units(0.5) 0 0 units(1);
       }
     }
   }
 
   .usa-footer-contact-links {
     @include at-media('mobile-lg') {
-      padding-top: $spacing-medium;
+      padding-top: units(2.5);
     }
   }
 
   .usa-footer-logo {
-    padding: $spacing-small 0;
+    padding: units(1) 0;
 
     @include at-media('mobile-lg') {
-      padding: $spacing-medium 0;
+      padding: units(2.5) 0;
     }
   }
 
@@ -383,8 +445,8 @@ li.usa-footer-primary-content {
       padding: 0;
 
       @include at-media('mobile-lg') {
-        padding-left: $spacing-large;
-        padding-right: $spacing-large;
+        padding-left: units(4);
+        padding-right: units(4);
       }
     }
 
@@ -393,7 +455,7 @@ li.usa-footer-primary-content {
       padding-right: 0;
 
       li {
-        margin-left: $spacing-md-small;
+        margin-left: units(2);
 
         @include at-media('mobile-lg') {
           margin-left: 0;
@@ -451,91 +513,26 @@ li.usa-footer-primary-content {
 }
 
 .usa-footer-logo-heading {
-  display: block;
-  margin-top: $spacing-small;
+  @include h3;
+  margin-top: units(1);
 
   @include at-media('mobile-lg') {
     display: inline-block;
-    margin-top: $spacing-large;
-    padding-left: $spacing-md-small;
+    margin-top: units(4);
+    padding-left: units(2);
   }
 }
 
 .usa-footer-big-logo-heading {
-  margin-top: $spacing-md-small;
+  margin-top: units(2);
 
   @include at-media('mobile-lg') {
-    margin-top: $spacing-medium;
+    margin-top: units(2.5);
   }
 }
 
 .usa-footer-slim-logo-heading {
   display: inline-block;
-  margin-top: $spacing-md-small;
-  padding-left: $spacing-md-small;
-}
-
-.usa-footer-contact-heading {
-  margin-top: 0;
-
-  @include at-media('mobile-lg') {
-    margin-top: 1rem;
-  }
-}
-
-.usa-social_link {
-  $background-height: 3rem; // Height of icon within hit area.
-  // Link hit target is 44 x 44 pixels following
-  // Apple iOS Human Interface Guidelines.
-  $hit-area: 4.4rem;
-
-  @include u-margin-bottom(1.5rem);
-  @include u-margin-left(0);
-  @include u-margin-right(1rem);
-  @include u-margin-top(2.5rem);
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: auto $background-height;
-  display: inline-block;
-  height: $hit-area;
-  left: -1.6rem; // relative left positioning
-  position: relative;
-  text-align: center;
-  width: $hit-area;
-
-  @include at-media('mobile-lg') {
-    @include u-margin-left($spacing-x-small);
-    @include u-margin-right(0);
-    @include u-margin-top(0);
-    @include u-margin-y(0);
-    left: $spacing-md-small;
-  }
-
-  span {
-    @include sr-only();
-  }
-}
-
-.usa-link-facebook {
-  @extend .usa-social_link;
-  background-image: url('#{$theme-image-path}/social-icons/png/facebook25.png');
-  background-image: url('#{$theme-image-path}/social-icons/svg/facebook25.svg');
-}
-
-.usa-link-twitter {
-  @extend .usa-social_link;
-  background-image: url('#{$theme-image-path}/social-icons/png/twitter16.png');
-  background-image: url('#{$theme-image-path}/social-icons/svg/twitter16.svg');
-}
-
-.usa-link-youtube {
-  @extend .usa-social_link;
-  background-image: url('#{$theme-image-path}/social-icons/png/youtube15.png');
-  background-image: url('#{$theme-image-path}/social-icons/svg/youtube15.svg');
-}
-
-.usa-link-rss {
-  @extend .usa-social_link;
-  background-image: url('#{$theme-image-path}/social-icons/png/rss25.png');
-  background-image: url('#{$theme-image-path}/social-icons/svg/rss25.svg');
+  margin-top: units(2);
+  padding-left: units(2);
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -147,12 +147,11 @@
 }
 
 .usa-footer-logo {
-  padding-top: units(1);
-  padding-bottom: units(2.5);
+  @include u-margin-y(1);
 
   @include at-media('mobile-lg') {
+    @include u-margin-y(0);    
     @include u-flex('align-center');
-    padding: units(2.5) 0;
   }
 }
 
@@ -171,7 +170,10 @@
 }
 
 .usa-footer-contact-links {
+  margin-top: units(3);
+
   @include at-media('mobile-lg') {
+    margin-top: 0;
     text-align: right;
   }
 }
@@ -471,14 +473,6 @@
   .usa-footer-contact-links {
     @include at-media('mobile-lg') {
       padding-top: units(2.5);
-    }
-  }
-
-  .usa-footer-logo {
-    padding: units(1) 0;
-
-    @include at-media('mobile-lg') {
-      padding: units(2.5) 0;
     }
   }
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -46,10 +46,9 @@
 
 .usa-footer-primary-link {
   @include u-padding-x($theme-site-margins-mobile);
-  @include u-padding-y(2.5);
+  @include u-padding-y(2);
   @include u-text('ink', 'no-underline', 'bold')
   display: block;
-  margin-top: 0;
 
   @include at-media('mobile-lg') {
     @include u-padding-x(0);
@@ -74,6 +73,7 @@
 
 .usa-footer-contact_info {
   display: inline-block;
+  line-height: line-height($theme-font-family-footer, 2);
 
   a {
     @include u-text('ink', 'no-underline');
@@ -150,7 +150,7 @@
   @include u-margin-y(1);
 
   @include at-media('mobile-lg') {
-    @include u-margin-y(0);    
+    @include u-margin-y(0);
     @include u-flex('align-center');
   }
 }
@@ -254,79 +254,32 @@
 
 // Slim footer styles
 
-.usa-footer-slim-logo-img {
-  float: left;
-  max-width: units(6);
-}
-
-.usa-footer-slim-logo-heading {
-  display: inline-block;
-  margin-top: units(2);
-  padding-left: units(2);
-}
-
 .usa-footer-slim {
   .usa-footer-nav {
-    a {
-      display: block;
-    }
-
-    .usa-footer-primary-content {
-      @include at-media('desktop') {
-        margin-right: 5%;
-        width: inherit;
-      }
-
-      &:last-child {
-        @include at-media('desktop') {
-          margin-right: 0;
-        }
-      }
+    @include at-media('desktop') {
+      @include u-padding-x(0);
     }
   }
 
-  .usa-footer-primary-link {
-    padding-bottom: units(2);
-    padding-top: units(2);
-  }
-
-  .usa-footer-primary-section {
-    > .usa-grid {
-      padding: 0;
-
-      @include at-media('mobile-lg') {
-        padding-left: units(4);
-        padding-right: units(4);
-      }
-    }
-
+  .usa-footer-address {
+    @include u-padding-y(2);
+    @include u-padding-x($theme-site-margins-mobile);
     @include at-media('mobile-lg') {
-      padding-bottom: 0;
-      padding-top: 0;
-
-      .usa-grid-full {
-        align-items: center;
-      }
+      @include u-padding(0);
     }
+  }
+
+  .usa-footer-logo {
+    @include u-flex('align-center');
+  }
+
+  .usa-footer-logo-img {
+    max-width: units(6);
   }
 
   .usa-footer-contact_info {
-    > * {
-      @include at-media('mobile-lg') {
-        margin: 0;
-      }
-    }
-
     @include at-media('mobile-lg') {
       @include u-padding-y(units(2));
-    }
-
-    @include at-media('mobile-lg') {
-      width: 100%;
-    }
-
-    @include at-media('desktop') {
-      @include span-columns(6);
     }
   }
 }
@@ -334,15 +287,6 @@
 // Medium footer styles
 
 .usa-footer-medium {
-  .usa-footer-contact_info {
-    p {
-      margin: 0 units(1) 0 0;
-
-      @include at-media('mobile-lg') {
-        margin: 0 0 0 units(1);
-      }
-    }
-  }
 
   .usa-footer-contact-heading {
     margin-top: 0;
@@ -351,11 +295,6 @@
       margin-top: units(0.5);
       margin-bottom: units(0.5);
     }
-  }
-
-  .usa-footer-primary-link {
-    padding-bottom: units(2);
-    padding-top: units(2);
   }
 
   .usa-footer-primary-section {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -10,7 +10,6 @@
   line-height: line-height($theme-font-family-footer, 1);
 }
 
-// TODO: can I use a regular grid-container and then use neg margin at mobile to make it all work? code would be cleaner and more consistent.
 .usa-footer-nav {
   @include u-margin-x('auto');
   @include u-padding-x(0);
@@ -66,7 +65,7 @@
   }
 }
 
-.usa-footer-primary-link ~ li a,
+.usa-footer-primary-link a,
 .usa-footer-secondary-link a {
   text-decoration: none;
 }
@@ -111,11 +110,8 @@
 
 // TODO: all these styles needed?
 .usa-sign_up-header {
-  @include typeset-h3;
-  @include at-media('mobile-lg') {
-    @include u-padding-y(2);
-    margin: 0;
-  }
+  @include h3;
+  margin: 0;
 }
 
 .usa-footer-secondary-section {
@@ -258,13 +254,20 @@
   }
 }
 
-// Medium footer styles
-
 // Big footer styles
 
 .usa-footer-big {
   .usa-footer-nav {
     @include u-margin-x($theme-site-margins-mobile * -1);
+    @include at-media('mobile-lg') {
+      border-bottom: 1px solid color('base-light');
+      padding-top: units(4);
+    }
+    @include at-media('tablet') {
+      @include u-margin-x(0);
+      @include u-padding-x(0);
+      border-bottom: none;
+    }
   }
 
   .usa-footer-primary-link {
@@ -272,6 +275,10 @@
     @include u-margin-y(0);
     line-height: line-height('heading', 2);
     text-decoration: none;
+
+    @include at-media('mobile-lg') {
+      @include u-padding-y(0);
+    }
   }
 
   .usa-footer-collapsible {
@@ -293,8 +300,13 @@
     }
 
     &.hidden {
-      ul {
+      .usa-unstyled-list {
         display: none;
+
+        // TODO: Kludge until js is fixed
+        @include at-media('mobile-lg') {
+          display: block;
+        }
       }
 
       .usa-footer-primary-link {
@@ -304,6 +316,7 @@
 
         @include at-media('mobile-lg') {
           background: none;
+          margin: 0;
           padding-left: 0;
         }
       }
@@ -314,7 +327,9 @@
       padding-bottom: units(2.5);
 
       @include at-media('mobile-lg') {
-        padding-bottom: 0;
+        @include u-padding-x(0);
+        padding-bottom: units(4);
+        padding-top: units(1.5);
       }
     }
   }
@@ -326,32 +341,6 @@
 
     & + .usa-footer-secondary-link {
       padding-top: units(2);
-    }
-  }
-
-  .usa-footer-secondary-section {
-    //TODO: orly?
-    @include at-media('mobile-lg') {
-      padding-top: units(2.5);
-      padding-bottom: units(2.5);
-    }
-  }
-
-  .usa-footer-contact_info {
-    display: block;
-
-    p {
-      margin: 0 units(1) 0 0;
-
-      @include at-media('mobile-lg') {
-        margin: units(0.5) 0 0 units(1);
-      }
-    }
-  }
-
-  .usa-footer-contact-links {
-    @include at-media('mobile-lg') {
-      padding-top: units(2.5);
     }
   }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -84,10 +84,7 @@
   }
 }
 
-/* stylelint-disable selector-no-qualifying-type */
-ul.usa-footer-primary-content,
-li.usa-footer-primary-content,
-li.usa-footer-primary-content {
+.usa-footer-primary-content {
   border-top: 1px solid color('base-light');
 
   @include at-media('mobile-lg') {
@@ -102,12 +99,10 @@ li.usa-footer-primary-content {
     }
   }
 }
-/* stylelint-enable */
 
 .usa-sign_up-block {
-  padding-bottom: 4.5rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  @include u-padding-y(2);
+  padding-bottom: units(5);
 
   @include at-media('mobile-lg') {
     float: right;
@@ -121,7 +116,7 @@ li.usa-footer-primary-content {
   button {
     float: none;
     margin-right: 0;
-    margin-top: 1.5rem;
+    margin-top: units(2);
   }
 
   input {
@@ -139,11 +134,40 @@ li.usa-footer-primary-content {
   }
 }
 
-.usa-footer-big-secondary-section {
+.usa-footer-topic {
+  margin: 0;
+  padding: units(2) 0;
+}
+
+.usa-sign_up-header {
   @include at-media('mobile-lg') {
-    padding-top: units(2.5);
-    padding-bottom: units(2.5);
+    margin: 0;
+    padding: units(2) 0;
   }
+}
+
+.usa-footer-logo {
+  padding-top: units(1);
+  padding-bottom: units(2.5);
+
+  @include at-media('mobile-lg') {
+    @include u-flex('align-center');
+    padding: units(2.5) 0;
+  }
+}
+
+.usa-footer-logo-img {
+  max-width: units(10);
+
+  @include at-media('mobile-lg') {
+    float: left;
+  }
+}
+
+.usa-footer-logo-heading {
+  @include h3;
+  @include u-margin-y(1);
+  line-height: line-height('heading', 1);
 }
 
 .usa-footer-contact-links {
@@ -175,10 +199,11 @@ li.usa-footer-primary-content {
 }
 
 .usa-social_link {
-  $background-height: units(4); // Height of icon within hit area.
-  // Link hit target is 44 x 44 pixels following
-  // Apple iOS Human Interface Guidelines.
-  $hit-area: 4.4rem;
+  $background-height: units(3); // Height of icon within hit area.
+  // Apple iOS Human Interface Guidelines recommends
+  // link hit target of 44 x 44 pixels following
+  // TODO: is 40px/units(5) acceptable?
+  $hit-area: units(5);
 
   background-position: center center;
   background-repeat: no-repeat;
@@ -226,6 +251,17 @@ li.usa-footer-primary-content {
 }
 
 // Slim footer styles
+
+.usa-footer-slim-logo-img {
+  float: left;
+  max-width: units(6);
+}
+
+.usa-footer-slim-logo-heading {
+  display: inline-block;
+  margin-top: units(2);
+  padding-left: units(2);
+}
 
 .usa-footer-slim {
   .usa-footer-nav {
@@ -315,14 +351,6 @@ li.usa-footer-primary-content {
     }
   }
 
-  .usa-footer-logo {
-    padding: units(1) 0;
-
-    @include at-media('mobile-lg') {
-      padding: units(2.5) 0;
-    }
-  }
-
   .usa-footer-primary-link {
     padding-bottom: units(2);
     padding-top: units(2);
@@ -347,6 +375,25 @@ li.usa-footer-primary-content {
 }
 
 // Big footer styles
+
+.usa-footer-big-secondary-section {
+  @include at-media('mobile-lg') {
+    padding-top: units(2.5);
+    padding-bottom: units(2.5);
+  }
+}
+
+.usa-footer-big-logo-img {
+  max-width: 10rem;
+}
+
+.usa-footer-big-logo-heading {
+  margin-top: units(2);
+
+  @include at-media('mobile-lg') {
+    margin-top: units(2.5);
+  }
+}
 
 .usa-footer-big {
   .usa-footer-collapsible {
@@ -481,58 +528,4 @@ li.usa-footer-primary-content {
       padding-top: 0.35em;
     }
   }
-}
-
-.usa-footer-topic {
-  margin: 0;
-  padding: 2rem 0;
-}
-
-.usa-sign_up-header {
-  @include at-media('mobile-lg') {
-    margin: 0;
-    padding: 2rem 0;
-  }
-}
-
-.usa-footer-logo-img {
-  max-width: 8rem;
-
-  @include at-media('mobile-lg') {
-    float: left;
-  }
-}
-
-.usa-footer-big-logo-img {
-  max-width: 10rem;
-}
-
-.usa-footer-slim-logo-img {
-  float: left;
-  max-width: 5rem;
-}
-
-.usa-footer-logo-heading {
-  @include h3;
-  margin-top: units(1);
-
-  @include at-media('mobile-lg') {
-    display: inline-block;
-    margin-top: units(4);
-    padding-left: units(2);
-  }
-}
-
-.usa-footer-big-logo-heading {
-  margin-top: units(2);
-
-  @include at-media('mobile-lg') {
-    margin-top: units(2.5);
-  }
-}
-
-.usa-footer-slim-logo-heading {
-  display: inline-block;
-  margin-top: units(2);
-  padding-left: units(2);
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -279,6 +279,11 @@
       background: none;
       margin-bottom: units(1);
       padding-left: 0;
+
+      &:hover {
+        cursor: auto;
+        text-decoration: none;
+      }
     }
   }
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -67,6 +67,16 @@
   text-decoration: none;
 }
 
+.usa-footer-secondary-link {
+  line-height: line-height($theme-font-family-footer, 2);
+  margin: 0;
+  padding: 0;
+
+  & + .usa-footer-secondary-link {
+    padding-top: units(2);
+  }
+}
+
 .usa-footer-contact_info {
   display: inline-block;
   line-height: line-height($theme-font-family-footer, 2);
@@ -311,16 +321,6 @@
         padding-bottom: units(4);
         padding-top: units(1.5);
       }
-    }
-  }
-
-  .usa-footer-secondary-link {
-    line-height: line-height($theme-font-family-footer, 2);
-    margin: 0;
-    padding: 0;
-
-    & + .usa-footer-secondary-link {
-      padding-top: units(2);
     }
   }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -14,10 +14,12 @@
 .usa-footer-nav {
   @include u-margin-x('auto');
   @include u-padding-x(0);
+  border-bottom: 1px solid color('base-light');
   max-width: units('desktop');
 
   @include at-media('mobile-lg') {
     @include u-padding-x($theme-site-margins-mobile);
+    border-bottom: none;
   }
   @include at-media('desktop') {
     @include u-padding-x($theme-site-margins);
@@ -88,39 +90,31 @@
   @include at-media('mobile-lg') {
     border: none;
   }
+}
 
-  // TODO: necessary? Is there a cleaner way to do this?
-  &:last-child {
-    border-bottom: 1px solid color('base-light');
+.usa-sign_up-block {
+  padding-bottom: units(4);
+  padding-top: units(3);
 
-    @include at-media('mobile-lg') {
-      border-bottom: none;
-    }
+  .usa-label {
+    margin-top: units(1.5);
+  }
+
+  * + .usa-label {
+    margin-top: units(1.5);
+  }
+
+  .usa-button {
+    margin-top: units(1.5)
   }
 }
 
-// TODO: what is this? preview?
-.usa-sign_up-block {
-  @include u-padding-y(2);
-  padding-bottom: units(5);
-
+// TODO: all these styles needed?
+.usa-sign_up-header {
+  @include typeset-h3;
   @include at-media('mobile-lg') {
-    float: right;
-    padding: 0;
-  }
-
-  label:first-of-type {
-    margin-top: 0;
-  }
-
-  button {
-    float: none;
-    margin-right: 0;
-    margin-top: units(2);
-  }
-
-  input {
-    width: 100%;
+    @include u-padding-y(2);
+    margin: 0;
   }
 }
 
@@ -130,20 +124,6 @@
 
   a {
     color: color('ink');
-  }
-}
-
-// TODO: all these styles needed?
-.usa-footer-topic {
-  margin: 0;
-  padding: units(2) 0;
-}
-
-// TODO: all these styles needed?
-.usa-sign_up-header {
-  @include at-media('mobile-lg') {
-    margin: 0;
-    padding: units(2) 0;
   }
 }
 
@@ -175,11 +155,11 @@
 }
 
 .usa-footer-contact-heading {
-  @include typeset-h3;
+  @include h3;
   margin-top: 0;
 
   @include at-media('mobile-lg') {
-    margin-top: 1rem;
+    @include u-margin-y(0.5);
   }
 }
 
@@ -280,68 +260,47 @@
 
 // Medium footer styles
 
-.usa-footer-medium {
-  .usa-footer-contact-heading {
-    margin-top: 0;
-
-    @include at-media('mobile-lg') {
-      margin-top: units(0.5);
-      margin-bottom: units(0.5);
-    }
-  }
-}
-
 // Big footer styles
 
-.usa-footer-big-secondary-section {
-  @include at-media('mobile-lg') {
-    padding-top: units(2.5);
-    padding-bottom: units(2.5);
-  }
-}
-
-.usa-footer-big-logo-img {
-  max-width: 10rem;
-}
-
-.usa-footer-big-logo-heading {
-  margin-top: units(2);
-
-  @include at-media('mobile-lg') {
-    margin-top: units(2.5);
-  }
-}
-
 .usa-footer-big {
+  .usa-footer-nav {
+    @include u-margin-x($theme-site-margins-mobile * -1);
+  }
+
+  .usa-footer-primary-link {
+    @include h4;
+    @include u-margin-y(0);
+    line-height: line-height('heading', 2);
+    text-decoration: none;
+  }
+
   .usa-footer-collapsible {
-    border-top: 1px solid color('base-light');
-
-    @include at-media('mobile-lg') {
-      border-top: none;
-    }
-
-    &:last-child {
-      border-bottom: 1px solid color('base-light');
+    .usa-footer-primary-link {
+      background-image: url('#{$theme-image-path}/arrow-down.png');
+      background-image: url('#{$theme-image-path}/arrow-down.svg');
+      background-position: units(2) center;
+      background-repeat: no-repeat;
+      background-size: units(1.5);
+      margin-bottom: 0;
+      margin-left: 0;
+      padding-left: units(4);
 
       @include at-media('mobile-lg') {
-        border-bottom: none;
+        background: none;
+        margin-bottom: units(1);
+        padding-left: 0;
       }
     }
 
     &.hidden {
       ul {
-        padding-bottom: 0;
-      }
-
-      li {
         display: none;
       }
 
-      .usa-footer-primary-link { /* stylelint-disable-line selector-no-qualifying-type */
+      .usa-footer-primary-link {
         background-image: url('#{$theme-image-path}/arrow-right.png');
         background-image: url('#{$theme-image-path}/arrow-right.svg');
         cursor: pointer;
-        display: block;
 
         @include at-media('mobile-lg') {
           background: none;
@@ -350,26 +309,31 @@
       }
     }
 
-    .usa-footer-primary-link {
-      background-image: url('#{$theme-image-path}/arrow-down.png');
-      background-image: url('#{$theme-image-path}/arrow-down.svg');
-      background-position: 1.5rem center;
-      background-repeat: no-repeat;
-      background-size: 1.3rem;
-      margin-bottom: 0;
-      margin-left: 0;
-      padding-left: 3.5rem;
+    .usa-unstyled-list {
+      @include u-padding-x($theme-site-margins-mobile)
+      padding-bottom: units(2.5);
 
       @include at-media('mobile-lg') {
-        background: none;
-        margin-bottom: .8rem;
         padding-bottom: 0;
-        padding-left: 0;
       }
+    }
+  }
 
-      > * {
-        @include margin(0 null);
-      }
+  .usa-footer-secondary-link  {
+    line-height: line-height($theme-font-family-footer, 2);
+    margin: 0;
+    padding: 0;
+
+    & + .usa-footer-secondary-link {
+      padding-top: units(2);
+    }
+  }
+
+  .usa-footer-secondary-section {
+    //TODO: orly?
+    @include at-media('mobile-lg') {
+      padding-top: units(2.5);
+      padding-bottom: units(2.5);
     }
   }
 
@@ -388,53 +352,6 @@
   .usa-footer-contact-links {
     @include at-media('mobile-lg') {
       padding-top: units(2.5);
-    }
-  }
-
-  .usa-footer-primary-section {
-    @include at-media('mobile-lg') {
-      padding-bottom: 4rem;
-      padding-top: 3rem;
-    }
-
-    > .usa-grid {
-      padding: 0;
-
-      @include at-media('mobile-lg') {
-        padding-left: units(4);
-        padding-right: units(4);
-      }
-    }
-
-    .usa-footer-primary-content {
-      padding-left: 0;
-      padding-right: 0;
-
-      li {
-        margin-left: units(2);
-
-        @include at-media('mobile-lg') {
-          margin-left: 0;
-        }
-      }
-
-      .usa-footer-primary-link {
-        margin-left: 0;
-      }
-    }
-  }
-
-  ul {
-    padding-bottom: 2.4rem;
-
-    @include at-media('mobile-lg') {
-      padding-bottom: 0;
-    }
-
-    li:not(.usa-footer-primary-link) {
-      line-height: $heading-line-height;
-      padding-bottom: 0.35em;
-      padding-top: 0.35em;
     }
   }
 }

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -69,7 +69,7 @@
     @if $gap == 0 {
       @include u-margin-x(append-important($props, 0));
 
-      > * {
+      > [class*='grid-col'] {
         @include u-padding-x(append-important($props, 0));
       }
     }

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -70,7 +70,7 @@
       @include u-margin-x(append-important($props, 0));
 
       > * {
-        @include u-padding-y(append-important($props, 0));
+        @include u-padding-x(append-important($props, 0));
       }
     }
     @else {

--- a/src/stylesheets/settings/_settings-utilities.scss
+++ b/src/stylesheets/settings/_settings-utilities.scss
@@ -296,7 +296,7 @@ $height-settings: (
 
 $justify-content-settings: (
   output:       true,
-  responsive:   false,
+  responsive:   true,
   active:       false,
   focus:        false,
   hover:        false,


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-footer-v2/components/detail/footer--default.html)

There are some relatively small (I think) differences in appearance between v2 and v1. 

- `footer-big@mobile-lg` expands the primary nav into two columns and keeps the form in a separate row.
- `footer-big@tablet` should be back the the same as v1
- The js that appends `hidden` to collapsible primary nav elements deactivates at a different breakpoint than `mobile-lg` — @el-mapache can we use the v2 breakpoint here? (right now fixed with a sass kludge)
- Obviously (perhaps) rewriting the component with v2 grid means this is a big breaking change for the component as well

- - -

On the plus side, I was able to cut about 35% of the initial code!