### PR TITLE
Remove component prefix var/refs and regularize theme var names

### DIFF
--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -55,11 +55,11 @@ $icon-size: units(4);
   }
 
   a {
-    color: color($theme-color-link);
+    color: color($theme-link-color);
 
     &:focus,
     &:hover {
-      color: color($theme-color-link-hover);
+      color: color($theme-link-hover-color);
     }
   }
 

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -11,13 +11,13 @@ Functions
 $root-font-size: if(
   $theme-respect-user-font-size,
   100%,
-  $theme-font-size-root
+  $theme-root-font-size
 );
 
 $root-font-size-equiv: if(
   $theme-respect-user-font-size,
   16px,
-  $theme-font-size-root
+  $theme-root-font-size
 );
 
 /*

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -28,7 +28,6 @@ Namespace
 ----------------------------------------
 */
 
-$ns-component: ns('component');
 $ns-utility: ns('utility');
 $ns-grid: ns('grid');
 

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -62,15 +62,15 @@ Sets:
 }
 
 @mixin typeset-link {
-  color: color($theme-color-link);
+  color: color($theme-link-color);
   text-decoration: underline;
 
   &:hover {
-    color: color($theme-color-link-hover);
+    color: color($theme-link-hover-color);
   }
 
   &:active {
-    color: color($theme-color-link-active);
+    color: color($theme-link-active-color);
   }
 
   &:focus {
@@ -78,7 +78,7 @@ Sets:
   }
 
   &:visited {
-    color: color($theme-color-link-visited);
+    color: color($theme-link-visited-color);
   }
 }
 

--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -113,3 +113,15 @@ $theme-color-disabled-family:  'gray' !default;
 $theme-color-disabled-light:   '#{$theme-color-disabled-family}-10' !default;
 $theme-color-disabled:         '#{$theme-color-disabled-family}-20' !default;
 $theme-color-disabled-dark:    '#{$theme-color-disabled-family}-30' !default;
+
+/*
+----------------------------------------
+General colors
+----------------------------------------
+*/
+
+// Links
+$theme-link-color:                    'primary' !default;
+$theme-link-visited-color:            'violet-70v' !default;
+$theme-link-hover-color:              'primary-darker' !default;
+$theme-link-active-color:             'primary-darker' !default;

--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -113,9 +113,3 @@ $theme-color-disabled-family:  'gray' !default;
 $theme-color-disabled-light:   '#{$theme-color-disabled-family}-10' !default;
 $theme-color-disabled:         '#{$theme-color-disabled-family}-20' !default;
 $theme-color-disabled-dark:    '#{$theme-color-disabled-family}-30' !default;
-
-// Link colors
-$theme-color-link:             'primary' !default;
-$theme-color-link-visited:     'violet-70v' !default;
-$theme-color-link-hover:       'primary-darker' !default;
-$theme-color-link-active:      'primary-darker' !default;

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -12,41 +12,47 @@ USWDS COMPONENT SETTINGS
 */
 
 // Accordion
-$theme-accordion-font-family: 'body' !default;
+$theme-accordion-font-family:         'body' !default;
 
 // Alert
-$theme-alert-font-family: 'ui' !default;
-$theme-alert-measure: 3 !default;
+$theme-alert-font-family:             'ui' !default;
+$theme-alert-measure:                 3 !default;
 
 // Banner
-$theme-banner-font-family: 'ui' !default;
+$theme-banner-font-family:            'ui' !default;
 
 // Button
-$theme-button-font-family: 'ui' !default;
-$theme-button-border-radius: 'md' !default;
-$theme-button-small-width: 6 !default;
+$theme-button-font-family:            'ui' !default;
+$theme-button-border-radius:          'md' !default;
+$theme-button-small-width:            6 !default;
 
 // Footer
-$theme-footer-font-family: 'body' !default;
+$theme-footer-font-family:            'body' !default;
 
 // Form and input
-$theme-checkbox-border-radius: 'sm' !default;
-$theme-form-font-family: 'ui' !default;
-$theme-input-line-height: 3 !default;
-$theme-input-max-width: 'mobile-lg' !default;
+$theme-checkbox-border-radius:        'sm' !default;
+$theme-form-font-family:              'ui' !default;
+$theme-input-line-height:             3 !default;
+$theme-input-max-width:               'mobile-lg' !default;
 
 // Header
