### PR TITLE
Promote better deprecation communication and compatibility

### DIFF
--- a/src/stylesheets/core/_deprecated.scss
+++ b/src/stylesheets/core/_deprecated.scss
@@ -1,0 +1,31 @@
+/*  deprecated.scss
+    ---
+    Occasionally the design system will deprecate
+    old variables or functionality. If we replace
+    the old functionality with something new, this is a
+    place to connect the old functionality to the
+    new functionality, in the service of better
+    continuity and backwards compatibility within a
+    major release cycle.
+
+    Note the USWDS version where we deprecated the
+    old functionality in a comment.
+
+    This file should started fresh at each
+    major version.
+*/
+
+// Deprecated in 2.2.0
+$theme-navigation-width: $theme-header-min-width;
+$theme-megamenu-logo-text-width: $theme-header-logo-text-width;
+
+// Deprecated in 2.0.2
+$theme-title-font-size: $theme-display-font-size;
+
+@mixin title {
+  @include display;
+}
+
+@mixin typeset-title {
+  @include typeset-display;
+}

--- a/src/stylesheets/core/_deprecated.scss
+++ b/src/stylesheets/core/_deprecated.scss
@@ -17,24 +17,14 @@
     major version.
 */
 
-@if $theme-show-deprecation-warnings {
-  @warn "\a"
-    + "--------------------------------------------------------------------\a"
-    + "Deprecated in USWDS 2.x\a"
-    + "--------------------------------------------------------------------\a"
-    + "2.2.0\a"
-    + "$theme-navigation-width \2192  $theme-header-min-width\a"
-    + "$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width\a"
-    + "--------------------------------------------------------------------\a"
-    + "2.0.2\a"
-    + "$theme-title-font-size \2192  $theme-display-font-size\a"
-    + "@include title \2192  @include display\a"
-    + "@include typeset-title \2192  @include typeset-display\a"
-    + "--------------------------------------------------------------------\a"
-    + "Disable this message using \a"
-    + "$theme-show-deprecation-warnings: false\a"
-    + "--------------------------------------------------------------------\a";
-}
+$uswds-deprecation-warnings: "\a"+ "--------------------------------------------------------------------\a"+
+  "Deprecated in USWDS 2.x\a"+ "--------------------------------------------------------------------\a"+
+  "2.2.0\a"+ "$theme-navigation-width \2192  $theme-header-min-width\a"+
+  "$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width\a"+ "--------------------------------------------------------------------\a"+
+  "2.0.2\a"+ "$theme-title-font-size \2192  $theme-display-font-size\a"+
+  "@include title \2192  @include display\a"+ "@include typeset-title \2192  @include typeset-display\a"+
+  "--------------------------------------------------------------------\a"+ "Disable this message using \a"+
+  "$theme-show-deprecation-warnings: false\a"+ "--------------------------------------------------------------------\a";
 
 // Deprecated in 2.2.0
 $theme-navigation-width: $theme-header-min-width;

--- a/src/stylesheets/core/_deprecated.scss
+++ b/src/stylesheets/core/_deprecated.scss
@@ -11,20 +11,11 @@
     Note the USWDS version where we deprecated the
     old functionality in a comment.
 
-    Add the deprecation to the warning.
+    Be sure to update notifications.scss.
 
     This file should started fresh at each
     major version.
 */
-
-$uswds-deprecation-warnings: "\a"+ "--------------------------------------------------------------------\a"+
-  "Deprecated in USWDS 2.x\a"+ "--------------------------------------------------------------------\a"+
-  "2.2.0\a"+ "$theme-navigation-width \2192  $theme-header-min-width\a"+
-  "$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width\a"+ "--------------------------------------------------------------------\a"+
-  "2.0.2\a"+ "$theme-title-font-size \2192  $theme-display-font-size\a"+
-  "@include title \2192  @include display\a"+ "@include typeset-title \2192  @include typeset-display\a"+
-  "--------------------------------------------------------------------\a"+ "Disable this message using \a"+
-  "$theme-show-deprecation-warnings: false\a"+ "--------------------------------------------------------------------\a";
 
 // Deprecated in 2.2.0
 $theme-navigation-width: $theme-header-min-width;

--- a/src/stylesheets/core/_deprecated.scss
+++ b/src/stylesheets/core/_deprecated.scss
@@ -11,9 +11,30 @@
     Note the USWDS version where we deprecated the
     old functionality in a comment.
 
