### PR TITLE
2.0.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
### Bug fixes

- The borderless table variant now displays properly in prose scope (https://github.com/uswds/uswds/pull/2881)
- Grid columns now display properly when your project doesn't explicitly include component styles (https://github.com/uswds/uswds/pull/2900)
- Extra large content no longer breaks `fill` and `auto` columns. (https://github.com/uswds/uswds/pull/2900)
- List items now have a maximum width, similar to their `<p>` counterparts. Additionally, when a list is the last child of a container, it now does have any bottom margin. Thanks @adunkman! (https://github.com/uswds/uswds/pull/2906)
- Media query styling now applies to print jobs, fixing a number of current issues with print output.  (https://github.com/uswds/uswds/pull/2910)

### Improvements

**More up-to-date node dependency** (https://github.com/uswds/uswds/pull/2900)
We updated the required node version to the current LTS version of node (10.15.1) and updated our dependencies to build properly in this environment. 

**Now we're exposing some internal component variables to user-accessible settings** (https://github.com/uswds/uswds/pull/2901)
Here's what we added:

```
// Accordion
$theme-accordion-border-width:        0.5;
$theme-accordion-border-color:        'base-lightest';

// Alert
$theme-alert-bar-width:               1;
$theme-alert-icon-size:               4;
$theme-alert-padding-x:               2.5;

// Banner
$theme-button-stroke-width:           2px;

// Footer
$theme-input-select-border-width:     2px;
$theme-input-select-size:             2.5;
$theme-input-state-border-width:      0.5;
```

**We expanded and improved our system color families and theme defaults**
These new colors are a bit more harmonious, and have a better 1.x-to-2.0 conversion.

- Added a `blue-cool` color family (https://github.com/uswds/uswds/pull/2902)
- Added a `red-cool` family (https://github.com/uswds/uswds/pull/2911)
- Saturated `gold-20v` (https://github.com/uswds/uswds/pull/2911)
- Desaturated `blue-cool` standard colors and added vivid variants (https://github.com/uswds/uswds/pull/2911)
- Made small hue consistency modifications to the following families (https://github.com/uswds/uswds/pull/2911):

  - `blue-warm`
  - `blue`
  - `gold`
  - `gray-cool`
  - `green-cool`
  - `mint`
  - `orange`
  - `red-cool`
  - `red`
  - `yellow`

- Updated the following theme palettes for better consistency with 1.x defaults (https://github.com/uswds/uswds/pull/2911)
  - `base`
  - `primary`
  - `accent-cool`
  - `error`
  - `warning`
  - `success`
  - `info`

Here's what changed:

**`base` changes**
```
$theme-color-base-family:           'gray-cool';
$theme-color-base-lightest:         'gray-5';
$theme-color-base-lighter:          'gray-cool-10';
$theme-color-base-light:            'gray-cool-30';
$theme-color-base:                  'gray-cool-50';
$theme-color-base-dark:             'gray-cool-60';
$theme-color-base-darker:           'gray-cool-70';
$theme-color-base-darkest:          'gray-90';
$theme-color-base-ink:              'gray-90';
```

**`primary` changes**
```
$theme-color-primary-lighter:       '#{$theme-color-primary-family}-10';
$theme-color-primary-vivid:         'blue-warm-60v';
```

**`accent-warm` changes**
```
$theme-color-accent-warm-family:    'orange';
$theme-color-accent-warm-lighter:   '#{$theme-color-accent-warm-family}-10';
$theme-color-accent-warm-light:     '#{$theme-color-accent-warm-family}-20v';
$theme-color-accent-warm:           '#{$theme-color-accent-warm-family}-30v';
$theme-color-accent-warm-darker:    '#{$theme-color-accent-warm-family}-60';
```

**`error` changes**
```
$theme-color-error-family:     'red-warm';
$theme-color-error-light:      '#{$theme-color-error-family}-30v';
$theme-color-error:            '#{$theme-color-error-family}-50v';
$theme-color-error-dark:       'red-60v';
$theme-color-error-darker:     'red-70';
```

**`warning` changes**
```
$theme-color-warning-lighter:  'yellow-5';
$theme-color-warning-light:    'yellow-10v';
$theme-color-warning-darker:   '#{$theme-color-warning-family}-50v';
```

**`success` changes**
```
$theme-color-success-light:    '#{$theme-color-success-family}-20v';
$theme-color-success-darker:   '#{$theme-color-success-family}-60';
```

**`info` changes**
```
$theme-color-info-darker:      'blue-cool-60';
```

### USWDS 1.x to 20 color conversion

![uswds conversion table](https://user-images.githubusercontent.com/11464021/53037625-88847480-342f-11e9-827e-4ce1eb77f3a0.png)

### Current USWDS theme defaults

![uswds-theme-defaults](https://user-images.githubusercontent.com/11464021/53037900-3728b500-3430-11e9-96f6-ec559c4ebd37.png)

### Current USWDS state defaults

![uswds-state-defaults](https://user-images.githubusercontent.com/11464021/53037907-3abc3c00-3430-11e9-9983-177f5c8da21c.png)

