### PR TITLE
Update accordion variant classes to require usa-accordion

### DIFF
--- a/src/components/06-accordion/accordion.njk
+++ b/src/components/06-accordion/accordion.njk
@@ -1,5 +1,5 @@
 <div class="usa-accordion{%
-  if accordion.variant %}-{{ accordion.variant }}{% endif %}"{%
+  if accordion.variant %} usa-accordion-{{ accordion.variant }}{% endif %}"{%
   if accordion.multiselectable == true %} aria-multiselectable="true"{% endif %}>
   {% for item in accordion.items %}
   <!-- Use the accurate heading level to maintain the document outline -->

--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -52,8 +52,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
   }
 }
 
-.usa-accordion,
-.usa-accordion-bordered {
+.usa-accordion {
   @include accordion-list-styles;
   @include accordion-nested-list;
   @include typeset($theme-accordion-font-family);


### PR DESCRIPTION
This was the only component I found that had this old styling technique.

Fixes #2736.