### PR TITLE
Fix hero heading alt class name

### DIFF
--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -3,7 +3,7 @@
     <div class="usa-hero__callout">
       <h2 class="usa-hero__heading">
         {%- if hero.callout -%}
-          <span class="usa-hero__callout-alt">{{ hero.callout }}</span>
+          <span class="usa-hero__heading--alt">{{ hero.callout }}</span>
         {%- endif -%}
         {{ hero.title }}
       </h2>

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -26,7 +26,7 @@
   line-height: line-height('heading', 2);
 }
 
-.usa-hero__callout-alt {
+.usa-hero__heading--alt {
   color: color('white');
   display: block;
 }


### PR DESCRIPTION
Changes `usa-hero__callout-alt` to `usa-hero__heading--alt` as the callout refers to the whole box and this refers to the heading which is what it actually is.