### PR TITLE
Apply :focus behavior to focusable elements only

### DIFF
--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -30,6 +30,7 @@ body {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
+// Apply :focus behavior to focusable elements only (For IE 11)
 input,
 select,
 textarea,


### PR DESCRIPTION
## Description
This pull request explicitly lists elements that are focusable and applies the focus mixin only to those elements, rather than applying the rule globally. The immediate goal of this is to patch the bug as described in Issue #2928.

Resolves https://github.com/uswds/uswds/issues/2928

## Additional information

Include any of the following (as necessary): 

- Even though this issue was discovered only in IE, I feel that this is also the more correct solution than applying the `:focus` rule globally.
- This solution is based on the solution described in this SO thread, https://stackoverflow.com/a/30753870.
- jQuery's `:focusable` selector also has interesting info, https://api.jqueryui.com/focusable-selector/.
- See issue for more context

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
    - May have messed up the `[Website]` part of this.
