### PR TITLE
Publish v1 branch with v1 tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ jobs:
           name: Build the USWDS package
           command: npm run release
       - run:
-          name: Publish to NPM
+          name: Publish to NPM with `v1` tag
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish
+            npm publish --tag v1
       - snyk/scan:
           organization: uswds
 


### PR DESCRIPTION
This will prevent the v1 branch from appearing as `latest`

reference: #3255 
fixes #3257 