### PR TITLE
Add backward compatible default to $theme-hero-image

### DIFF
--- a/src/stylesheets/packages/_required.scss
+++ b/src/stylesheets/packages/_required.scss
@@ -5,6 +5,8 @@
 @import '../settings/settings-color';
 @import '../settings/settings-spacing';
 @import '../settings/settings-utilities';
+
+// components import needs to be last
 @import '../settings/settings-components';
 
 @import '../core/functions';

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -57,7 +57,7 @@ $theme-header-max-width:              'desktop' !default;
 $theme-header-min-width:              'desktop' !default;
 
 // Hero
-$theme-hero-image:                    '../img/hero.png' !default;
+$theme-hero-image:                    '#{$theme-image-path}/hero.png' !default;
 
 // Navigation
 $theme-navigation-font-family:        'ui' !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -57,7 +57,7 @@ $theme-header-max-width:              'desktop';
 $theme-header-min-width:              'desktop';
 
 // Hero
-$theme-hero-image:                    '../img/hero.png';
+$theme-hero-image:                    '#{$theme-image-path}/hero.png';
 
 // Navigation
 $theme-navigation-font-family:        'ui';

--- a/src/stylesheets/theme/styles.scss
+++ b/src/stylesheets/theme/styles.scss
@@ -13,10 +13,12 @@
 
 @import 'uswds-theme-general';
 @import 'uswds-theme-typography';
-@import 'uswds-theme-components';
 @import 'uswds-theme-spacing';
 @import 'uswds-theme-color';
 @import 'uswds-theme-utilities';
+
+// components import needs to be last
+@import 'uswds-theme-components';
 
 // -------------------------------------
 // Import individual USWDS packages...


### PR DESCRIPTION
[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds/dw-add-bc-hero-var/components/detail/hero.html)

**Hero image theme setting default is now backward compatible:** The `$theme-hero-image` theme variable now has a default equivalent to its effective value pre `v2.2.0` so users that had a working version of their hero are more likely to see no issues upgrading to the latest version of USWDS. 
- Although the new default includes a variable reference to `$theme-image-path`, users can change this to any path needed. It need not refer to `$theme-image-path`. 
- This new default requires that the component theme variables (`uswds-theme-components`) be imported after `uswds-theme-general`. We suggest that `uswds-theme-components` be the last of the theme variables imported. 

Old default:
> `$theme-hero-image:  '..img/hero.png'`

New default:
> `$theme-hero-image:  '#{$theme-image-path}/hero.png'`

Issue: https://github.com/uswds/uswds/issues/3118