### PR TITLE
Move aria search to form. Remove styling on aria role.

### DIFF
--- a/src/components/search/search--header.njk
+++ b/src/components/search/search--header.njk
@@ -1,7 +1,5 @@
-<form class="usa-search usa-search--small {% if search_js %} js-search-form{% endif %}">
-  <div role="search">
-    <label class="usa-sr-only" for="{{ id_prefix }}search-field-small">Search small</label>
-    <input class="usa-input" id="{{ id_prefix }}search-field-small" type="search" name="search">
-    <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
-  </div>
+<form class="usa-search usa-search--small {% if search_js %} js-search-form{% endif %}" role="search">
+  <label class="usa-sr-only" for="{{ id_prefix }}search-field-small">Search small</label>
+  <input class="usa-input" id="{{ id_prefix }}search-field-small" type="search" name="search">
+  <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
 </form>

--- a/src/components/search/search.njk
+++ b/src/components/search/search.njk
@@ -1,35 +1,29 @@
 <h6>Search big</h6>
 
-<form class="usa-search usa-search--big">
-  <div role="search">
-    <label class="usa-sr-only" for="search-field-big">Search</label>
-    <input class="usa-input" id="search-field-big" type="search" name="search">
-    <button class="usa-button" type="submit">
-      <span class="usa-search__submit-text">Search</span>
-    </button>
-  </div>
+<form class="usa-search usa-search--big" role="search">
+  <label class="usa-sr-only" for="search-field-big">Search</label>
+  <input class="usa-input" id="search-field-big" type="search" name="search">
+  <button class="usa-button" type="submit">
+    <span class="usa-search__submit-text">Search</span>
+  </button>
 </form>
 
 <h6>Search default</h6>
 
-<form class="usa-search">
-  <div role="search">
-    <label class="usa-sr-only" for="search-field">Search</label>
-    <input class="usa-input" id="search-field" type="search" name="search">
-    <button class="usa-button" type="submit">
-      <span class="usa-search__submit-text">Search</span>
-    </button>
-  </div>
+<form class="usa-search" role="search">
+  <label class="usa-sr-only" for="search-field">Search</label>
+  <input class="usa-input" id="search-field" type="search" name="search">
+  <button class="usa-button" type="submit">
+    <span class="usa-search__submit-text">Search</span>
+  </button>
 </form>
 
 <h6>Search small</h6>
 
-<form class="usa-search usa-search--small">
-  <div role="search">
-    <label class="usa-sr-only" for="search-field-small">Search</label>
-    <input class="usa-input" id="search-field-small" type="search" name="search">
-    <button class="usa-button" type="submit">
-      <span class="usa-sr-only">Search</span>
-    </button>
-  </div>
+<form class="usa-search usa-search--small" role="search">
+  <label class="usa-sr-only" for="search-field-small">Search</label>
+  <input class="usa-input" id="search-field-small" type="search" name="search">
+  <button class="usa-button" type="submit">
+    <span class="usa-sr-only">Search</span>
+  </button>
 </form>

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -42,13 +42,6 @@ $z-index-overlay: 400;
   .usa-search {
     @include at-media($theme-navigation-width) {
       float: right;
-    }
-  }
-
-  // Accessibility: The <div> with search role
-  [role=search] {
-    @include at-media($theme-navigation-width) {
-      float: right;
       max-width: calc(#{$theme-search-min-width} + #{units($theme-button-small-width)});
       width: 100%;
     }

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -10,10 +10,7 @@
   @include clearfix;
   @include typeset($theme-search-font-family);
   position: relative;
-
-  [role=search] {
-    display: flex;
-  }
+  display: flex;
 
   [type=submit] {
     @include search-icon;


### PR DESCRIPTION
## Description

PR removes `<div role="search">` from the search component and moves `role="search"` to the enclosing form instead. Reasoning behind the change:

- `<form role="search">` is enough to describe a search form.
- Most examples I've seen on `role="search"` put it on `<form>`.
    - https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html
    - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role
- The same appearance can be achieved without the extra `<div>`.