### PR TITLE
Github Repo - README.md: fix file extension typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ scss
 - `_uswds-theme-utilities.scss`: Utility class output settings
 - `styles.scss`: The primary Sass file that you'll compile. It collects theme settings, USWDS source files, and custom CSS
 
-`styles.css` looks something like the following code. It adds all the project theme settings, then adds USWDS source, and finally adds your project's custom styles:
+`styles.scss` looks something like the following code. It adds all the project theme settings, then adds USWDS source, and finally adds your project's custom styles:
 
 ```scss
 @import "uswds-theme-general";


### PR DESCRIPTION
## Github Repo  - README.md fix file extension typo

## Description

Under the "Sass and theme settings" section the line the references the `styles` file refers to it as `styles.css`, but it seems like it should be `styles.scss` since that is where the imports actually happen. 

