### PR TITLE
Use settings to control hero image

### DIFF
--- a/src/components/layouts/landing-inner.njk
+++ b/src/components/layouts/landing-inner.njk
@@ -5,10 +5,10 @@
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-4">
-        <h2 class="font-heading-xl margin-top-0 tablet:margin-bottom-0">{{ tagline.title }}</h2>
+        <h2 class="font-heading-xl margin-top-0 tablet:margin-bottom-0">{{ tagline.title | safe }}</h2>
       </div>
       <div class="tablet:grid-col-8 usa-prose">
-        {{ tagline.content }}
+        {{ tagline.content | safe }}
       </div>
     </div>
   </section>

--- a/src/components/test/kitchen-sink.njk
+++ b/src/components/test/kitchen-sink.njk
@@ -16,10 +16,10 @@
         <div class="tablet:grid-col-9 usa-layout-docs__main usa-prose">
           <h1>{{ page.title }}</h1>
 
-          <p class="usa-intro">{{ page.lead }}</p>
+          <p class="usa-intro">{{ page.lead | safe }}</p>
 
           <p class="usa-content">
-            {{ page.body }}
+            {{ page.body | safe }}
 
             <ul>
             {% for list in page.lists %}

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -5,7 +5,7 @@
   @include border-box-sizing;
   @include typeset;
   @include u-padding-y($theme-site-margins-width);
-  background-image: url('#{$theme-image-path}/hero.png');
+  background-image: url('#{$theme-hero-image}');
   background-position: center;
   background-size: cover;
   color: color('white');

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -56,6 +56,9 @@ $theme-header-logo-text-width:        33% !default;
 $theme-header-max-width:              'desktop' !default;
 $theme-header-min-width:              'desktop' !default;
 
+// Hero
+$theme-hero-image:                    '../img/hero.png' !default;
+
 // Navigation
 $theme-navigation-font-family:        'ui' !default;
 $theme-megamenu-columns:              3 !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -56,6 +56,9 @@ $theme-header-logo-text-width:        33%;
 $theme-header-max-width:              'desktop';
 $theme-header-min-width:              'desktop';
 
+// Hero
+$theme-hero-image:                    '../img/hero.png';
+
 // Navigation
 $theme-navigation-font-family:        'ui';
 $theme-megamenu-columns:              3;


### PR DESCRIPTION
**Use settings to control hero image:** Now you can change the hero image in settings.

:warning: This change affects settings. Your settings file will require the new settings below:

| file | setting variable | controls | default |
|---|---|---|---
components | `$theme-hero image` | path to the hero image, relative to the compiled stylesheet | `'../img/hero.png'`


- - -

Fixes https://github.com/uswds/uswds/issues/3093