### PR TITLE
Change hero heading to h1

### DIFF
--- a/src/components/hero/hero.njk
+++ b/src/components/hero/hero.njk
@@ -1,12 +1,12 @@
 <section class="usa-hero">
   <div class="grid-container">
     <div class="usa-hero__callout">
-      <h2 class="usa-hero__heading">
+      <h1 class="usa-hero__heading">
         {%- if hero.callout -%}
           <span class="usa-hero__heading--alt">{{ hero.callout }}</span>
         {%- endif -%}
         {{ hero.title }}
-      </h2>
+      </h1>
       {%- if hero.paragraph -%}
         <p>{{ hero.paragraph }}</p>
       {%- endif -%}


### PR DESCRIPTION
Changes the hero heading to an `h1` so that there's an h1 on the page. 

More thoughts around this in [:lock: Slack](https://gsa-tts.slack.com/archives/C054CHWSJ/p1553034277079600?thread_ts=1553026442.077200&cid=C054CHWSJ).

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/mb-update-hero-heading/components/detail/layout--landing.html)

Fixes #2594. 