### PR TITLE
Update government banner button underline display

### DIFF
--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -163,6 +163,7 @@
   line-height: line-height($theme-banner-font-family, 2);
   padding-top: units(0);
   padding-left: units(0);
+  text-decoration: none;
   width: auto;
 
   @include at-media-max('tablet') {
@@ -170,14 +171,14 @@
   }
 
   @include at-media('tablet') {
-    @include add-icon('angle-arrow-down-primary', 'after', 1, 1, 0.5, 'hover');
+    @include add-icon('angle-arrow-down-primary', 'after', 1, 1, 2px, 'hover');
     @include u-pin('none');
     display: inline;
     margin-left: units(1);
     position: relative;
 
     &:hover {
-      @include u-text('primary-darker', underline);
+      @include u-text('primary-darker');
     }
   }
 
@@ -207,7 +208,7 @@
     }
 
     @include at-media('tablet') {
-      @include add-icon('angle-arrow-up-primary', 'after', 1, 1, 0.5, 'hover');
+      @include add-icon('angle-arrow-up-primary', 'after', 1, 1, 2px, 'hover');
       height: auto;
       padding: units(0);
       position: relative;
@@ -227,6 +228,7 @@
 
 .usa-banner-button-text {
   @include add-sr-only;
+  text-decoration: underline;
 
   @include at-media('tablet') {
     @include add-no-sr-only;


### PR DESCRIPTION
Put the underline on the span not button. Reduce space between button text and arrow icon.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-banner-button)

Fixes #2781. 