### PR TITLE
Issue-3256: Prevent focus outline from being overridden.

### DIFF
--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -44,8 +44,8 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
     color: color("white");
   }
 
-  &:focus,
-  &.usa-focus {
+  &:not([disabled]):focus,
+  &:not([disabled]).usa-focus {
     outline-offset: units(0.5);
   }
 


### PR DESCRIPTION
## Description

Fixes #3256 

## Additional information

https://user-images.githubusercontent.com/11464021/70549602-557bb080-1b29-11ea-8b7a-86d8e76a4f3c.gif

Focus styles in `_buttons.scss` were being overriden by the specificity of `:not` in `src/stylesheets/global/_focus.scss:5`.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
