### PR TITLE
Add snyk auth step to circle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
       - run:
           name: Setup Snyk
           command: sudo npm install -g snyk
+      - run: # run snyk auth - authenticate snyk use environment variables to add token
+          name: snyk auth
+          command: snyk auth $SNYK_TOKEN
       - run:
           name: Run test
           command: npm test


### PR DESCRIPTION
So we're no longer relying on our individual user token and uses the snyk environment variable. This ensures that public contributions no longer fail on CircleCI.

## New Snyk auth step
<img width="1205" alt="Screen Shot 2019-04-10 at 10 27 39 AM" src="https://user-images.githubusercontent.com/5249443/55900190-7b584c00-5b7b-11e9-9970-291496235a9b.png">

Fixes #3026