### PR TITLE
Include utilities last in uswds import order

### DIFF
--- a/src/stylesheets/packages/_uswds-components.scss
+++ b/src/stylesheets/packages/_uswds-components.scss
@@ -61,10 +61,10 @@ Output USWDS components and styles
 @import '../components/sidenav';
 @import '../components/skipnav';
 
-// Utilities
+// Layout grid
 // -------------------------------------
 // Not included
 
-// Layout grid
+// Utilities
 // -------------------------------------
 // Not included

--- a/src/stylesheets/packages/_uswds-fonts.scss
+++ b/src/stylesheets/packages/_uswds-fonts.scss
@@ -41,10 +41,10 @@ USWDS project
 // -------------------------------------
 // Not included
 
-// Utilities
+// Layout grid
 // -------------------------------------
 // Not included
 
-// Layout grid
+// Utilities
 // -------------------------------------
 // Not included

--- a/src/stylesheets/packages/_uswds-layout-grid.scss
+++ b/src/stylesheets/packages/_uswds-layout-grid.scss
@@ -39,10 +39,10 @@ USWDS project
 // -------------------------------------
 // Not included
 
-// Utilities
-// -------------------------------------
-// Not included
-
 // Layout grid
 // -------------------------------------
 @import '../core/layout-grid';
+
+// Utilities
+// -------------------------------------
+// Not included

--- a/src/stylesheets/packages/_uswds-utilities.scss
+++ b/src/stylesheets/packages/_uswds-utilities.scss
@@ -31,13 +31,13 @@ project
 // -------------------------------------
 // Not included
 
+// Layout grid
+// -------------------------------------
+// Not included
+
 // Utilities
 // -------------------------------------
 @import '../utilities/palettes/all';
 @import '../utilities/rules/all';
 @import '../utilities/rules/package';
 @include render-utilities-in($utilities-package);
-
-// Layout grid
-// -------------------------------------
-// Not included

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -66,13 +66,13 @@ Output all USWDS
 @import 'components/sidenav';
 @import 'components/skipnav';
 
+// Layout grid
+// -------------------------------------
+@import 'core/layout-grid';
+
 // Utilities
 // -------------------------------------
 @import 'utilities/palettes/all';
 @import 'utilities/rules/all';
 @import 'utilities/rules/package';
 @include render-utilities-in($utilities-package);
-
-// Layout grid
-// -------------------------------------
-@import 'core/layout-grid';


### PR DESCRIPTION
Since utilities should override all other components and objects, they should come last in the import order.

- - -

Fixes uswds/uswds-site#673