### PR TITLE
Box-sizing and more vars

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -55,6 +55,7 @@ $accordion-border: units(0.5) solid color('base-lightest');
 .usa-accordion {
   @include accordion-list-styles;
   @include accordion-nested-list;
+  @include border-box-sizing;
   @include typeset($theme-accordion-font-family);
 
   + .usa-accordion,

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -28,6 +28,7 @@ $icon-size: units(4);
 
 .usa-alert {
   @include typeset($theme-alert-font-family);
+  @include border-box-sizing;
 
   background-color: color('base-lightest');
   background-position: $h-padding $h-padding;

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -1,5 +1,6 @@
 .usa-banner {
   @include typeset($theme-banner-font-family);
+  @include border-box-sizing;
   background-color: color('base-lightest');
 
   @include at-media('tablet') {

--- a/src/stylesheets/components/_checklist.scss
+++ b/src/stylesheets/components/_checklist.scss
@@ -24,8 +24,9 @@
 }
 
 .usa-checklist {
-  @include typeset;
   @include add-list-reset;
+  @include border-box-sizing;
+  @include typeset;
   margin: 0;
 }
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -1,6 +1,7 @@
 // General footer styles
 
 .usa-footer {
+  @include border-box-sizing;
   @include typeset($theme-footer-font-family);
   overflow: hidden;
 }

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -4,6 +4,7 @@
     $theme-body-font-size,
     $theme-input-line-height
   );
+  @include border-box-sizing;
 }
 
 .usa-form {

--- a/src/stylesheets/components/_graphic-list.scss
+++ b/src/stylesheets/components/_graphic-list.scss
@@ -2,6 +2,7 @@
 
 .usa-graphic_list {
   @include typeset;
+  @include border-box-sizing;
 
   .usa-graphic_list-row {
     .usa-media_block {

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -29,8 +29,9 @@ $z-index-overlay: 400;
 // ---------------------------------
 
 .usa-header {
-  @include typeset($theme-header-font-family);
   @include clearfix;
+  @include typeset($theme-header-font-family);
+  @include border-box-sizing;
   z-index: z-index($z-index-header);
 
   a {

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -2,6 +2,7 @@
 // ==========================
 
 .usa-hero {
+  @include border-box-sizing;
   @include typeset;
   @include u-padding-y($theme-site-margins-width);
   background-image: url('#{$theme-image-path}/hero.png');

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -35,6 +35,7 @@ $nav-link-arrow-icon-size: 1;
 // ---------------------------------
 
 .usa-navbar {
+  @include border-box-sizing;
   height: units($size-touch-target);
 
   @include at-media-max($theme-navigation-width) {

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -5,6 +5,7 @@
 }
 
 .usa-search {
+  @include border-box-sizing;
   @include clearfix;
   @include typeset($theme-search-font-family);
   position: relative;

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -63,8 +63,9 @@
   }
 }
 
-// Extra specificity to override rules set in reset.css.
+// Extra specificity to override rules set in normalize.css.
 input[type=search] { /* stylelint-disable-line selector-no-qualifying-type */
+  box-sizing: border-box;
   appearance: none;
 }
 
@@ -74,6 +75,7 @@ input[type=search] { /* stylelint-disable-line selector-no-qualifying-type */
   border-bottom-right-radius: 0;
   border-right: none;
   border-top-right-radius: 0;
+  box-sizing: border-box;
   float: left;
   font-size: font-size($theme-search-font-family, 'xs');
   height: units(4);

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -65,7 +65,6 @@
 
 // Extra specificity to override rules set in reset.css.
 input[type=search] { /* stylelint-disable-line selector-no-qualifying-type */
-  box-sizing: border-box;
   appearance: none;
 }
 
@@ -75,7 +74,6 @@ input[type=search] { /* stylelint-disable-line selector-no-qualifying-type */
   border-bottom-right-radius: 0;
   border-right: none;
   border-top-right-radius: 0;
-  box-sizing: border-box;
   float: left;
   font-size: font-size($theme-search-font-family, 'xs');
   height: units(4);

--- a/src/stylesheets/components/_section.scss
+++ b/src/stylesheets/components/_section.scss
@@ -1,4 +1,5 @@
 .usa-section {
+  @include border-box-sizing;
   @include u-padding-y($theme-site-margins-width);
 
   @include at-media('tablet') {

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -1,4 +1,5 @@
 .usa-sidenav {
+  @include border-box-sizing;
   @include nav-list;
   @include typeset($theme-sidenav-font-family, 'sm', 3);
   border-bottom: units(1px) solid color('base-lighter');

--- a/src/stylesheets/components/_skipnav.scss
+++ b/src/stylesheets/components/_skipnav.scss
@@ -1,4 +1,5 @@
 .usa-skipnav {
+  @include border-box-sizing;
   @include typeset;
   background: transparent;
   left: 0;

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -1,7 +1,7 @@
 // Apply a natural box layout model to all elements, but allowing components to
 // change
 
-@if $theme-apply-global-border-box-sizing {
+@if $theme-global-border-box-sizing {
   html {
     box-sizing: border-box;
   }

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -1,14 +1,16 @@
 // Apply a natural box layout model to all elements, but allowing components to
 // change
 
-html {
-  box-sizing: border-box;
-}
+@if $theme-apply-global-border-box-sizing {
+  html {
+    box-sizing: border-box;
+  }
 
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
 }
 
 body {

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -47,6 +47,7 @@
 
 // helper mixins
 @import 'override-prose';
+@import 'use-border-box-styling';
 
 // general mixins
 @import 'add-bar';

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -47,7 +47,7 @@
 
 // helper mixins
 @import 'override-prose';
-@import 'use-border-box-styling';
+@import 'use-border-box-sizing';
 
 // general mixins
 @import 'add-bar';

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -46,8 +46,8 @@
 @import 'utilities/z-index';
 
 // helper mixins
+@import 'border-box-sizing';
 @import 'override-prose';
-@import 'use-border-box-sizing';
 
 // general mixins
 @import 'add-bar';

--- a/src/stylesheets/core/mixins/_border-box-sizing.scss
+++ b/src/stylesheets/core/mixins/_border-box-sizing.scss
@@ -1,4 +1,4 @@
-@mixin use-border-box-sizing {
+@mixin border-box-sizing {
   @if not $theme-apply-global-border-box-sizing {
     box-sizing: border-box;
 
@@ -9,5 +9,11 @@
     & *::before {
       box-sizing: inherit;
     }
+  }
+}
+
+@mixin this-border-box-sizing {
+  @if not $theme-apply-global-border-box-sizing {
+    box-sizing: border-box;
   }
 }

--- a/src/stylesheets/core/mixins/_border-box-sizing.scss
+++ b/src/stylesheets/core/mixins/_border-box-sizing.scss
@@ -1,5 +1,5 @@
 @mixin border-box-sizing {
-  @if not $theme-apply-global-border-box-sizing {
+  @if not $theme-global-border-box-sizing {
     box-sizing: border-box;
 
     &::after,
@@ -13,7 +13,7 @@
 }
 
 @mixin this-border-box-sizing {
-  @if not $theme-apply-global-border-box-sizing {
+  @if not $theme-global-border-box-sizing {
     box-sizing: border-box;
   }
 }

--- a/src/stylesheets/core/mixins/_focus.scss
+++ b/src/stylesheets/core/mixins/_focus.scss
@@ -1,28 +1,28 @@
 // Focus state mixin
 @mixin focus-outline(
-  $width: $theme-width-focus,
-  $style: $theme-style-focus,
-  $color: $theme-color-focus,
-  $offset: $theme-offset-focus,
+  $width: $theme-focus-width,
+  $style: $theme-focus-style,
+  $color: $theme-focus-color,
+  $offset: $theme-focus-offset,
 ) {
   $width: if(
     $width == null,
-    $theme-width-focus,
+    $theme-focus-width,
     $width
   );
   $style: if(
     $style == null,
-    $theme-style-focus,
+    $theme-focus-style,
     $style
   );
   $color: if(
     $color == null,
-    $theme-color-focus,
+    $theme-focus-color,
     $color
   );
   $offset: if(
     $offset == null,
-    $theme-offset-focus,
+    $theme-focus-offset,
     $offset
   );
   outline: units($width) $style color($color);

--- a/src/stylesheets/core/mixins/_layout-grid.scss
+++ b/src/stylesheets/core/mixins/_layout-grid.scss
@@ -11,6 +11,7 @@
     @include u-maxw($props);
   }
   @include add-responsive-site-margins;
+  @include this-border-box-sizing;
 }
 
 @mixin grid-row($props...) {
@@ -18,6 +19,7 @@
   $flex: append-important($grid-global, wrap);
   @include u-display($display);
   @include u-flex($flex);
+  @include this-border-box-sizing;
 }
 
 @mixin grid-gap-responsive {
@@ -43,6 +45,7 @@
   @include u-margin-x( unquote('#{$neg-prefix}-#{calc-gap-offset($gap-mobile)}'));
 
   > * {
+    @include this-border-box-sizing;
     @include u-padding-x(calc-gap-offset($gap-mobile));
   }
 
@@ -50,6 +53,7 @@
     @include u-margin-x( unquote('#{$neg-prefix}-#{calc-gap-offset($gap-desktop)}'));
 
     > * {
+      @include this-border-box-sizing;
       @include u-padding-x(calc-gap-offset($gap-desktop));
     }
   }
@@ -67,6 +71,7 @@
       @include u-margin-x(append-important($props, 0));
 
       > * {
+        @include this-border-box-sizing;
         @include u-padding-x(append-important($props, 0));
       }
     }
@@ -79,6 +84,7 @@
       }
       @include u-margin-x(append-important($props, unquote('#{$neg-prefix}-#{calc-gap-offset($gap)}')));
       > * {
+        @include this-border-box-sizing;
         @include u-padding-x(append-important($props, calc-gap-offset($gap)));
       }
     }
@@ -87,6 +93,8 @@
 
 @mixin grid-col($props...) {
   $props: unpack($props);
+  @include this-border-box-sizing;
+
   @if length($props) == 0 {
     @include u-flex(fill);
     @include u-width(auto);

--- a/src/stylesheets/core/mixins/_use-border-box-sizing.scss
+++ b/src/stylesheets/core/mixins/_use-border-box-sizing.scss
@@ -1,0 +1,13 @@
+@mixin use-border-box-sizing {
+  @if not $theme-apply-global-border-box-sizing {
+    box-sizing: border-box;
+
+    &::after,
+    &::before,
+    & *,
+    & *::after,
+    & *::before {
+    box-sizing: border-box;
+    }
+  }
+}

--- a/src/stylesheets/core/mixins/_use-border-box-sizing.scss
+++ b/src/stylesheets/core/mixins/_use-border-box-sizing.scss
@@ -7,7 +7,7 @@
     & *,
     & *::after,
     & *::before {
-    box-sizing: border-box;
+      box-sizing: inherit;
     }
   }
 }

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -24,6 +24,7 @@ $button-stroke: inset 0 0 0 units(2px);
 
 .usa-button,
 .usa-button:visited {
+  @include border-box-sizing;
   @include typeset($theme-button-font-family, null, 1);
   @include add-knockout-font-smoothing;
   appearance: none;

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -7,7 +7,7 @@ $input-state-border-width: 0.5;
 
 @mixin range-focus {
   background-color: color('white');
-  box-shadow: 0 0 0 units(2px) color($theme-color-focus);
+  box-shadow: 0 0 0 units(2px) color($theme-focus-color);
 }
 
 @mixin range-track {

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -40,6 +40,7 @@ $input-state-border-width: 0.5;
 .usa-select,
 .usa-range,
 .usa-form-hint {
+  @include border-box-sizing;
   @include typeset(
     $theme-form-font-family,
     $theme-body-font-size,

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -55,7 +55,6 @@ $input-state-border-width: 0.5;
   @include u-border(1px, 'base-dark');
   appearance: none;
   border-radius: 0;
-  box-sizing: border-box;
   color: color('ink'); // standardize on firefox
   display: block;
   height: units(5);

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -1,4 +1,5 @@
 %usa-table {
+  @include border-box-sizing;
   @include typeset;
   border-spacing: 0;
   margin: units(2.5) 0;

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -1,4 +1,5 @@
 .usa-tag {
+  @include border-box-sizing;
   @include u-font('ui', '2xs');
   @include u-text('white', 'uppercase');
   background-color: color('base-dark');

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -10,6 +10,14 @@ html {
   }
 }
 
+@if $theme-apply-global-border-box-sizing {
+  *,
+  *::after,
+  *::before {
+    box-sizing: border-box;
+  }
+}
+
 %usa-heading {
   @include typeset-heading;
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -10,14 +10,6 @@ html {
   }
 }
 
-@if $theme-apply-global-border-box-sizing {
-  *,
-  *::after,
-  *::before {
-    box-sizing: border-box;
-  }
-}
-
 %usa-heading {
   @include typeset-heading;
 }

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -53,7 +53,7 @@ property of all site elements to
 ----------------------------------------
 */
 
-$theme-apply-global-border-box-sizing: false !default;
+$theme-apply-global-border-box-sizing: true !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -47,7 +47,7 @@ $theme-namespace: (
 ----------------------------------------
 Border box sizing
 ----------------------------------------
-When set to true, it sets the box-sizing
+When set to true, sets the box-sizing
 property of all site elements to
 `border-box`.
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -53,7 +53,7 @@ property of all site elements to
 ----------------------------------------
 */
 
-$theme-apply-global-border-box-sizing: true !default;
+$theme-global-border-box-sizing: true !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -48,14 +48,12 @@ $theme-namespace: (
 Border box sizing
 ----------------------------------------
 When set to true, it sets the box-sizing
-property of all elements to
+property of all site elements to
 `border-box`.
-
-TODO: How are we using this?
 ----------------------------------------
 */
 
-$border-box-sizing: false !default;
+$theme-apply-global-border-box-sizing: false !default;
 
 /*
 ----------------------------------------
@@ -63,10 +61,10 @@ Focus styles
 ----------------------------------------
 */
 
-$theme-color-focus:  'blue-40v' !default;
-$theme-offset-focus: 0 !default;
-$theme-style-focus:  solid !default;
-$theme-width-focus:  0.5 !default;
+$theme-focus-color:  'blue-40v' !default;
+$theme-focus-offset: 0 !default;
+$theme-focus-style:  solid !default;
+$theme-focus-width:  0.5 !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -53,7 +53,7 @@ property of all site elements to
 ----------------------------------------
 */
 
-$theme-apply-global-border-box-sizing: false;
+$theme-apply-global-border-box-sizing: true;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -7,7 +7,7 @@
 ========================================
 ========================================
 ----------------------------------------
-USWDS THEME GENERAL SETTINGS
+USWDS GENERAL SETTINGS
 ----------------------------------------
 */
 
@@ -48,14 +48,12 @@ $theme-namespace: (
 Border box sizing
 ----------------------------------------
 When set to true, it sets the box-sizing
-property of all elements to
+property of all site elements to
 `border-box`.
-
-TODO: How are we using this?
 ----------------------------------------
 */
 
-$border-box-sizing: false;
+$theme-apply-global-border-box-sizing: false;
 
 /*
 ----------------------------------------
@@ -63,10 +61,10 @@ Focus styles
 ----------------------------------------
 */
 
-$theme-color-focus:  'blue-40v';
-$theme-offset-focus: 0;
-$theme-style-focus:  solid;
-$theme-width-focus:  0.5;
+$theme-focus-color:  'blue-40v';
+$theme-focus-offset: 0;
+$theme-focus-style:  solid;
+$theme-focus-width:  0.5;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -47,7 +47,7 @@ $theme-namespace: (
 ----------------------------------------
 Border box sizing
 ----------------------------------------
-When set to true, it sets the box-sizing
+When set to true, sets the box-sizing
 property of all site elements to
 `border-box`.
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -53,7 +53,7 @@ property of all site elements to
 ----------------------------------------
 */
 
-$theme-apply-global-border-box-sizing: true;
+$theme-global-border-box-sizing: true;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
As I was going through the vars (again) I found a few more that needed to be updated to the new format. One of these was the old Bourbon border-box mixin.

In the sprit of not styling elements and allowing USWDS to exist on legacy sites, I implemented the functionality of this var:

- `$theme-global-border-box-sizing` is a setting. It has the default value of `true`.
- When true, we apply border-box box-sizing at the html level and `*` gets `box-sizing: inherit` as currently implemented
- If false, we do _not_ apply box-sizing at this level and a new mixin I added to all our components (`box-sizing()`) adds this box-sizing rule at the component level. 