### PR TITLE
USWDS-3348: Create button group component

### DIFF
--- a/src/components/11-button-groups/button-groups--segmented.njk
+++ b/src/components/11-button-groups/button-groups--segmented.njk
@@ -62,3 +62,18 @@
     <button class="usa-button usa-button--accent-cool">Button</button>
   </li>
 </ul>
+
+<h6>Segmented outline inverse buttons</h6>
+<div class="bg-base-darkest padding-1" style="max-width: fit-content">
+  <ul class="usa-button-group usa-button-group--segmented">
+    <li class="usa-button-group__item">
+      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
+    </li>
+    <li class="usa-button-group__item">
+      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
+    </li>
+    <li class="usa-button-group__item">
+      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
+    </li>
+  </ul>
+</div>

--- a/src/components/11-button-groups/button-groups--segmented.njk
+++ b/src/components/11-button-groups/button-groups--segmented.njk
@@ -1,79 +1,12 @@
-<h6>Segmented buttons</h6>
+<h6>Segmented</h6>
 <ul class="usa-button-group usa-button-group--segmented">
   <li class="usa-button-group__item">
-    <button class="usa-button">Button</button>
+    <button class="usa-button">Map</button>
   </li>
   <li class="usa-button-group__item">
-    <button class="usa-button">Button</button>
+    <button class="usa-button usa-button--outline">Satellite</button>
   </li>
   <li class="usa-button-group__item">
-    <button class="usa-button">Button</button>
+    <button class="usa-button usa-button--outline">Hybrid</button>
   </li>
 </ul>
-
-<h6>Segmented outline buttons</h6>
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Button</button>
-  </li>
-</ul>
-
-<h6>Segmented secondary buttons</h6>
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Button</button>
-  </li>
-</ul>
-
-<h6>Segmented base buttons</h6>
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Button</button>
-  </li>
-</ul>
-
-<h6>Segmented accent buttons</h6>
-<ul class="usa-button-group usa-button-group--segmented">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool">Button</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool">Button</button>
-  </li>
-</ul>
-
-<h6>Segmented outline inverse buttons</h6>
-<div class="bg-base-darkest padding-1" style="max-width: fit-content">
-  <ul class="usa-button-group usa-button-group--segmented">
-    <li class="usa-button-group__item">
-      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
-    </li>
-    <li class="usa-button-group__item">
-      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
-    </li>
-    <li class="usa-button-group__item">
-      <button class="usa-button usa-button--outline usa-button--inverse">Button</button>
-    </li>
-  </ul>
-</div>

--- a/src/components/11-button-groups/button-groups--segmented.njk
+++ b/src/components/11-button-groups/button-groups--segmented.njk
@@ -1,0 +1,64 @@
+<h6>Segmented buttons</h6>
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button class="usa-button">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Button</button>
+  </li>
+</ul>
+
+<h6>Segmented outline buttons</h6>
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Button</button>
+  </li>
+</ul>
+
+<h6>Segmented secondary buttons</h6>
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Button</button>
+  </li>
+</ul>
+
+<h6>Segmented base buttons</h6>
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Button</button>
+  </li>
+</ul>
+
+<h6>Segmented accent buttons</h6>
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool">Button</button>
+  </li>
+</ul>

--- a/src/components/11-button-groups/button-groups.config.yml
+++ b/src/components/11-button-groups/button-groups.config.yml
@@ -1,5 +1,5 @@
 label: Button groups
-status: wip
+status: ready
 preview: "@uswds-framed"
 
 variants:

--- a/src/components/11-button-groups/button-groups.config.yml
+++ b/src/components/11-button-groups/button-groups.config.yml
@@ -1,0 +1,16 @@
+label: Button groups
+status: wip
+preview: "@uswds-framed"
+
+variants:
+  - name: default
+    label: Default
+    context:
+      label:
+        classes: "usa-button-group"
+
+  - name: segmented
+    label: Segmented
+    context:
+      label:
+        classes: "usa-button-group usa-button-group--segmented"

--- a/src/components/11-button-groups/button-groups.njk
+++ b/src/components/11-button-groups/button-groups.njk
@@ -1,9 +1,9 @@
 <h6>Default</h6>
 <ul class="usa-button-group">
   <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Button</button>
