### PR TITLE
Add closing div to outline inverse buttons

### DIFF
--- a/src/components/02-buttons/buttons.njk
+++ b/src/components/02-buttons/buttons.njk
@@ -10,6 +10,6 @@
 <button class="usa-button {{ classes }}" disabled>Disabled</button>
 {%- endif -%}
 
-{%- if (classes == 'usa-button--outline-inverse') %}
+{%- if (classes == 'usa-button--outline usa-button--inverse') %}
 </div>
 {%- endif %}


### PR DESCRIPTION
The closing div was not appearing and this fixes that. Now it matches the classes in the opening div.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/add-closing-div-btns/components/detail/buttons--outline-inverse.html)