### PR TITLE
Improve package documentation and usage

### DIFF
--- a/src/stylesheets/packages/_uswds-components.scss
+++ b/src/stylesheets/packages/_uswds-components.scss
@@ -1,13 +1,5 @@
 /*! uswds @version */
 
-// Required
-// -------------------------------------
-@import 'packages/required';
-
-// Global
-// -------------------------------------
-@import 'packages/global';
-
 // Base
 // -------------------------------------
 @import 'base/body';

--- a/src/stylesheets/theme/styles.scss
+++ b/src/stylesheets/theme/styles.scss
@@ -21,13 +21,42 @@
 // Import individual USWDS packages...
 // See https://designsystem.digital.gov/components/
 
+// First import required and global packages...
 // @import 'packages/required';
 // @import 'packages/global';
+
+// Then import individual packages...
+// @import 'packages/form-controls';
+// @import 'packages/form-templates';
+// @import 'packages/layout-grid';
+// @import 'packages/layout-grid';
+// @import 'packages/typography';
+// @import 'packages/validation';
+// @import 'packages/usa-accordion';
+// @import 'packages/usa-alert';
 // @import 'packages/usa-banner';
-// ...
+// @import 'packages/usa-button';
+// @import 'packages/usa-checklist';
+// @import 'packages/usa-footer';
+// @import 'packages/usa-header';
+// @import 'packages/usa-hero';
+// @import 'packages/usa-media-block';
+// @import 'packages/usa-megamenu';
+// @import 'packages/usa-nav-container';
+// @import 'packages/usa-nav';
+// @import 'packages/usa-navbar';
+// @import 'packages/usa-search';
+// @import 'packages/usa-sidenav';
+// @import 'packages/usa-skipnav';
+// @import 'packages/usa-table';
+// @import 'packages/usa-tag';
+
+// or package sets...
+// @import 'packages/uswds-components';
+// @import 'packages/uswds-utilities';
 
 // -------------------------------------
-// ...or import the complete USWDS package
+// ...or import the complete USWDS kit
 
 @import 'uswds';
 

--- a/src/stylesheets/theme/styles.scss
+++ b/src/stylesheets/theme/styles.scss
@@ -25,7 +25,7 @@
 // @import 'packages/required';
 // @import 'packages/global';
 
-// Then import individual packages...
+// Then import individual component packages...
 // @import 'packages/form-controls';
 // @import 'packages/form-templates';
 // @import 'packages/layout-grid';

--- a/src/stylesheets/theme/styles.scss
+++ b/src/stylesheets/theme/styles.scss
@@ -18,15 +18,16 @@
 @import 'uswds-theme-utilities';
 
 // -------------------------------------
-// Import individual USWDS modules...
+// Import individual USWDS packages...
+// See https://designsystem.digital.gov/components/
 
-// @import 'uswds-fonts';
-// @import 'uswds-layout-grid';
-// @import 'uswds-components';
-// @import 'uswds-utilities';
+// @import 'packages/required';
+// @import 'packages/global';
+// @import 'packages/usa-banner';
+// ...
 
 // -------------------------------------
-// ...or import all USWDS modules
+// ...or import the complete USWDS package
 
 @import 'uswds';
 

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -8,46 +8,9 @@
 // -------------------------------------
 @import 'packages/global';
 
-// Base
-// -------------------------------------
-@import 'base/body';
-@import 'base/accessibility';
-
-// Elements
-// -------------------------------------
-@import 'elements/buttons';
-@import 'elements/embed';
-@import 'elements/figure';
-@import 'elements/form-controls/all';
-@import 'elements/layout-grid';
-@import 'elements/table';
-@import 'elements/tags';
-@import 'elements/typography/content';
-@import 'elements/typography/links';
-@import 'elements/typography/list';
-@import 'elements/typography/prose';
-
 // Components
 // -------------------------------------
-@import 'components/accordions';
-@import 'components/alerts';
-@import 'components/banner';
-@import 'components/checklist';
-@import 'components/footer';
-@import 'components/forms';
-@import 'components/graphic-list';
-@import 'components/header';
-@import 'components/hero';
-@import 'components/layout';
-@import 'components/media-block';
-@import 'components/megamenu';
-@import 'components/nav-container';
-@import 'components/navbar';
-@import 'components/navigation';
-@import 'components/search';
-@import 'components/section';
-@import 'components/sidenav';
-@import 'components/skipnav';
+@import 'packages/uswds-components';
 
 // Utilities
 // -------------------------------------

--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -51,8 +51,4 @@
 
 // Utilities
 // -------------------------------------
-@import 'utilities/utility-fonts';
-@import 'utilities/palettes/all';
-@import 'utilities/rules/all';
-@import 'utilities/rules/package';
-@include render-utilities-in($utilities-package);
+@import 'packages/uswds-utilities';


### PR DESCRIPTION
**Improve package documentation and usage:** This improves the package documentation in the theme `styles.scss` by including all available packages in the comments. It also modifies the package contents of `uswds-components` to require the `required` and `global` packages — to be consistent with other packages.

:warning: If you use the `uswds-components` package, you will no need to include the `required` and `global` packages before including `uswds-components`. 