### PR TITLE
Update external link example to use hyphen

### DIFF
--- a/src/components/01-type/links.njk
+++ b/src/components/01-type/links.njk
@@ -2,7 +2,7 @@
 
 <p><a class="usa-link usa-color-text-visited" href="javascript:void(0);">This</a> is a visited link.</p>
 
-<p>This is a link that goes to an <a class="usa-link usa-external-link" href="https://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
+<p>This is a link that goes to an <a class="usa-link usa-link--external" href="https://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
 
 <div class="usa-background-dark">
   <p><a class="usa-link" href="javascript:void(0);">This</a> is a text link on a dark background.</p>

--- a/src/components/01-type/links.njk
+++ b/src/components/01-type/links.njk
@@ -2,7 +2,7 @@
 
 <p><a class="usa-link usa-color-text-visited" href="javascript:void(0);">This</a> is a visited link.</p>
 
-<p>This is a link that goes to an <a class="usa-link usa-external_link" href="https://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
+<p>This is a link that goes to an <a class="usa-link usa-external-link" href="https://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
 
 <div class="usa-background-dark">
   <p><a class="usa-link" href="javascript:void(0);">This</a> is a text link on a dark background.</p>

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -41,13 +41,14 @@ html {
 // [href^="http:"]:not([href*="my-domain.com"])
 // [href^="https:"]:not([href*="my-domain.com"])
 
-.usa-external-link {
+.usa-link--external {
   @include external-link(external-link, external-link-hover);
+
+  &.usa-link--alt {
+    @include external-link(external-link-alt, external-link-alt-hover);
+  }
 }
 
-.usa-external-link-alt {
-  @include external-link(external-link-alt, external-link-alt-hover);
-}
 
 // Remove user agent styles
 

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -49,7 +49,6 @@ html {
   }
 }
 
-
 // Remove user agent styles
 
 cite,


### PR DESCRIPTION
Now it shows up.

Following BEM, should it be written as `usa-link--external`?

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/fix-external-link/components/detail/links.html)