### PR TITLE
[UI component]: Remove additional positioning rules on banner close button

### DIFF
--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -196,7 +196,6 @@
         @include u-pin("y");
         @include u-pin("right");
         background-color: color("base-lighter");
-        bottom: 0;
         height: auto;
       }
     }
@@ -206,16 +205,6 @@
       height: auto;
       padding: units(0);
       position: relative;
-    }
-
-    &::after {
-      position: absolute;
-      right: units(2);
-      top: units(1.5);
-
-      @include at-media("tablet") {
-        position: static;
-      }
     }
   }
 }


### PR DESCRIPTION
Addresses #3270 by removing the extra positioning rules. Also removed the bottom: 0 declaration in line 199 because u-pin("y") already sets bottom: 0.
