### PR TITLE
Make SCSS code snippets in README render nicely on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Visit the [Style tokens section](https://v2.designsystem.digital.gov/style/) of 
 ### Using tokens in theme settings
 The following is an example of theme settings from `_uswds-theme-spacing.scss`:
 
-```sass
+```scss
 $theme-site-max-width:              'desktop';
 $theme-site-margins-breakpoint:     'desktop';
 $theme-site-margins-width:          4;
@@ -297,7 +297,7 @@ $theme-site-margins-mobile-width:   2;
 
 The USWDS uses those tokens to build component styles:
 
-```sass
+```scss
 .usa-example {
   @include u-padding-x($theme-site-margins-mobile-width);
   max-width: units($theme-site-max-width);
@@ -310,7 +310,7 @@ The USWDS uses those tokens to build component styles:
 
 This is the functional equivalent of:
 
-```sass
+```scss
 .usa-example {
   @include u-padding-x(2);
   max-width: units('desktop');


### PR DESCRIPTION
## Description

Currently, the SCSS code snippets in the README (super useful, by the way!) are rendering a bit oddly on GitHub. GitHub is highlighting semicolons as if they were errors:

<img width="851" alt="scss-code-snippets-github" src="https://user-images.githubusercontent.com/3209501/59466518-22af6480-8df3-11e9-8d8f-31b5bce3c704.png">

Changing the syntax highlighting from `sass` to `scss` resolves the issue. Here is the same block of README with the change applied:

<img width="852" alt="scss-code-snippets-github-fixed" src="https://user-images.githubusercontent.com/3209501/59466628-6ace8700-8df3-11e9-89fb-4876bafd7626.png">
