### PR TITLE
Use size xs for sidenav sublist elements

### DIFF
--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -14,4 +14,5 @@
 
 .usa-sidenav-sublist {
   @include nav-sublist;
+  font-size: font-size($theme-sidenav-font-family, 'xs');
 }

--- a/src/stylesheets/core/mixins/_nav-list.scss
+++ b/src/stylesheets/core/mixins/_nav-list.scss
@@ -1,6 +1,7 @@
-$sidenav-inset: 2;
-$sidenav-child-inset: 4;
-$sidenav-grandchild-inset: 6;
+$sidenav-level-1-inset: 2;
+$sidenav-level-2-inset: 4;
+$sidenav-level-3-inset: 6;
+$sidenav-level-4-inset: 8;
 
 @mixin nav-list {
   @include unstyled-list();
@@ -12,7 +13,7 @@ $sidenav-grandchild-inset: 6;
   a {
     color: color('base-dark');
     display: block;
-    padding: units(1) units($sidenav-inset);
+    padding: units(1) units($sidenav-level-1-inset);
     text-decoration: none;
 
     &:hover {
@@ -68,13 +69,19 @@ $sidenav-grandchild-inset: 6;
     }
   }
 
-  // children and grandchildren
+  // level 2+
   a {
-    padding-left: units($sidenav-child-inset);
+    padding-left: units($sidenav-level-2-inset);
   }
 
-  // grandchildren
+  // level 3+
   & & a {
-    padding-left: units($sidenav-grandchild-inset);
+    padding-left: units($sidenav-level-3-inset);
+  }
+
+  // level 4+
+  & & & a {
+    content: 'foobar';
+    padding-left: units($sidenav-level-4-inset);
   }
 }


### PR DESCRIPTION
🔎 [Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-nav-list-fixes/components/preview/sidenav--compare.html)

<img width="1048" alt="screen shot 2018-09-25 at 2 46 03 pm" src="https://user-images.githubusercontent.com/11464021/46045117-8fea6080-c0d1-11e8-8076-6fa6872393b0.png">

- - -

Adds great-grandchild indenting as well