### PR TITLE
Remove object namespace

### DIFF
--- a/src/stylesheets/core/mixins/_utility-builder.scss
+++ b/src/stylesheets/core/mixins/_utility-builder.scss
@@ -17,12 +17,11 @@ loop
     null
   );
   $this-mq: null;
-  $this-type: map-get($utility, type);
 
   @if $mq {
     $this-mq: '#{$mq}\\:';
   }
-  .#{$this-mq}#{$pseudoclass}\:#{ns($this-type)}#{$selector}:#{$pseudoclass} {
+  .#{$this-mq}#{$pseudoclass}\:#{ns('utility')}#{$selector}:#{$pseudoclass} {
     @each $this-property in $property {
       #{$this-property}: unquote('#{$value}#{$important}');
     }
@@ -54,7 +53,6 @@ loop
   );
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
   $mq: null;
-  $this-type: map-get($utility, type);
   $value-is-map: if(
     type-of($val-props) == 'map',
     true,
@@ -67,7 +65,7 @@ loop
 
     @if map-get($theme-utility-breakpoints, $media-key) {
       @include at-media($media-key) {
-        .#{$mq}\:#{ns($this-type)}#{$selector} {
+        .#{$mq}\:#{ns('utility')}#{$selector} {
           @if $value-is-map and map-has-key($val-props, extend) {
             @include add-utility-declaration($val-props, extend, $important);
           }
@@ -113,14 +111,13 @@ future version of Sass' warning.
     null
   );
   $mq: null;
-  $this-type: map-get($utility, type);
   $value-is-map: if(
     type-of($val-props) == 'map',
     true,
     false
   );
 
-  .#{ns($this-type)}#{$selector} {
+  .#{ns('utility')}#{$selector} {
     @if $value-is-map and map-has-key($val-props, extend) {
       @include add-utility-declaration($val-props, extend, $important);
     }

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -44,10 +44,6 @@ $theme-namespace: (
     namespace:  'grid-',
     output:     true,
   ),
-  'object': (
-    namespace:  'add-',
-    output:     true,
-  ),
   'utility': (
     namespace:  'u-',
     output:     false,

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -44,10 +44,6 @@ $theme-namespace: (
     namespace:  'grid-',
     output:     true,
   ),
-  'object': (
-    namespace:  'add-',
-    output:     true,
-  ),
   'utility': (
     namespace:  'u-',
     output:     false,

--- a/src/stylesheets/utilities/rules/add-aspect.scss
+++ b/src/stylesheets/utilities/rules/add-aspect.scss
@@ -18,7 +18,7 @@ example:
 
 $add-aspect: (
   add-aspect: (
-    base: 'aspect',
+    base: 'add-aspect',
     modifiers: null,
     values: (
       9x16: (

--- a/src/stylesheets/utilities/rules/add-list-reset.scss
+++ b/src/stylesheets/utilities/rules/add-list-reset.scss
@@ -18,7 +18,7 @@ example:
 
 $add-list-reset: (
   list-reset: (
-    base: 'list',
+    base: 'add-list',
     modifiers: null,
     values: (
       reset: (


### PR DESCRIPTION
- Remove `object` from namespace options since it proved confusing to users
- Output all utilities with utility namespace
- Add `add-` manually to those utilities that previously added them with the object namespace