### PR TITLE
Update radio buttons and checkboxes to use BEM notation

### DIFF
--- a/src/components/07-form/controls/checkboxes.njk
+++ b/src/components/07-form/controls/checkboxes.njk
@@ -2,19 +2,19 @@
   <fieldset class="usa-fieldset">
     <legend class="usa-sr-only">Historical figures 1</legend>
     <ul class="usa-input-list">
-      <li>
+      <li class="usa-checkbox">
         <input class="usa-checkbox__input" id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
         <label class="usa-checkbox__label" for="truth">Sojourner Truth</label>
       </li>
-      <li>
+      <li class="usa-checkbox">
         <input class="usa-checkbox__input" id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
         <label class="usa-checkbox__label" for="douglass">Frederick Douglass</label>
       </li>
-      <li>
+      <li class="usa-checkbox">
         <input class="usa-checkbox__input" id="washington" type="checkbox" name="historical-figures-1" value="washington">
         <label class="usa-checkbox__label" for="washington">Booker T. Washington</label>
       </li>
-      <li>
+      <li class="usa-checkbox">
         <input class="usa-checkbox__input" id="carver" type="checkbox" name="historical-figures-1" disabled>
         <label class="usa-checkbox__label" for="carver">George Washington Carver</label>
       </li>

--- a/src/components/07-form/controls/checkboxes.njk
+++ b/src/components/07-form/controls/checkboxes.njk
@@ -3,20 +3,20 @@
     <legend class="usa-sr-only">Historical figures 1</legend>
     <ul class="usa-input-list">
       <li>
-        <input class="usa-checkbox-input" id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
-        <label class="usa-checkbox-label" for="truth">Sojourner Truth</label>
+        <input class="usa-checkbox__input" id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
+        <label class="usa-checkbox__label" for="truth">Sojourner Truth</label>
       </li>
       <li>
-        <input class="usa-checkbox-input" id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
-        <label class="usa-checkbox-label" for="douglass">Frederick Douglass</label>
+        <input class="usa-checkbox__input" id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
+        <label class="usa-checkbox__label" for="douglass">Frederick Douglass</label>
       </li>
       <li>
-        <input class="usa-checkbox-input" id="washington" type="checkbox" name="historical-figures-1" value="washington">
-        <label class="usa-checkbox-label" for="washington">Booker T. Washington</label>
+        <input class="usa-checkbox__input" id="washington" type="checkbox" name="historical-figures-1" value="washington">
+        <label class="usa-checkbox__label" for="washington">Booker T. Washington</label>
       </li>
       <li>
-        <input class="usa-checkbox-input" id="carver" type="checkbox" name="historical-figures-1" disabled>
-        <label class="usa-checkbox-label" for="carver">George Washington Carver</label>
+        <input class="usa-checkbox__input" id="carver" type="checkbox" name="historical-figures-1" disabled>
+        <label class="usa-checkbox__label" for="carver">George Washington Carver</label>
       </li>
     </ul>
   </fieldset>

--- a/src/components/07-form/controls/radio-buttons.njk
+++ b/src/components/07-form/controls/radio-buttons.njk
@@ -2,15 +2,15 @@
   <fieldset class="usa-fieldset">
     <legend class="usa-sr-only">Historical figures 2</legend>
     <ul class="usa-input-list">
-      <li>
+      <li class="usa-radio">
         <input class="usa-radio__input" id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
         <label class="usa-radio__label" for="stanton">Elizabeth Cady Stanton</label>
       </li>
-      <li>
+      <li class="usa-radio">
         <input class="usa-radio__input" id="anthony" type="radio" name="historical-figures-2" value="anthony">
         <label class="usa-radio__label" for="anthony">Susan B. Anthony</label>
       </li>
-      <li>
+      <li class="usa-radio">
         <input class="usa-radio__input" id="tubman" type="radio" name="historical-figures-2" value="tubman">
         <label class="usa-radio__label" for="tubman">Harriet Tubman</label>
       </li>

--- a/src/components/07-form/controls/radio-buttons.njk
+++ b/src/components/07-form/controls/radio-buttons.njk
@@ -3,16 +3,16 @@
     <legend class="usa-sr-only">Historical figures 2</legend>
     <ul class="usa-input-list">
       <li>
-        <input class="usa-radio-input" id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
-        <label class="usa-radio-label" for="stanton">Elizabeth Cady Stanton</label>
+        <input class="usa-radio__input" id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
+        <label class="usa-radio__label" for="stanton">Elizabeth Cady Stanton</label>
       </li>
       <li>
-        <input class="usa-radio-input" id="anthony" type="radio" name="historical-figures-2" value="anthony">
-        <label class="usa-radio-label" for="anthony">Susan B. Anthony</label>
+        <input class="usa-radio__input" id="anthony" type="radio" name="historical-figures-2" value="anthony">
+        <label class="usa-radio__label" for="anthony">Susan B. Anthony</label>
       </li>
       <li>
