### PR TITLE
Fix iOS footer collapse on scroll

### DIFF
--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -20,8 +20,10 @@ const BUTTON_SELECTOR = '.usa-footer__primary-link';
  * @return {Promise}
  */
 const resizeTo = width => new Promise((resolve) => {
-  window.innerWidth = width;
-  window.dispatchEvent(new CustomEvent('resize'));
+  if (width !== window.innerWidth) {
+    window.innerWidth = width;
+    window.dispatchEvent(new CustomEvent('resize'));
+  }
   setTimeout(resolve, DEBOUNCE_RATE + 10);
 });
 
@@ -86,7 +88,8 @@ describe('big footer accordion', () => {
   });
 
   it('closes panel on subsequent click', () => {
-    return resizeTo(400)
+    return resizeTo(800)
+      .then(() => resizeTo(400))
       .then(() => {
         buttons[0].click();
         assertHidden(lists[ 0 ], false);
@@ -96,7 +99,8 @@ describe('big footer accordion', () => {
   });
 
   it('closes other panels on small screens', () => {
-    return resizeTo(400)
+    return resizeTo(800)
+      .then(() => resizeTo(400))
       .then(() => {
         buttons[0].click();
         assertHidden(lists[ 0 ], false);

--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -20,10 +20,8 @@ const BUTTON_SELECTOR = '.usa-footer__primary-link';
  * @return {Promise}
  */
 const resizeTo = width => new Promise((resolve) => {
-  if (width !== window.innerWidth) {
-    window.innerWidth = width;
-    window.dispatchEvent(new CustomEvent('resize'));
-  }
+  window.innerWidth = width;
+  window.dispatchEvent(new CustomEvent('resize'));
   setTimeout(resolve, DEBOUNCE_RATE + 10);
 });
 

--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -30,7 +30,11 @@ function showPanel() {
   }
 }
 
+let lastInnerWidth;
+
 const resize = debounce(() => {
+  if (lastInnerWidth === window.innerWidth) return;
+  lastInnerWidth = window.innerWidth;
   const hidden = window.innerWidth < HIDE_MAX_WIDTH;
   select(COLLAPSIBLE).forEach(list => list.classList.toggle(HIDDEN, hidden));
 }, DEBOUNCE_RATE);


### PR DESCRIPTION
Resolves #3046

## Description

Fixes an issue where iOS footer sections were closing whenever the user scrolls up &/or down.