+    Add the deprecation to the warning.
+
     This file should started fresh at each
     major version.
 */
+
+@if $theme-show-deprecation-warnings {
+  @warn "\a"
+    + "--------------------------------------------------------------------\a"
+    + "Deprecated in USWDS 2.x\a"
+    + "--------------------------------------------------------------------\a"
+    + "2.2.0\a"
+    + "$theme-navigation-width \2192  $theme-header-min-width\a"
+    + "$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width\a"
+    + "--------------------------------------------------------------------\a"
+    + "2.0.2\a"
+    + "$theme-title-font-size \2192  $theme-display-font-size\a"
+    + "@include title \2192  @include display\a"
+    + "@include typeset-title \2192  @include typeset-display\a"
+    + "--------------------------------------------------------------------\a"
+    + "Disable this message using \a"
+    + "$theme-show-deprecation-warnings: false\a"
+    + "--------------------------------------------------------------------\a";
+}
 
 // Deprecated in 2.2.0
 $theme-navigation-width: $theme-header-min-width;

--- a/src/stylesheets/core/_notifications.scss
+++ b/src/stylesheets/core/_notifications.scss
@@ -9,11 +9,33 @@
 
 */
 
-$uswds-notifications: "\a"+ "--------------------------------------------------------------------\a"+
-  "USWDS Notifications\a"+ "--------------------------------------------------------------------\a"+
-  'Please make sure you\'re importing the components settings in \a your Sass entry point (often styles.scss) using something like \a `@import "uswds-theme-components"` \a';
+$uswds-notifications: "
+--------------------------------------------------------------------
+\2709  USWDS Notifications
+--------------------------------------------------------------------
+2.4.0: If your component settings aren't working as expected, make
+sure you're importing the components settings in your Sass entry
+point (often styles.scss) with `@import \"uswds-theme-components\"`.
+A bug in 2.0 omitted that import.
+--------------------------------------------------------------------
+2.2.0: We changed the names of some settings.
+$theme-navigation-width \2192  $theme-header-min-width
+$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width
+--------------------------------------------------------------------
+2.0.2: We changed the names of some settings and mixins.
+$theme-title-font-size \2192  $theme-display-font-size
+@include title \2192  @include display
+@include typeset-title \2192  @include typeset-display";
+
+$uswds-notification-disable-message: "
+--------------------------------------------------------------------
+These are notifications from the USWDS team, not necessarily a
+problem with your code.
+
+Disable notifications using $theme-show-notifications: false
+--------------------------------------------------------------------";
 
 @if $theme-show-notifications {
   @warn "#{$uswds-notifications}"
-    + "#{$uswds-deprecation-warnings}";
+    + "#{$uswds-notification-disable-message}";
 }

--- a/src/stylesheets/core/_notifications.scss
+++ b/src/stylesheets/core/_notifications.scss
@@ -9,7 +9,7 @@
 
 */
 
-$uswds-notifications: "
+$uswds-notifications: "\a
 --------------------------------------------------------------------
 \2709  USWDS Notifications
 --------------------------------------------------------------------
@@ -19,21 +19,23 @@ point (often styles.scss) with `@import \"uswds-theme-components\"`.
 A bug in 2.0 omitted that import.
 --------------------------------------------------------------------
 2.2.0: We changed the names of some settings.
-$theme-navigation-width \2192  $theme-header-min-width
-$theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width
+
+- $theme-navigation-width \2192  $theme-header-min-width
+- $theme-megamenu-logo-text-width \2192  $theme-header-logo-text-width
 --------------------------------------------------------------------
 2.0.2: We changed the names of some settings and mixins.
-$theme-title-font-size \2192  $theme-display-font-size
-@include title \2192  @include display
-@include typeset-title \2192  @include typeset-display";
+
+- $theme-title-font-size \2192  $theme-display-font-size
+- @include title \2192  @include display
+- @include typeset-title \2192  @include typeset-display";
 
 $uswds-notification-disable-message: "
 --------------------------------------------------------------------
 These are notifications from the USWDS team, not necessarily a
 problem with your code.
 
