### PR TITLE
Add setup snyk command to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
             npm publish
       - run:
+          name: Setup Snyk
+          command: sudo npm install -g snyk
+      - run:
           name: Update dependencies in Snyk dashboard
           command: snyk monitor --org=uswds
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ references:
     restore_cache:
       keys:
         - v1-uswds-dependencies-{{ checksum "package-lock.json" }}
-        - v1-uswds-dependencies-
 
 jobs:
   build:
@@ -24,7 +23,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-uswds-dependencies-{{ checksum "package-lock.json" }}
-          - v1-uswds-dependencies-
       - run: npm install
       - save_cache:
           paths:
@@ -51,7 +49,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-uswds-dependencies-{{ checksum "package-lock.json" }}
-          - v1-uswds-dependencies-
       - run: npm install --ignore-scripts
       - run:
           name: Build the USWDS package


### PR DESCRIPTION
Snyk is not installed before we run `snyk monitor --org=uswds` in the deploy step.

Also, removes `v1-uswds-dependencies-` cache key.