### PR TITLE
Fix buttons naming scheme

### DIFF
--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -2,41 +2,35 @@ label: Buttons
 status: ready
 
 variants:
-  - name: primary
-    context:
-      category: primary
-      label: Primary buttons
-      classes: 'usa-button'
-
   - name: secondary
     context:
-      category: secondary
+      category: alternate
       label: Secondary buttons
       classes: 'usa-button-secondary'
 
-  - name: secondary-inverse
-    context:
-      category: secondary-inverse
-      label: Secondary inverse buttons
-      classes: 'usa-button-secondary-inverse'
-
-  - name: aqua
+  - name: accent-cool
     context:
       category: alternate
-      label: Aqua buttons
-      classes: 'usa-button-primary-alt'
+      label: Accent cool buttons
+      classes: 'usa-button-accent-cool'
 
-  - name: gray
+  - name: base
     context:
       category: alternate
       label: Gray buttons
-      classes: 'usa-button-gray'
+      classes: 'usa-button-base'
 
-  - name: red
+  - name: outline
     context:
-      category: alternate
-      label: Red buttons
-      classes: 'usa-button-red'
+      category: outline
+      label: outline buttons
+      classes: 'usa-button-outline'
+
+  - name: outline-inverse
+    context:
+      category: outline-inverse
+      label: outline inverse buttons
+      classes: 'usa-button-outline-inverse'
 
   - name: big
     context:

--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -1,5 +1,5 @@
-{%- if (classes == 'usa-button-secondary-inverse') -%}
-<div class="dark-bg">
+{%- if (classes == 'usa-button-outline-inverse') -%}
+<div class="bg-base-darkest">
 {% endif -%}
 
 <button class="usa-button {{ classes }}">Default</button>
@@ -10,12 +10,6 @@
 <button class="usa-button {{ classes }}" disabled>Disabled</button>
 {%- endif -%}
 
-{%- if (classes == 'usa-button-secondary-inverse') %}
+{%- if (classes == 'usa-button-outline-inverse') %}
 </div>
-
-<style scoped>
-  .dark-bg {
-    background-color: #212121;
-  }
-</style>
 {%- endif %}

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -60,7 +60,7 @@ $button-stroke: inset 0 0 0 2px;
     background-color: color('primary-darker');
   }
 
-  &.usa-button-primary-alt {
+  &.usa-button-accent-cool {
     @include no-knockout-font-smoothing;
     background-color: color('accent-cool');
     color: color('ink');
@@ -78,7 +78,7 @@ $button-stroke: inset 0 0 0 2px;
     }
   }
 
-  &.usa-button-secondary {
+  &.usa-button-outline {
     @include no-knockout-font-smoothing;
     background-color: color('white');
     box-shadow: $button-stroke color('primary');
@@ -97,7 +97,7 @@ $button-stroke: inset 0 0 0 2px;
     }
   }
 
-  &.usa-button-secondary-inverse,
+  &.usa-button-outline-inverse,
   &.usa-button-outline-inverse {    // Outline inverse to be deprecated in 2.0
     background: transparent;
     box-shadow: $button-stroke color('base-lighter');
@@ -116,7 +116,7 @@ $button-stroke: inset 0 0 0 2px;
     }
   }
 
-  &.usa-button-gray {
+  &.usa-button-base {
     background-color: color('base');
 
     &:hover,
@@ -130,7 +130,7 @@ $button-stroke: inset 0 0 0 2px;
     }
   }
 
-  &.usa-button-red {
+  &.usa-button-secondary {
     background-color: color('secondary');
 
     &:hover,
@@ -168,10 +168,10 @@ $button-stroke: inset 0 0 0 2px;
   @include disabledesque
 }
 
-.usa-button-secondary-disabled,          // Deprecated
-.usa-button-secondary-inverse-disabled,  // Deprecated
-.usa-button-secondary:disabled,
-.usa-button-secondary-inverse:disabled,
+.usa-button-outline-disabled,          // Deprecated
+.usa-button-outline-inverse-disabled,  // Deprecated
+.usa-button-outline:disabled,
+.usa-button-outline-inverse:disabled,
 .usa-button-outline-inverse:disabled {   // Outline inverse to be deprecated in 2.0
   pointer-events: none;
 
@@ -186,17 +186,17 @@ $button-stroke: inset 0 0 0 2px;
   }
 }
 
-html .usa-button-secondary-disabled, // Deprecated
-.usa-button-secondary-disabled, // Deprecated
-.usa-button-secondary:disabled {
+html .usa-button-outline-disabled, // Deprecated
+.usa-button-outline-disabled, // Deprecated
+.usa-button-outline:disabled {
   background-color: color('white');
   box-shadow: $button-stroke color('disabled');
   color: color('disabled');
 }
 
-html .usa-button-secondary-inverse-disabled, // Deprecated
-.usa-button-secondary-inverse-disabled,  // Deprecated
-.usa-button-secondary-inverse:disabled,
+html .usa-button-outline-inverse-disabled, // Deprecated
+.usa-button-outline-inverse-disabled,  // Deprecated
+.usa-button-outline-inverse:disabled,
 .usa-button-outline-inverse:disabled {   // Outline inverse to be deprecated in 2.0
   background-color: transparent;
   box-shadow: $button-stroke color('base');


### PR DESCRIPTION
Align button naming scheme with our themed colors, change back to "outline" button, returning to how they were named before.

Fixes #2171. 