### PR TITLE
Constrain focus to tabbable elements [IE 11 fix]

### DIFF
--- a/src/stylesheets/core/_base.scss
+++ b/src/stylesheets/core/_base.scss
@@ -32,7 +32,27 @@ body {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
-*:focus,
+// Apply :focus behavior to focusable elements only (For IE 11)
+input,
+select,
+textarea,
+button {
+  &:not([disabled]) {
+    &:focus {
+      @include focus-outline;
+    }
+  }
+}
+
+iframe,
+[href],
+[tabindex],
+[contentEditable=true] {
+  &:focus {
+    @include focus-outline;
+  }
+}
+
 .usa-focus {
   @include focus-outline;
 }


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-update-focus/components/preview/kitchen-sink.html) ✨ 

This applies the same technique to the 2.0 branch that we applied in the 1.x branch here: https://github.com/uswds/uswds/pull/2983

Now, IE 11 won't apply focus highlighting to non-tabbable elements.

Before:
<img width="626" alt="Screen Shot 2019-03-25 at 4 37 55 AM" src="https://user-images.githubusercontent.com/11464021/54916910-cd307f00-4eb7-11e9-8318-218a1eafa3e1.png">

After:
<img width="620" alt="Screen Shot 2019-03-25 at 4 33 56 AM" src="https://user-images.githubusercontent.com/11464021/54916770-83479900-4eb7-11e9-8f16-82a563dea85c.png">


- - - 

Fixes #2928 