### PR TITLE
Add `offset-none` to the responsive offset loop

### DIFF
--- a/src/stylesheets/core/_layout-grid.scss
+++ b/src/stylesheets/core/_layout-grid.scss
@@ -146,6 +146,12 @@ $namespace-grid: ns('grid');
         }
       }
     }
+    @include at-media($mq-key) {
+      .#{$mq-key}\:#{$namespace-grid}offset-none {
+        $props: append-important($grid-global, none);
+        @include grid-offset($props);
+      }
+    }
   }
 }
 /* stylelint-enable */


### PR DESCRIPTION
Thanks to @robertromore for bringing this up in https://github.com/uswds/uswds/pull/3013

We'd omitted `offset-none` from the responsive offsets loop. Since `none` isn't one of the keys in `$system-layout-grid-widths`, we have to add it to the loop manually, as we do in https://github.com/uswds/uswds/blob/a7cbda2e71f4ee07848f1097adbf4f25cb44f003/src/stylesheets/core/_layout-grid.scss#L133

**faulty loop:**
```scss
// responsive offsets
@each $mq-key, $mq-value in $system-breakpoints {
  @if map-get($theme-utility-breakpoints, $mq-key) {
    @each $width-key, $width-value in $system-layout-grid-widths {
      @include at-media($mq-key) {
        .#{$mq-key}\:#{$namespace-grid}offset-#{$width-key} {
          $props: append-important($grid-global, $width-key);
          @include grid-offset($props);
        }
      }
    }
// --> need to add the offset-none rule here.
  }
}
```

**updated loop:**
```scss
// responsive offsets
@each $mq-key, $mq-value in $system-breakpoints {
  @if map-get($theme-utility-breakpoints, $mq-key) {
    @each $width-key, $width-value in $system-layout-grid-widths {
      @include at-media($mq-key) {
        .#{$mq-key}\:#{$namespace-grid}offset-#{$width-key} {
          $props: append-important($grid-global, $width-key);
          @include grid-offset($props);
        }
      }
    }
    @include at-media($mq-key) {
      .#{$mq-key}\:#{$namespace-grid}offset-none {
        $props: append-important($grid-global, none);
        @include grid-offset($props);
      }
    }
  }
}
```