### PR TITLE
Fix spacing between links in the big footer

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -68,7 +68,7 @@
     @include typeset-link;
   }
 
-  & + .usa-footer-secondary-link {
+  & + .usa-footer__secondary-link {
     padding-top: units(2);
   }
 

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -61,7 +61,6 @@
 
 .usa-footer__secondary-link {
   line-height: line-height($theme-footer-font-family, 2);
-  margin: 0 0 0 units(1);
   padding: 0;
 
   a {


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-footer-links/components/detail/footer--big.html)
This fixes footer link spacing by fixing a stray non-BEM class.

<img width="957" alt="Screen Shot 2019-03-11 at 3 36 56 PM" src="https://user-images.githubusercontent.com/11464021/54162663-8b153100-4413-11e9-9c47-1e0ca74cee09.png">

- - -

Fixes #2938 