### PR TITLE
Remove Bourbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "axe-core": "^2.6.1",
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",
-    "bourbon": "4.2.7",
     "chalk": "^2.0.1",
     "chrome-launcher": "^0.3.2",
     "chrome-remote-interface": "^0.25.6",

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -606,16 +606,3 @@ $grid-global: '';
 @if $utilities-use-important {
   $grid-global: '!important';
 }
-
-/*
-----------------------------------------
-Set $asset-pipeline to true if you're
-using the Rails Asset Pipeline
-----------------------------------------
-TODO: This should be set in settings
-Has something to do with the bourbon font builder
-See: https://github.com/uswds/uswds/pull/1500
-----------------------------------------
-*/
-
-$asset-pipeline:      false !default;

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -58,6 +58,7 @@
 @import 'at-media';
 @import 'button-unstyled';
 @import 'focus';
+@import 'font-face';
 @import 'icon';
 @import 'layout-grid';
 @import 'nav-list';

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -57,6 +57,7 @@
 @import 'add-responsive-site-margins';
 @import 'at-media';
 @import 'button-unstyled';
+@import 'clearfix';
 @import 'focus';
 @import 'font-face';
 @import 'icon';

--- a/src/stylesheets/core/mixins/_clearfix.scss
+++ b/src/stylesheets/core/mixins/_clearfix.scss
@@ -1,0 +1,7 @@
+@mixin clearfix {
+  &::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}

--- a/src/stylesheets/core/mixins/_clearfix.scss
+++ b/src/stylesheets/core/mixins/_clearfix.scss
@@ -1,7 +1,7 @@
 @mixin clearfix {
   &::after {
     clear: both;
-    content: "";
+    content: '';
     display: block;
   }
 }

--- a/src/stylesheets/core/mixins/_font-face.scss
+++ b/src/stylesheets/core/mixins/_font-face.scss
@@ -1,3 +1,5 @@
+
+// Output the @font-face rule
 @mixin at-font-face(
   $font-family,
   $file-path,
@@ -18,6 +20,7 @@
   }
 }
 