-        <input class="usa-radio-input" id="tubman" type="radio" name="historical-figures-2" value="tubman">
-        <label class="usa-radio-label" for="tubman">Harriet Tubman</label>
+        <input class="usa-radio__input" id="tubman" type="radio" name="historical-figures-2" value="tubman">
+        <label class="usa-radio__label" for="tubman">Harriet Tubman</label>
       </li>
     </ul>
   </fieldset>

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -166,8 +166,8 @@ $input-select-margin-right: 1.5;
   }
 }
 
-.usa-checkbox-input,
-.usa-radio-input {
+.usa-checkbox__input,
+.usa-radio__input {
   // The actual input element is only visible to screen readers, because
   // all visual styling is done via the label.
   @include sr-only();
@@ -181,8 +181,8 @@ $input-select-margin-right: 1.5;
   }
 }
 
-.usa-checkbox-label,
-.usa-radio-label {
+.usa-checkbox__label,
+.usa-radio__label {
   cursor: pointer;
   display: inherit;
   font-weight: font-weight('normal');
@@ -192,8 +192,8 @@ $input-select-margin-right: 1.5;
   text-indent: units(-$input-select-margin-right - $theme-input-select-size);
 }
 
-.usa-checkbox-label::before,
-.usa-radio-label::before {
+.usa-checkbox__label::before,
+.usa-radio__label::before {
   background: color('white');
   content: '\a0';
   display: inline-block;
@@ -202,34 +202,34 @@ $input-select-margin-right: 1.5;
   vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
 }
 
-.usa-checkbox-label::before {
+.usa-checkbox__label::before {
   @include u-square($theme-input-select-size);
   border-radius: radius($theme-checkbox-border-radius);
 }
 
-.usa-radio-label::before {
+.usa-radio__label::before {
   @include u-circle($theme-input-select-size);
 }
 
-.usa-checkbox-label::before,
-.usa-radio-label::before {
+.usa-checkbox__label::before,
+.usa-radio__label::before {
   box-shadow: 0 0 0 units($theme-input-select-border-width) color('base');
   line-height: units($theme-input-select-size);
   margin-right: units($input-select-margin-right);
 }
 
-.usa-checkbox-input:checked + .usa-checkbox-label::before,
-.usa-radio-input:checked + .usa-radio-label::before {
+.usa-checkbox__input:checked + .usa-checkbox__label::before,
+.usa-radio__input:checked + .usa-radio__label::before {
   background-color: color('primary');
   box-shadow: 0 0 0 units($theme-input-select-border-width) color('primary');
 }
 
-.usa-radio-input:checked + .usa-radio-label::before {
+.usa-radio__input:checked + .usa-radio__label::before {
   box-shadow: 0 0 0 units($theme-input-select-border-width) color('primary'), inset 0 0 0 units($theme-input-select-border-width) color('white');
 }
 
-.usa-checkbox-input:checked + .usa-checkbox-label::before,
-.usa-checkbox-input:checked:disabled + .usa-checkbox-label::before {
+.usa-checkbox__input:checked + .usa-checkbox__label::before,
+.usa-checkbox__input:checked:disabled + .usa-checkbox__label::before {
   @include add-background-svg('correct8');
   background-position: center center;
 
@@ -242,20 +242,20 @@ $input-select-margin-right: 1.5;
   }
 }
 
-.usa-radio-input:focus + .usa-radio-label::before {
+.usa-radio__input:focus + .usa-radio__label::before {
   @include focus-outline(null, null, null, 0.5);
 }
 
-.usa-checkbox-input:disabled + .usa-checkbox-label {
+.usa-checkbox__input:disabled + .usa-checkbox__label {
   color: color('disabled');
 }
 
-.usa-checkbox-input:focus + .usa-checkbox-label::before {
+.usa-checkbox__input:focus + .usa-checkbox__label::before {
   @include focus-outline;
 }
 
-.usa-checkbox-input:disabled + .usa-checkbox-label::before,
-.usa-radio-input:disabled + .usa-radio-label::before {
+.usa-checkbox__input:disabled + .usa-checkbox__label::before,
+.usa-radio__input:disabled + .usa-radio__label::before {
   background: color('disabled-light');
   box-shadow: 0 0 0 units($theme-input-select-border-width) color('disabled');
   cursor: not-allowed;


### PR DESCRIPTION
In this case, we do not have a `.block` set explicitly even though it's the `<li>` element. We do have a `.block__element`. I've also heard that some folks add the `.block` even if there's no styling needed, but I left it out for now unless others feel strongly it should be added.

Part of #2949. 