+    <a href="#" class="usa-button usa-button--outline">Back</a>
   </li>
   <li class="usa-button-group__item">
-    <button class="usa-button">Button</button>
+    <button class="usa-button">Continue</button>
   </li>
 </ul>

--- a/src/components/11-button-groups/button-groups.njk
+++ b/src/components/11-button-groups/button-groups.njk
@@ -1,0 +1,91 @@
+<ul class="usa-button-group">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Cancel</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Continue</button>
+  </li>
+</ul>
+
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Underline</button>
+  </li>
+</ul>
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Italic</button>
+  </li>
+</ul>
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Underline</button>
+  </li>
+</ul>
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button">Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--outline">Underline</button>
+  </li>
+</ul>
+
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--secondary">Underline</button>
+  </li>
+</ul>
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool" disabled>Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool" disabled>Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--accent-cool" disabled>Underline</button>
+  </li>
+</ul>
+
+<ul class="usa-button-group usa-button-group--segmented margin-top-3">
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Bold</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Italic</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button class="usa-button usa-button--base">Underline</button>
+  </li>
+</ul>

--- a/src/components/11-button-groups/button-groups.njk
+++ b/src/components/11-button-groups/button-groups.njk
@@ -1,91 +1,9 @@
+<h6>Default</h6>
 <ul class="usa-button-group">
   <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Cancel</button>
+    <button class="usa-button usa-button--outline">Button</button>
   </li>
   <li class="usa-button-group__item">
-    <button class="usa-button">Continue</button>
-  </li>
-</ul>
-
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Underline</button>
-  </li>
-</ul>
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Italic</button>
-  </li>
-</ul>
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button">Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button">Underline</button>
-  </li>
-</ul>
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button">Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--outline">Underline</button>
-  </li>
-</ul>
-
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--secondary">Underline</button>
-  </li>
-</ul>
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool" disabled>Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool" disabled>Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--accent-cool" disabled>Underline</button>
-  </li>
-</ul>
-
-<ul class="usa-button-group usa-button-group--segmented margin-top-3">
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Bold</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Italic</button>
-  </li>
-  <li class="usa-button-group__item">
-    <button class="usa-button usa-button--base">Underline</button>
+    <button class="usa-button">Button</button>
   </li>
 </ul>

--- a/src/stylesheets/components/_button-groups.scss
+++ b/src/stylesheets/components/_button-groups.scss
@@ -41,10 +41,19 @@
   flex-wrap: nowrap;
   margin-left: 0;
   margin-right: 0;
