### PR TITLE
In banner template, clarify that it's .gov + HTTPS that make sites official

### DIFF
--- a/spec/unit/banner/template.html
+++ b/spec/unit/banner/template.html
@@ -30,7 +30,7 @@
                     <div class="usa-media-block__body">
                         <p>
                             <strong>The site is secure.</strong>
-                            <br> The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+                            <br> Combined with .gov, the <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
This small change aims to clarify that it's both things described in the banner _combined_ that make a site official (.gov and HTTPS). There is some public confusion about this: https://krebsonsecurity.com/2020/03/us-government-sites-give-bad-security-advice/

I opted to not say "Combined with .gov _or .mil_" because the header reads "The .gov means it’s official."

As has been [said before](https://github.com/uswds/uswds-site/issues/315#issuecomment-311774919), the broader issue in addressing potential confusion is in downstreaming this change, but this is a fair start.