### PR TITLE
Add border-collapse rule to tables

### DIFF
--- a/src/stylesheets/core/placeholders/_table.scss
+++ b/src/stylesheets/core/placeholders/_table.scss
@@ -1,6 +1,7 @@
 %usa-table {
   @include border-box-sizing;
   @include typeset;
+  border-collapse: collapse;
   border-spacing: 0;
   margin: units(2.5) 0;
 


### PR DESCRIPTION
This add a `border-collapse: collapse` rule to our tables to to fix a bug introduced when we upgraded our version of Normalize. Thanks for the heads up @maya! 

Before:
<img width="1052" alt="Screen Shot 2019-12-02 at 9 39 18 AM" src="https://user-images.githubusercontent.com/11464021/69981707-b7b03200-14e7-11ea-9004-bc1ecdd74866.png">

After:
<img width="1048" alt="Screen Shot 2019-12-02 at 9 38 58 AM" src="https://user-images.githubusercontent.com/11464021/69981714-bb43b900-14e7-11ea-81a3-f1450c96dbd2.png">

Reference: https://github.com/uswds/uswds/issues/3243
