### PR TITLE
Add docs links to settings files

### DIFF
--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS COLOR SETTINGS
 ----------------------------------------
+
+Read more about color settings and
+USWDS color tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens/color
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -10,7 +10,7 @@
 USWDS COLOR SETTINGS
 ----------------------------------------
 -
-Read more about color settings and
+Read more about settings and
 USWDS color tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/color
 -

--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS COLOR SETTINGS
 ----------------------------------------
-
+-
 Read more about color settings and
 USWDS color tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/color
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -11,7 +11,7 @@ USWDS COMPONENT SETTINGS
 ----------------------------------------
 -
 Read more about settings and
-USWDS tokens in the documentation:
+USWDS style tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
 -
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS COMPONENT SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens
+
+----------------------------------------
 */
 
 // Accordion

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS COMPONENT SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS GENERAL SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -11,7 +11,7 @@ USWDS GENERAL SETTINGS
 ----------------------------------------
 -
 Read more about settings and
-USWDS tokens in the documentation:
+USWDS style tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
 -
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS GENERAL SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-spacing.scss
+++ b/src/stylesheets/settings/_settings-spacing.scss
@@ -9,6 +9,13 @@
 ----------------------------------------
 USWDS SPACING SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS spacing units tokens in the 
+documentation:
+https://v2.designsystem.digital.gov/style-tokens/spacing-units
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/settings/_settings-spacing.scss
+++ b/src/stylesheets/settings/_settings-spacing.scss
@@ -9,12 +9,12 @@
 ----------------------------------------
 USWDS SPACING SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
-USWDS spacing units tokens in the 
+USWDS spacing units tokens in the
 documentation:
 https://v2.designsystem.digital.gov/style-tokens/spacing-units
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS TYPOGRAPHY SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS typography tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/typography
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS TYPOGRAPHY SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS typography tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens/typography
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/settings/_settings-utilities.scss
+++ b/src/stylesheets/settings/_settings-utilities.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS UTILITIES SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS utilities in the documentation:
+https://v2.designsystem.digital.gov/utilities
+
+----------------------------------------
 */
 
 $utilities-use-important:     false !default;

--- a/src/stylesheets/settings/_settings-utilities.scss
+++ b/src/stylesheets/settings/_settings-utilities.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS UTILITIES SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS utilities in the documentation:
 https://v2.designsystem.digital.gov/utilities
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -10,7 +10,7 @@
 USWDS THEME COLOR SETTINGS
 ----------------------------------------
 -
-Read more about color settings and
+Read more about settings and
 USWDS color tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/color
 -

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS THEME COLOR SETTINGS
 ----------------------------------------
-
+-
 Read more about color settings and
 USWDS color tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/color
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS THEME COLOR SETTINGS
 ----------------------------------------
+
+Read more about color settings and
+USWDS color tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens/color
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS THEME COMPONENT SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -11,7 +11,7 @@ USWDS THEME COMPONENT SETTINGS
 ----------------------------------------
 -
 Read more about settings and
-USWDS tokens in the documentation:
+USWDS style tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
 -
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS THEME COMPONENT SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens
+
+----------------------------------------
 */
 
 // Accordion

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS GENERAL SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -11,7 +11,7 @@ USWDS GENERAL SETTINGS
 ----------------------------------------
 -
 Read more about settings and
-USWDS tokens in the documentation:
+USWDS style tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
 -
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS GENERAL SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-spacing.scss
+++ b/src/stylesheets/theme/_uswds-theme-spacing.scss
@@ -9,12 +9,12 @@
 ----------------------------------------
 USWDS THEME SPACING SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS spacing units tokens in the
 documentation:
 https://v2.designsystem.digital.gov/style-tokens/spacing-units
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-spacing.scss
+++ b/src/stylesheets/theme/_uswds-theme-spacing.scss
@@ -9,6 +9,13 @@
 ----------------------------------------
 USWDS THEME SPACING SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS spacing units tokens in the
+documentation:
+https://v2.designsystem.digital.gov/style-tokens/spacing-units
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS THEME TYPOGRAPHY SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS typography tokens in the documentation:
+https://v2.designsystem.digital.gov/style-tokens/typography
+
+----------------------------------------
 */
 
 /*

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS THEME TYPOGRAPHY SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS typography tokens in the documentation:
 https://v2.designsystem.digital.gov/style-tokens/typography
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-utilities.scss
+++ b/src/stylesheets/theme/_uswds-theme-utilities.scss
@@ -9,11 +9,11 @@
 ----------------------------------------
 USWDS THEME UTILITIES SETTINGS
 ----------------------------------------
-
+-
 Read more about settings and
 USWDS utilities in the documentation:
 https://v2.designsystem.digital.gov/utilities
-
+-
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-utilities.scss
+++ b/src/stylesheets/theme/_uswds-theme-utilities.scss
@@ -9,6 +9,12 @@
 ----------------------------------------
 USWDS THEME UTILITIES SETTINGS
 ----------------------------------------
+
+Read more about settings and
+USWDS utilities in the documentation:
+https://v2.designsystem.digital.gov/utilities
+
+----------------------------------------
 */
 
 $utilities-use-important:     false;


### PR DESCRIPTION
Since the settings files are highly connected to the idea of style tokens — that is, most settings variables are design to accept settings tokens — let's link to the style tokens section of the documentation, and to a specific tokens section (like spacing units) if the settings files is specifically tied to one of those tokens sections.

_Note: These links are not yet valid, but will be within a day or so._