### PR TITLE
Sync mixins and add missing mixins

### DIFF
--- a/src/stylesheets/core/mixins/_add-list-reset.scss
+++ b/src/stylesheets/core/mixins/_add-list-reset.scss
@@ -1,5 +1,15 @@
-@mixin add-list-reset {
-  @include u-margin-y(0);
-  list-style-type: none;
-  padding-left: 0;
+@mixin add-list-reset($value...) {
+  $important: null;
+  @if length($value) > 0 and has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  margin-bottom: 0#{$important};
+  margin-top: 0#{$important};
+  list-style-type: none#{$important};
+  padding-left: 0#{$important};
+}
+
+@mixin list-reset($value...) {
+  @include add-list-reset($value...);
 }

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -39,6 +39,7 @@
 @import 'utilities/text-align';
 @import 'utilities/text-decoration';
 @import 'utilities/text-decoration-color';
+@import 'utilities/text-indent';
 @import 'utilities/top';
 @import 'utilities/vertical-align';
 @import 'utilities/white-space';

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -19,7 +19,6 @@
 @import 'utilities/justify-content';
 @import 'utilities/left';
 @import 'utilities/line-height';
-@import 'utilities/list-reset';
 @import 'utilities/margin';
 @import 'utilities/max-height';
 @import 'utilities/max-width';

--- a/src/stylesheets/core/mixins/utilities/_border-radius.scss
+++ b/src/stylesheets/core/mixins/utilities/_border-radius.scss
@@ -1,4 +1,4 @@
-// Outputs line-height
+// Outputs border-radius
 
 @mixin u-radius($value...) {
   $value: unpack($value);
@@ -8,4 +8,48 @@
     $important: ' !important';
   }
   border-radius: get-uswds-value(border-radius, $value) #{$important};
+}
+
+@mixin u-radius-bottom($value...) {
+  $value: unpack($value);
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  border-bottom-left-radius: get-uswds-value(border-radius, $value) #{$important};
+  border-bottom-right-radius: get-uswds-value(border-radius, $value) #{$important};
+}
+
+@mixin u-radius-left($value...) {
+  $value: unpack($value);
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  border-bottom-left-radius: get-uswds-value(border-radius, $value) #{$important};
+  border-top-left-radius: get-uswds-value(border-radius, $value) #{$important};
+}
+
+@mixin u-radius-right($value...) {
+  $value: unpack($value);
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  border-bottom-right-radius: get-uswds-value(border-radius, $value) #{$important};
+  border-top-right-radius: get-uswds-value(border-radius, $value) #{$important};
+}
+
+@mixin u-radius-top($value...) {
+  $value: unpack($value);
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  border-top-left-radius: get-uswds-value(border-radius, $value) #{$important};
+  border-top-right-radius: get-uswds-value(border-radius, $value) #{$important};
 }

--- a/src/stylesheets/core/mixins/utilities/_list-reset.scss
+++ b/src/stylesheets/core/mixins/utilities/_list-reset.scss
@@ -1,9 +1,0 @@
-@mixin u-list-reset($value...) {
-  $important: null;
-  @if length($value) > 0 and has-important($value) {
-    $value: remove($value, '!important');
-    $important: ' !important';
-  }
-  list-style-type: none#{$important};
-  padding-left: 0#{$important};
-}

--- a/src/stylesheets/core/mixins/utilities/_pin.scss
+++ b/src/stylesheets/core/mixins/utilities/_pin.scss
@@ -56,3 +56,35 @@ $utility-pin-options: 'all', 'x', 'y', 'top', 'bottom', 'left', 'right', 'none';
     }
   }
 }
+
+@mixin u-pin-none($value...) {
+  @include u-pin('none', $value...)
+}
+
+@mixin u-pin-all($value...) {
+  @include u-pin('all', $value...)
+}
+
+@mixin u-pin-y($value...) {
+  @include u-pin('y', $value...)
+}
+
+@mixin u-pin-x($value...) {
+  @include u-pin('x', $value...)
+}
+
+@mixin u-pin-bottom($value...) {
+  @include u-pin('bottom', $value...)
+}
+
+@mixin u-pin-left($value...) {
+  @include u-pin('left', $value...)
+}
+
+@mixin u-pin-right($value...) {
+  @include u-pin('right', $value...)
+}
+
+@mixin u-pin-top($value...) {
+  @include u-pin('top', $value...)
+}

--- a/src/stylesheets/core/mixins/utilities/_pin.scss
+++ b/src/stylesheets/core/mixins/utilities/_pin.scss
@@ -58,33 +58,33 @@ $utility-pin-options: 'all', 'x', 'y', 'top', 'bottom', 'left', 'right', 'none';
 }
 
 @mixin u-pin-none($value...) {
-  @include u-pin('none', $value...)
+  @include u-pin('none', $value...);
 }
 
 @mixin u-pin-all($value...) {
-  @include u-pin('all', $value...)
+  @include u-pin('all', $value...);
 }
 
 @mixin u-pin-y($value...) {
-  @include u-pin('y', $value...)
+  @include u-pin('y', $value...);
 }
 
 @mixin u-pin-x($value...) {
-  @include u-pin('x', $value...)
+  @include u-pin('x', $value...);
 }
 
 @mixin u-pin-bottom($value...) {
-  @include u-pin('bottom', $value...)
+  @include u-pin('bottom', $value...);
 }
 
 @mixin u-pin-left($value...) {
-  @include u-pin('left', $value...)
+  @include u-pin('left', $value...);
 }
 
 @mixin u-pin-right($value...) {
-  @include u-pin('right', $value...)
+  @include u-pin('right', $value...);
 }
 
 @mixin u-pin-top($value...) {
-  @include u-pin('top', $value...)
+  @include u-pin('top', $value...);
 }

--- a/src/stylesheets/core/mixins/utilities/_text-indent.scss
+++ b/src/stylesheets/core/mixins/utilities/_text-indent.scss
@@ -1,0 +1,10 @@
+// Outputs text-indent property
+
+@mixin u-text-indent($value...) {
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  text-indent: get-uswds-value('text-indent', $value...) #{$important};
+}


### PR DESCRIPTION
This PR makes mixin names more consistent:

- `u-pin()` mixin now uses the format `u-pin-[side]` instead of `u-pin([side])` for simplicity
- added `u-text-indent()` mixin
- removed `u-list-reset()` since there's already `add-list-reset()` but also included `list-reset()` as a clone of `add-list-reset()` for backward compatibility
- added `u-radius-[modifier]()` mixins. Ex: `u-radius-left('pill')`
