### PR TITLE
USWDS-3130: Fix unhelpful error message for lh().

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -515,7 +515,7 @@ a family and a line-height scale unit
 @function lh($props...) {
   $props: unpack($props);
 
-  @if not length($props) == 2 {
+  @if not(length($props) == 2) {
     @error 'lh() needs both a valid face and line height token '
       + 'in the format `lh(FACE, HEIGHT)`.';
   }


### PR DESCRIPTION
## Description
Fixes #3130. `not` needs to be wrapped in parenthesis when used in `if` blocks.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
