### PR TITLE
Update add-list-reset to include a 0 top * bottom margin

### DIFF
--- a/src/stylesheets/core/mixins/_add-list-reset.scss
+++ b/src/stylesheets/core/mixins/_add-list-reset.scss
@@ -1,4 +1,5 @@
 @mixin add-list-reset {
+  @include u-margin-y(0);
   list-style-type: none;
   padding-left: 0;
 }


### PR DESCRIPTION
## Description

Changes implemented by this update:
- Edit the add-list-reset mixin to include a margin-bottom & margin-top of 0.
- Fixes issue with the basic header having additional space above the sub-nav items (uswds-site issue [#662](https://github.com/uswds/uswds-site/issues/662))

## Additional information

Before:
<img width="538" alt="screen shot 2018-11-01 at 3 03 58 pm" src="https://user-images.githubusercontent.com/2197515/47873481-ac23a080-dde7-11e8-8095-b122c4acf35c.png">


After:
<img width="538" alt="screen shot 2018-11-01 at 3 05 37 pm" src="https://user-images.githubusercontent.com/2197515/47873480-ac23a080-dde7-11e8-82e9-906bc2ab3b10.png">
