### PR TITLE
Use `system` in palette names; add compile warning switch

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -234,7 +234,7 @@
 
   .usa-footer-contact_info {
     @include at-media('mobile-lg') {
-      @include u-padding-y(units(2));
+      @include u-padding-y(2);
       margin-top: 0;
     }
   }

--- a/src/stylesheets/components/_section.scss
+++ b/src/stylesheets/components/_section.scss
@@ -3,7 +3,7 @@
   @include u-padding-y($theme-site-margins-width);
 
   @include at-media('tablet') {
-    @include u-padding-y(units(8));
+    @include u-padding-y(8);
   }
 }
 

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -779,9 +779,9 @@ functions and mixins.
 
   @if map-has-key($our-extended-values, $quoted-value) {
     @if $theme-show-compile-warnings {
-    @warn '`#{$value}` is an extended USWDS `#{$property}` token. '
-      + 'This is OK, but only components built with standard tokens can be accepted back into the system. '
-      + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
+      @warn '`#{$value}` is an extended USWDS `#{$property}` token. '
+        + 'This is OK, but only components built with standard tokens can be accepted back into the system. '
+        + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
     }
 
     @return map-get($our-extended-values, $quoted-value);

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -481,15 +481,15 @@ withholds certain errors.
 
 @function utility-font($family, $scale) {
   @if not map-has-key($project-cap-heights, $family) {
-    @error '#{$family} is not a valid font family. '
-      + 'Valid values: #{map-keys($project-cap-heights)}';
+    @error '#{$family} is not a valid font family token. '
+      + 'Valid tokens: #{map-keys($project-cap-heights)}';
   }
 
   $quote-scale: smart-quote($scale);
 
   @if not map-get($all-type-scale, $quote-scale) {
-    @error '`#{$scale}` is not a valid font scale. '
-      + 'Valid values: #{map-keys($all-type-scale)}';
+    @error '`#{$scale}` is not a valid font scale token. '
+      + 'Valid tokens: #{map-keys($all-type-scale)}';
   }
 
   $this-cap: map-get($project-cap-heights, $family);
@@ -516,7 +516,7 @@ a family and a line-height scale unit
   $props: unpack($props);
 
   @if not length($props) == 2 {
-    @error 'lh() needs both a valid face and line height unit '
+    @error 'lh() needs both a valid face and line height token '
       + 'in the format `lh(FACE, HEIGHT)`.';
   }
 
@@ -524,13 +524,13 @@ a family and a line-height scale unit
   $scale: smart-quote(nth($props, 2));
 
   @if not map-has-key($project-cap-heights, $family) {
-    @error '#{$family} is not a valid font family. '
-      + 'Valid values: #{map-keys($project-cap-heights)}';
+    @error '#{$family} is not a valid font family token. '
+      + 'Valid tokens: #{map-keys($project-cap-heights)}';
   }
 
   @if not map-get($system-line-height, $scale) {
-    @error '`#{$scale}` is not a valid line-height unit. '
-      + 'Valid values: #{map-keys($system-line-height)}';
+    @error '`#{$scale}` is not a valid line-height token. '
+      + 'Valid tokens: #{map-keys($system-line-height)}';
   }
 
   @if not map-get($project-cap-heights, $family) {
@@ -637,8 +637,8 @@ Get a value from the system type scale
   }
 
   @if not map-has-key($system-type-scale, $scale) {
-    @error '`#{$scale}` is not a valid type scale value. '
-      + 'Valid values: #{map-keys($system-type-scale)}';
+    @error '`#{$scale}` is not a valid type scale token. '
+      + 'Valid tokens: #{map-keys($system-type-scale)}';
   }
 
   @return map-get($system-type-scale, $scale);
@@ -659,14 +659,14 @@ grid.
   $gap-size: smart-quote($gap-size);
 
   @if not map-has-key($spacing-to-value, $gap-size) {
-    @error '`#{$gap-size}` is not a valid USWDS gap size.';
+    @error '`#{$gap-size}` is not a valid USWDS gap size token.';
   }
 
   $numeric-eq: map-get($spacing-to-value, $gap-size);
   $numeric-eq-half: inspect($numeric-eq / 2);
 
   @if not map-has-key($spacing-to-token, $numeric-eq-half) {
-    @error '`#{$gap-size}` is not a valid USWDS gap size. '
+    @error '`#{$gap-size}` is not a valid USWDS gap size token. '
       + 'Column gaps need to have a standard size half their width.';
   }
 
@@ -764,11 +764,12 @@ functions and mixins.
     $output: map-get($our-standard-values, $quoted-value);
 
     @if not $output {
-      // TODO: reinstate
-      // @warn '`#{$value}` is set as a `false` value '
-      //     + 'for the #{$property} property in your project settings '
-      //     + 'and will not output properly. '
-      //     + 'Set the value of `#{$value}` in project settings.';
+      @if $theme-show-compile-warnings {
+        @warn '`#{$value}` is set as a `false` value '
+          + 'for the #{$property} property in your project settings '
+          + 'and will not output properly. '
+          + 'Set the value of `#{$value}` in project settings.';
+      }
 
       @return map-get($our-standard-values, $quoted-value);
     }
@@ -777,25 +778,27 @@ functions and mixins.
   }
 
   @if map-has-key($our-extended-values, $quoted-value) {
-    // TODO: reinstate
-    // @warn '`#{$value}` is an extended USWDS `#{$property}` unit. '
-    //     + 'This is OK, but only components built with standard values can be accepted back into the system. '
-    //     + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
+    @if $theme-show-compile-warnings {
+    @warn '`#{$value}` is an extended USWDS `#{$property}` token. '
+      + 'This is OK, but only components built with standard tokens can be accepted back into the system. '
+      + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
+    }
 
     @return map-get($our-extended-values, $quoted-value);
   }
 
   @if not (type-of($value) == 'number' and not unitless($value)) {
-    @error '`#{$value}` is not a valid `#{$property}` value. '
-      + 'You should correct this. Standard `#{$property}` values: '
+    @error '`#{$value}` is not a valid `#{$property}` token. '
+      + 'You should correct this. Standard `#{$property}` tokens: '
       + ' #{map-keys($our-standard-values)}';
   }
 
-  // TODO: reinstate
-  // @warn '`#{$value}` is not a USWDS `#{$property}` unit. '
-  //     + 'This is OK, but only components built with standard '
-  //     + 'values can be accepted back into the system. '
-  //     + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
+  @if $theme-show-compile-warnings {
+    @warn '`#{$value}` is not a USWDS `#{$property}` token. '
+      + 'This is OK, but only components built with standard '
+      + 'tokens can be accepted back into the system. '
+      + 'Standard `#{$property}` values: #{map-keys($our-standard-values)}';
+  }
 
   @return $value;
 }
