### PR TITLE
Update and sync packages with uswds.scss

### DIFF
--- a/src/stylesheets/packages/_uswds-components.scss
+++ b/src/stylesheets/packages/_uswds-components.scss
@@ -9,6 +9,7 @@ Output USWDS components and styles
 */
 
 // Settings
+// -------------------------------------
 @import '../settings/settings-general';
 @import '../settings/settings-typography';
 @import '../settings/settings-color';
@@ -16,8 +17,8 @@ Output USWDS components and styles
 @import '../settings/settings-utilities';
 
 // Tools
+// -------------------------------------
 @import '../lib/bourbon';
-@import '../lib/neat';
 @import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
@@ -26,24 +27,28 @@ Output USWDS components and styles
 @import '../core/mixins/all';
 
 // Generic
+// -------------------------------------
 @import '../lib/normalize';
 @import '../core/grid';
 @import '../core/base';
 
 // Elements
+// -------------------------------------
 @import '../elements/buttons';
 @import '../elements/embed';
 @import '../elements/figure';
 @import '../elements/inputs';
-@import '../elements/tags';
 @import '../elements/list';
 @import '../elements/table';
+@import '../elements/tags';
 @import '../elements/typography';
 
 // Components
+// -------------------------------------
 @import '../components/accordions';
 @import '../components/alerts';
 @import '../components/banner';
+@import '../components/checklist';
 @import '../components/footer';
 @import '../components/forms';
 @import '../components/graphic-list';
@@ -56,3 +61,11 @@ Output USWDS components and styles
 @import '../components/section';
 @import '../components/sidenav';
 @import '../components/skipnav';
+
+// Utilities
+// -------------------------------------
+// Not included
+
+// Layout grid
+// -------------------------------------
+// Not included

--- a/src/stylesheets/packages/_uswds-fonts.scss
+++ b/src/stylesheets/packages/_uswds-fonts.scss
@@ -10,6 +10,7 @@ USWDS project
 */
 
 // Settings
+// -------------------------------------
 @import '../settings/settings-general';
 @import '../settings/settings-typography';
 @import '../settings/settings-color';
@@ -17,8 +18,8 @@ USWDS project
 @import '../settings/settings-utilities';
 
 // Tools
+// -------------------------------------
 @import '../lib/bourbon';
-@import '../lib/neat';
 @import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
@@ -27,4 +28,23 @@ USWDS project
 @import '../core/mixins/all';
 
 // Generic
+// -------------------------------------
 @import '../core/font-face';
+// no normalize
+// no base
+
+// Elements
+// -------------------------------------
+// Not included
+
+// Components
+// -------------------------------------
+// Not included
+
+// Utilities
+// -------------------------------------
+// Not included
+
+// Layout grid
+// -------------------------------------
+// Not included

--- a/src/stylesheets/packages/_uswds-layout-grid.scss
+++ b/src/stylesheets/packages/_uswds-layout-grid.scss
@@ -10,6 +10,7 @@ USWDS project
 */
 
 // Settings
+// -------------------------------------
 @import '../settings/settings-general';
 @import '../settings/settings-typography';
 @import '../settings/settings-color';
@@ -17,6 +18,7 @@ USWDS project
 @import '../settings/settings-utilities';
 
 // Tools
+// -------------------------------------
 @import '../lib/bourbon';
 @import '../core/font-definitions';
 @import '../core/functions';
@@ -25,5 +27,22 @@ USWDS project
 @import '../core/properties';
 @import '../core/mixins/all';
 
+// Generic
+// -------------------------------------
+// Not included
+
+// Elements
+// -------------------------------------
+// Not included
+
+// Components
+// -------------------------------------
+// Not included
+
 // Utilities
+// -------------------------------------
+// Not included
+
+// Layout grid
+// -------------------------------------
 @import '../core/layout-grid';

--- a/src/stylesheets/packages/_uswds-utilities.scss
+++ b/src/stylesheets/packages/_uswds-utilities.scss
@@ -10,6 +10,7 @@ project
 */
 
 // Settings
+// -------------------------------------
 @import '../settings/settings-general';
 @import '../settings/settings-typography';
 @import '../settings/settings-color';
@@ -17,8 +18,8 @@ project
 @import '../settings/settings-utilities';
 
 // Tools
+// -------------------------------------
 @import '../lib/bourbon';
-@import '../lib/neat';
 @import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
@@ -26,8 +27,17 @@ project
 @import '../core/properties';
 @import '../core/mixins/all';
 
+// Components
+// -------------------------------------
+// Not included
+
 // Utilities
+// -------------------------------------
 @import '../utilities/palettes/all';
 @import '../utilities/rules/all';
 @import '../utilities/rules/package';
 @include render-utilities-in($utilities-package);
+
+// Layout grid
+// -------------------------------------
+// Not included

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -8,10 +8,12 @@ Output all USWDS
 - fonts
 - components
 - utilities
+- layout grid
 ----------------------------------------
 */
 
 // Settings
+// -------------------------------------
 @import 'settings/settings-general';
 @import 'settings/settings-typography';
 @import 'settings/settings-color';
@@ -19,6 +21,7 @@ Output all USWDS
 @import 'settings/settings-utilities';
 
 // Tools
+// -------------------------------------
 @import 'lib/bourbon';
 @import 'core/font-definitions';
 @import 'core/functions';
@@ -28,11 +31,13 @@ Output all USWDS
 @import 'core/mixins/all';
 
 // Generic
+// -------------------------------------
 @import 'core/font-face';
 @import 'lib/normalize';
 @import 'core/base';
 
 // Elements
+// -------------------------------------
 @import 'elements/buttons';
 @import 'elements/embed';
 @import 'elements/figure';
@@ -43,6 +48,7 @@ Output all USWDS
 @import 'elements/typography';
 
 // Components
+// -------------------------------------
 @import 'components/accordions';
 @import 'components/alerts';
 @import 'components/banner';
@@ -61,8 +67,12 @@ Output all USWDS
 @import 'components/skipnav';
 
 // Utilities
+// -------------------------------------
 @import 'utilities/palettes/all';
 @import 'utilities/rules/all';
 @import 'utilities/rules/package';
 @include render-utilities-in($utilities-package);
+
+// Layout grid
+// -------------------------------------
 @import 'core/layout-grid';


### PR DESCRIPTION
There are four standalone packages that install only certain part of USWDS:

- `stylesheets/packages/_uswds-components.scss`
- `stylesheets/packages/_uswds-fonts.scss`
- `stylesheets/packages/_uswds-layout-grid.scss`
- `stylesheets/packages/_uswds-utilities.scss`

This PR synchronizes their imports with the imports in the master stylesheet, `uswds.scss`