### PR TITLE
Allow letter-spacing() function to accept numerical equivalents

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -1063,6 +1063,15 @@ system letter-spacing
 */
 
 @function letter-spacing($value) {
+  $lh-map: map-get($system-properties, letter-spacing);
+  $fn-map: map-get($lh-map, function);
+  @if map-has-key($fn-map, $value) {
+    @return map-get($fn-map, $value);
+  }
+  @if type-of($value) == 'number' {
+    @error '`#{$value}` is a not a valid letter-spacing token. '
+      + 'Valid letter-spacing tokens: #{map-keys($fn-map)}';
+  }
   @return get-uswds-value(letter-spacing, $value);
 }
 

--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -294,6 +294,15 @@ $system-properties: (
       'ls-3':	      .15em,
     ),
     extended: (),
+    function: (
+      'auto':	      initial,
+      -3:	          -.03em,
+      -2:	          -.02em,
+      -1:	          -.01em,
+      1:	          .05em,
+      2:	          .1em,
+      3:	          .15em,
+    ),
   ),
   line-height: (
     standard: (


### PR DESCRIPTION
This is not a terribly elegant solution, but it gets around building another custom function or having some roundabout way of supporting the two ways of expressing letter-spacing:

- utility mixin: `u-text('ls-neg-1')`
- function: `ls(-1)`

The utility itself stays the same: `.text-ls-[token]`