### PR TITLE
Remove mandelbrot scripts to remove jquery vuln

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -41,7 +41,8 @@ web.theme(
     // display context data in YAML
     format: "yaml",
     // which panels to show
-    panels: ["html", "notes", "view", "context", "resources", "info"]
+    panels: ["html", "notes", "view", "context", "resources", "info"],
+    scripts: []
   })
 );
 


### PR DESCRIPTION
This is a quick-and-dirty fix to disable an old version of Javascript. 