### PR TITLE
Fix font stack output

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -599,17 +599,19 @@ role-based font token.
 
 @function get-font-stack($token) {
   $type-token: convert-to-font-type($token);
+  $output-display-name: true;
   $this-stack: null;
   $this-font-map: map-get($project-font-type-tokens, $type-token);
   @if map-get($this-font-map, 'typeface-token') {
     $this-font-token: map-get($this-font-map, 'typeface-token');
-    $this-name: map-deep-get(
-      $all-typeface-tokens,
-      $this-font-token,
-      'display-name'
-    );
+    $this-typeface-data: map-get($all-typeface-tokens, $this-font-token);
+    $this-name: map-get($this-typeface-data, 'display-name');
+    @if map-has-key($this-typeface-data, 'system-font') {
+      $output-display-name: false;
+    }
     @if map-get($this-font-map, 'custom-stack') {
       $this-stack: map-get($this-font-map, 'custom-stack');
+      $output-display-name: true;
     }
     @else {
       $this-stack: map-deep-get(
@@ -617,6 +619,12 @@ role-based font token.
         $this-font-token,
         'stack'
       );
+    }
+    @if map-get($this-typeface-data, 'display-name') == null {
+      $output-display-name: false;
+    }
+    @if not $output-display-name {
+      @return #{$this-stack};
     }
     @return #{$this-name}, #{$this-stack};
   }

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -598,21 +598,28 @@ role-based font token.
 */
 
 @function get-font-stack($token) {
+  // Start by converting to a type token (sans, serif, etc)
   $type-token: convert-to-font-type($token);
   $output-display-name: true;
   $this-stack: null;
+  // Get the font type metadata
   $this-font-map: map-get($project-font-type-tokens, $type-token);
+  // Only output if the font type has an assigned typeface token
   @if map-get($this-font-map, 'typeface-token') {
     $this-font-token: map-get($this-font-map, 'typeface-token');
+    // Get the typeface metadata
     $this-typeface-data: map-get($all-typeface-tokens, $this-font-token);
     $this-name: map-get($this-typeface-data, 'display-name');
+    // If it's a system typeface, don't output the display name
     @if map-has-key($this-typeface-data, 'system-font') {
       $output-display-name: false;
     }
+    // If there's a custom stack, use it and output the display name
     @if map-get($this-font-map, 'custom-stack') {
       $this-stack: map-get($this-font-map, 'custom-stack');
       $output-display-name: true;
     }
+    // Otherwise, just get the token's default stack
     @else {
       $this-stack: map-deep-get(
         $all-typeface-tokens,
@@ -620,6 +627,7 @@ role-based font token.
         'stack'
       );
     }
+    // If the typeface has no display name (system fonts), don't output the display name 
     @if map-get($this-typeface-data, 'display-name') == null {
       $output-display-name: false;
     }

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -177,16 +177,19 @@ $system-typeface-tokens: (
     display-name: null,
     cap-height: 362px,
     stack: $font-stack-system,
+    system-font: true,
   ),
   'georgia': (
     display-name: 'Georgia',
     cap-height: 346px,
     stack: $font-stack-georgia,
+    system-font: true,
   ),
   'helvetica': (
     display-name: 'Helvetica',
     cap-height: 357px,
     stack: $font-stack-helvetica,
+    system-font: true,
   ),
   'tahoma': (
     display-name: 'Tahoma',

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -186,7 +186,7 @@ $system-typeface-tokens: (
     system-font: true,
   ),
   'helvetica': (
-    display-name: 'Helvetica',
+    display-name: 'Helvetica Neue',
     cap-height: 357px,
     stack: $font-stack-helvetica,
     system-font: true,


### PR DESCRIPTION
This fixes a problem where we might be outputting font stacks with a leading comma or using a redundant display name at the start of the stack.

- - -

We have four internal font stacks that we can assign to to typefaces, composed of common fallbacks installed on most systems:
```
$font-stack-system: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
$font-stack-georgia: 'Georgia', 'Cambria', 'Times New Roman', 'Times', serif;
$font-stack-helvetica: 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial', sans-serif;
$font-stack-monospace: 'Bitstream Vera Sans Mono', 'Consolas', 'Courier', monospace;
```

Plus, users can define custom stacks for font types in settings:
```
$theme-font-cond-custom-stack:  false !default;
$theme-font-icon-custom-stack:  false !default;
$theme-font-lang-custom-stack:  false !default;
$theme-font-mono-custom-stack:  false !default;
$theme-font-sans-custom-stack:  false !default;
$theme-font-serif-custom-stack: false !default;
```

The output font stack is the display name of the typeface plus the value of either the system-assigned stack or the user's custom stack.

For example, Source Sans Pro gets the `$font-stack-helvetica` stack by default and is output as 
```
font-family: #{display-name}, #{font-stack};
```

But the builder should not put a display name at the top of the stack in a couple of scenarios:
- If the user is using system fonts
- If the typeface is the same as the stack (i.e. `helvetica` or `georgia`) and no custom stack is defined

Now the stack builder function is smart enough to do that. It will withhold the leading display name if the display name is `null` (in the case of `'system'`) or if the assigned typeface is one of the common system fonts we're already using as a stack (in the case of `'georgia'` or `'helvetica'`).

- - -

Fixes #2944 