### PR TITLE
[Themes] Allow link colors to be themed

### DIFF
--- a/src/stylesheets/core/mixins/_typography.scss
+++ b/src/stylesheets/core/mixins/_typography.scss
@@ -51,15 +51,15 @@ Sets:
 }
 
 @mixin typeset-link {
-  color: color($theme-link-color);
+  color: color($theme-link-color, set-theme);
   text-decoration: underline;
 
   &:hover {
-    color: color($theme-link-hover-color);
+    color: color($theme-link-hover-color, set-theme);
   }
 
   &:active {
-    color: color($theme-link-active-color);
+    color: color($theme-link-active-color, set-theme);
   }
 
   &:focus {
@@ -67,7 +67,7 @@ Sets:
   }
 
   &:visited {
-    color: color($theme-link-visited-color);
+    color: color($theme-link-visited-color, set-theme);
   }
 }
 


### PR DESCRIPTION
## Description

As a developer adopting the design system, I'd like to theme the design system's colors — **including the link colors** — to match my project's existing brand guide.

Currently, I can only theme some colors, which can result in an inconsistent visual design. For example, I can change my primary color to my brand's shade of blue, but then this clashes with the design system's default shade of blue used for links. By supporting themeable link colors, I can make those shades consistent.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