-$theme-header-font-family: 'ui' !default;
-$theme-megamenu-logo-text-width: 33% !default;
+$theme-header-font-family:            'ui' !default;
+$theme-megamenu-logo-text-width:      33% !default;
+
+// Links
+$theme-link-color:                    'primary' !default;
+$theme-link-visited-color:            'violet-70v' !default;
+$theme-link-hover-color:              'primary-darker' !default;
+$theme-link-active-color:             'primary-darker' !default;
 
 // Navigation
-$theme-navigation-font-family: 'ui' !default;
-$theme-navigation-width: 'desktop' !default;
+$theme-navigation-font-family:        'ui' !default;
+$theme-navigation-width:              'desktop' !default;
 
 // Search
-$theme-search-font-family: 'ui' !default;
-$theme-search-min-width: 27ch !default;
+$theme-search-font-family:            'ui' !default;
+$theme-search-min-width:              27ch !default;
 
 // Sidenav
-$theme-sidenav-current-border-width: 0.5 !default;
-$theme-sidenav-font-family: 'ui' !default;
+$theme-sidenav-current-border-width:  0.5 !default;
+$theme-sidenav-font-family:           'ui' !default;

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -39,12 +39,6 @@ $theme-input-max-width:               'mobile-lg' !default;
 $theme-header-font-family:            'ui' !default;
 $theme-megamenu-logo-text-width:      33% !default;
 
