### PR TITLE
Update hero content display and margins

### DIFF
--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -9,9 +9,7 @@
       </h2>
 
       {% if hero.paragraph %}
-        <div class="usa-hero-content">
-          <p>{{ hero.paragraph }}</p>
-        </div>
+        <p>{{ hero.paragraph }}</p>
       {% endif %}
 
       {% if hero.button %}

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -1,13 +1,6 @@
 // Hero feature
 // ==========================
 
-@mixin hero-top-padding {
-  @include u-margin-top(2);
-  @include at-media('mobile-lg') {
-    @include u-margin-top(3);
-  }
-}
-
 .usa-hero {
   @include typeset;
   @include u-padding-y($theme-site-margins-width);
@@ -23,18 +16,6 @@
 
   @include at-media('tablet') {
     max-width: units('mobile');
-  }
-
-  .usa-button {
-    @include hero-top-padding;
-  }
-}
-
-.usa-hero-content {
-  @include hero-top-padding;
-
-  p {
-    @include typeset-p;
   }
 }
 

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -20,9 +20,9 @@
 }
 
 .usa-hero-content {
-  @include u-margin-y(2);
+  @include u-margin-top(2);
   @include at-media('mobile-lg') {
-    @include u-margin-y(3);
+    @include u-margin-top(3);
   }
 
   p {

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -1,6 +1,13 @@
 // Hero feature
 // ==========================
 
+@mixin hero-top-padding {
+  @include u-margin-top(2);
+  @include at-media('mobile-lg') {
+    @include u-margin-top(3);
+  }
+}
+
 .usa-hero {
   @include typeset;
   @include u-padding-y($theme-site-margins-width);
@@ -17,13 +24,14 @@
   @include at-media('tablet') {
     max-width: units('mobile');
   }
+
+  .usa-button {
+    @include hero-top-padding;
+  }
 }
 
 .usa-hero-content {
-  @include u-margin-top(2);
-  @include at-media('mobile-lg') {
-    @include u-margin-top(3);
-  }
+  @include hero-top-padding;
 
   p {
     @include typeset-p;


### PR DESCRIPTION
Removes the `usa-hero-content` and allows text to take it's natural top margin styling.

Fixes: #2773. The `#3` approach.