### PR TITLE
USWDS-3350: Provide updated guidance for numeric fields.

### DIFF
--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -1,7 +1,7 @@
 <form class="usa-form">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Date of birth</legend>
-    <span class="usa-hint" id="dobHint">For example: 04 28 1986</span>
+    <span class="usa-hint" id="dobHint">For example: 4 28 1986</span>
     <div class="usa-memorable-date">
       <div class="usa-form-group usa-form-group--month">
         <label class="usa-label" for="date_of_birth_1">Month</label>

--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -5,15 +5,15 @@
     <div class="usa-memorable-date">
       <div class="usa-form-group usa-form-group--month">
         <label class="usa-label" for="date_of_birth_1">Month</label>
-        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="number" min="1" max="12" value="">
+        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="text" pattern="[0-9]*" inputmode="numeric" value="">
       </div>
       <div class="usa-form-group usa-form-group--day">
         <label class="usa-label" for="date_of_birth_2">Day</label>
-        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="number" min="1" max="31" value="">
+        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="text" pattern="[0-9]*" inputmode="numeric" value="">
       </div>
       <div class="usa-form-group usa-form-group--year">
         <label class="usa-label" for="date_of_birth_3">Year</label>
-        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" type="number" min="1900" max="2019" value="">
+        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" type="text" minlength="4" maxlength="4" pattern="[0-9]*" inputmode="numeric" value="">
       </div>
     </div>
   </fieldset>

--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -5,11 +5,11 @@
     <div class="usa-memorable-date">
       <div class="usa-form-group usa-form-group--month">
         <label class="usa-label" for="date_of_birth_1">Month</label>
-        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="text" pattern="[0-9]*" inputmode="numeric" value="">
+        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric" value="">
       </div>
       <div class="usa-form-group usa-form-group--day">
         <label class="usa-label" for="date_of_birth_2">Day</label>
-        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="text" pattern="[0-9]*" inputmode="numeric" value="">
+        <input class="usa-input usa-input--inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" type="text" maxlength="2" pattern="[0-9]*" inputmode="numeric" value="">
       </div>
       <div class="usa-form-group usa-form-group--year">
         <label class="usa-label" for="date_of_birth_3">Year</label>
@@ -18,3 +18,5 @@
     </div>
   </fieldset>
 </form>
+
+[]OPK

--- a/src/components/07-form/controls/date-input.njk
+++ b/src/components/07-form/controls/date-input.njk
@@ -18,5 +18,3 @@
     </div>
   </fieldset>
 </form>
-
-[]OPK


### PR DESCRIPTION
## Description
First draft of https://github.com/uswds/uswds/issues/3350.  The new HTML reflects a [GDS recent change](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/), also found on [Gov.uk design system](https://design-system.service.gov.uk/components/date-input/). 

## Additional information
* No changes to visual treatment
* Triggers the `tel` keypad, which makes entering dates easier
* **Note:** Switching the input from `number` to `text` disallows the `min` and `max` attributes for validation. GDS does not include this validation either. 

<img width="584" alt="Screen Shot 2020-03-16 at 3 15 39 PM" src="https://user-images.githubusercontent.com/1094951/76794133-c40d8180-679c-11ea-8c2f-ce89b5e47c2e.png">

* Pull request on documentation site: https://github.com/uswds/uswds-site/pull/890


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
