### PR TITLE
Install all USWDS in Federalist script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:js": "gulp javascript",
     "cover": "nyc --reporter=lcov --config config/nycrc.yml gulp cover",
     "format-tokens": "node ./src/utils/style-format.js --file './src/data/colors' --output './src/stylesheets/core/system-tokens'",
-    "federalist": "npm install --only=dev && gulp build && fractal build",
+    "federalist": "npm install && gulp build && fractal build",
     "lint": "eslint src/js/**/*.js spec/**/*.js",
     "mocha": "mocha --opts spec/mocha.opts",
     "prepare": "gulp build",


### PR DESCRIPTION
**Install all USWDS in Federalist script, not just the dev dependencies.** This fixes a new dependency-related error in 2.3.0 where USWDS would not build properly on Federalist.

[Preview](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/uswds/uswds/dw-fix-federalist-build/)