### PR TITLE
[Banner / Nav Primary] Prevent FOUC caused by hidden elements when page loads

### DIFF
--- a/src/components/08-navigation/_nav-primary.njk
+++ b/src/components/08-navigation/_nav-primary.njk
@@ -4,7 +4,7 @@
   <li class="usa-nav__primary-item">
     {% if link.links -%}
     <button class="usa-accordion__button usa-nav__link{% if link.is_current %}  usa-current{% endif %}" aria-expanded="false" aria-controls="{{ nav.id_prefix }}{{ link.id }}"><span>{{ link.text }}</span></button>
-    <{% if nav.mega %}div{% else %}ul{% endif %} id="{{ nav.id_prefix }}{{ link.id }}" class="usa-nav__submenu{% if nav.mega %} usa-megamenu{% endif %}">
+    <{% if nav.mega %}div{% else %}ul{% endif %} id="{{ nav.id_prefix }}{{ link.id }}" class="usa-nav__submenu{% if nav.mega %} usa-megamenu{% endif %}" hidden>
       {%- if nav.id_prefix == "basic-" or nav.id_prefix == "extended-" -%}
         {%- for child in link.links -%}
           {%- if loop.index < 4 -%}

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -10,7 +10,7 @@
           <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
         </div>
         <button class="usa-accordion__button usa-banner__button"
-          aria-expanded="false" aria-controls="gov-banner">
+          aria-expanded="false" aria-controls="gov-banner" hidden>
           <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>


### PR DESCRIPTION
## Description

When loading a page where a banner/navigation are rendered, the hidden content is showing until the JS kicks in and adds the `hidden` attribute which hides it.
This is causing the hidden elements to flash on the page for a moment and gives the impression of [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) does. 

## Additional information

Include any of the following (as necessary): 

* This issue is particularly more evident in Chrome
* The issue can be also reproduced on https://designsystem.digital.gov/
    1. Load site with Chrome
    2. Open Dev Tools
    3. Hold down left mouse button on the Refresh button and select "Empty Cache and Hard Reload" (this is in order to get a non-cached version which makes the FOUC more evident)
        <img width="248" alt="empty-reload" src="https://user-images.githubusercontent.com/11734/60224724-8cd6f900-9838-11e9-87ad-c3ac683d4ae5.png">


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
