### PR TITLE
Header and banner width now controlled in settings

### DIFF
--- a/src/components/08-navigation/_nav-primary.njk
+++ b/src/components/08-navigation/_nav-primary.njk
@@ -16,7 +16,7 @@
       {%- else -%}
         <div class="grid-row grid-gap-4">
           {%- for group in link.links | batch(3) -%}
-            <div class="desktop:grid-col-3">
+            <div class="usa-col">
               <ul class="usa-nav__submenu-list">
                 {%- for child in group -%}
                   <li class="usa-nav__submenu-item">

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -10,7 +10,7 @@
 }
 
 .usa-banner__content {
-  @include grid-container($theme-site-max-width);
+  @include grid-container($theme-banner-max-width);
   @include add-responsive-site-margins;
   background-color: color('transparent');
   font-size: font-size($theme-banner-font-family, 4);
@@ -41,7 +41,7 @@
 
 .usa-banner__inner {
   @include add-responsive-site-margins;
-  @include grid-container;
+  @include grid-container($theme-banner-max-width);
   @include grid-row;
   @include u-flex('align-start');
   padding-right: units(0);

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -40,14 +40,14 @@ $z-index-overlay: 400;
 
   // The search <form>
   .usa-search {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       float: right;
     }
   }
 
   // Accessibility: The <div> with search role
   [role=search] {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       float: right;
       max-width: calc(#{$theme-search-min-width} + #{units($theme-button-small-width)});
       width: 100%;
@@ -60,28 +60,28 @@ $z-index-overlay: 400;
   }
 
   + .usa-hero {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       border-top: units(1px) solid color('white');
     }
   }
 
   + .usa-section,
   + main {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       border-top: units(1px) solid color('base-lighter');
     }
   }
 }
 
 .usa-logo {
-  @include at-media-max($theme-navigation-width) {
+  @include at-media-max($theme-header-min-width) {
     @include u-flex('fill');
     font-size: font-size($theme-header-font-family, '2xs');
     line-height: line-height($theme-header-font-family, 1);
     margin-left: units($theme-site-margins-mobile-width);
   }
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     margin-top: units(4);
     margin-bottom: units(2);
     font-size: font-size($theme-header-font-family, 'lg');
@@ -113,7 +113,7 @@ $z-index-overlay: 400;
   text-decoration: none;
   text-transform: uppercase;
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     display: none;
   }
 
@@ -151,10 +151,10 @@ $z-index-overlay: 400;
 // ---------------------------------
 
 .usa-header--basic {
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     .usa-navbar {
       position: relative;
-      width: $theme-megamenu-logo-text-width; // TODO: review this more
+      width: $theme-header-logo-text-width; // TODO: review this more
     }
 
     .usa-nav {
@@ -188,7 +188,7 @@ $z-index-overlay: 400;
       display: flex;
       flex-direction: column;
 
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         display: block;
         float: right;
         margin-top: units(-5);
@@ -201,7 +201,7 @@ $z-index-overlay: 400;
 // ---------------------------------
 
 .usa-header--extended {
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     padding-top: 0;
 
     .usa-current,
@@ -212,7 +212,7 @@ $z-index-overlay: 400;
   }
 
   .usa-logo {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       font-size: font-size($theme-header-font-family, 'xl');
       margin: units(4) 0 units(3);
       max-width: 50%;
@@ -220,8 +220,8 @@ $z-index-overlay: 400;
   }
 
   .usa-navbar {
-    @include at-media($theme-navigation-width) {
-      @include grid-container;
+    @include at-media($theme-header-min-width) {
+      @include grid-container($theme-header-max-width);
       display: block;
       height: auto;
       overflow: auto;
@@ -229,7 +229,7 @@ $z-index-overlay: 400;
   }
 
   .usa-nav {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       border-top: units(1px) solid color('base-lighter');
       padding: 0;
       width: 100%;
@@ -237,35 +237,36 @@ $z-index-overlay: 400;
   }
 
   .usa-nav__inner {
-    @include at-media($theme-navigation-width) {
-      @include grid-container;
-      padding-left: units(2) !important; /* stylelint-disable declaration-no-important  */
+    @include at-media($theme-header-min-width) {
+      @include grid-container($theme-header-max-width);
       position: relative;
+
     }
   }
 
   .usa-nav__primary {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include clearfix;
+      margin-left: units(-2);
     }
   }
 
   .usa-nav__link {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include u-padding-y(2);
     }
   }
 
   .usa-nav__submenu {
     .usa-grid-full {
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         padding-left: units(1.5);
       }
     }
   }
 
   .usa-nav__submenu.usa-megamenu {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       left: 0;
       padding-left: units($theme-site-margins-width);
     }

--- a/src/stylesheets/components/_megamenu.scss
+++ b/src/stylesheets/components/_megamenu.scss
@@ -7,24 +7,33 @@
   width: 100%;
 }
 
+.usa-megamenu {
+  .usa-col {
+    @include at-media($theme-header-min-width) {
+      @include u-flex(12/$theme-megamenu-columns);
+    }
+  }
+}
+
+
 .usa-megamenu.usa-nav__submenu {
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     @include u-padding-x(0);
     @include u-padding-y(4);
-    left: -$theme-megamenu-logo-text-width;
+    left: -$theme-header-logo-text-width;
     right: 0;
     width: auto;
   }
 
   &::before {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include outer-megamenu;
       right: 100%;
     }
   }
 
   &::after {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include outer-megamenu;
       left: 100%;
     }

--- a/src/stylesheets/components/_nav-container.scss
+++ b/src/stylesheets/components/_nav-container.scss
@@ -1,7 +1,7 @@
 .usa-nav-container {
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     @include clearfix;
-    @include grid-container;
+    @include grid-container($theme-header-max-width);
     @include u-padding-x($theme-site-margins-width);
   }
 }