@@ -829,7 +832,7 @@ Derive a color from a color shortcode
     }
     @return $our-color;
   }
-  @error '`#{$shortcode}` is not a valid color shortcode.';
+  @error '`#{$shortcode}` is not a valid color token.';
 }
 
 /*
@@ -913,8 +916,8 @@ Derive a color from a color triplet:
     }
   }
   @else {
-    @error '`#{$color-family}` is not a valid theme family. '
-      + 'Valid families: #{map-keys($all-project-colors)}';
+    @error '`#{$color-family}` is not a valid theme family token. '
+      + 'Valid family tokens: #{map-keys($all-project-colors)}';
   }
   @return map-deep-get($all-project-colors, $color-family, $color-grade);
 }
@@ -935,8 +938,8 @@ the desired final units (currently rem)
   );
 
   @if not map-has-key($project-spacing-standard, $converted) {
-    @error '`#{$value}` is not a valid spacing unit. '
-      + 'Valid spacing unit values: '
+    @error '`#{$value}` is not a valid spacing unit token. '
+      + 'Valid spacing unit tokens: '
       + '#{map-keys($project-spacing-standard)}';
   }
 
@@ -987,8 +990,8 @@ border-radii
     @return map-get($all-border-radius, $value);
   }
   @else {
-    @error '`#{$value}` is not a valid border radius value. '
-      + 'Valid values: #{map-keys($all-border-radius)}';
+    @error '`#{$value}` is not a valid border radius token. '
+      + 'Valid tokens: #{map-keys($all-border-radius)}';
   }
 }
 
@@ -1144,12 +1147,12 @@ Get type scale value from a [family] and
   $our-scale: smart-quote($scale);
 
   @if not map-has-key($project-cap-heights, $our-family) {
-    @error '#{$our-family} is not a valid font family. '
-      + 'Valid values: #{map-keys($project-cap-heights)}';
+    @error '#{$our-family} is not a valid font family token. '
+      + 'Valid tokens: #{map-keys($project-cap-heights)}';
   }
   @if not map-get($all-type-scale, $our-scale) {
-    @error '`#{$our-scale}` is not a valid font scale. '
-      + 'Valid values: #{map-keys($all-type-scale)}';
+    @error '`#{$our-scale}` is not a valid font scale token. '
+      + 'Valid token: #{map-keys($all-type-scale)}';
   }
 
   $this-cap: map-get($project-cap-heights, $our-family);

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -89,7 +89,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-title {
@@ -104,7 +104,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-h1 {
@@ -119,7 +119,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-h2 {
@@ -134,7 +134,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-h3 {
@@ -149,7 +149,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-h4 {
@@ -164,7 +164,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-bold);
+  font-weight: fw('bold');
 }
 
 @mixin typeset-h5 {
@@ -179,7 +179,7 @@ Sets:
     $theme-heading-line-height
   );
 
-  font-weight: fw($theme-font-weight-normal);
+  font-weight: fw('normal');
   letter-spacing: ls('ls-1');
   text-transform: uppercase;
 }

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -24,6 +24,17 @@ $theme-image-path:  '../img' !default;
 
 /*
 ----------------------------------------
+Show compile warnings
+----------------------------------------
+Show Sass warnings when functions and
+mixins use nonstanard or false tokens.
+----------------------------------------
+*/
+
+$theme-show-compile-warnings: true !default;
+
+/*
+----------------------------------------
 Namespace
 ----------------------------------------
 */

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -24,6 +24,17 @@ $theme-image-path:  '../img';
 
 /*
 ----------------------------------------
+Show compile warnings
+----------------------------------------
+Show Sass warnings when functions and
+mixins use nonstanard or false tokens.
+----------------------------------------
+*/
+
+$theme-show-compile-warnings: true;
+
+/*
+----------------------------------------
 Namespace
 ----------------------------------------
 */

