### PR TITLE
Release 2.0.0 beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6784,7 +6784,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -6927,7 +6928,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6941,6 +6943,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7080,7 +7083,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7094,6 +7098,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7231,6 +7236,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7424,7 +7430,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.2",
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
### Internal
- Say goodbye to @maya
- Welcome @saracope to the core team
- Added a new build process to `uswds-site` to modularize the CSS output and compile only the Sass necessary to see the change. For instance, utility classes, layout grid, fonts, and USWDS components don't need to be re-generated when making a change to custom Sass. (https://github.com/uswds/uswds-site/pull/674)
  - Add new gulp scripts and npm scripts to process only the necessary Sass
  - Add conditional stylesheets to `uswds-site` that load individual CSS modules when in the local environment and a single, minified CSS file when built through Federalist
  - This can speed up most builds by about 10x!

### Additions
- Added Public Sans to its own repo: `uswds/public-sans`
- Added basic gulp pipeline to its own repo: `uswds/uswds-gulp`

### Updates
- Updated the font license information in LICENSE.md (https://github.com/uswds/uswds/pull/2800)

### Bug fixes
- Fixed a typo that prevented the `gray`, `gray-warm`, and `gray-cool` grade 60 colors from appearing (https://github.com/uswds/uswds/pull/2801)
- Gray cool and Gray warm were reversed in token data. Now they aren't and should output correctly. (https://github.com/uswds/uswds/pull/2823)
- Added the `ui` font family to line-height. Now you can use something like `line-height('ui', 3)` (https://github.com/uswds/uswds/pull/2824)
- Fixed a problem with the display of some items in our documentation (https://github.com/uswds/uswds-site/issues/673)
- Addressed a potential vulnerability with `mem@1.1.0` by updating to `yargs@12.0.2` (https://github.com/uswds/uswds/pull/2842)
- Fixed a bug where `a` elements classed with `usa-button` variants were being overridden by `usa-button:visited` styles. (https://github.com/uswds/uswds/pull/2827) 
  - Thanks @stphnwlkr! 

### Improvements
- Added a AAA magic number to the docs and updated contrast references to WCAG 2.0 (https://github.com/uswds/uswds-site/pull/656)
- Removed utility classes from any component (https://github.com/uswds/uswds/pull/2823)
  - ⚠️ **breaking change:** _Removes a `flex-justify` utility from the footer component and revises footer markup to add this rule to component code. This markup would need to be updated._
- Modified some nunjucks templates to improve the rendering of markup code in the components docs (https://github.com/uswds/uswds/pull/2823)
- Added any public-facing mixin into files within the `core/mixins` folder so they can be imported without importing any styles (https://github.com/uswds/uswds/pull/2844)
- Removed `_uswds-theme.scss` stylesheet from the theme stylesheets. This was an abstraction file that collected all the settings files together, but it proved a little confusing and may have been a premature optimization. Now all the settings files are included directly in `styles.scss` (https://github.com/uswds/uswds/pull/2830)
- The 'object' namespace was causing confusion and wasn't useful enough to justify its inclusion. (https://github.com/uswds/uswds/pull/2829)
  - Removed `object` from namespace options since it proved confusing to users
  - Output all utilities with utility namespace
  - Add `add-` manually to those utilities that previously added them with the object namespace
- Now the letterspacing function can accept numerical equivalents and not just `'ls-[token]'` strings. So `ls(-2)` is now valid. (https://github.com/uswds/uswds/pull/2826)
- Added a `$theme-show-compile-warnings` setting (default: `true`) to show compile warnings when using false or nonstandard tokens (https://github.com/uswds/uswds/pull/2828)
- Use the word 'token' instead of 'value' in compile errors to align with our naming convention (https://github.com/uswds/uswds/pull/2828)
- Use 'system' instead of 'uswds' in palette names (ex: `$palette-font-system-mono-micro` instead of `$palette-font-uswds-mono-micro`) to align with our naming convention. (https://github.com/uswds/uswds/pull/2828)
  - ⚠️ **Breaking change:** _Any palette using `uswds` in its name needs to be update to use `system` instead, as show above._ 

### Documentation
- Removed out of date references and added notes when some documentation or features were consipicuously absent (https://github.com/uswds/uswds-site/pull/657)
  - Removed references to palette variables
  - Updated USWDS 2.0 token references
  - Added notes when documentation is notably not in with USWDS 2.0 (typesetting, for instance)
- Updated readme with USWDS 2.0-specific information (https://github.com/uswds/uswds/pull/2819)
  - Installing using npm
  - Using the USWDS package
  - Sass and theme settings
  - Sass compilation requirements
  - Customization, theming, and tokens
- Added design principles and design notes to the Public Sans readme (https://github.com/uswds/public-sans/issues/18)
- Fixed the order of colors in the the system colors sidenav to reflect the actual order of the content (https://github.com/uswds/uswds-site/pull/665)
- Updated our color guidance to include more specific guidance around contrast sensitivity and Irlen Syndrome. (https://github.com/uswds/uswds-site/pull/664)
  - Added references to the bottom of the page
  - Included new guidance on using color for readability
  - Thanks @vizionsinmotion!
