### PR TITLE
Fix landing page tagline section

### DIFF
--- a/src/components/layouts/landing-inner.njk
+++ b/src/components/layouts/landing-inner.njk
@@ -3,11 +3,13 @@
 
   {% if tagline %}
   <section class="grid-container usa-section">
-    <div class="usa-width-one-third">
-      <h2>{{ tagline.title }}</h2>
-    </div>
-    <div class="usa-width-two-thirds">
-      {{ tagline.content }}
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-4">
+        <h2 class="font-heading-xl margin-top-0">{{ tagline.title }}</h2>
+      </div>
+      <div class="tablet:grid-col-8 usa-prose">
+        {{ tagline.content }}
+      </div>
     </div>
   </section>
   {% endif %}
@@ -16,7 +18,7 @@
 
   <section class="usa-section">
     <div class="grid-container">
-      <h2 class="font-heading-xl">Section heading</h2>
+      <h2 class="font-heading-xl margin-top-0">Section heading</h2>
       <p class="usa-font-lead">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
       <a class="usa-button usa-button--big" href="#">Call to action</a>
     </div>

--- a/src/components/layouts/landing-inner.njk
+++ b/src/components/layouts/landing-inner.njk
@@ -5,7 +5,7 @@
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-4">
-        <h2 class="font-heading-xl margin-y-0">{{ tagline.title }}</h2>
+        <h2 class="font-heading-xl margin-top-0 tablet:margin-bottom-0">{{ tagline.title }}</h2>
       </div>
       <div class="tablet:grid-col-8 usa-prose">
         {{ tagline.content }}

--- a/src/components/layouts/landing-inner.njk
+++ b/src/components/layouts/landing-inner.njk
@@ -5,7 +5,7 @@
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-4">
-        <h2 class="font-heading-xl margin-top-0">{{ tagline.title }}</h2>
+        <h2 class="font-heading-xl margin-y-0">{{ tagline.title }}</h2>
       </div>
       <div class="tablet:grid-col-8 usa-prose">
         {{ tagline.content }}
@@ -18,7 +18,7 @@
 
   <section class="usa-section">
     <div class="grid-container">
-      <h2 class="font-heading-xl margin-top-0">Section heading</h2>
+      <h2 class="font-heading-xl margin-y-0">Section heading</h2>
       <p class="usa-font-lead">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
       <a class="usa-button usa-button--big" href="#">Call to action</a>
     </div>

--- a/src/components/layouts/landing.njk
+++ b/src/components/layouts/landing.njk
@@ -5,5 +5,5 @@
 {% endblock %}
 
 {% block body %}
-  {% render '@layout--landing-inner', true %}
+  {% render '@layout--landing-inner' %}
 {% endblock %}


### PR DESCRIPTION
Ensures that the tagline section appears.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-landing-page/components/preview/layout--landing.html)

---

There's an ongoing issue that the browser's user agent stylesheets are providing margins for various texts - paragraph text, headings, etc... so our top and bottom margins are not consistent. And there's no way to get proper em-based relative margins in the utilities. 

When adding `.usa-prose` to a text section at the bottom, the margins on the headings are correct but it negatively effects `.usa-lead`: it overrides the line-height and max-width. Also, it changes the button text to blue so it's unreadable. So, the **selector strength is too strong** `.usa-prose > p` overrides `.usa-font-lead` which is added directly to the `p` element.

<img width="1041" alt="Screen Shot 2019-03-08 at 3 13 00 PM" src="https://user-images.githubusercontent.com/5249443/54061256-e39ac300-41b4-11e9-8ffd-43dd0d95a32c.png">

Currently, I added `margin-top-0` to those headings, but I don't think that's a great approach and it doesn't give me the 0.5em bottom margins that I'd expect. The bottom margins are the larger user agent stylesheet.

Fixes #2920. 