### PR TITLE
Remove redundant ARIA roles and add ARIA labels for navs

### DIFF
--- a/src/components/08-navigation/sidenav.njk
+++ b/src/components/08-navigation/sidenav.njk
@@ -11,7 +11,7 @@
   {%- endfor -%}
 {%- endmacro -%}
 
-<nav>
+<nav aria-label="Secondary navigation">
   <ul class="usa-sidenav">
     {{ nav_list(sidenav.links, 'usa-sidenav__sublist') }}
   </ul>

--- a/src/components/09-header/header--basic.njk
+++ b/src/components/09-header/header--basic.njk
@@ -1,8 +1,8 @@
 <div class="usa-overlay"></div>
-<header class="usa-header usa-header--basic{% if header.primary.mega %} usa-header--megamenu{% endif %}" role="banner">
+<header class="usa-header usa-header--basic{% if header.primary.mega %} usa-header--megamenu{% endif %}">
   <div class="usa-nav-container">
     {% render '@site-title', {header: header}, true -%}
-    <nav role="navigation" class="usa-nav">
+    <nav aria-label="Primary navaigation" class="usa-nav">
       {% render '@nav-primary', {nav: header.primary}, true -%}
     </nav>
   </div>

--- a/src/components/09-header/header--basic.njk
+++ b/src/components/09-header/header--basic.njk
@@ -2,7 +2,7 @@
 <header class="usa-header usa-header--basic{% if header.primary.mega %} usa-header--megamenu{% endif %}">
   <div class="usa-nav-container">
     {% render '@site-title', {header: header}, true -%}
-    <nav aria-label="Primary navaigation" class="usa-nav">
+    <nav aria-label="Primary navigation" class="usa-nav">
       {% render '@nav-primary', {nav: header.primary}, true -%}
     </nav>
   </div>

--- a/src/components/09-header/header--extended.njk
+++ b/src/components/09-header/header--extended.njk
@@ -1,7 +1,7 @@
 <div class="usa-overlay"></div>
-<header class="usa-header usa-header--extended" role="banner">
+<header class="usa-header usa-header--extended">
   {%- render '@site-title', {header: header}, true -%}
-  <nav role="navigation" class="usa-nav">
+  <nav aria-label="Primary navaigation" class="usa-nav">
     <div class="usa-nav__inner">
       {%- render '@nav-primary', {nav: header.primary}, true -%}
       {%- render '@nav-secondary', {nav: header.secondary, id_prefix: header.primary.id_prefix}, true -%}

--- a/src/components/09-header/header--extended.njk
+++ b/src/components/09-header/header--extended.njk
@@ -1,7 +1,7 @@
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--extended">
   {%- render '@site-title', {header: header}, true -%}
-  <nav aria-label="Primary navaigation" class="usa-nav">
+  <nav aria-label="Primary navigation" class="usa-nav">
     <div class="usa-nav__inner">
       {%- render '@nav-primary', {nav: header.primary}, true -%}
       {%- render '@nav-secondary', {nav: header.secondary, id_prefix: header.primary.id_prefix}, true -%}

--- a/src/components/10-footer/footer--big.njk
+++ b/src/components/10-footer/footer--big.njk
@@ -1,4 +1,4 @@
-<footer class="usa-footer usa-footer--big" role="contentinfo">
+<footer class="usa-footer usa-footer--big">
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
   </div>

--- a/src/components/10-footer/footer--slim.njk
+++ b/src/components/10-footer/footer--slim.njk
@@ -1,4 +1,4 @@
-<footer class="usa-footer usa-footer--slim" role="contentinfo">
+<footer class="usa-footer usa-footer--slim">
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
   </div>

--- a/src/components/10-footer/footer.njk
+++ b/src/components/10-footer/footer.njk
@@ -1,4 +1,4 @@
-<footer class="usa-footer" role="contentinfo">
+<footer class="usa-footer">
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
   </div>


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds/dw-improve-aria/components/preview/layout--docs.html)

**Improve accessible ARIA markup:** Adding manual ARIA roles to semantic elements with implicit roles (like `header`, `nav` and `footer`) is redundant in modern HTML 5, so we should not include these roles in our markup. However, if there are multiple navigation elements on a page, each should have a unique and sensical identification — here assigned with `aria-label`.

> Reference: https://www.w3.org/WAI/tutorials/page-structure/regions/#navigation

<img width="676" alt="Screen Shot 2019-09-18 at 12 05 16 PM" src="https://user-images.githubusercontent.com/11464021/65177947-9d98a480-da0c-11e9-8725-fa7f7d6f4c95.png">

 > Above: Test page now validated with no warnings or errors

- - -

Fixes https://github.com/uswds/uswds/issues/3080