### PR TITLE
Use `ex` unit for measure values

### DIFF
--- a/src/components/01-type/typesetting.njk
+++ b/src/components/01-type/typesetting.njk
@@ -2,7 +2,7 @@
   <div class="usa-line-length-example usa-prose">
     <h6 class="usa-heading-alt">Line length</h6>
     <section class="typography-example usa-prose margin-top-1">
-      <p><strong>75 characters (66ch) max-width:</strong> Yosemite National Park is set within California’s Sierra Nevada mountains. It’s famed for its giant, ancient sequoias, and for Tunnel View, the iconic vista of towering Bridalveil Fall and the granite cliffs of El Capitan and Half Dome.</p>
+      <p><strong>75 characters (68ex) max-width:</strong> Yosemite National Park is set within California’s Sierra Nevada mountains. It’s famed for its giant, ancient sequoias, and for Tunnel View, the iconic vista of towering Bridalveil Fall and the granite cliffs of El Capitan and Half Dome.</p>
     </section>
   </div>
 

--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -435,6 +435,7 @@ $system-properties: (
       3:	    $system-measure-base,
       4:	    $system-measure-large,
       5:	    $system-measure-larger,
+      6:	    $system-measure-largest,
       'none':   none,
     ),
     extended: (),

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -369,11 +369,12 @@ Measure
 ----------------------------------------
 */
 
-$system-measure-smaller:      40ch;
-$system-measure-small:        60ch;
-$system-measure-base:         66ch;
-$system-measure-large:        72ch;
-$system-measure-larger:       77ch;
+$system-measure-smaller:      44ex;
+$system-measure-small:        60ex;
+$system-measure-base:         64ex;
+$system-measure-large:        68ex;
+$system-measure-larger:       74ex;
+$system-measure-largest:      88ex;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -26,7 +26,7 @@ $theme-accordion-font-family:         'body' !default;
 $theme-alert-bar-width:               1 !default;
 $theme-alert-font-family:             'ui' !default;
 $theme-alert-icon-size:               4 !default;
-$theme-alert-measure:                 3 !default;
+$theme-alert-measure:                 5 !default;
 $theme-alert-padding-x:               2.5 !default;
 
 // Banner

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -381,11 +381,12 @@ Font role tokens
 ----------------------------------------
 Measure (max-width) tokens
 ----------------------------------------
-1:       40ch
-2:       60ch
-3:       66ch
-4:       72ch
-5:       77ch
+1:       44ex
+2:       60ex
+3:       64ex
+4:       68ex
+5:       74ex
+6:       88ex
 none:    none
 ----------------------------------------
 */
@@ -411,12 +412,12 @@ $theme-title-font-size:            '3xl' !default;
 
 // Text and prose
 $theme-text-measure-narrow:        1 !default;
-$theme-text-measure:               3 !default;
-$theme-text-measure-wide:          4 !default;
+$theme-text-measure:               4 !default;
+$theme-text-measure-wide:          6 !default;
 $theme-prose-font-family:          'body' !default;
 
 // Lead text
 $theme-lead-font-family:           'heading' !default;
 $theme-lead-font-size:             'lg' !default;
 $theme-lead-line-height:           6 !default;
-$theme-lead-measure:               5 !default;
+$theme-lead-measure:               6 !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -26,7 +26,7 @@ $theme-accordion-font-family:         'body';
 $theme-alert-bar-width:               1;
 $theme-alert-font-family:             'ui';
 $theme-alert-icon-size:               4;
-$theme-alert-measure:                 3;
+$theme-alert-measure:                 5;
 $theme-alert-padding-x:               2.5;
 
 // Banner

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -7,7 +7,7 @@
 ========================================
 ========================================
 ----------------------------------------
-USWDS 2.0.0 Beta 6
+USWDS 2.0.0 Beta 5
 ----------------------------------------
 TYPOGRAPHY SETTINGS
 ----------------------------------------
@@ -381,11 +381,12 @@ Font role tokens
 ----------------------------------------
 Measure (max-width) tokens
 ----------------------------------------
-1:       40ch
-2:       60ch
-3:       66ch
-4:       72ch
-5:       77ch
+1:       44ex
+2:       60ex
+3:       64ex
+4:       68ex
+5:       74ex
+6:       88ex
 none:    none
 ----------------------------------------
 */
@@ -411,12 +412,12 @@ $theme-title-font-size:            '3xl';
 
 // Text and prose
 $theme-text-measure-narrow:        1;
-$theme-text-measure:               3;
-$theme-text-measure-wide:          4;
+$theme-text-measure:               4;
+$theme-text-measure-wide:          6;
 $theme-prose-font-family:          'body';
 
 // Lead text
 $theme-lead-font-family:           'heading';
 $theme-lead-font-size:             'lg';
 $theme-lead-line-height:           6;
-$theme-lead-measure:               5;
+$theme-lead-measure:               6;

--- a/src/stylesheets/utilities/rules/measure.scss
+++ b/src/stylesheets/utilities/rules/measure.scss
@@ -11,8 +11,8 @@ output:
   max-width: [value];
 ----------------------------------------
 example:
-  .measure-base {
-    max-width: 66ch; }
+  .measure-4 {
+    max-width: 68ex; }
 ----------------------------------------
 */
 


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-update-measure/components/detail/typesetting.html)

- - -

This updates our measure tokens to use `ex` units instead of `ch` per the reasoning in #2960.

This rebalances our measure tokens to be concentrated within our guidance range of 45-90 characters (see https://practicaltypography.com/line-length.html) and should result in output that's more consistent from typeface to typeface because the `ex` is the height of the `x` character and our normalization scheme tends to make this value more consistent from face to face.

Now our docs and `usa-prose` measure are what they say they are: ~75 characters (`measure 4`).

<img width="626" alt="Screen Shot 2019-03-18 at 10 02 15 AM" src="https://user-images.githubusercontent.com/11464021/54548402-12f3c180-4965-11e9-9a19-02de6e161608.png">


However, this is something of a breaking change in that the new measure tokens tend to be narrower than their old values and will need to be updated per the chart that follows.

| token | desired output | new value | old value | old output in Public Sans 
| --- | --- | --- | --- | ---
| `1` | ~50 characters | `44ex` | `40ch` | 51 characters
| `2` | ~66 characters | `60ex` | `60ch` | 80 characters
| `3` | ~72 characters | `64ex` | `66ch` | 88 characters
| `4` | ~78 characters | `68ex` | `72ch` | 95 characters
| `5` | ~86 characters | `74ex` | `77ch` | 100 characters
| `6` | ~96 characters | `88ex` | — | —

| Beta 6 | Beta 7
| --- | ---
| '1' | '1'
| '2' | '4'
| '3' | '5'
| '4' | '6'
| '5' | '6'

- - -

Fixes #2960 