+  justify-content: space-between;
+
+  @include at-media("mobile-lg") {
+    justify-content: flex-start;
+  }
 
   .usa-button {
     position: relative;
-    width: auto;
+    width: calc(100% + #{units($theme-button-stroke-width)});
+
+    @include at-media("mobile-lg") {
+      width: auto;
+    }
 
     // Ensures edges are not cut off when interacting with outline buttons
     &:hover,
@@ -60,6 +69,11 @@
   .usa-button-group__item {
     margin-left: 0;
     margin-right: 0;
+    width: 100%;
+
+    @include at-media("mobile-lg") {
+      width: auto;
+    }
 
     &:first-child > .usa-button {
       border-top-right-radius: 0;
@@ -71,7 +85,13 @@
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
       margin-right: 0;
-      margin-left: -(units($theme-button-stroke-width)) / 2;
+      margin-left: -(units($theme-button-stroke-width));
+      width: calc(100% + #{units($theme-button-stroke-width)});
+
+      @include at-media("mobile-lg") {
+        margin-left: -(units($theme-button-stroke-width)) / 2;
+        width: auto;
+      }
     }
 
     &:not(:first-child):not(:last-child) > .usa-button {
@@ -115,6 +135,23 @@
     &:not(:last-child) .usa-button:active::before,
     &:not(:last-child) .usa-button--outline::before {
       display: none;
+    }
+  }
+}
+
+.usa-button-group--segmented.usa-button-group--stretched {
+  //justify-content: space-between;
+
+  .usa-button {
+    //width: calc(100% + #{units($theme-button-stroke-width)});
+  }
+
+  .usa-button-group__item {
+    //width: 100%;
+
+    &:last-child > .usa-button {
+    //  margin-left: -(units($theme-button-stroke-width));
+    //  width: calc(100% + #{units($theme-button-stroke-width)});
     }
   }
 }

--- a/src/stylesheets/components/_button-groups.scss
+++ b/src/stylesheets/components/_button-groups.scss
@@ -1,0 +1,104 @@
+// Default styles
+.usa-button-group {
+  @include unstyled-list;
+  display: flex;
+}
+
+.usa-button-group__item {
+  margin-left: units(0.5);
+  margin-right: units(0.5);
+
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  .usa-button {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+// Segemented styles
+.usa-button-group--segmented {
+
+  .usa-button {
+    position: relative;
+    width: auto;
+
+    // Ensures edges are not cut off when interacting with outline buttons
+    &:hover,
+    &:active{
+      z-index: 2;
+    }
+
+    &:focus {
+      z-index: 3;
+    }
+  }
+
+  .usa-button-group__item {
+    margin-left: 0;
+    margin-right: 0;
+
+    &:first-child > .usa-button {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      margin-right: -(units($theme-button-stroke-width)) / 2;
+    }
+
+    &:last-child > .usa-button {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      margin-right: 0;
+      margin-left: -(units($theme-button-stroke-width)) / 2;
+    }
+
+
+    &:not(:first-child):not(:last-child) > .usa-button {
+      border-radius: 0;
+      margin-right: -(units($theme-button-stroke-width)) / 2;
+      margin-left: -(units($theme-button-stroke-width)) / 2;
+    }
+
+    // Creates separators 
+    &:not(:last-child) .usa-button::before {
+      border-right: 1px solid color("primary-dark");
+      bottom: 0;
+      content: "";
+      display: block;
+      height: 100%;
+      position: absolute;
+      right: 1px;
+      top: 0;
+      width: 1px;
+      z-index: 3;
+    }
+
+    &:not(:last-child) .usa-button--secondary::before {
+      border-right-color: color("secondary-dark")
+    }
+
+    &:not(:last-child) .usa-button--accent-cool::before {
+      border-right-color: color("accent-cool-dark")
+    }
+
+    &:not(:last-child) .usa-button--base::before {
+      border-right-color: color("base-dark")
+    }
+
+    &:not(:last-child) .usa-button--secondary:disabled::before,
+    &:not(:last-child) .usa-button--accent-cool:disabled::before,
+    &:not(:last-child) .usa-button--base:disabled::before {
+      border-right-color: color("base");
+    }
+
+    &:not(:last-child) .usa-button:active::before,
+    &:not(:last-child) .usa-button--outline::before {
+      display: none;
+    }
+  }
+}

--- a/src/stylesheets/components/_button-groups.scss
+++ b/src/stylesheets/components/_button-groups.scss
@@ -24,14 +24,13 @@
 
 // Segemented styles
 .usa-button-group--segmented {
-
   .usa-button {
     position: relative;
     width: auto;
 
     // Ensures edges are not cut off when interacting with outline buttons
     &:hover,
-    &:active{
+    &:active {
       z-index: 2;
     }
 
@@ -57,14 +56,13 @@
       margin-left: -(units($theme-button-stroke-width)) / 2;
     }
 
-
     &:not(:first-child):not(:last-child) > .usa-button {
       border-radius: 0;
       margin-right: -(units($theme-button-stroke-width)) / 2;
       margin-left: -(units($theme-button-stroke-width)) / 2;
     }
 
-    // Creates separators 
+    // Creates separators
     &:not(:last-child) .usa-button::before {
       border-right: 1px solid color("primary-dark");
       bottom: 0;
@@ -79,15 +77,15 @@
     }
 
     &:not(:last-child) .usa-button--secondary::before {
-      border-right-color: color("secondary-dark")
+      border-right-color: color("secondary-dark");
     }
 
     &:not(:last-child) .usa-button--accent-cool::before {
-      border-right-color: color("accent-cool-dark")
+      border-right-color: color("accent-cool-dark");
     }
 
     &:not(:last-child) .usa-button--base::before {
-      border-right-color: color("base-dark")
+      border-right-color: color("base-dark");
     }
 
     &:not(:last-child) .usa-button--secondary:disabled::before,

--- a/src/stylesheets/components/_button-groups.scss
+++ b/src/stylesheets/components/_button-groups.scss
@@ -1,13 +1,13 @@
 // Default styles
 .usa-button-group {
   @include u-margin-y(0);
-  list-style-type: none;
-  padding-left: 0;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  list-style-type: none;
   margin-left: units(-0.5);
   margin-right: units(-0.5);
+  padding-left: 0;
 
   @include at-media("mobile-lg") {
     flex-direction: row;
@@ -16,12 +16,6 @@
 
 .usa-button-group__item {
   margin: units(0.5);
-
-  &:first-child {
-    @include at-media("mobile-lg") {
-      //margin-left: 0;
-    }
-  }
 
   &:last-child {
     @include at-media("mobile-lg") {
@@ -39,9 +33,9 @@
 .usa-button-group--segmented {
   flex-direction: row;
   flex-wrap: nowrap;
+  justify-content: space-between;
   margin-left: 0;
   margin-right: 0;
-  justify-content: space-between;
 
   @include at-media("mobile-lg") {
     justify-content: flex-start;
@@ -135,23 +129,6 @@
     &:not(:last-child) .usa-button:active::before,
     &:not(:last-child) .usa-button--outline::before {
       display: none;
-    }
-  }
-}
-
-.usa-button-group--segmented.usa-button-group--stretched {
-  //justify-content: space-between;
-
-  .usa-button {
-    //width: calc(100% + #{units($theme-button-stroke-width)});
-  }
-
-  .usa-button-group__item {
-    //width: 100%;
-
-    &:last-child > .usa-button {
-    //  margin-left: -(units($theme-button-stroke-width));
-    //  width: calc(100% + #{units($theme-button-stroke-width)});
     }
   }
 }

--- a/src/stylesheets/components/_button-groups.scss
+++ b/src/stylesheets/components/_button-groups.scss
@@ -1,19 +1,32 @@
 // Default styles
 .usa-button-group {
-  @include unstyled-list;
+  @include u-margin-y(0);
+  list-style-type: none;
+  padding-left: 0;
   display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  margin-left: units(-0.5);
+  margin-right: units(-0.5);
+
+  @include at-media("mobile-lg") {
+    flex-direction: row;
+  }
 }
 
 .usa-button-group__item {
-  margin-left: units(0.5);
-  margin-right: units(0.5);
+  margin: units(0.5);
 
   &:first-child {
-    margin-left: 0;
+    @include at-media("mobile-lg") {
+      //margin-left: 0;
+    }
   }
 
   &:last-child {
-    margin-right: 0;
+    @include at-media("mobile-lg") {
+      margin-right: 0;
+    }
   }
 
   .usa-button {
@@ -24,6 +37,11 @@
 
 // Segemented styles
 .usa-button-group--segmented {
+  flex-direction: row;
+  flex-wrap: nowrap;
+  margin-left: 0;
+  margin-right: 0;
+
   .usa-button {
     position: relative;
     width: auto;

--- a/src/stylesheets/packages/_usa-button-groups.scss
+++ b/src/stylesheets/packages/_usa-button-groups.scss
@@ -1,0 +1,2 @@
+// src
+@import "../components/button-groups";

--- a/src/stylesheets/packages/_uswds-components.scss
+++ b/src/stylesheets/packages/_uswds-components.scss
@@ -24,6 +24,7 @@
 @import "../components/accordions";
 @import "../components/alerts";
 @import "../components/banner";
+@import "../components/button-groups";
 @import "../components/checklist";
 @import "../components/footer";
 @import "../components/forms";


### PR DESCRIPTION
#3348 Button group example

## Additional info

This includes component for `button-group` component, which has default styling and a `segmented` variant.

**Default**
<img width="226" alt="Screen Shot 2020-03-26 at 1 44 16 PM" src="https://user-images.githubusercontent.com/1094951/77678794-12bed680-6f68-11ea-8171-a6c85773c8ff.png">

**Segmented**
<img width="296" alt="Screen Shot 2020-03-26 at 1 43 58 PM" src="https://user-images.githubusercontent.com/1094951/77678831-210cf280-6f68-11ea-9947-fb78ce1ff93b.png">

Tested:
- Chrome
- iOS
- Safari
- Edge
- E11
- Firefox


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
