### PR TITLE
Add order mixin and improve error handling

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -757,6 +757,7 @@ functions and mixins.
     @return nth($value, 2);
   }
 
+
   $value: nth($value, 1);
   $converted: number-to-token($value);
   $quoted-value: if(
@@ -772,13 +773,11 @@ functions and mixins.
 
     @if not $output {
       @if $theme-show-compile-warnings {
-        @warn '`#{$value}` is set as a `false` value '
+        @error '`#{$value}` is set as a `false` value '
           + 'for the #{$property} property in your project settings '
           + 'and will not output properly. '
           + 'Set the value of `#{$value}` in project settings.';
       }
-
-      @return map-get($our-standard-values, $quoted-value);
     }
 
     @return $output;
@@ -794,6 +793,7 @@ functions and mixins.
     @return map-get($our-extended-values, $quoted-value);
   }
 
+  // TODO: what are these last two cases? Evaluate.
   @if not (type-of($value) == 'number' and not unitless($value)) {
     @error '`#{$value}` is not a valid `#{$property}` token. '
       + 'You should correct this. Standard `#{$property}` tokens: '

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -757,7 +757,6 @@ functions and mixins.
     @return nth($value, 2);
   }
 
-
   $value: nth($value, 1);
   $converted: number-to-token($value);
   $quoted-value: if(

--- a/src/stylesheets/core/mixins/_all.scss
+++ b/src/stylesheets/core/mixins/_all.scss
@@ -27,6 +27,7 @@
 @import 'utilities/min-width';
 @import 'utilities/outline';
 @import 'utilities/outline-color';
+@import 'utilities/order';
 @import 'utilities/overflow';
 @import 'utilities/padding';
 @import 'utilities/pin';

--- a/src/stylesheets/core/mixins/utilities/_order.scss
+++ b/src/stylesheets/core/mixins/utilities/_order.scss
@@ -1,0 +1,10 @@
+// Outputs order
+
+@mixin u-order($value...) {
+  $important: null;
+  @if has-important($value) {
+    $value: remove($value, '!important');
+    $important: ' !important';
+  }
+  order: get-uswds-value(order, $value...) #{$important};
+}

--- a/src/stylesheets/core/mixins/utilities/_overflow.scss
+++ b/src/stylesheets/core/mixins/utilities/_overflow.scss
@@ -1,4 +1,4 @@
-// Outputs line-height
+// Outputs overflow
 
 @mixin u-overflow($value...) {
   $important: null;

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -33,7 +33,7 @@ $theme-image-path:  '../img' !default;
 Show compile warnings
 ----------------------------------------
 Show Sass warnings when functions and
-mixins use nonstanard or false tokens.
+mixins use non-standard tokens.
 ----------------------------------------
 */
 

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -33,7 +33,7 @@ $theme-image-path:  '../img';
 Show compile warnings
 ----------------------------------------
 Show Sass warnings when functions and
-mixins use nonstanard or false tokens.
+mixins use non-standard tokens.
 ----------------------------------------
 */
 


### PR DESCRIPTION
- Add `order()` mixin
- Throw an error if utility mixins get a `false` value
- Improve documentation of `$theme-show-compile-warnings` setting