### PR TITLE
Add borderless table styles to mixin passed to prose scope

### DIFF
--- a/src/stylesheets/core/mixins/_usa-table-styles.scss
+++ b/src/stylesheets/core/mixins/_usa-table-styles.scss
@@ -1,8 +1,8 @@
 @mixin usa-table-styles {
   table {
     @extend %usa-table;
-    &.usa-table.borderless {
-      @extend %usa-table-borderless;
-    }
+  }
+  .usa-table-borderless {
+    @extend %usa-table-borderless;
   }
 }

--- a/src/stylesheets/core/mixins/_usa-table-styles.scss
+++ b/src/stylesheets/core/mixins/_usa-table-styles.scss
@@ -1,5 +1,8 @@
 @mixin usa-table-styles {
   table {
     @extend %usa-table;
+    &.usa-table.borderless {
+      @extend %usa-table-borderless;
+    }
   }
 }

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -35,10 +35,6 @@
   }
 }
 
-.usa-table {
-  @extend %usa-table;
-}
-
 %usa-table-borderless {
   thead {
     th {
@@ -58,6 +54,10 @@
       padding-left: 0;
     }
   }
+}
+
+.usa-table {
+  @extend %usa-table;
 }
 
 .usa-table-borderless {

--- a/src/stylesheets/elements/_table.scss
+++ b/src/stylesheets/elements/_table.scss
@@ -39,7 +39,7 @@
   @extend %usa-table;
 }
 
-.usa-table-borderless {
+%usa-table-borderless {
   thead {
     th {
       background-color: transparent;
@@ -58,4 +58,8 @@
       padding-left: 0;
     }
   }
+}
+
+.usa-table-borderless {
+  @extend %usa-table-borderless;
 }


### PR DESCRIPTION
This allows the borderless table variant to display properly in prose scope