-Disable notifications using $theme-show-notifications: false
---------------------------------------------------------------------";
+Disable notifications using `$theme-show-notifications: false`
+--------------------------------------------------------------------\a";
 
 @if $theme-show-notifications {
   @warn "#{$uswds-notifications}"

--- a/src/stylesheets/core/_notifications.scss
+++ b/src/stylesheets/core/_notifications.scss
@@ -1,0 +1,19 @@
+/*  notifications.scss
+    ---
+    Adds a notification at the top of each USWDS
+    compile. Use this file for important notifications
+    and updates to the design system.
+
+    This file should started fresh at each
+    major version.
+
+*/
+
+$uswds-notifications: "\a"+ "--------------------------------------------------------------------\a"+
+  "USWDS Notifications\a"+ "--------------------------------------------------------------------\a"+
+  'Please make sure you\'re importing the components settings in \a your Sass entry point (often styles.scss) using something like \a `@import "uswds-theme-components"` \a';
+
+@if $theme-show-notifications {
+  @warn "#{$uswds-notifications}"
+    + "#{$uswds-deprecation-warnings}";
+}

--- a/src/stylesheets/packages/_required.scss
+++ b/src/stylesheets/packages/_required.scss
@@ -15,3 +15,6 @@
 @import "../core/properties";
 @import "../core/mixins/all";
 @import "../core/placeholders/all";
+
+// deprecated import needs to be last
+@import "../core/deprecated";

--- a/src/stylesheets/packages/_required.scss
+++ b/src/stylesheets/packages/_required.scss
@@ -18,3 +18,4 @@
 
 // deprecated import needs to be last
 @import "../core/deprecated";
+@import "../core/notifications";

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -34,12 +34,12 @@ Show compile warnings
 Show Sass warnings when functions and
 mixins use non-standard tokens.
 AND
-Show deprecation notifications.
+Show updates and notifications.
 ----------------------------------------
 */
 
 $theme-show-compile-warnings: true !default;
-$theme-show-deprecation-warnings: true !default;
+$theme-show-notifications: true !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -33,10 +33,13 @@ Show compile warnings
 ----------------------------------------
 Show Sass warnings when functions and
 mixins use non-standard tokens.
+AND
+Show deprecation notifications.
 ----------------------------------------
 */
 
 $theme-show-compile-warnings: true !default;
+$theme-show-deprecation-warnings: true !default;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -33,10 +33,13 @@ Show compile warnings
 ----------------------------------------
 Show Sass warnings when functions and
 mixins use non-standard tokens.
+AND
+Show deprecation notifications.
 ----------------------------------------
 */
 
 $theme-show-compile-warnings: true;
+$theme-show-deprecation-warnings: true;
 
 /*
 ----------------------------------------

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -34,12 +34,12 @@ Show compile warnings
 Show Sass warnings when functions and
 mixins use non-standard tokens.
 AND
-Show deprecation notifications.
+Show updates and notifications.
 ----------------------------------------
 */
 
 $theme-show-compile-warnings: true;
-$theme-show-deprecation-warnings: true;
+$theme-show-notifications: true;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
**We're handling deprecations more gracefully.**  Occasionally the design system will deprecate variables or functionality. Now we'll display a deprecation message in the terminal when compiling USWDS Sass to better communicate these changes. We're also improving backward compatibility by supporting deprecated variables, functions, and mixins throughout the major version cycle. This way, we can continue to improve how our code is structured while minimizing the effects of this restructuring on your projects.

This is how the deprecation warning prints in the terminal:

```
--------------------------------------------------------------------
✉ USWDS Notifications
--------------------------------------------------------------------
2.4.0: If your component settings aren't working as expected, make
sure you're importing the components settings in your Sass entry
point (often styles.scss) with `@import "uswds-theme-components"`.
A bug in 2.0 omitted that import.
--------------------------------------------------------------------
2.2.0: We changed the names of some settings.
$theme-navigation-width → $theme-header-min-width
$theme-megamenu-logo-text-width → $theme-header-logo-text-width
--------------------------------------------------------------------
2.0.2: We changed the names of some settings and mixins.
$theme-title-font-size → $theme-display-font-size
@include title → @include display
@include typeset-title → @include typeset-display
--------------------------------------------------------------------
These are notifications from the USWDS team, not necessarily a
problem with your code.

Disable notifications using $theme-show-notifications: false
--------------------------------------------------------------------
```

### Success criteria
- [ ] Deprecated or changed variables, mixins, and functions continue to work throughout the major version
- [ ] Accurate warning shows on compile, with the changed functionality and its replacement
- [ ] Warning may be disabled

Fixes #3254 