+// Loop through weights, then call at-font-face
 @mixin generate-font-face($font-type, $font-weights, $font-name, $dir, $font-style) {
   @each $weight, $filename in $font-type {
     @each $key, $outputweight in $font-weights {
@@ -33,6 +36,7 @@
   }
 }
 
+// Collect all font metadata, then call generate-font-face
 @mixin render-font-face($this-font-face) {
   $these-weights: $project-font-weights;
   @if $theme-output-all-weights {

--- a/src/stylesheets/core/mixins/_font-face.scss
+++ b/src/stylesheets/core/mixins/_font-face.scss
@@ -1,0 +1,67 @@
+@mixin at-font-face(
+  $font-family,
+  $file-path,
+  $font-weight,
+  $font-style
+) {
+  $file-path: unquote($file-path);
+
+  @font-face {
+    font-family: unquote($font-family);
+    font-style: unquote($font-style);
+    font-weight: $font-weight;
+    src: 
+      url(#{$file-path}.eot?#iefix) format("embedded-opentype"),
+      url(#{$file-path}.woff2) format("woff2"),
+      url(#{$file-path}.woff) format("woff"),
+      url(#{$file-path}.ttf) format("truetype");
+  }
+}
+
+@mixin generate-font-face($font-type, $font-weights, $font-name, $dir, $font-style) {
+  @each $weight, $filename in $font-type {
+    @each $key, $outputweight in $font-weights {
+      @if $outputweight == $weight and $filename {
+        @include at-font-face(
+          '#{$font-name}',
+          '#{$theme-font-path}/#{$dir}/#{$filename}',
+          #{$weight},
+          #{$font-style}
+        );
+      }
+    }
+  }
+}
+
+@mixin render-font-face($this-font-face) {
+  $these-weights: $project-font-weights;
+  @if $theme-output-all-weights {
+    $these-weights: (
+      100: 100,
+      200: 200,
+      300: 300,
+      400: 400,
+      500: 500,
+      600: 600,
+      700: 700,
+      800: 800,
+      900: 900
+    );
+  }
+
+  @if $this-font-face and map-deep-get($all-font-definitions, $this-font-face, generate) {
+    $this-font: map-get($all-font-definitions, $this-font-face);
+    $font-name: map-get($this-font, name);
+    $roman: map-get($this-font, roman);
+    $italic: map-get($this-font, italic);
+    $dir: map-get($this-font, dir);
+
+    @if $roman {
+      @include generate-font-face($roman, $these-weights, $font-name, $dir, normal);
+    }
+
+    @if $italic {
+      @include generate-font-face($italic, $these-weights, $font-name, $dir, italic);
+    }
+  }
+}

--- a/src/stylesheets/core/mixins/_font-face.scss
+++ b/src/stylesheets/core/mixins/_font-face.scss
@@ -10,11 +10,11 @@
     font-family: unquote($font-family);
     font-style: unquote($font-style);
     font-weight: $font-weight;
-    src: 
-      url(#{$file-path}.eot?#iefix) format("embedded-opentype"),
-      url(#{$file-path}.woff2) format("woff2"),
-      url(#{$file-path}.woff) format("woff"),
-      url(#{$file-path}.ttf) format("truetype");
+    src:
+      url(#{$file-path}.eot?#iefix) format('embedded-opentype'),
+      url(#{$file-path}.woff2) format('woff2'),
+      url(#{$file-path}.woff) format('woff'),
+      url(#{$file-path}.ttf) format('truetype');
   }
 }
 

--- a/src/stylesheets/core/mixins/_font-face.scss
+++ b/src/stylesheets/core/mixins/_font-face.scss
@@ -8,6 +8,10 @@
 ) {
   $file-path: unquote($file-path);
 
+  // TODO: If $theme-use-rails-pipeline use font-url() statements
+  // instead of url()
+  // Dunno why I can't do this without an error...
+
   @font-face {
     font-family: unquote($font-family);
     font-style: unquote($font-style);

--- a/src/stylesheets/core/mixins/_utility-builder.scss
+++ b/src/stylesheets/core/mixins/_utility-builder.scss
@@ -386,53 +386,5 @@ through all possible variants
 }
 
 // Helper to generate an @font-face declaration
-@mixin generate-font-face($font-type, $font-weights, $font-name, $dir, $font-style) {
-  @each $weight, $filename in $font-type {
-    @each $key, $outputweight in $font-weights {
-      @if $outputweight == $weight and $filename {
-        @include font-face(
-          '#{$font-name}',
-          '#{$theme-font-path}/#{$dir}/#{$filename}',
-          #{$weight},
-          #{$font-style},
-          $file-formats: eot woff2 woff ttf
-        );
-      }
-    }
-  }
-}
-
-@mixin render-font-face($this-font-face) {
-  $these-weights: $project-font-weights;
-  @if $theme-output-all-weights {
-    $these-weights: (
-      100: 100,
-      200: 200,
-      300: 300,
-      400: 400,
-      500: 500,
-      600: 600,
-      700: 700,
-      800: 800,
-      900: 900
-    );
-  }
-
-  @if $this-font-face and map-deep-get($all-font-definitions, $this-font-face, generate) {
-    $this-font: map-get($all-font-definitions, $this-font-face);
-    $font-name: map-get($this-font, name);
-    $roman: map-get($this-font, roman);
-    $italic: map-get($this-font, italic);
-    $dir: map-get($this-font, dir);
-
-    @if $roman {
-      @include generate-font-face($roman, $these-weights, $font-name, $dir, normal);
-    }
-
-    @if $italic {
-      @include generate-font-face($italic, $these-weights, $font-name, $dir, italic);
-    }
-  }
-}
 
 /* stylelint-enable */

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -74,19 +74,6 @@ $theme-content-styles: 'scoped' !default;
 
 /*
 ----------------------------------------
-Use Rails font pipeline
-----------------------------------------
-If true, outputs @font-face rules with
-`font-url`.
-----------------------------------------
-** Currently not working **
-----------------------------------------
-*/
-
-// $theme-use-rails-pipeline: false !default;
-
-/*
-----------------------------------------
 Custom font definitions
 ----------------------------------------
 Add a new custom font definition if

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -74,6 +74,19 @@ $theme-content-styles: 'scoped' !default;
 
 /*
 ----------------------------------------
+Use Rails font pipeline
+----------------------------------------
+If true, outputs @font-face rules with
+`font-url`.
+----------------------------------------
+** Currently not working **
+----------------------------------------
+*/
+
+// $theme-use-rails-pipeline: false !default;
+
+/*
+----------------------------------------
 Custom font definitions
 ----------------------------------------
 Add a new custom font definition if

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -23,7 +23,7 @@ Output all USWDS
 
 // Tools
 // -------------------------------------
-@import 'lib/bourbon';
+//@import 'lib/bourbon';
 @import 'core/font-definitions';
 @import 'core/functions';
 @import 'core/system-tokens';

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -23,7 +23,6 @@ Output all USWDS
 
 // Tools
 // -------------------------------------
-//@import 'lib/bourbon';
 @import 'core/font-definitions';
 @import 'core/functions';
 @import 'core/system-tokens';


### PR DESCRIPTION
🔎 [Preview](#) TK

- - -

- Removes bourbon as a dependency and from imports
- Adds `clearfix()` mixin used by Bourbon
- Adds `at-font-face` mixin to replace Bourbon mixin
- Removes Rails pipeline support since I can't get my mixin to output `font-url` statements without an error. I don't know why this is...

- - -

Resolves #2694 