-// Links
-$theme-link-color:                    'primary' !default;
-$theme-link-visited-color:            'violet-70v' !default;
-$theme-link-hover-color:              'primary-darker' !default;
-$theme-link-active-color:             'primary-darker' !default;
-
 // Navigation
 $theme-navigation-font-family:        'ui' !default;
 $theme-navigation-width:              'desktop' !default;

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -29,10 +29,6 @@ Namespace
 */
 
 $theme-namespace: (
-  'component': (
-    namespace:  'usa-',
-    output:     true,
-  ),
   'grid': (
     namespace:  'grid-',
     output:     true,

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -222,7 +222,7 @@ $theme-font-weight-heavy:         false !default;
 
 /*
 ----------------------------------------
-Defaults
+General typography settings
 ----------------------------------------
 Type scale tokens
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -19,7 +19,7 @@ Setting $theme-respect-user-font-size to
 true sets the root font size to 100% and
 uses ems for media queries
 ----------------------------------------
-$theme-font-size-root only applies when
+$theme-root-font-size only applies when
 $theme-respect-user-font-size is set to
 false.
 
@@ -33,7 +33,7 @@ Accepts true or false
 
 $theme-respect-user-font-size: true !default;
 
-// $theme-font-size-root only applies when
+// $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
 // false.
 
@@ -43,7 +43,7 @@ $theme-respect-user-font-size: true !default;
 
 // Accepts values in px
 
-$theme-font-size-root: 10px !default;
+$theme-root-font-size: 10px !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -115,7 +115,7 @@ $theme-color-disabled:         '#{$theme-color-disabled-family}-20';
 $theme-color-disabled-dark:    '#{$theme-color-disabled-family}-30';
 
 // Link colors
-$theme-color-link:             'primary';
-$theme-color-link-visited:     'violet-70v';
-$theme-color-link-hover:       'primary-darker';
-$theme-color-link-active:      'primary-darker';
+$theme-link-color:             'primary';
+$theme-link-visited-color:     'violet-70v';
+$theme-link-hover-color:       'primary-darker';
+$theme-link-active-color:      'primary-darker';

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -114,7 +114,13 @@ $theme-color-disabled-light:   '#{$theme-color-disabled-family}-10';
 $theme-color-disabled:         '#{$theme-color-disabled-family}-20';
 $theme-color-disabled-dark:    '#{$theme-color-disabled-family}-30';
 
-// Link colors
+/*
+----------------------------------------
+General colors
+----------------------------------------
+*/
+
+// Links
 $theme-link-color:             'primary';
 $theme-link-visited-color:     'violet-70v';
 $theme-link-hover-color:       'primary-darker';

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -39,12 +39,6 @@ $theme-input-max-width:               'mobile-lg';
 $theme-header-font-family:            'ui';
 $theme-megamenu-logo-text-width:      33%;
 
-// Links
-$theme-link-color:                    'primary';
-$theme-link-visited-color:            'violet-70v';
-$theme-link-hover-color:              'primary-darker';
-$theme-link-active-color:             'primary-darker';
-
 // Navigation
 $theme-navigation-font-family:        'ui';
 $theme-navigation-width:              'desktop';

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -12,41 +12,47 @@ USWDS THEME COMPONENT SETTINGS
 */
 
 // Accordion
-$theme-accordion-font-family: 'body';
+$theme-accordion-font-family:         'body';
 
 // Alert
-$theme-alert-font-family: 'ui';
-$theme-alert-measure: 3;
+$theme-alert-font-family:             'ui';
+$theme-alert-measure:                 3;
 
 // Banner
-$theme-banner-font-family: 'ui';
+$theme-banner-font-family:            'ui';
 
 // Button
-$theme-button-font-family: 'ui';
-$theme-button-border-radius: 'md';
-$theme-button-small-width: 6;
+$theme-button-font-family:            'ui';
+$theme-button-border-radius:          'md';
+$theme-button-small-width:            6;
 
 // Footer
-$theme-footer-font-family: 'body';
+$theme-footer-font-family:            'body';
 
 // Form and input
-$theme-checkbox-border-radius: 'sm';
-$theme-form-font-family: 'ui';
-$theme-input-line-height: 3;
-$theme-input-max-width: 'mobile-lg';
+$theme-checkbox-border-radius:        'sm';
+$theme-form-font-family:              'ui';
+$theme-input-line-height:             3;
+$theme-input-max-width:               'mobile-lg';
 
 // Header
-$theme-header-font-family: 'ui';
-$theme-megamenu-logo-text-width: 33%;
+$theme-header-font-family:            'ui';
+$theme-megamenu-logo-text-width:      33%;
+
+// Links
+$theme-link-color:                    'primary';
+$theme-link-visited-color:            'violet-70v';
+$theme-link-hover-color:              'primary-darker';
+$theme-link-active-color:             'primary-darker';
 
 // Navigation
-$theme-navigation-font-family: 'ui';
-$theme-navigation-width: 'desktop';
+$theme-navigation-font-family:        'ui';
+$theme-navigation-width:              'desktop';
 
 // Search
-$theme-search-font-family: 'ui';
-$theme-search-min-width: 27ch;
+$theme-search-font-family:            'ui';
+$theme-search-min-width:              27ch;
 
 // Sidenav
-$theme-sidenav-current-border-width: 0.5;
-$theme-sidenav-font-family: 'ui';
+$theme-sidenav-current-border-width:  0.5;
+$theme-sidenav-font-family:           'ui';

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -19,7 +19,7 @@ Setting $theme-respect-user-font-size to
 true sets the root font size to 100% and
 uses ems for media queries
 ----------------------------------------
-$theme-font-size-root only applies when
+$theme-root-font-size only applies when
 $theme-respect-user-font-size is set to
 false.
 
@@ -33,7 +33,7 @@ Accepts true or false
 
 $theme-respect-user-font-size: true;
 
-// $theme-font-size-root only applies when
+// $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to
 // false.
 
@@ -43,7 +43,7 @@ $theme-respect-user-font-size: true;
 
 // Accepts values in px
 
-$theme-font-size-root: 10px;
+$theme-root-font-size: 10px;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -222,7 +222,7 @@ $theme-font-weight-heavy:         false;
 
 /*
 ----------------------------------------
-Defaults
+General typography settings
 ----------------------------------------
 Type scale tokens
 ----------------------------------------


### PR DESCRIPTION
- ~Removes vars and refs related to changing the component prefix~ Already done in #2785 
- Uses a `$theme-[component]-[property]` naming format for all vars that reference a specific component or type. A var like `$theme-color-primary` stays as is, as, in this case, `color` itself is the type. Examples:
  - `$theme-link-color`
  - `$theme-root-font-size`
  - `$theme-navigation-font-family`
  - `$theme-color-primary-darker`