### PR TITLE
Tighten the letterspacing of `letterspacing 1`

### DIFF
--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -289,7 +289,7 @@ $system-properties: (
       'ls-neg-3':	  -.03em,
       'ls-neg-2':	  -.02em,
       'ls-neg-1':	  -.01em,
-      'ls-1':	      .05em,
+      'ls-1':	      .025em,
       'ls-2':	      .1em,
       'ls-3':	      .15em,
     ),


### PR DESCRIPTION
No preview

Uses 0.025 for the letter-spacing value of `letterspacing 1` to address the issue in #2962 

Fixes #2962 