### PR TITLE
[Labels] Change ordering of usa-label--{state} classes so they take precedence

### DIFF
--- a/src/stylesheets/elements/form-controls/_global.scss
+++ b/src/stylesheets/elements/form-controls/_global.scss
@@ -51,12 +51,6 @@ $input-select-margin-right: 1.5;
   }
 }
 
-.usa-label--error {
-  display: block;
-  font-weight: font-weight("bold");
-  margin-top: 0;
-}
-
 .usa-error-message {
   @include u-padding-y(0.5);
   color: color("error-dark");
@@ -68,15 +62,21 @@ $input-select-margin-right: 1.5;
   color: color("base");
 }
 
-.usa-label--required {
-  color: color("error-dark");
-}
-
 .usa-label {
   display: block;
   line-height: line-height($theme-form-font-family, 2);
   margin-top: units(3);
   max-width: units($theme-input-max-width);
+}
+
+.usa-label--error {
+  display: block;
+  font-weight: font-weight("bold");
+  margin-top: 0;
+}
+
+.usa-label--required {
+  color: color("error-dark");
 }
 
 .usa-legend {

--- a/src/stylesheets/elements/form-controls/_global.scss
+++ b/src/stylesheets/elements/form-controls/_global.scss
@@ -70,7 +70,6 @@ $input-select-margin-right: 1.5;
 }
 
 .usa-label--error {
-  display: block;
   font-weight: font-weight("bold");
   margin-top: 0;
 }


### PR DESCRIPTION
## Description

- Changed the ordering of the "state" classes for `usa-label`. This address an issue I ran into where the `usa-label--error` class wasn't removing the top margin that's added by the `usa-label` class, even though `usa-label--error` included `margin-top: 0` in its declaration. This seemed due to the ordering of those styles.
- Removed a redundant `display: block` property from `usa-label--error`, which is already applied with the default `usa-label` class.

## Additional information

![image](https://user-images.githubusercontent.com/371943/74852792-14630200-530b-11ea-9d0e-83264c2f10a2.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
