### PR TITLE
Remove alert__paragraph

### DIFF
--- a/src/components/01-type/lists.njk
+++ b/src/components/01-type/lists.njk
@@ -1,7 +1,7 @@
 
   <div class="grid-row grid-gap">
     <div class="mobile-lg:grid-col-4">
-      <h6 class="usa-heading-alt">Unordered list</h6>
+      <h6 class="margin-0">Unordered list</h6>
       <ul class="usa-list">
         <li>Unordered list item</li>
         <li>Unordered list item</li>
@@ -9,8 +9,8 @@
       </ul>
     </div>
 
-    <div class="mobile-lg:grid-col-4">
-      <h6 class="usa-heading-alt">Ordered list</h6>
+    <div class="mobile-lg:grid-col-4 margin-top-4 mobile-lg:margin-top-0">
+      <h6 class="margin-0">Ordered list</h6>
       <ol class="usa-list">
         <li>Ordered list item</li>
         <li>Ordered list item</li>
@@ -18,8 +18,8 @@
       </ol>
     </div>
 
-    <div class="mobile-lg:grid-col-4">
-      <h6 class="usa-heading-alt">Unstyled list</h6>
+    <div class="mobile-lg:grid-col-4 margin-top-4 mobile-lg:margin-top-0">
+      <h6 class="margin-0">Unstyled list</h6>
       <ul class="usa-list usa-list--unstyled">
         <li>Unstyled list item</li>
         <li>Unstyled list item</li>

--- a/src/components/05-alerts/alerts.config.yml
+++ b/src/components/05-alerts/alerts.config.yml
@@ -36,14 +36,6 @@ variants:
         title: Error status
         role: "alert"
 
-  - name: paragraph
-    label: Paragraph
-    context:
-      alert:
-        classes: "usa-alert--info usa-alert__paragraph"
-        title: "Informative status: Paragraph width"
-        content: "Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
-
   - name: no-header
     label: No header
     context:

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -128,7 +128,3 @@ $padding-left: units($theme-alert-padding-x) + units($theme-alert-bar-width);
     padding-left: 0;
   }
 }
-
-.usa-alert__paragraph {
-  width: measure($theme-alert-measure);
-}

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -26,7 +26,6 @@ $theme-accordion-font-family:         'body' !default;
 $theme-alert-bar-width:               1 !default;
 $theme-alert-font-family:             'ui' !default;
 $theme-alert-icon-size:               4 !default;
-$theme-alert-measure:                 5 !default;
 $theme-alert-padding-x:               2.5 !default;
 
 // Banner

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -26,7 +26,6 @@ $theme-accordion-font-family:         'body';
 $theme-alert-bar-width:               1;
 $theme-alert-font-family:             'ui';
 $theme-alert-icon-size:               4;
-$theme-alert-measure:                 5;
 $theme-alert-padding-x:               2.5;
 
 // Banner


### PR DESCRIPTION
[Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/dw-remove-alert-paragraph/) ✨ 

This component was not a proper subcomponent to begin with. Even as a variant, its functionality is now better controlled with utilities as in `.usa-alert.measure-5`.

- - -

Fixes #2975 