### PR TITLE
Add components theme variables to theme/styles

### DIFF
--- a/src/stylesheets/theme/styles.scss
+++ b/src/stylesheets/theme/styles.scss
@@ -13,6 +13,7 @@
 
 @import 'uswds-theme-general';
 @import 'uswds-theme-typography';
+@import 'uswds-theme-components';
 @import 'uswds-theme-spacing';
 @import 'uswds-theme-color';
 @import 'uswds-theme-utilities';


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds/dw-add-components-import/)

**Properly include component theme variables:** Now we're properly including the component theme variables from `_uswds-theme-components.scss` in `theme/styles.scss` so anyone who uses that file in their Sass compile process (like users of `uswds-gulp`) will see component theme settings applied as expected. 

These should be the proper theme imports for USWDS projects:
```
@import 'uswds-theme-general';
@import 'uswds-theme-typography';
@import 'uswds-theme-components'; <-- previously missing
@import 'uswds-theme-spacing';
@import 'uswds-theme-color';
@import 'uswds-theme-utilities';
```
 
Issue: https://github.com/uswds/uswds/issues/3117