### PR TITLE
Change title to display in vars and mixins

### DIFF
--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -86,19 +86,19 @@ Sets:
   }
 }
 
-@mixin title {
+@mixin display {
   @include typeset(
     'heading',
-    $theme-title-font-size,
+    $theme-display-font-size,
     $theme-heading-line-height
   );
 
   font-weight: fw('bold');
 }
 
-@mixin typeset-title {
+@mixin typeset-display {
   @include typeset-heading;
-  @include title;
+  @include display;
 }
 
 @mixin h1 {

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -77,7 +77,7 @@ dfn {
   }
 
   @include at-media('tablet') {
-    @include typeset-title;
+    @include typeset-display;
   }
 }
 

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -407,7 +407,7 @@ $theme-h5-font-size:               'xs' !default;
 $theme-h6-font-size:               '3xs' !default;
 $theme-heading-line-height:        2 !default;
 $theme-small-font-size:            '2xs' !default;
-$theme-title-font-size:            '3xl' !default;
+$theme-display-font-size:          '3xl' !default;
 
 // Text and prose
 $theme-text-measure-narrow:        1 !default;

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -407,7 +407,7 @@ $theme-h5-font-size:               'xs';
 $theme-h6-font-size:               '3xs';
 $theme-heading-line-height:        2;
 $theme-small-font-size:            '2xs';
-$theme-title-font-size:            '3xl';
+$theme-display-font-size:          '3xl';
 
 // Text and prose
 $theme-text-measure-narrow:        1;


### PR DESCRIPTION
Using `title` confused people who thought it was meant for the `h1`. Using `display` clarifies this and uses commonly accepted typography language.