### PR TITLE
Use theme typeface tokens instead of system tokens

### DIFF
--- a/src/stylesheets/core/placeholders/_table.scss
+++ b/src/stylesheets/core/placeholders/_table.scss
@@ -28,7 +28,7 @@
   }
 
   caption {
-    @include u-font('serif', 'xs');
+    @include u-font('body', 'xs');
     font-weight: $theme-font-weight-bold;
     margin-bottom: units(1.5);
     text-align: left;


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds/dw-use-theme-tokens/)

**All component font functions now use role-based tokens:** Now code will generate properly, even if a user decides not to use a certain font type in their project (like `serif`). 
> Example: a project uses only a sans-serif font on their site, all other font types are set to `false`.

Fixes https://github.com/uswds/uswds/issues/3042