### PR TITLE
[mobile] Align big footer links with section heading

### DIFF
--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -61,8 +61,8 @@
 
 .usa-footer__secondary-link {
   line-height: line-height($theme-footer-font-family, 2);
-  padding: 0;
   margin-left: units(2);
+  padding: 0;
 
   a {
     @include typeset-link;

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -62,6 +62,7 @@
 .usa-footer__secondary-link {
   line-height: line-height($theme-footer-font-family, 2);
   padding: 0;
+  margin-left: units(2);
 
   a {
     @include typeset-link;


### PR DESCRIPTION
[Preview mobile](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-align-mobile-footer-links/components/detail/footer--big.html)

This adds a bit more left margin to big footer links to align them with their section heading at mobile width:

<img width="455" alt="Screen Shot 2019-03-11 at 4 20 16 PM" src="https://user-images.githubusercontent.com/11464021/54164419-c61a6300-4419-11e9-9edb-50017d24d885.png">
