### PR TITLE
Remove underline from accordion button

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -26,6 +26,7 @@ $accordion-border: units($theme-accordion-border-width) solid color($theme-accor
   font-weight: font-weight('bold');
   margin: 0;
   padding: units(2) units(2.5) * 2 + units(2) units(2) units(2.5);
+  text-decoration: none;
   width: 100%;
 
   &:hover {

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -85,14 +85,6 @@
   @include u-margin-y(0);
   font-size: font-size($theme-banner-font-family, 1);
   line-height: line-height($theme-banner-font-family, 2);
-
-  .usa-banner__header--expanded & {
-    display: none;
-
-    @include at-media('tablet') {
-      display: block;
-    }
-  }
 }
 
 .usa-banner__header-action {
@@ -102,6 +94,10 @@
   margin-bottom: units(0);
   margin-top: units(2px);
   text-decoration: underline;
+
+  .usa-banner__header--expanded & {
+    display: none;
+  }
 
   @include at-media('tablet') {
     display: none;
@@ -119,7 +115,7 @@
   }
 }
 
-.usa-banner__header-expanded {
+.usa-banner__header--expanded {
   padding-right: units($size-touch-target + 1);
 
   @include at-media('tablet') {


### PR DESCRIPTION
`.usa-button-unstyled` is now styled like a standard link, so we need to manually remove the underline from accordion buttons.

Also, something got messed up in the banner and it was hiding the wrong text at mobile when expanded.

[Accordion](https://federalist-proxy-staging.app.cloud.gov/preview/uswds/uswds/dw-accordion-button/components/preview/accordion--bordered.html)
[Banner](https://federalist-proxy-staging.app.cloud.gov/preview/uswds/uswds/dw-accordion-button/components/preview/banner.html)