### PR TITLE
Fix filter expression

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -20,7 +20,7 @@ var autoprefixerOptions = require('./browsers');
 var path = require('path');
 
 var entryFileFilter = filter('uswds.scss', { restore: true });
-var normalizeCssFilter = filter('normalize.css', { restore: true });
+var normalizeCssFilter = filter('**/normalize.css', { restore: true });
 
 const IGNORE_STRING = 'This file is ignored';
 const ignoreStylelintIgnoreWarnings = lintResults =>


### PR DESCRIPTION
src/stylesheets/lib/normalize.css was not getting generated in copy-vendor-sass,
causing the build to fail.
