### PR TITLE
Update button unstyled mixin and remove CSS nesting

### DIFF
--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -1,4 +1,5 @@
 @mixin button-unstyled {
+  @include no-knockout-font-smoothing;
   @include typeset-link;
   background-color: transparent;
   border: 0;
@@ -8,11 +9,12 @@
   margin: 0;
   padding: 0;
   text-align: left;
-  -webkit-font-smoothing: auto;
 
   &:hover,
   &:active {
+    @include no-knockout-font-smoothing;
     background-color: transparent;
+    box-shadow: none;
     text-decoration: underline;
   }
 }

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -212,14 +212,6 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
   }
 }
 
-.usa-button,
-.usa-button--accent-cool,
-.usa-button--base,
-.usa-button--big,
-.usa-button--inverse,
-.usa-button--outline,
-.usa-button--secondary {
-  &.usa-button--unstyled {
-    @include button-unstyled;
-  }
+.usa-button--unstyled {
+  @include button-unstyled;
 }


### PR DESCRIPTION
Improves the mixin to ensure the no box-shadow property applies to hover and focus states, uses the no knockout include instead of just the webkit property and adds that to the hover and focus states. Removes CSS nesting from unstyled button class.