### PR TITLE
USWDS - Skipnav: Add typeset-link mixin to skipnav.

### DIFF
--- a/src/stylesheets/components/_skipnav.scss
+++ b/src/stylesheets/components/_skipnav.scss
@@ -1,6 +1,7 @@
 .usa-skipnav {
   @include border-box-sizing;
   @include typeset;
+  @include typeset-link;
   background: transparent;
   left: 0;
   padding: units(1) units(2);


### PR DESCRIPTION
## Description

Fixes #3391. Skipnav links were showing up unstyled.

## Additional information

Added `@include typeset-link;` mixin to `_skipnav.scss`.

![image](https://user-images.githubusercontent.com/3385219/79354605-3be8dc00-7f02-11ea-8164-abb18b1360bc.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
