### PR TITLE
Fix border display bug in sidenav

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -100,7 +100,7 @@ $nav-link-arrow-icon-size: 1;
   // Until the $theme-navigation-width,
   // use the usa-nav-list styles for the slide-in nav
   @include at-media-max($theme-navigation-width) {
-    @include nav-list;
+    @include nav-list('nav');
     margin-top: units(3);
     order: 2;
 

--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -1,6 +1,6 @@
 .usa-sidenav {
   @include border-box-sizing;
-  @include nav-list;
+  @include nav-list('sidenav');
   @include typeset($theme-sidenav-font-family, 'sm', 3);
   border-bottom: units(1px) solid color('base-lighter');
 

--- a/src/stylesheets/core/mixins/_nav-list.scss
+++ b/src/stylesheets/core/mixins/_nav-list.scss
@@ -3,11 +3,19 @@ $sidenav-level-2-inset: 4;
 $sidenav-level-3-inset: 6;
 $sidenav-level-4-inset: 8;
 
-@mixin nav-list {
+@mixin nav-list($type) {
   @include unstyled-list();
 
-  &__item {
-    border-top: units(1px) solid color('base-lighter');
+  @if $type == 'sidenav' {
+    &__item {
+      border-top: units(1px) solid color('base-lighter');
+    }
+  }
+
+  @if $type == 'nav' {
+    &-item {
+      border-top: units(1px) solid color('base-lighter');
+    }
   }
 
   a {
@@ -56,7 +64,7 @@ $sidenav-level-4-inset: 8;
   @include unstyled-list();
   margin: 0;
 
-  &__item {
+  &-item {
     border-top: units(1px) solid color('base-lighter');
     font-size: font-size($theme-sidenav-font-family, '2xs');
   }

--- a/src/stylesheets/core/mixins/_nav-list.scss
+++ b/src/stylesheets/core/mixins/_nav-list.scss
@@ -6,7 +6,7 @@ $sidenav-level-4-inset: 8;
 @mixin nav-list {
   @include unstyled-list();
 
-  &-item {
+  &__item {
     border-top: units(1px) solid color('base-lighter');
   }
 
@@ -56,7 +56,7 @@ $sidenav-level-4-inset: 8;
   @include unstyled-list();
   margin: 0;
 
-  &-item {
+  &__item {
     border-top: units(1px) solid color('base-lighter');
     font-size: font-size($theme-sidenav-font-family, '2xs');
   }


### PR DESCRIPTION
[Sidenav preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-sidenav-dividers/components/detail/sidenav--compare.html)
[Topnav mobile preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-sidenav-dividers/components/detail/header--basic-mega.html)

This fixes the sidenav mixin so we build properly-formatted rules (with `__item` in some instances and  `-item` in others, depending on the context).

<img width="959" alt="Screen Shot 2019-03-11 at 3 48 01 PM" src="https://user-images.githubusercontent.com/11464021/54163136-32df2e80-4415-11e9-96b5-74730d6b2de2.png">

- - -

Fixes #2939 