--- a/src/stylesheets/components/_navbar.scss
+++ b/src/stylesheets/components/_navbar.scss
@@ -2,13 +2,13 @@
   @include border-box-sizing;
   height: units($size-touch-target);
 
-  @include at-media-max($theme-navigation-width) {
+  @include at-media-max($theme-header-min-width) {
     @include u-flex('align-center');
     border-bottom: units(1px) solid color('base-lighter');
     display: flex;
   }
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     border-bottom: none;
     display: inline-block;
     height: auto;

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -26,7 +26,7 @@ $nav-link-arrow-icon-size: 1;
 // ---------------------------------
 .usa-nav {
   @include typeset($theme-navigation-font-family, null, 1);
-  @include at-media-max($theme-navigation-width) {
+  @include at-media-max($theme-header-min-width) {
     @include u-pin('right');
     @include u-pin('y');
     position: fixed;
@@ -45,13 +45,13 @@ $nav-link-arrow-icon-size: 1;
     }
   }
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     float: right;
     position: relative;
   }
 
   .usa-search {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       margin-left: units(2);
     }
   }
@@ -62,9 +62,9 @@ $nav-link-arrow-icon-size: 1;
 
 .usa-nav__primary {
 
-  // Until the $theme-navigation-width,
+  // Until the $theme-header-width,
   // use the usa-nav-list styles for the slide-in nav
-  @include at-media-max($theme-navigation-width) {
+  @include at-media-max($theme-header-min-width) {
     @include nav-list('nav');
     margin-top: units(3);
     order: 2;
@@ -74,8 +74,8 @@ $nav-link-arrow-icon-size: 1;
     }
   }
 
-  // At $theme-navigation-width and wider...
-  @include at-media($theme-navigation-width) {
+  // At $theme-header-width and wider...
+  @include at-media($theme-header-min-width) {
     display: flex;
   }
 
@@ -89,14 +89,14 @@ $nav-link-arrow-icon-size: 1;
   // just level 1 nav items...
   > .usa-nav__primary-item {
     line-height: line-height($theme-navigation-font-family, 2);
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       font-size: font-size($theme-navigation-font-family, '2xs');
       line-height: line-height($theme-navigation-font-family, 1);
     }
 
     // ...and their direct links
     > a {
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         @include primary-nav-link;
         color: color($nav-link-color);
         display: block;
@@ -110,7 +110,7 @@ $nav-link-arrow-icon-size: 1;
   }
 
   a {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include u-padding-y(1);
     }
   }
@@ -125,7 +125,7 @@ $nav-link-arrow-icon-size: 1;
     padding: units(1.5) units(2);
     text-decoration: none;
 
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       @include primary-nav-link;
       font-size: font-size($theme-navigation-font-family, '2xs');
       font-weight: font-weight('bold');
@@ -136,7 +136,7 @@ $nav-link-arrow-icon-size: 1;
       background-color: color('base-lightest');
       text-decoration: none;
 
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         background-color: transparent;
       }
     }
