### PR TITLE
Clone font size and family functions to shorter names

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -1055,6 +1055,10 @@ role-based or type-based font family
   @return font-family($value);
 }
 
+@function family($value) {
+  @return font-family($value);
+}
+
 /*
 ----------------------------------------
 letter-spacing()
@@ -1167,6 +1171,14 @@ Get type scale value from a [family] and
   }
 
   @return normalize-type-scale($this-cap, $this-scale);
+}
+
+@function fs($family, $scale) {
+  @return font-size($family, $scale);
+}
+
+@function size($family, $scale) {
+  @return font-size($family, $scale);
 }
 
 /*


### PR DESCRIPTION
Add a few substitute functions with shorter function names

- `font-size()` --> `size()`
- `font-size()` --> `fs()`
- `font-family()` --> `family()`
- `font-family()` --> `ff()` 