### PR TITLE
[VA.gov] - [Focusable Elements] - Apply :focus behavior to focusable elements only

### DIFF
--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -30,17 +30,26 @@ body {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
-a[href],
-area[href],
-input:not([disabled]),
-select:not([disabled]),
-textarea:not([disabled]),
-button:not([disabled]),
+input,
+select,
+textarea,
+button {
+  &:not([disabled]) {
+    &:focus {
+      @include focus;
+    }
+  }
+}
+
 iframe,
+[href],
 [tabindex],
-[contentEditable=true],
-.usa-focus {
-  &:not([tabindex='-1']) {
+[contentEditable=true] {
+  &:focus {
     @include focus;
   }
+}
+
+.usa-focus {
+  @include focus;
 }

--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -30,7 +30,17 @@ body {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
-*:focus,
+a[href],
+area[href],
+input:not([disabled]),
+select:not([disabled]),
+textarea:not([disabled]),
+button:not([disabled]),
+iframe,
+[tabindex],
+[contentEditable=true],
 .usa-focus {
-  @include focus;
+  &:not([tabindex='-1']) {
+    @include focus;
+  }
 }


### PR DESCRIPTION
## Description
This pull request explicitly lists elements that are focusable and applies the focus mixin only to those elements, rather than applying the rule globally. The immediate goal of this is to patch the bug as described in Issue #2928.

Resolves https://github.com/uswds/uswds/issues/2928

## Additional information

Include any of the following (as necessary): 

- Even though this issue was discovered only in IE, I feel that this is also the more correct solution than applying the `:focus` rule globally.
- This solution is based on the solution described in this SO thread, https://stackoverflow.com/a/30753870.
- jQuery's `:focusable` selector also has interesting info, https://api.jqueryui.com/focusable-selector/.
- See issue for more context

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
    - May have messed up the `[Website]` part of this.
