### PR TITLE
Remove font-definitions from pacakges

### DIFF
--- a/src/stylesheets/packages/_uswds-components.scss
+++ b/src/stylesheets/packages/_uswds-components.scss
@@ -19,7 +19,6 @@ Output USWDS components and styles
 
 // Tools
 // -------------------------------------
-@import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
 @import '../core/variables';

--- a/src/stylesheets/packages/_uswds-fonts.scss
+++ b/src/stylesheets/packages/_uswds-fonts.scss
@@ -20,7 +20,6 @@ USWDS project
 
 // Tools
 // -------------------------------------
-@import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
 @import '../core/variables';

--- a/src/stylesheets/packages/_uswds-layout-grid.scss
+++ b/src/stylesheets/packages/_uswds-layout-grid.scss
@@ -20,7 +20,6 @@ USWDS project
 
 // Tools
 // -------------------------------------
-@import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
 @import '../core/variables';

--- a/src/stylesheets/packages/_uswds-utilities.scss
+++ b/src/stylesheets/packages/_uswds-utilities.scss
@@ -20,7 +20,6 @@ project
 
 // Tools
 // -------------------------------------
-@import '../core/font-definitions';
 @import '../core/functions';
 @import '../core/system-tokens';
 @import '../core/variables';


### PR DESCRIPTION
This file was deprecated and needed to be removed from the packages as well as from uswds.scss.