### PR TITLE
Use primary-dark for link hover color (was primary-darker)

### DIFF
--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -129,5 +129,5 @@ General colors
 // Links
 $theme-link-color:                    'primary' !default;
 $theme-link-visited-color:            'violet-70v' !default;
-$theme-link-hover-color:              'primary-darker' !default;
+$theme-link-hover-color:              'primary-dark' !default;
 $theme-link-active-color:             'primary-darker' !default;

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -129,5 +129,5 @@ General colors
 // Links
 $theme-link-color:             'primary';
 $theme-link-visited-color:     'violet-70v';
-$theme-link-hover-color:       'primary-darker';
+$theme-link-hover-color:       'primary-dark';
 $theme-link-active-color:      'primary-darker';


### PR DESCRIPTION
Per discussion in #3022. 

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/mb-update-link-hover-color/components/detail/links.html)