### PR TITLE
Add a new var to control if layout grid gets !important

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -602,6 +602,6 @@ Grid
 
 $grid-global: '';
 
-@if $utilities-use-important {
+@if $theme-layout-grid-uses-important {
   $grid-global: '!important';
 }

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -602,6 +602,6 @@ Grid
 
 $grid-global: '';
 
-@if $theme-layout-grid-uses-important {
+@if $theme-layout-grid-use-important {
   $grid-global: '!important';
 }

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -58,6 +58,17 @@ $theme-namespace: (
 
 /*
 ----------------------------------------
+Layout grid
+----------------------------------------
+Should the layout grid classes output
+with !important
+----------------------------------------
+*/
+
+$theme-layout-grid-uses-important: false !default;
+
+/*
+----------------------------------------
 Border box sizing
 ----------------------------------------
 When set to true, sets the box-sizing

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -65,7 +65,7 @@ with !important
 ----------------------------------------
 */
 
-$theme-layout-grid-uses-important: false !default;
+$theme-layout-grid-use-important: false !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -58,6 +58,17 @@ $theme-namespace: (
 
 /*
 ----------------------------------------
+Layout grid
+----------------------------------------
+Should the layout grid classes output
+with !important
+----------------------------------------
+*/
+
+$theme-layout-grid-uses-important: false !default;
+
+/*
+----------------------------------------
 Border box sizing
 ----------------------------------------
 When set to true, sets the box-sizing

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -65,7 +65,7 @@ with !important
 ----------------------------------------
 */
 
-$theme-layout-grid-uses-important: false !default;
+$theme-layout-grid-use-important: false !default;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-grid-important/)

Adds a `$theme-layout-grid-uses-important` bool to settings-general. Previously, layout grid would get `!important` if `$utilities-use-important` was set to true.

Fixes https://github.com/uswds/uswds/issues/2887