### PR TITLE
[v2] [List styles] Add max width, remove bottom margin on last-child.

### DIFF
--- a/src/stylesheets/core/mixins/_unstyled-list.scss
+++ b/src/stylesheets/core/mixins/_unstyled-list.scss
@@ -6,5 +6,6 @@
 
   > li {
     margin-bottom: 0;
+    max-width: unset;
   }
 }

--- a/src/stylesheets/elements/_list.scss
+++ b/src/stylesheets/elements/_list.scss
@@ -1,11 +1,16 @@
 %usa-list {
   @include u-margin-y(1em);
   padding-left: 3ch;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 %usa-list-item {
   line-height: line-height($theme-body-font-family, $theme-body-line-height);
   margin-bottom: 0.25em;
+  max-width: measure($theme-text-measure);
 
   &:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
List items should have a maximum width, similar to their `<p>` counterparts. Additionally, when a list is the last child of a container, it should not contain a margin-bottom (see the left border in the screenshot below).

| Before | After |
|-------|-------|
| ![Screenshot of list items which do not have maximum width constraints and have extra margin-bottom](https://user-images.githubusercontent.com/14930/52427435-e4650a00-2acd-11e9-8702-0ffef9149e2e.png) | ![Screenshot of list items which are constrained by a maximum width, and do not contain extra margin-bottom](https://user-images.githubusercontent.com/14930/52427332-c8616880-2acd-11e9-9f8b-ce5e5b945d0f.png) |

Thoughts? Was going to open an issue, but figured it’d be easier to demonstrate with a PR directly. 