### PR TITLE
Fix spacing and layout bugs

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -264,7 +264,7 @@ $z-index-overlay: 400;
     }
   }
 
-  .usa-megamenu {
+  .usa-nav__submenu.usa-megamenu {
     @include at-media($theme-navigation-width) {
       left: 0;
       padding-left: units($theme-site-margins-width);

--- a/src/stylesheets/components/_megamenu.scss
+++ b/src/stylesheets/components/_megamenu.scss
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.usa-megamenu {
+.usa-megamenu.usa-nav__submenu {
   @include at-media($theme-navigation-width) {
     @include u-padding-x(0);
     @include u-padding-y(4);

--- a/src/stylesheets/components/_megamenu.scss
+++ b/src/stylesheets/components/_megamenu.scss
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.usa-megamenu.usa-nav__submenu {
+.usa-megamenu {
   @include at-media($theme-navigation-width) {
     @include u-padding-x(0);
     @include u-padding-y(4);

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -464,6 +464,7 @@ Converts a value in px to a value in rem
     @return false;
   }
   $px-to-rem: ($pixels / $root-font-size-equiv) * 1rem;
+  $px-to-rem: round($px-to-rem * 100)/100;
 
   @return $px-to-rem;
 }

--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -562,6 +562,7 @@ a family and a line-height scale unit
   $this-cap: map-get($project-cap-heights, $family);
   $this-line-height: map-get($system-line-height, $scale);
   $normalized-line-height: $this-line-height / ($system-base-cap-height / $this-cap);
+  $normalized-line-height: round($normalized-line-height * 10)/10;
 
   @return $normalized-line-height;
 }


### PR DESCRIPTION
- Fixes a CSS specificity error introduced in 2.1.0 affecting the extended header's megamenu.
- Fixes a spacing issue affecting the header nav indicator bars present since 2.0 that seems to be a result of rounding errors in line-height calculation.

- - -

<img width="1070" alt="Screen Shot 2019-09-17 at 1 40 26 PM" src="https://user-images.githubusercontent.com/11464021/65077962-e428c900-d950-11e9-99c8-72f261dfa6e1.png">

> Above: Proper 3-column megamenu in the extended header

- - -

<img width="653" alt="Screen Shot 2019-09-17 at 1 37 51 PM" src="https://user-images.githubusercontent.com/11464021/65077741-6ebcf880-d950-11e9-8d57-b47ddfe26269.png">

> Above: Indicator bars now have a consistent placement below the link.

- - -

Fixes https://github.com/uswds/uswds/issues/3097
Fixes https://github.com/uswds/uswds/issues/3096