### PR TITLE
Removes references to usa- prefix in scss

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -28,7 +28,6 @@ Namespace
 ----------------------------------------
 */
 
-$ns-component: ns('component');
 $ns-utility: ns('utility');
 $ns-grid: ns('grid');
 

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -29,10 +29,6 @@ Namespace
 */
 
 $theme-namespace: (
-  'component': (
-    namespace:  'usa-',
-    output:     true,
-  ),
   'grid': (
     namespace:  'grid-',
     output:     true,

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -29,10 +29,6 @@ Namespace
 */
 
 $theme-namespace: (
-  'component': (
-    namespace:  'usa-',
-    output:     true,
-  ),
   'grid': (
     namespace:  'grid-',
     output:     true,


### PR DESCRIPTION

## Removes references to `usa-` prefix in scss

## Description

Removes vestigial hooks for overriding `usa` namespace for classes. We aren't planning on implementing this at this point and leaving the code in might be confusing to users.