@@ -146,14 +146,14 @@ $nav-link-arrow-icon-size: 1;
       background-position: right 0 center;
       background-size: units($nav-link-accordion-icon-size);
 
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         @include add-background-svg('angle-arrow-down');
         background-size: units($nav-link-arrow-icon-size);
         background-position: right units(2) top $button-vertical-offset;
       }
 
       &:hover {
-        @include at-media($theme-navigation-width) {
+        @include at-media($theme-header-min-width) {
           @include add-background-svg('angle-arrow-down-primary');
         }
       }
@@ -164,7 +164,7 @@ $nav-link-arrow-icon-size: 1;
       background-position: right 0 center;
       background-size: units($nav-link-accordion-icon-size);
 
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         @include add-background-svg('angle-arrow-up-white');
         @include add-knockout-font-smoothing;
         background-size: units($nav-link-arrow-icon-size);
@@ -177,7 +177,7 @@ $nav-link-arrow-icon-size: 1;
 
   .usa-accordion__button {
     span {
-      @include at-media($theme-navigation-width) {
+      @include at-media($theme-header-min-width) {
         margin-right: 0;
         padding-right: units(2);
       }
@@ -191,7 +191,7 @@ $nav-link-arrow-icon-size: 1;
 .usa-nav__secondary {
   margin-top: units(2);
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     // Note: Previius calc() couldn't work. don't hardcode rem vals
     bottom: units(8); // XXX magic number
     font-size: font-size($theme-navigation-font-family, '2xs');
@@ -205,7 +205,7 @@ $nav-link-arrow-icon-size: 1;
     margin-top: units(2);
     width: 100%;
 
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       margin-left: 0;
       margin-top: units(1);
     }
@@ -217,7 +217,7 @@ $nav-link-arrow-icon-size: 1;
   line-height: line-height($theme-navigation-font-family, 3);
   margin-top: units(3);
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     float: right;
     line-height: line-height($theme-navigation-font-family, 1);
     margin-bottom: units(0.5);
@@ -225,7 +225,7 @@ $nav-link-arrow-icon-size: 1;
   }
 
   .usa-nav__secondary-item {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       display: inline;
       padding-left: units(0.5);
 
@@ -254,11 +254,11 @@ $nav-link-arrow-icon-size: 1;
 // ---------------------------------
 
 .usa-nav__submenu {
-  @include at-media-max($theme-navigation-width) {
+  @include at-media-max($theme-header-min-width) {
     @include nav-sublist;
   }
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     @include add-list-reset;
     background-color: color('primary-darker');
     width: units('card-lg');
@@ -272,7 +272,7 @@ $nav-link-arrow-icon-size: 1;
   }
 
   .usa-nav__submenu-item {
-    @include at-media($theme-navigation-width) {
+    @include at-media($theme-header-min-width) {
       & + * {
         margin-top: units(1.5);
       }
@@ -323,7 +323,7 @@ $nav-link-arrow-icon-size: 1;
     text-decoration: none;
   }
 
-  @include at-media($theme-navigation-width) {
+  @include at-media($theme-header-min-width) {
     display: none;
   }
 

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -30,6 +30,7 @@ $theme-alert-padding-x:               2.5 !default;
 
 // Banner
 $theme-banner-font-family:            'ui' !default;
+$theme-banner-max-width:              'desktop' !default;
 
 // Button
 $theme-button-font-family:            'ui' !default;
@@ -51,11 +52,13 @@ $theme-input-state-border-width:      0.5 !default;
 
 // Header
 $theme-header-font-family:            'ui' !default;
-$theme-megamenu-logo-text-width:      33% !default;
+$theme-header-logo-text-width:        33% !default;
+$theme-header-max-width:              'desktop' !default;
+$theme-header-min-width:              'desktop' !default;
 
 // Navigation
 $theme-navigation-font-family:        'ui' !default;
-$theme-navigation-width:              'desktop' !default;
+$theme-megamenu-columns:              3 !default;
 
 // Search
 $theme-search-font-family:            'ui' !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -30,6 +30,7 @@ $theme-alert-padding-x:               2.5;
 
 // Banner
 $theme-banner-font-family:            'ui';
+$theme-banner-max-width:              'desktop';
 
 // Button
 $theme-button-font-family:            'ui';
@@ -51,11 +52,13 @@ $theme-input-state-border-width:      0.5;
 
 // Header
 $theme-header-font-family:            'ui';
-$theme-megamenu-logo-text-width:      33%;
+$theme-header-logo-text-width:        33%;
+$theme-header-max-width:              'desktop';
+$theme-header-min-width:              'desktop';
 
 // Navigation
 $theme-navigation-font-family:        'ui';
-$theme-navigation-width:              'desktop';
+$theme-megamenu-columns:              3;
 
 // Search
 $theme-search-font-family:            'ui';


### PR DESCRIPTION
**Header and banner width now controlled in settings:** Now there are explicit settings for controlling the max-width of the gov banner and the header.

:warning: This change affects the markup of the megamenu.
:warning: This change affects settings: `$theme-megamenu-logo-text-width` has been deprecated and replaced with `$theme-header-logo-text-width`. Your settings file will require the new settings below:

| setting variable | controls | default |
|---|---|---
`$theme-banner-max-width` | maximum width of the banner | `desktop`
`$theme-header-max-width` | maximum width of the header | `desktop`
`$theme-header-min-width` | breakpoint at which full header shows | `desktop`
`$theme-header-logo-text-width` | width of the logo/title region of the header (replaces `$theme-megamenu-logo-text-width` | 33%
`$theme-megamenu-columns` | numbner of columns in the megamenu | 3

- - -

Fixes https://github.com/uswds/uswds/issues/3098