### PR TITLE
[WIP] Add responsive headings

### DIFF
--- a/src/components/01-type/typesetting.njk
+++ b/src/components/01-type/typesetting.njk
@@ -8,6 +8,7 @@
 
   <h6 class="usa-heading-alt">Spacing</h6>
   <section class="example-spacing usa-prose margin-top-1 font-sans-sm measure-3 bg-primary-lighter">
+    <p class="usa-display">Display text</p>
     <h1>Page heading</h1>
     <p class="usa-intro">Great Smoky Mountains National Park straddles the border of North Carolina and Tennessee.</p>
 

--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -87,11 +87,27 @@ Sets:
 }
 
 @mixin display {
-  @include typeset(
-    'heading',
-    $theme-display-font-size,
-    $theme-heading-line-height
-  );
+  @if $theme-responsive-headings == true {
+    @include typeset(
+      'heading',
+      $theme-display-mobile-font-size,
+      $theme-heading-line-height
+    );
+
+    @include at-media('mobile-lg') {
+      @include typeset(
+        'heading',
+        $theme-display-font-size
+      );
+    }
+  }
+  @else {
+    @include typeset(
+      'heading',
+      $theme-display-font-size,
+      $theme-heading-line-height
+    );
+  }
 
   font-weight: fw('bold');
 }
@@ -102,11 +118,27 @@ Sets:
 }
 
 @mixin h1 {
-  @include typeset(
-    'heading',
-    $theme-h1-font-size,
-    $theme-heading-line-height
-  );
+  @if $theme-responsive-headings == true {
+    @include typeset(
+      'heading',
+      $theme-h1-mobile-font-size,
+      $theme-heading-line-height
+    );
+
+    @include at-media('mobile-lg') {
+      @include typeset(
+        'heading',
+        $theme-h1-font-size
+      );
+    }
+  }
+  @else {
+    @include typeset(
+      'heading',
+      $theme-h1-font-size,
+      $theme-heading-line-height
+    );
+  }
 
   font-weight: fw('bold');
 }
@@ -117,11 +149,27 @@ Sets:
 }
 
 @mixin h2 {
-  @include typeset(
-    'heading',
-    $theme-h2-font-size,
-    $theme-heading-line-height
-  );
+  @if $theme-responsive-headings == true {
+    @include typeset(
+      'heading',
+      $theme-h2-mobile-font-size,
+      $theme-heading-line-height
+    );
+
+    @include at-media('mobile-lg') {
+      @include typeset(
+        'heading',
+        $theme-h2-font-size
+      );
+    }
+  }
+  @else {
+    @include typeset(
+      'heading',
+      $theme-h2-font-size,
+      $theme-heading-line-height
+    );
+  }
 
   font-weight: fw('bold');
 }
@@ -132,11 +180,27 @@ Sets:
 }
 
 @mixin h3 {
-  @include typeset(
-    'heading',
-    $theme-h3-font-size,
-    $theme-heading-line-height
-  );
+  @if $theme-responsive-headings == true {
+    @include typeset(
+      'heading',
+      $theme-h3-mobile-font-size,
+      $theme-heading-line-height
+    );
+
+    @include at-media('mobile-lg') {
+      @include typeset(
+        'heading',
+        $theme-h3-font-size
+      );
+    }
+  }
+  @else {
+    @include typeset(
+      'heading',
+      $theme-h3-font-size,
+      $theme-heading-line-height
+    );
+  }
 
   font-weight: fw('bold');
 }

--- a/src/stylesheets/elements/_typography.scss
+++ b/src/stylesheets/elements/_typography.scss
@@ -69,16 +69,8 @@ dfn {
 }
 
 .usa-display {
-  @include typeset-h3;
+  @include typeset-display;
   margin-bottom: 0;
-
-  @include at-media('mobile-lg') {
-    @include typeset-h1;
-  }
-
-  @include at-media('tablet') {
-    @include typeset-display;
-  }
 }
 
 .usa-intro {

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -96,3 +96,11 @@ Icons
 */
 
 $theme-icon-image-size: 2 !default;
+
+/*
+----------------------------------------
+Responsive headings
+----------------------------------------
+*/
+
+$theme-responsive-headings: true !default;

--- a/src/stylesheets/settings/_settings-typography.scss
+++ b/src/stylesheets/settings/_settings-typography.scss
@@ -399,15 +399,24 @@ $theme-body-line-height:           5 !default;
 $theme-style-body-element:         false !default;
 
 // Headings
+$theme-display-font-size:          '3xl' !default;
 $theme-h1-font-size:               '2xl' !default;
 $theme-h2-font-size:               'xl' !default;
 $theme-h3-font-size:               'lg' !default;
 $theme-h4-font-size:               'sm' !default;
 $theme-h5-font-size:               'xs' !default;
 $theme-h6-font-size:               '3xs' !default;
-$theme-heading-line-height:        2 !default;
 $theme-small-font-size:            '2xs' !default;
-$theme-display-font-size:          '3xl' !default;
+$theme-heading-line-height:        2 !default;
+
+// Responsive headings
+$theme-display-mobile-font-size:   '2xl' !default;
+$theme-h1-mobile-font-size:        'xl' !default;
+$theme-h2-mobile-font-size:        'lg' !default;
+$theme-h3-mobile-font-size:        'md' !default;
+$theme-h4-mobile-font-size:        $theme-h4-font-size !default;
+$theme-h5-mobile-font-size:        $theme-h5-font-size !default;
+$theme-h6-mobile-font-size:        $theme-h6-font-size !default;
 
 // Text and prose
 $theme-text-measure-narrow:        1 !default;

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -96,3 +96,11 @@ Icons
 */
 
 $theme-icon-image-size: 2;
+
+/*
+----------------------------------------
+Responsive headings
+----------------------------------------
+*/
+
+$theme-responsive-headings: true;

--- a/src/stylesheets/theme/_uswds-theme-typography.scss
+++ b/src/stylesheets/theme/_uswds-theme-typography.scss
@@ -399,15 +399,15 @@ $theme-body-line-height:           5;
 $theme-style-body-element:         false;
 
 // Headings
+$theme-display-font-size:          '3xl';
 $theme-h1-font-size:               '2xl';
 $theme-h2-font-size:               'xl';
 $theme-h3-font-size:               'lg';
 $theme-h4-font-size:               'sm';
 $theme-h5-font-size:               'xs';
 $theme-h6-font-size:               '3xs';
-$theme-heading-line-height:        2;
 $theme-small-font-size:            '2xs';
-$theme-display-font-size:          '3xl';
+$theme-heading-line-height:        2;
 
 // Text and prose
 $theme-text-measure-narrow:        1;


### PR DESCRIPTION
- Added setting: `$theme-responsive-headings` and set to `true` for testing purposes, may change to `false` if this goes into production.
- Added responsive style for `display`, `h1`, `h2`, `h3`. Left `h4`-`h6` mixins alone, but can update the mixins to match the previous ones.
  - The mixins seem kind of repetitive and wondered if there's a better solution out there. 


![](http://g.recordit.co/Hqk4uEuks4.gif)

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/uswds/uswds/add-responsive-headings/components/detail/typesetting.html)




/cc @hursey013 