### PR TITLE
Use direct link to zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ How you implement the design system depends on the needs of your project and you
 
 ### Download
 
-1. Download the [USWDS zip file](https://github.com/uswds/uswds/releases/tag/v2.6.0) from the latest USWDS release and open that file.
+1. Download the [USWDS zip file](https://github.com/uswds/uswds/releases/download/v2.6.0/uswds-2.6.0.zip) from the latest USWDS release and open that file.
 
    After extracting the zip file you should see the following file and folder structure:
 


### PR DESCRIPTION
This changes the release download link to link directly to the USWDS release package zip, reducing confusion about what zip files constitutes the package from the release page.