### PR TITLE
Remove post-deploy Snyk step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,6 @@ jobs:
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
             npm publish
-      - snyk/scan:
-          organization: uswds
 
 workflows:
   version: 2


### PR DESCRIPTION
We test the package on build and don't need to re-test post-deploy.