### PR TITLE
Use `all` for media queries instead of screen only

### DIFF
--- a/src/stylesheets/core/mixins/_at-media.scss
+++ b/src/stylesheets/core/mixins/_at-media.scss
@@ -1,4 +1,5 @@
 // Mobile-first media query helper
+
 @mixin at-media($bp) {
   $quoted-bp: smart-quote($bp);
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);

--- a/src/stylesheets/core/mixins/_at-media.scss
+++ b/src/stylesheets/core/mixins/_at-media.scss
@@ -13,7 +13,7 @@
   @else {
     @warn '`#{$bp}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}';
   }
-  @media screen and (min-width: #{$bp}) {
+  @media all and (min-width: #{$bp}) {
     @content;
   }
 }
@@ -33,7 +33,7 @@
   @else {
     @warn '`#{$bp}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}';
   }
-  @media screen and (max-width: #{$bp}) {
+  @media all and (max-width: #{$bp}) {
     @content;
   }
 }


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-print-mqs/components/preview/layout--landing.html)

This PR changes the scope of media queries to all media types instead of screen only. This allows media query styling to apply to print jobs, fixing a number of current issues with print performance. In testing, printing to standard 8.5 x 11" paper results in mobile-style output, which is perfect.

We haven't uncovered any potential problems with this new scope, but it's worth a bit more research time to make sure there aren't any unintended consequences, especially accessibility issues.

**Q:** are there some places where reverse text will be an issue?

Fixes https://github.com/uswds/uswds/issues/2907
Fixes https://github.com/uswds/uswds/issues/2883

- - -

<img width="521" alt="screen shot 2019-02-15 at 9 32 45 am" src="https://user-images.githubusercontent.com/11464021/52873805-bce0f380-3104-11e9-8e79-3001509be6cd.png">

- - -

With `Print background graphics` checked:

<img width="527" alt="screen shot 2019-02-15 at 9 35 03 am" src="https://user-images.githubusercontent.com/11464021/52873947-12b59b80-3105-11e9-9f13-34d8a01a78f9.png">

