### PR TITLE
add snyk monitor to deploy in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ jobs:
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
             npm publish
+      - run:
+          name: Update dependencies in Snyk dashboard
+          command: snyk monitor --org=uswds
 
 workflows:
   version: 2


### PR DESCRIPTION
This adds `snyk monitor` to the deploy step in circleci which updates the dependency snapshot snyk uses to report vulnerabilities.