### PR TITLE
Repair border() mixin to accept valid units string tokens

### DIFF
--- a/src/stylesheets/core/mixins/utilities/_border.scss
+++ b/src/stylesheets/core/mixins/utilities/_border.scss
@@ -1,14 +1,11 @@
 $border-utilities: (
-  width: map-collect(
+  'width': map-collect(
     map-deep-get($system-properties, border-width, standard),
     map-deep-get($system-properties, border-width, extended)
   ),
-  style: map-collect(
+  'style': map-collect(
     map-deep-get($system-properties, border-style, standard),
     map-deep-get($system-properties, border-style, extended)
-  ),
-  color: map-collect(
-    $system-required-colors
   )
 );
 
@@ -19,6 +16,8 @@ $border-utilities: (
     $important: ' !important';
   }
   $has-style: false;
+  $widths: map-get($border-utilities, 'width');
+
   @each $this-value in $value {
     $match: false;
     @if map-has-key($all-color-shortcodes, smart-quote($this-value)) {
@@ -41,7 +40,6 @@ $border-utilities: (
     }
     @else if type-of($this-value) == 'number' {
       $converted-value: number-to-value($this-value);
-      $widths: map-get($border-utilities, width);
       @if map-has-key($widths, $converted-value) {
         $match: true;
         $final-value: map-get($widths, $converted-value);
@@ -64,9 +62,28 @@ $border-utilities: (
         @error '#{$this-value} is not a valid border width. Accepted values: #{map-keys($widths)}';
       }
     }
+    @else if map-has-key($widths, smart-quote($this-value)) {
+      $match: true;
+      $this-value: smart-quote($this-value);
+      $final-value: map-get($widths, $this-value);
+      @if $side == n {
+        border-width: $final-value#{$important};
+      }
+      @else if $side == x {
+        border-left-width: $final-value#{$important};
+        border-right-width: $final-value#{$important};
+      }
+      @else if $side == y {
+        border-bottom-width: $final-value#{$important};
+        border-top-width: $final-value#{$important};
+      }
+      @else {
+        border-#{$side}-width: $final-value#{$important};
+      }
+    }
     @else {
       $converted-value: smart-quote($this-value);
-      $styles: map-get($border-utilities, style);
+      $styles: map-get($border-utilities, 'style');
       @if map-has-key($styles, $converted-value) {
         $match: true;
         $has-style: true;
@@ -87,11 +104,13 @@ $border-utilities: (
         }
       }
       @else {
-        @error '#{$this-value} is not a valid border style.';
+        @error '`#{$this-value}` is not a valid `border` token. '
+          + 'Use valid color, units, and border-style tokens '
+          + 'separated by commas.';
       }
     }
     @if not $match {
-      @error '`#{$this-value}` is not a valid `border` value.';
+      @error '`#{$this-value}` is not a valid `border` token.';
     }
   }
   @if not $has-style {


### PR DESCRIPTION
Fixes the `border()` mixin to accept any valid border-width unit token and improves the error message if the mixin includes an invalid token.