### PR TITLE
[Internal] Allow state colors to be themed

### DIFF
--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -319,37 +319,37 @@ $project-colors: (
 
 $project-state-colors: (
   "error": (
-    "lighter": color($theme-color-error-lighter),
-    "light": color($theme-color-error-light),
-    "default": color($theme-color-error),
-    "dark": color($theme-color-error-dark),
-    "darker": color($theme-color-error-darker)
+    "lighter": color($theme-color-error-lighter, set-theme),
+    "light": color($theme-color-error-light, set-theme),
+    "default": color($theme-color-error, set-theme),
+    "dark": color($theme-color-error-dark, set-theme),
+    "darker": color($theme-color-error-darker, set-theme)
   ),
   "warning": (
-    "lighter": color($theme-color-warning-lighter),
-    "light": color($theme-color-warning-light),
-    "default": color($theme-color-warning),
-    "dark": color($theme-color-warning-dark),
-    "darker": color($theme-color-warning-darker)
+    "lighter": color($theme-color-warning-lighter, set-theme),
+    "light": color($theme-color-warning-light, set-theme),
+    "default": color($theme-color-warning, set-theme),
+    "dark": color($theme-color-warning-dark, set-theme),
+    "darker": color($theme-color-warning-darker, set-theme)
   ),
   "success": (
-    "lighter": color($theme-color-success-lighter),
-    "light": color($theme-color-success-light),
-    "default": color($theme-color-success),
-    "dark": color($theme-color-success-dark),
-    "darker": color($theme-color-success-darker)
+    "lighter": color($theme-color-success-lighter, set-theme),
+    "light": color($theme-color-success-light, set-theme),
+    "default": color($theme-color-success, set-theme),
+    "dark": color($theme-color-success-dark, set-theme),
+    "darker": color($theme-color-success-darker, set-theme)
   ),
   "info": (
-    "lighter": color($theme-color-info-lighter),
-    "light": color($theme-color-info-light),
-    "default": color($theme-color-info),
-    "dark": color($theme-color-info-dark),
-    "darker": color($theme-color-info-darker)
+    "lighter": color($theme-color-info-lighter, set-theme),
+    "light": color($theme-color-info-light, set-theme),
+    "default": color($theme-color-info, set-theme),
+    "dark": color($theme-color-info-dark, set-theme),
+    "darker": color($theme-color-info-darker, set-theme)
   ),
   "disabled": (
-    "light": color($theme-color-disabled-light),
-    "default": color($theme-color-disabled),
-    "dark": color($theme-color-disabled-dark)
+    "light": color($theme-color-disabled-light, set-theme),
+    "default": color($theme-color-disabled, set-theme),
+    "dark": color($theme-color-disabled-dark, set-theme)
   )
 );
 
@@ -418,29 +418,29 @@ $tokens-color-theme: (
 );
 
 $tokens-color-state: (
-  "error-lighter": color($theme-color-error-lighter),
-  "error-light": color($theme-color-error-light),
-  "error": color($theme-color-error),
-  "error-dark": color($theme-color-error-dark),
-  "error-darker": color($theme-color-error-darker),
-  "warning-lighter": color($theme-color-warning-lighter),
-  "warning-light": color($theme-color-warning-light),
-  "warning": color($theme-color-warning),
-  "warning-dark": color($theme-color-warning-dark),
-  "warning-darker": color($theme-color-warning-darker),
-  "success-lighter": color($theme-color-success-lighter),
-  "success-light": color($theme-color-success-light),
-  "success": color($theme-color-success),
-  "success-dark": color($theme-color-success-dark),
-  "success-darker": color($theme-color-success-darker),
-  "info-lighter": color($theme-color-info-lighter),
-  "info-light": color($theme-color-info-light),
-  "info": color($theme-color-info),
-  "info-dark": color($theme-color-info-dark),
-  "info-darker": color($theme-color-info-darker),
-  "disabled-light": color($theme-color-disabled-light),
-  "disabled": color($theme-color-disabled),
-  "disabled-dark": color($theme-color-disabled-dark)
+  "error-lighter": color($theme-color-error-lighter, set-theme, no-warn),
+  "error-light": color($theme-color-error-light, set-theme, no-warn),
+  "error": color($theme-color-error, set-theme, no-warn),
+  "error-dark": color($theme-color-error-dark, set-theme, no-warn),
+  "error-darker": color($theme-color-error-darker, set-theme, no-warn),
+  "warning-lighter": color($theme-color-warning-lighter, set-theme, no-warn),
+  "warning-light": color($theme-color-warning-light, set-theme, no-warn),
+  "warning": color($theme-color-warning, set-theme, no-warn),
+  "warning-dark": color($theme-color-warning-dark, set-theme, no-warn),
+  "warning-darker": color($theme-color-warning-darker, set-theme, no-warn),
+  "success-lighter": color($theme-color-success-lighter, set-theme, no-warn),
+  "success-light": color($theme-color-success-light, set-theme, no-warn),
+  "success": color($theme-color-success, set-theme, no-warn),
+  "success-dark": color($theme-color-success-dark, set-theme, no-warn),
+  "success-darker": color($theme-color-success-darker, set-theme, no-warn),
+  "info-lighter": color($theme-color-info-lighter, set-theme, no-warn),
+  "info-light": color($theme-color-info-light, set-theme, no-warn),
+  "info": color($theme-color-info, set-theme, no-warn),
+  "info-dark": color($theme-color-info-dark, set-theme, no-warn),
+  "info-darker": color($theme-color-info-darker, set-theme, no-warn),
+  "disabled-light": color($theme-color-disabled-light, set-theme, no-warn),
+  "disabled": color($theme-color-disabled, set-theme, no-warn),
+  "disabled-dark": color($theme-color-disabled-dark, set-theme, no-warn)
 );
 
 $project-color-shortcodes: map-collect(


### PR DESCRIPTION
Internal clone of https://github.com/uswds/uswds/pull/3287

**Allow non-token values in state color settings.** Now state tokens (like `"warning"`) can accept non-token colors, just as we introduced for theme colors in `2.4.0`. Teams using non-token values can now keep colors consistent between theme and state. Using non-token values will throw a warning in the compile process, but this, like all compile warnings, can be disabled by setting `$theme-show-compile-warnings: false`. Thanks @sawyerh!

- - -

## Description

As a developer adopting the design system, I'd like to theme the design system's colors — **including the error/warning/success/info colors** — to match my project's existing brand guide.

Currently, I can only theme some colors, which can result in an inconsistent visual design. For example, I can change my primary button color to my brand's shade of green, but then this clashes with the design system's default shade of green used for success elements. By supporting themeable state colors, I can make those shades consistent.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