--- a/src/stylesheets/utilities/palettes/_font-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_font-palettes.scss
@@ -910,11 +910,11 @@ $palette-font-theme-roles-all:(
 
 /*
 ----------------------------------------
-uswds font sizes
+system font sizes
 ----------------------------------------
 */
 
-$palette-font-uswds-mono-micro: (
+$palette-font-system-mono-micro: (
   mono-micro: (
     slug: 'mono-micro',
     isReadable: true,
@@ -922,7 +922,7 @@ $palette-font-uswds-mono-micro: (
   ),
 );
 
-$palette-font-uswds-mono-1: (
+$palette-font-system-mono-1: (
   mono-1: (
     slug: 'mono-1',
     isReadable: true,
@@ -930,7 +930,7 @@ $palette-font-uswds-mono-1: (
   ),
 );
 
-$palette-font-uswds-mono-2: (
+$palette-font-system-mono-2: (
   mono-2: (
     slug: 'mono-2',
     isReadable: true,
@@ -938,7 +938,7 @@ $palette-font-uswds-mono-2: (
   ),
 );
 
-$palette-font-uswds-mono-3: (
+$palette-font-system-mono-3: (
   mono-3: (
     slug: 'mono-3',
     isReadable: true,
@@ -946,7 +946,7 @@ $palette-font-uswds-mono-3: (
   ),
 );
 
-$palette-font-uswds-mono-4: (
+$palette-font-system-mono-4: (
   mono-4: (
     slug: 'mono-4',
     isReadable: true,
@@ -954,7 +954,7 @@ $palette-font-uswds-mono-4: (
   ),
 );
 
-$palette-font-uswds-mono-5: (
+$palette-font-system-mono-5: (
   mono-5: (
     slug: 'mono-5',
     isReadable: true,
@@ -962,7 +962,7 @@ $palette-font-uswds-mono-5: (
   ),
 );
 
-$palette-font-uswds-mono-6: (
+$palette-font-system-mono-6: (
   mono-6: (
     slug: 'mono-6',
     isReadable: true,
@@ -970,7 +970,7 @@ $palette-font-uswds-mono-6: (
   ),
 );
 
-$palette-font-uswds-mono-7: (
+$palette-font-system-mono-7: (
   mono-7: (
     slug: 'mono-7',
     isReadable: true,
@@ -978,7 +978,7 @@ $palette-font-uswds-mono-7: (
   ),
 );
 
-$palette-font-uswds-mono-8: (
+$palette-font-system-mono-8: (
   mono-8: (
     slug: 'mono-8',
     isReadable: true,
@@ -986,7 +986,7 @@ $palette-font-uswds-mono-8: (
   ),
 );
 
-$palette-font-uswds-mono-9: (
+$palette-font-system-mono-9: (
   mono-9: (
     slug: 'mono-9',
     isReadable: true,
@@ -994,7 +994,7 @@ $palette-font-uswds-mono-9: (
   ),
 );
 
-$palette-font-uswds-mono-10: (
+$palette-font-system-mono-10: (
   mono-10: (
     slug: 'mono-10',
     isReadable: true,
@@ -1002,7 +1002,7 @@ $palette-font-uswds-mono-10: (
   ),
 );
 
-$palette-font-uswds-mono-11: (
+$palette-font-system-mono-11: (
   mono-11: (
     slug: 'mono-11',
     isReadable: true,
@@ -1010,7 +1010,7 @@ $palette-font-uswds-mono-11: (
   ),
 );
 
-$palette-font-uswds-mono-12: (
+$palette-font-system-mono-12: (
   mono-12: (
     slug: 'mono-12',
     isReadable: true,
@@ -1018,7 +1018,7 @@ $palette-font-uswds-mono-12: (
   ),
 );
 
-$palette-font-uswds-mono-13: (
+$palette-font-system-mono-13: (
   mono-13: (
     slug: 'mono-13',
     isReadable: true,
@@ -1026,7 +1026,7 @@ $palette-font-uswds-mono-13: (
   ),
 );
 
-$palette-font-uswds-mono-14: (
+$palette-font-system-mono-14: (
   mono-14: (
     slug: 'mono-14',
     isReadable: true,
@@ -1034,7 +1034,7 @@ $palette-font-uswds-mono-14: (
   ),
 );
 
-$palette-font-uswds-mono-15: (
+$palette-font-system-mono-15: (
   mono-15: (
     slug: 'mono-15',
     isReadable: true,
@@ -1042,7 +1042,7 @@ $palette-font-uswds-mono-15: (
   ),
 );
 
-$palette-font-uswds-mono-16: (
+$palette-font-system-mono-16: (
   mono-16: (
     slug: 'mono-16',
     isReadable: true,
@@ -1050,7 +1050,7 @@ $palette-font-uswds-mono-16: (
   ),
 );
 
-$palette-font-uswds-mono-17: (
+$palette-font-system-mono-17: (
   mono-17: (
     slug: 'mono-17',
     isReadable: true,
@@ -1058,7 +1058,7 @@ $palette-font-uswds-mono-17: (
   ),
 );
 
-$palette-font-uswds-mono-18: (
+$palette-font-system-mono-18: (
   mono-18: (
     slug: 'mono-18',
     isReadable: true,
@@ -1066,7 +1066,7 @@ $palette-font-uswds-mono-18: (
   ),
 );
 
-$palette-font-uswds-mono-19: (
+$palette-font-system-mono-19: (
   mono-19: (
     slug: 'mono-19',
     isReadable: true,
@@ -1074,7 +1074,7 @@ $palette-font-uswds-mono-19: (
   ),
 );
 
-$palette-font-uswds-mono-20: (
+$palette-font-system-mono-20: (
   mono-20: (
     slug: 'mono-20',
     isReadable: true,
@@ -1082,47 +1082,47 @@ $palette-font-uswds-mono-20: (
   ),
 );
 
-$palette-font-uswds-mono-sm: map-collect(
-  $palette-font-uswds-mono-micro,
-  $palette-font-uswds-mono-1,
-  $palette-font-uswds-mono-2,
-  $palette-font-uswds-mono-3
+$palette-font-system-mono-sm: map-collect(
+  $palette-font-system-mono-micro,
+  $palette-font-system-mono-1,
+  $palette-font-system-mono-2,
+  $palette-font-system-mono-3
 );
 
-$palette-font-uswds-mono-medium: map-collect(
-  $palette-font-uswds-mono-4,
-  $palette-font-uswds-mono-5,
-  $palette-font-uswds-mono-6,
-  $palette-font-uswds-mono-7,
-  $palette-font-uswds-mono-8
+$palette-font-system-mono-medium: map-collect(
+  $palette-font-system-mono-4,
+  $palette-font-system-mono-5,
+  $palette-font-system-mono-6,
+  $palette-font-system-mono-7,
+  $palette-font-system-mono-8
 );
 
-$palette-font-uswds-mono-lg: map-collect(
-  $palette-font-uswds-mono-9,
-  $palette-font-uswds-mono-10,
-  $palette-font-uswds-mono-11,
-  $palette-font-uswds-mono-12,
-  $palette-font-uswds-mono-13,
-  $palette-font-uswds-mono-14
+$palette-font-system-mono-lg: map-collect(
+  $palette-font-system-mono-9,
+  $palette-font-system-mono-10,
+  $palette-font-system-mono-11,
+  $palette-font-system-mono-12,
+  $palette-font-system-mono-13,
+  $palette-font-system-mono-14
 );
 
-$palette-font-uswds-mono-xlarge: map-collect(
-  $palette-font-uswds-mono-15,
-  $palette-font-uswds-mono-16,
-  $palette-font-uswds-mono-17,
-  $palette-font-uswds-mono-18,
-  $palette-font-uswds-mono-19,
-  $palette-font-uswds-mono-20
+$palette-font-system-mono-xlarge: map-collect(
+  $palette-font-system-mono-15,
+  $palette-font-system-mono-16,
+  $palette-font-system-mono-17,
+  $palette-font-system-mono-18,
+  $palette-font-system-mono-19,
+  $palette-font-system-mono-20
 );
 
-$palette-font-uswds-mono-all: map-collect(
-  $palette-font-uswds-mono-sm,
-  $palette-font-uswds-mono-medium,
-  $palette-font-uswds-mono-lg,
-  $palette-font-uswds-mono-xlarge
+$palette-font-system-mono-all: map-collect(
+  $palette-font-system-mono-sm,
+  $palette-font-system-mono-medium,
+  $palette-font-system-mono-lg,
+  $palette-font-system-mono-xlarge
 );
 
-$palette-font-uswds-sans-micro: (
+$palette-font-system-sans-micro: (
   sans-micro: (
     slug: 'sans-micro',
     isReadable: true,
@@ -1130,7 +1130,7 @@ $palette-font-uswds-sans-micro: (
   ),
 );
 
-$palette-font-uswds-sans-1: (
+$palette-font-system-sans-1: (
   sans-1: (
     slug: 'sans-1',
     isReadable: true,
@@ -1138,7 +1138,7 @@ $palette-font-uswds-sans-1: (
   ),
 );
 
-$palette-font-uswds-sans-2: (
+$palette-font-system-sans-2: (
   sans-2: (
     slug: 'sans-2',
     isReadable: true,
@@ -1146,7 +1146,7 @@ $palette-font-uswds-sans-2: (
   ),
 );
 
-$palette-font-uswds-sans-3: (
+$palette-font-system-sans-3: (
   sans-3: (
     slug: 'sans-3',
     isReadable: true,
@@ -1154,7 +1154,7 @@ $palette-font-uswds-sans-3: (
   ),
 );
 
-$palette-font-uswds-sans-4: (
+$palette-font-system-sans-4: (
   sans-4: (
     slug: 'sans-4',
     isReadable: true,
@@ -1162,7 +1162,7 @@ $palette-font-uswds-sans-4: (
   ),
 );
 
-$palette-font-uswds-sans-5: (
+$palette-font-system-sans-5: (
   sans-5: (
     slug: 'sans-5',
     isReadable: true,
@@ -1170,7 +1170,7 @@ $palette-font-uswds-sans-5: (
   ),
 );
 
-$palette-font-uswds-sans-6: (
+$palette-font-system-sans-6: (
   sans-6: (
     slug: 'sans-6',
     isReadable: true,
@@ -1178,7 +1178,7 @@ $palette-font-uswds-sans-6: (
   ),
 );
 
-$palette-font-uswds-sans-7: (
+$palette-font-system-sans-7: (
   sans-7: (
     slug: 'sans-7',
     isReadable: true,
@@ -1186,7 +1186,7 @@ $palette-font-uswds-sans-7: (
   ),
 );
 
-$palette-font-uswds-sans-8: (
+$palette-font-system-sans-8: (
   sans-8: (
     slug: 'sans-8',
     isReadable: true,
@@ -1194,7 +1194,7 @@ $palette-font-uswds-sans-8: (
   ),
 );
 
-$palette-font-uswds-sans-9: (
+$palette-font-system-sans-9: (
   sans-9: (
     slug: 'sans-9',
     isReadable: true,
@@ -1202,7 +1202,7 @@ $palette-font-uswds-sans-9: (
   ),
 );
 
-$palette-font-uswds-sans-10: (
+$palette-font-system-sans-10: (
   sans-10: (
     slug: 'sans-10',
     isReadable: true,
@@ -1210,7 +1210,7 @@ $palette-font-uswds-sans-10: (
   ),
 );
 
-$palette-font-uswds-sans-11: (
+$palette-font-system-sans-11: (
   sans-11: (
     slug: 'sans-11',
     isReadable: true,
@@ -1218,7 +1218,7 @@ $palette-font-uswds-sans-11: (
   ),
 );
 
-$palette-font-uswds-sans-12: (
+$palette-font-system-sans-12: (
   sans-12: (
     slug: 'sans-12',
     isReadable: true,
@@ -1226,7 +1226,7 @@ $palette-font-uswds-sans-12: (
   ),
 );
 
-$palette-font-uswds-sans-13: (
+$palette-font-system-sans-13: (
   sans-13: (
     slug: 'sans-13',
     isReadable: true,
@@ -1234,7 +1234,7 @@ $palette-font-uswds-sans-13: (
   ),
 );
 
-$palette-font-uswds-sans-14: (
+$palette-font-system-sans-14: (
   sans-14: (
     slug: 'sans-14',
     isReadable: true,
@@ -1242,7 +1242,7 @@ $palette-font-uswds-sans-14: (
   ),
 );
 
-$palette-font-uswds-sans-15: (
+$palette-font-system-sans-15: (
   sans-15: (
     slug: 'sans-15',
     isReadable: true,
@@ -1250,7 +1250,7 @@ $palette-font-uswds-sans-15: (
   ),
 );
 
-$palette-font-uswds-sans-16: (
+$palette-font-system-sans-16: (
   sans-16: (
     slug: 'sans-16',
     isReadable: true,
@@ -1258,7 +1258,7 @@ $palette-font-uswds-sans-16: (
   ),
 );
 
-$palette-font-uswds-sans-17: (
+$palette-font-system-sans-17: (
   sans-17: (
     slug: 'sans-17',
     isReadable: true,
@@ -1266,7 +1266,7 @@ $palette-font-uswds-sans-17: (
   ),
 );
 
-$palette-font-uswds-sans-18: (
+$palette-font-system-sans-18: (
   sans-18: (
     slug: 'sans-18',
     isReadable: true,
@@ -1274,7 +1274,7 @@ $palette-font-uswds-sans-18: (
   ),
 );
 
-$palette-font-uswds-sans-19: (
+$palette-font-system-sans-19: (
   sans-19: (
     slug: 'sans-19',
     isReadable: true,
@@ -1282,7 +1282,7 @@ $palette-font-uswds-sans-19: (
   ),
 );
 
-$palette-font-uswds-sans-20: (
+$palette-font-system-sans-20: (
   sans-20: (
     slug: 'sans-20',
     isReadable: true,
@@ -1290,47 +1290,47 @@ $palette-font-uswds-sans-20: (
   ),
 );
 
-$palette-font-uswds-sans-sm: map-collect(
-  $palette-font-uswds-sans-micro,
-  $palette-font-uswds-sans-1,
-  $palette-font-uswds-sans-2,
-  $palette-font-uswds-sans-3
+$palette-font-system-sans-sm: map-collect(
+  $palette-font-system-sans-micro,
+  $palette-font-system-sans-1,
+  $palette-font-system-sans-2,
+  $palette-font-system-sans-3
 );
 
-$palette-font-uswds-sans-medium: map-collect(
-  $palette-font-uswds-sans-4,
-  $palette-font-uswds-sans-5,
-  $palette-font-uswds-sans-6,
-  $palette-font-uswds-sans-7,
-  $palette-font-uswds-sans-8
+$palette-font-system-sans-medium: map-collect(
+  $palette-font-system-sans-4,
+  $palette-font-system-sans-5,
+  $palette-font-system-sans-6,
+  $palette-font-system-sans-7,
+  $palette-font-system-sans-8
 );
 
-$palette-font-uswds-sans-lg: map-collect(
-  $palette-font-uswds-sans-9,
-  $palette-font-uswds-sans-10,
-  $palette-font-uswds-sans-11,
-  $palette-font-uswds-sans-12,
-  $palette-font-uswds-sans-13,
-  $palette-font-uswds-sans-14
+$palette-font-system-sans-lg: map-collect(
+  $palette-font-system-sans-9,
+  $palette-font-system-sans-10,
+  $palette-font-system-sans-11,
+  $palette-font-system-sans-12,
+  $palette-font-system-sans-13,
+  $palette-font-system-sans-14
 );
 
-$palette-font-uswds-sans-xlarge: map-collect(
-  $palette-font-uswds-sans-15,
-  $palette-font-uswds-sans-16,
-  $palette-font-uswds-sans-17,
-  $palette-font-uswds-sans-18,
-  $palette-font-uswds-sans-19,
-  $palette-font-uswds-sans-20
+$palette-font-system-sans-xlarge: map-collect(
+  $palette-font-system-sans-15,
+  $palette-font-system-sans-16,
+  $palette-font-system-sans-17,
+  $palette-font-system-sans-18,
+  $palette-font-system-sans-19,
+  $palette-font-system-sans-20
 );
 
-$palette-font-uswds-sans-all: map-collect(
-  $palette-font-uswds-sans-sm,
-  $palette-font-uswds-sans-medium,
-  $palette-font-uswds-sans-lg,
-  $palette-font-uswds-sans-xlarge
+$palette-font-system-sans-all: map-collect(
+  $palette-font-system-sans-sm,
+  $palette-font-system-sans-medium,
+  $palette-font-system-sans-lg,
+  $palette-font-system-sans-xlarge
 );
 
-$palette-font-uswds-serif-micro: (
+$palette-font-system-serif-micro: (
   serif-micro: (
     slug: 'serif-micro',
     isReadable: true,
@@ -1338,7 +1338,7 @@ $palette-font-uswds-serif-micro: (
   ),
 );
 
-$palette-font-uswds-serif-1: (
+$palette-font-system-serif-1: (
   serif-1: (
     slug: 'serif-1',
     isReadable: true,
@@ -1346,7 +1346,7 @@ $palette-font-uswds-serif-1: (
   ),
 );
 
-$palette-font-uswds-serif-2: (
+$palette-font-system-serif-2: (
   serif-2: (
     slug: 'serif-2',
     isReadable: true,
@@ -1354,7 +1354,7 @@ $palette-font-uswds-serif-2: (
   ),
 );
 
-$palette-font-uswds-serif-3: (
+$palette-font-system-serif-3: (
   serif-3: (
     slug: 'serif-3',
     isReadable: true,
@@ -1362,7 +1362,7 @@ $palette-font-uswds-serif-3: (
   ),
 );
 
-$palette-font-uswds-serif-4: (
+$palette-font-system-serif-4: (
   serif-4: (
     slug: 'serif-4',
     isReadable: true,
@@ -1370,7 +1370,7 @@ $palette-font-uswds-serif-4: (
   ),
 );
 
-$palette-font-uswds-serif-5: (
+$palette-font-system-serif-5: (
   serif-5: (
     slug: 'serif-5',
     isReadable: true,
@@ -1378,7 +1378,7 @@ $palette-font-uswds-serif-5: (
   ),
 );
 
-$palette-font-uswds-serif-6: (
+$palette-font-system-serif-6: (
   serif-6: (
     slug: 'serif-6',
     isReadable: true,
@@ -1386,7 +1386,7 @@ $palette-font-uswds-serif-6: (
   ),
 );
 
-$palette-font-uswds-serif-7: (
+$palette-font-system-serif-7: (
   serif-7: (
     slug: 'serif-7',
     isReadable: true,
@@ -1394,7 +1394,7 @@ $palette-font-uswds-serif-7: (
   ),
 );
 
-$palette-font-uswds-serif-8: (
+$palette-font-system-serif-8: (
   serif-8: (
     slug: 'serif-8',
     isReadable: true,
@@ -1402,7 +1402,7 @@ $palette-font-uswds-serif-8: (
   ),
 );
 
-$palette-font-uswds-serif-9: (
+$palette-font-system-serif-9: (
   serif-9: (
     slug: 'serif-9',
     isReadable: true,
@@ -1410,7 +1410,7 @@ $palette-font-uswds-serif-9: (
   ),
 );
 
-$palette-font-uswds-serif-10: (
+$palette-font-system-serif-10: (
   serif-10: (
     slug: 'serif-10',
     isReadable: true,
@@ -1418,7 +1418,7 @@ $palette-font-uswds-serif-10: (
   ),
 );
 
-$palette-font-uswds-serif-11: (
+$palette-font-system-serif-11: (
   serif-11: (
     slug: 'serif-11',
     isReadable: true,
@@ -1426,7 +1426,7 @@ $palette-font-uswds-serif-11: (
   ),
 );
 
-$palette-font-uswds-serif-12: (
+$palette-font-system-serif-12: (
   serif-12: (
     slug: 'serif-12',
     isReadable: true,
@@ -1434,7 +1434,7 @@ $palette-font-uswds-serif-12: (
   ),
 );
 
-$palette-font-uswds-serif-13: (
+$palette-font-system-serif-13: (
   serif-13: (
     slug: 'serif-13',
     isReadable: true,
@@ -1442,7 +1442,7 @@ $palette-font-uswds-serif-13: (
   ),
 );
 
-$palette-font-uswds-serif-14: (
+$palette-font-system-serif-14: (
   serif-14: (
     slug: 'serif-14',
     isReadable: true,
@@ -1450,7 +1450,7 @@ $palette-font-uswds-serif-14: (
   ),
 );
 
-$palette-font-uswds-serif-15: (
+$palette-font-system-serif-15: (
   serif-15: (
     slug: 'serif-15',
     isReadable: true,
@@ -1458,7 +1458,7 @@ $palette-font-uswds-serif-15: (
   ),
 );
 
-$palette-font-uswds-serif-16: (
+$palette-font-system-serif-16: (
   serif-16: (
     slug: 'serif-16',
     isReadable: true,
@@ -1466,7 +1466,7 @@ $palette-font-uswds-serif-16: (
   ),
 );
 
-$palette-font-uswds-serif-17: (
+$palette-font-system-serif-17: (
   serif-17: (
     slug: 'serif-17',
     isReadable: true,
@@ -1474,7 +1474,7 @@ $palette-font-uswds-serif-17: (
   ),
 );
 
-$palette-font-uswds-serif-18: (
+$palette-font-system-serif-18: (
   serif-18: (
     slug: 'serif-18',
     isReadable: true,
@@ -1482,7 +1482,7 @@ $palette-font-uswds-serif-18: (
   ),
 );
 
-$palette-font-uswds-serif-19: (
+$palette-font-system-serif-19: (
   serif-19: (
     slug: 'serif-19',
     isReadable: true,
@@ -1490,7 +1490,7 @@ $palette-font-uswds-serif-19: (
   ),
 );
 
-$palette-font-uswds-serif-20: (
+$palette-font-system-serif-20: (
   serif-20: (
     slug: 'serif-20',
     isReadable: true,
@@ -1498,137 +1498,137 @@ $palette-font-uswds-serif-20: (
   ),
 );
 
-$palette-font-uswds-serif-sm: map-collect(
-  $palette-font-uswds-serif-micro,
-  $palette-font-uswds-serif-1,
-  $palette-font-uswds-serif-2,
-  $palette-font-uswds-serif-3
+$palette-font-system-serif-sm: map-collect(
+  $palette-font-system-serif-micro,
+  $palette-font-system-serif-1,
+  $palette-font-system-serif-2,
+  $palette-font-system-serif-3
 );
 
-$palette-font-uswds-serif-medium: map-collect(
-  $palette-font-uswds-serif-4,
-  $palette-font-uswds-serif-5,
-  $palette-font-uswds-serif-6,
-  $palette-font-uswds-serif-7,
-  $palette-font-uswds-serif-8
+$palette-font-system-serif-medium: map-collect(
+  $palette-font-system-serif-4,
+  $palette-font-system-serif-5,
+  $palette-font-system-serif-6,
+  $palette-font-system-serif-7,
+  $palette-font-system-serif-8
 );
 
-$palette-font-uswds-serif-lg: map-collect(
-  $palette-font-uswds-serif-9,
-  $palette-font-uswds-serif-10,
-  $palette-font-uswds-serif-11,
-  $palette-font-uswds-serif-12,
-  $palette-font-uswds-serif-13,
-  $palette-font-uswds-serif-14
+$palette-font-system-serif-lg: map-collect(
+  $palette-font-system-serif-9,
+  $palette-font-system-serif-10,
+  $palette-font-system-serif-11,
+  $palette-font-system-serif-12,
+  $palette-font-system-serif-13,
+  $palette-font-system-serif-14
 );
 
-$palette-font-uswds-serif-xlarge: map-collect(
-  $palette-font-uswds-serif-15,
-  $palette-font-uswds-serif-16,
-  $palette-font-uswds-serif-17,
-  $palette-font-uswds-serif-18,
-  $palette-font-uswds-serif-19,
-  $palette-font-uswds-serif-20
+$palette-font-system-serif-xlarge: map-collect(
+  $palette-font-system-serif-15,
+  $palette-font-system-serif-16,
+  $palette-font-system-serif-17,
+  $palette-font-system-serif-18,
+  $palette-font-system-serif-19,
+  $palette-font-system-serif-20
 );
 
-$palette-font-uswds-serif-all: map-collect(
-  $palette-font-uswds-serif-sm,
-  $palette-font-uswds-serif-medium,
-  $palette-font-uswds-serif-lg,
-  $palette-font-uswds-serif-xlarge
+$palette-font-system-serif-all: map-collect(
+  $palette-font-system-serif-sm,
+  $palette-font-system-serif-medium,
+  $palette-font-system-serif-lg,
+  $palette-font-system-serif-xlarge
 );
 
-$palette-font-uswds-mono:(
-  'palette-font-uswds-mono-micro':  $palette-font-uswds-mono-micro,
-  'palette-font-uswds-mono-1':      $palette-font-uswds-mono-1,
-  'palette-font-uswds-mono-2':      $palette-font-uswds-mono-2,
-  'palette-font-uswds-mono-3':      $palette-font-uswds-mono-3,
-  'palette-font-uswds-mono-4':      $palette-font-uswds-mono-4,
-  'palette-font-uswds-mono-5':      $palette-font-uswds-mono-5,
-  'palette-font-uswds-mono-6':      $palette-font-uswds-mono-6,
-  'palette-font-uswds-mono-7':      $palette-font-uswds-mono-7,
-  'palette-font-uswds-mono-8':      $palette-font-uswds-mono-8,
-  'palette-font-uswds-mono-9':      $palette-font-uswds-mono-9,
-  'palette-font-uswds-mono-10':     $palette-font-uswds-mono-10,
-  'palette-font-uswds-mono-11':     $palette-font-uswds-mono-11,
-  'palette-font-uswds-mono-12':     $palette-font-uswds-mono-12,
-  'palette-font-uswds-mono-13':     $palette-font-uswds-mono-13,
-  'palette-font-uswds-mono-14':     $palette-font-uswds-mono-14,
-  'palette-font-uswds-mono-15':     $palette-font-uswds-mono-15,
-  'palette-font-uswds-mono-16':     $palette-font-uswds-mono-16,
-  'palette-font-uswds-mono-17':     $palette-font-uswds-mono-17,
-  'palette-font-uswds-mono-18':     $palette-font-uswds-mono-18,
-  'palette-font-uswds-mono-19':     $palette-font-uswds-mono-19,
-  'palette-font-uswds-mono-20':     $palette-font-uswds-mono-20,
-  'palette-font-uswds-mono-sm':     $palette-font-uswds-mono-sm,
-  'palette-font-uswds-mono-medium': $palette-font-uswds-mono-medium,
-  'palette-font-uswds-mono-lg':     $palette-font-uswds-mono-lg,
-  'palette-font-uswds-mono-xlarge': $palette-font-uswds-mono-xlarge,
-  'palette-font-uswds-mono-all':    $palette-font-uswds-mono-all,
+$palette-font-system-mono:(
+  'palette-font-system-mono-micro':  $palette-font-system-mono-micro,
+  'palette-font-system-mono-1':      $palette-font-system-mono-1,
+  'palette-font-system-mono-2':      $palette-font-system-mono-2,
+  'palette-font-system-mono-3':      $palette-font-system-mono-3,
+  'palette-font-system-mono-4':      $palette-font-system-mono-4,
+  'palette-font-system-mono-5':      $palette-font-system-mono-5,
+  'palette-font-system-mono-6':      $palette-font-system-mono-6,
+  'palette-font-system-mono-7':      $palette-font-system-mono-7,
+  'palette-font-system-mono-8':      $palette-font-system-mono-8,
+  'palette-font-system-mono-9':      $palette-font-system-mono-9,
+  'palette-font-system-mono-10':     $palette-font-system-mono-10,
+  'palette-font-system-mono-11':     $palette-font-system-mono-11,
+  'palette-font-system-mono-12':     $palette-font-system-mono-12,
+  'palette-font-system-mono-13':     $palette-font-system-mono-13,
+  'palette-font-system-mono-14':     $palette-font-system-mono-14,
+  'palette-font-system-mono-15':     $palette-font-system-mono-15,
+  'palette-font-system-mono-16':     $palette-font-system-mono-16,
+  'palette-font-system-mono-17':     $palette-font-system-mono-17,
+  'palette-font-system-mono-18':     $palette-font-system-mono-18,
+  'palette-font-system-mono-19':     $palette-font-system-mono-19,
+  'palette-font-system-mono-20':     $palette-font-system-mono-20,
+  'palette-font-system-mono-sm':     $palette-font-system-mono-sm,
+  'palette-font-system-mono-medium': $palette-font-system-mono-medium,
+  'palette-font-system-mono-lg':     $palette-font-system-mono-lg,
+  'palette-font-system-mono-xlarge': $palette-font-system-mono-xlarge,
+  'palette-font-system-mono-all':    $palette-font-system-mono-all,
 );
 
-$palette-font-uswds-sans:(
-  'palette-font-uswds-sans-micro':  $palette-font-uswds-sans-micro,
-  'palette-font-uswds-sans-1':      $palette-font-uswds-sans-1,
-  'palette-font-uswds-sans-2':      $palette-font-uswds-sans-2,
-  'palette-font-uswds-sans-3':      $palette-font-uswds-sans-3,
-  'palette-font-uswds-sans-4':      $palette-font-uswds-sans-4,
-  'palette-font-uswds-sans-5':      $palette-font-uswds-sans-5,
-  'palette-font-uswds-sans-6':      $palette-font-uswds-sans-6,
-  'palette-font-uswds-sans-7':      $palette-font-uswds-sans-7,
-  'palette-font-uswds-sans-8':      $palette-font-uswds-sans-8,
-  'palette-font-uswds-sans-9':      $palette-font-uswds-sans-9,
-  'palette-font-uswds-sans-10':     $palette-font-uswds-sans-10,
-  'palette-font-uswds-sans-11':     $palette-font-uswds-sans-11,
-  'palette-font-uswds-sans-12':     $palette-font-uswds-sans-12,
-  'palette-font-uswds-sans-13':     $palette-font-uswds-sans-13,
-  'palette-font-uswds-sans-14':     $palette-font-uswds-sans-14,
-  'palette-font-uswds-sans-15':     $palette-font-uswds-sans-15,
-  'palette-font-uswds-sans-16':     $palette-font-uswds-sans-16,
-  'palette-font-uswds-sans-17':     $palette-font-uswds-sans-17,
-  'palette-font-uswds-sans-18':     $palette-font-uswds-sans-18,
-  'palette-font-uswds-sans-19':     $palette-font-uswds-sans-19,
-  'palette-font-uswds-sans-20':     $palette-font-uswds-sans-20,
-  'palette-font-uswds-sans-sm':     $palette-font-uswds-sans-sm,
-  'palette-font-uswds-sans-medium': $palette-font-uswds-sans-medium,
-  'palette-font-uswds-sans-lg':     $palette-font-uswds-sans-lg,
-  'palette-font-uswds-sans-xlarge': $palette-font-uswds-sans-xlarge,
-  'palette-font-uswds-sans-all':    $palette-font-uswds-sans-all,
+$palette-font-system-sans:(
+  'palette-font-system-sans-micro':  $palette-font-system-sans-micro,
+  'palette-font-system-sans-1':      $palette-font-system-sans-1,
+  'palette-font-system-sans-2':      $palette-font-system-sans-2,
+  'palette-font-system-sans-3':      $palette-font-system-sans-3,
+  'palette-font-system-sans-4':      $palette-font-system-sans-4,
+  'palette-font-system-sans-5':      $palette-font-system-sans-5,
+  'palette-font-system-sans-6':      $palette-font-system-sans-6,
+  'palette-font-system-sans-7':      $palette-font-system-sans-7,
+  'palette-font-system-sans-8':      $palette-font-system-sans-8,
+  'palette-font-system-sans-9':      $palette-font-system-sans-9,
+  'palette-font-system-sans-10':     $palette-font-system-sans-10,
+  'palette-font-system-sans-11':     $palette-font-system-sans-11,
+  'palette-font-system-sans-12':     $palette-font-system-sans-12,
+  'palette-font-system-sans-13':     $palette-font-system-sans-13,
+  'palette-font-system-sans-14':     $palette-font-system-sans-14,
+  'palette-font-system-sans-15':     $palette-font-system-sans-15,
+  'palette-font-system-sans-16':     $palette-font-system-sans-16,
+  'palette-font-system-sans-17':     $palette-font-system-sans-17,
+  'palette-font-system-sans-18':     $palette-font-system-sans-18,
+  'palette-font-system-sans-19':     $palette-font-system-sans-19,
+  'palette-font-system-sans-20':     $palette-font-system-sans-20,
+  'palette-font-system-sans-sm':     $palette-font-system-sans-sm,
+  'palette-font-system-sans-medium': $palette-font-system-sans-medium,
+  'palette-font-system-sans-lg':     $palette-font-system-sans-lg,
+  'palette-font-system-sans-xlarge': $palette-font-system-sans-xlarge,
+  'palette-font-system-sans-all':    $palette-font-system-sans-all,
 );
 
-$palette-font-uswds-serif:(
-  'palette-font-uswds-serif-micro':  $palette-font-uswds-serif-micro,
-  'palette-font-uswds-serif-1':      $palette-font-uswds-serif-1,
-  'palette-font-uswds-serif-2':      $palette-font-uswds-serif-2,
-  'palette-font-uswds-serif-3':      $palette-font-uswds-serif-3,
-  'palette-font-uswds-serif-4':      $palette-font-uswds-serif-4,
-  'palette-font-uswds-serif-5':      $palette-font-uswds-serif-5,
-  'palette-font-uswds-serif-6':      $palette-font-uswds-serif-6,
-  'palette-font-uswds-serif-7':      $palette-font-uswds-serif-7,
-  'palette-font-uswds-serif-8':      $palette-font-uswds-serif-8,
-  'palette-font-uswds-serif-9':      $palette-font-uswds-serif-9,
-  'palette-font-uswds-serif-10':     $palette-font-uswds-serif-10,
-  'palette-font-uswds-serif-11':     $palette-font-uswds-serif-11,
-  'palette-font-uswds-serif-12':     $palette-font-uswds-serif-12,
-  'palette-font-uswds-serif-13':     $palette-font-uswds-serif-13,
-  'palette-font-uswds-serif-14':     $palette-font-uswds-serif-14,
-  'palette-font-uswds-serif-15':     $palette-font-uswds-serif-15,
-  'palette-font-uswds-serif-16':     $palette-font-uswds-serif-16,
-  'palette-font-uswds-serif-17':     $palette-font-uswds-serif-17,
-  'palette-font-uswds-serif-18':     $palette-font-uswds-serif-18,
-  'palette-font-uswds-serif-19':     $palette-font-uswds-serif-19,
-  'palette-font-uswds-serif-20':     $palette-font-uswds-serif-20,
-  'palette-font-uswds-serif-sm':     $palette-font-uswds-serif-sm,
-  'palette-font-uswds-serif-medium': $palette-font-uswds-serif-medium,
-  'palette-font-uswds-serif-lg':     $palette-font-uswds-serif-lg,
-  'palette-font-uswds-serif-xlarge': $palette-font-uswds-serif-xlarge,
-  'palette-font-uswds-serif-all':    $palette-font-uswds-serif-all,
+$palette-font-system-serif:(
+  'palette-font-system-serif-micro':  $palette-font-system-serif-micro,
+  'palette-font-system-serif-1':      $palette-font-system-serif-1,
+  'palette-font-system-serif-2':      $palette-font-system-serif-2,
+  'palette-font-system-serif-3':      $palette-font-system-serif-3,
+  'palette-font-system-serif-4':      $palette-font-system-serif-4,
+  'palette-font-system-serif-5':      $palette-font-system-serif-5,
+  'palette-font-system-serif-6':      $palette-font-system-serif-6,
+  'palette-font-system-serif-7':      $palette-font-system-serif-7,
+  'palette-font-system-serif-8':      $palette-font-system-serif-8,
+  'palette-font-system-serif-9':      $palette-font-system-serif-9,
+  'palette-font-system-serif-10':     $palette-font-system-serif-10,
+  'palette-font-system-serif-11':     $palette-font-system-serif-11,
+  'palette-font-system-serif-12':     $palette-font-system-serif-12,
+  'palette-font-system-serif-13':     $palette-font-system-serif-13,
+  'palette-font-system-serif-14':     $palette-font-system-serif-14,
+  'palette-font-system-serif-15':     $palette-font-system-serif-15,
+  'palette-font-system-serif-16':     $palette-font-system-serif-16,
+  'palette-font-system-serif-17':     $palette-font-system-serif-17,
+  'palette-font-system-serif-18':     $palette-font-system-serif-18,
+  'palette-font-system-serif-19':     $palette-font-system-serif-19,
+  'palette-font-system-serif-20':     $palette-font-system-serif-20,
+  'palette-font-system-serif-sm':     $palette-font-system-serif-sm,
+  'palette-font-system-serif-medium': $palette-font-system-serif-medium,
+  'palette-font-system-serif-lg':     $palette-font-system-serif-lg,
+  'palette-font-system-serif-xlarge': $palette-font-system-serif-xlarge,
+  'palette-font-system-serif-all':    $palette-font-system-serif-all,
 );
 
-$palette-font-uswds-all: (
-  'palette-font-uswds-all': map-collect(
-    $palette-font-uswds-mono-all,
-    $palette-font-uswds-sans-all,
-    $palette-font-uswds-serif-all
+$palette-font-system-all: (
+  'palette-font-system-all': map-collect(
+    $palette-font-system-mono-all,
+    $palette-font-system-sans-all,
+    $palette-font-system-serif-all
   ),
 );

--- a/src/stylesheets/utilities/palettes/_palette-registry.scss
+++ b/src/stylesheets/utilities/palettes/_palette-registry.scss
@@ -9,16 +9,16 @@ available utility palettes
 
 $palette-registry: map-collect(
   $palette-spacing-units,
-  $palette-spacing-uswds,
+  $palette-spacing-system,
   $palette-font-theme-mono,
   $palette-font-theme-sans,
   $palette-font-theme-serif,
   $palette-font-theme-all,
   $palette-font-theme-roles-all,
-  $palette-font-uswds-mono,
-  $palette-font-uswds-sans,
-  $palette-font-uswds-serif,
-  $palette-font-uswds-all,
+  $palette-font-system-mono,
+  $palette-font-system-sans,
+  $palette-font-system-serif,
+  $palette-font-system-all,
   $palette-font-misc,
   $palette-all-color-palettes,
   $palette-black-transparent,
@@ -46,6 +46,6 @@ $palette-registry: map-collect(
   $palette-violet,
   $palette-white-transparent,
   $palette-yellow,
-  $palette-colors-uswds-all,
+  $palette-colors-system-all,
   $palette-standard
 );

--- a/src/stylesheets/utilities/palettes/_spacing-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_spacing-palettes.scss
@@ -8,16 +8,16 @@ in utilities
 ----------------------------------------
 */
 
-$palette-spacing-uswds:(
-  'palette-spacing-uswds-smaller': map-get($system-spacing, smaller),
-  'palette-spacing-uswds-small':   map-get($system-spacing, small),
-  'palette-spacing-uswds-medium':  map-get($system-spacing, medium),
-  'palette-spacing-uswds-large':   map-get($system-spacing, large),
-  'palette-spacing-uswds-larger':  map-get($system-spacing, larger),
-  'palette-spacing-uswds-largest': map-get($system-spacing, largest),
-  'palette-spacing-uswds-smaller-negative': map-get($system-spacing, smaller-negative),
-  'palette-spacing-uswds-small-negative': map-get($system-spacing, small-negative),
-  'palette-spacing-uswds-all': map-collect(
+$palette-spacing-system:(
+  'palette-spacing-system-smaller': map-get($system-spacing, smaller),
+  'palette-spacing-system-small':   map-get($system-spacing, small),
+  'palette-spacing-system-medium':  map-get($system-spacing, medium),
+  'palette-spacing-system-large':   map-get($system-spacing, large),
+  'palette-spacing-system-larger':  map-get($system-spacing, larger),
+  'palette-spacing-system-largest': map-get($system-spacing, largest),
+  'palette-spacing-system-smaller-negative': map-get($system-spacing, smaller-negative),
+  'palette-spacing-system-small-negative': map-get($system-spacing, small-negative),
+  'palette-spacing-system-all': map-collect(
     map-get($system-spacing, smaller),
     map-get($system-spacing, small),
     map-get($system-spacing, medium),
@@ -25,11 +25,11 @@ $palette-spacing-uswds:(
     map-get($system-spacing, larger),
     map-get($system-spacing, largest)
   ),
-  'palette-spacing-uswds-negative': map-collect(
+  'palette-spacing-system-negative': map-collect(
     map-get($system-spacing, smaller-negative),
     map-get($system-spacing, small-negative)
   ),
-  'palette-spacing-uswds-breakpoints': map-collect(
+  'palette-spacing-system-breakpoints': map-collect(
     map-get($system-spacing, large),
     map-get($system-spacing, larger),
     map-get($system-spacing, largest)

--- a/src/stylesheets/utilities/palettes/colors/_all-colors-palettes.scss
+++ b/src/stylesheets/utilities/palettes/colors/_all-colors-palettes.scss
@@ -1,5 +1,5 @@
-$palette-colors-uswds-all: (
-  'palette-colors-uswds-all': map-collect(
+$palette-colors-system-all: (
+  'palette-colors-system-all': map-collect(
     $palette-black-transparent-all,
     $palette-gray-cool-all,
     $palette-gray-all,


### PR DESCRIPTION
- Use `system` instead of `uswds` in palette names (ex: `$palette-font-system-mono-micro`) to sync with our naming convention
- Use `token` instead of `value` in compile erros to sync with our naming contenvtion
- Add `$theme-show-compile-warnings` (default: `true`) to show compile warnings when using false or nonstandard tokens
- Fix all compile warnings in our code

- - -

Fixes #2808 
Fixes #2825