### PR TITLE
Use 72ex for measure-5

### DIFF
--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -373,7 +373,7 @@ $system-measure-smaller:      44ex;
 $system-measure-small:        60ex;
 $system-measure-base:         64ex;
 $system-measure-large:        68ex;
-$system-measure-larger:       74ex;
+$system-measure-larger:       72ex;
 $system-measure-largest:      88ex;
 
 /*


### PR DESCRIPTION
This changes the value of `measure 5` to `72ex` from `74ex` — it was just feeling a little too long. It works out to about 80 characters per line, and this feels like a good limit for a long line.