### PR TITLE
2.0.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
**Note: Items with a ⚠️ icon are potentially breaking changes**

### Internal
- Welcome @greensteph to the USWDS Core team 🎉 

### Bug fixes
- Checkboxes now print correctly (https://github.com/uswds/uswds/pull/2872)
- The `$theme-font-definitions` variable for adding custom font definitions is no longer overridden by the system default. Thanks for the heads up @yomatters! (https://github.com/uswds/uswds/pull/2875)
- Added the missing `u-text-indent()` mixin. Thanks for the heads up @jeremyzilar! (https://github.com/uswds/uswds/pull/2874)
- Fixed errors when compiling with Dart Sass or Jekyll. Thanks to Matt Langan in the #uswds-public channel for surfacing this! (https://github.com/uswds/uswds/pull/2867)
 
### Improvements
#### New mixins and improved mixin functionality (https://github.com/uswds/uswds/pull/2874)
- `u-pin()` mixin now uses the format `u-pin-[side]` instead of `u-pin([side])` for simplicity
> **Example:** `u-pin-y` instead of `u-pin('y')` — though the latter will still work
- Removed `u-list-reset()` since there's already `add-list-reset()` but also included `list-reset()` as a clone of `add-list-reset()` for backward compatibility
> ⚠️ Replace any instance of `u-list-reset` with `add-list-reset`
- Added `u-radius-[modifier]()` mixins.
> **Example:** `u-pin-radius-left('pill')`

#### Clearer more consistent palette names (https://github.com/uswds/uswds/pull/2877)
This is a big one with lots of potentially breaking changes. See the [pull request](https://github.com/uswds/uswds/pull/2877) and the [v2 documentation](https://v2.designsystem.digital.gov/) for a more complete record of the changes and the final palette names.

> ⚠️ If you've experimented with using palettes for your utility classes, you will need to update to the new names or you will get `Palette not found in the registry` errors when you compile.

- Palette naming is additive: each subset has the palette name of its parent, plus a subset suffix
- Default palettes use `palette-[property]-default` not `palette-system-[property]`
- Palettes with no suffix include all tokens in the category
- Palettes attempt to mimic the token categories/functions/properties: like `units`, `color`, and `font`
- Palettes attempt to mimic the token categories/functions/properties: like `units`, `color`, and `font`
- Palettes have a relative subset suffix (like `-small`, `-smaller`)
- Palettes that include all values in a set, have **no special suffix** (`-all` goes away)
- Any palette that had a `-negative` grouping now also has a corresponding `-positive`
- The `-negative` and `-positive` groups now appear before the sizing groups
- The `font-weights` category is now `font-weight` 
- Numeric `font-weights` use the `-system` suffix, not `-numeric`

#### More predictable prose scope component (https://github.com/uswds/uswds/pull/2878)
The `.usa-prose` component allows developers to style unclassed elements within a scoped container. However, this could result in unpredictable behavior (like style specificity errors) if other components are inside in a `usa-prose` container. Now, `usa-prose` only affects _direct children_ (using the `>` selector). See the [pull request](https://github.com/uswds/uswds/pull/2878) for more details and context.
> ⚠️ Make sure any content you want styled with `usa-prose` is a direct child of `usa-prose` — this could mean adding `usa-prose` to `grid-col` or `section` elements previously styled simply by being inside `usa-prose`.

#### Improvements to Public Sans (https://github.com/uswds/uswds/pull/2873)
- Better, more readable numbers
- Narrower italic
- Thickened light and normal weights
- Better spacing of tabular figures

### Documentation
- Now data tables are responsive, even at very narrow widths! Thanks for the technique @line47! (https://github.com/uswds/uswds-site/pull/691)
- Lots of updated docs around utilities and palettes (https://github.com/uswds/uswds-site/pull/691)
- Removed the utility output section since it was largely redundant with the utility examples and the style tokens sections (https://github.com/uswds/uswds-site/pull/691)
- Added a banner to the main site that directs folks to the v2 Beta site. (https://github.com/uswds/uswds-site/pull/689)
- Removed unsupported `webp` images
- Fixed a bunch of typos 🎉 
- Fixed code block wrapping
- Fixed the navigation on the `Developers` page (https://github.com/uswds/uswds-site/pull/687)
- Fixed some problems with svg rendering (https://github.com/uswds/uswds-site/pull/684)