### PR TITLE
Reduce slim alert icon size

### DIFF
--- a/src/components/05-alerts/alerts.config.yml
+++ b/src/components/05-alerts/alerts.config.yml
@@ -49,7 +49,7 @@ variants:
     context:
       alert:
         classes: "usa-alert--info"
-        content: "lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod."
+        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod."
 
   - name: slim
     label: Slim

--- a/src/components/05-alerts/alerts.config.yml
+++ b/src/components/05-alerts/alerts.config.yml
@@ -56,4 +56,4 @@ variants:
     context:
       alert:
         classes: "usa-alert--info usa-alert--slim"
-        content: "lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod."
+        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod."

--- a/src/components/05-alerts/alerts.config.yml
+++ b/src/components/05-alerts/alerts.config.yml
@@ -11,14 +11,14 @@ variants:
     context:
       alert:
         classes: "usa-alert--info"
-        title: Information Status
+        title: Informative status
 
   - name: info
     label: Success
     context:
       alert:
         classes: "usa-alert--success"
-        title: Success Status
+        title: Success status
 
 
   - name: warning
@@ -26,14 +26,14 @@ variants:
     context:
       alert:
         classes: "usa-alert--warning"
-        title: Warning Status
+        title: Warning status
 
   - name: error
     label: Error
     context:
       alert:
         classes: "usa-alert--error"
-        title: Error Status
+        title: Error status
         role: "alert"
 
   - name: paragraph
@@ -41,7 +41,7 @@ variants:
     context:
       alert:
         classes: "usa-alert--info usa-alert__paragraph"
-        title: Information Status - Paragraph Width
+        title: "Informative status: Paragraph width"
         content: "Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
 
   - name: no-header

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -62,17 +62,6 @@ $padding-left: units($theme-alert-padding-x) + units($theme-alert-bar-width);
   }
 }
 
-.usa-alert--slim {
-  background-position: units($theme-alert-padding-x) center;
-  padding-bottom: units($theme-alert-bar-width);
-  padding-top: units($theme-alert-bar-width);
-
-  .usa-alert__text:only-child {
-    margin-bottom: units(0.5);
-    padding-top: units(0.5);
-  }
-}
-
 .usa-alert__icon {
   display: table-cell;
   padding-right: units($theme-alert-bar-width);
@@ -114,6 +103,22 @@ $padding-left: units($theme-alert-padding-x) + units($theme-alert-bar-width);
     .usa-alert__body {
       padding-left: units($theme-alert-icon-size) + units($theme-alert-padding-x);
     }
+  }
+}
+
+.usa-alert--slim {
+  background-position: units($theme-alert-padding-x) center;
+  background-size: units(5);
+  padding-bottom: units($theme-alert-bar-width);
+  padding-top: units($theme-alert-bar-width);
+
+  .usa-alert__body {
+    padding-left: units(5);
+  }
+
+  .usa-alert__text:only-child {
+    margin-bottom: units(0.5);
+    padding-top: units(0.5);
   }
 }
 


### PR DESCRIPTION
Reduces the slim alert icon size so it follows the designs which has them smaller:
<img width="725" alt="Screen Shot 2019-03-11 at 6 22 30 PM" src="https://user-images.githubusercontent.com/5249443/54168232-c66f2a00-442a-11e9-92d7-ad0c6bbc29b6.png">

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/update-slim-alert-icon/components/detail/alerts--slim.html)

Fixes #2755 