### PR TITLE
USWDS - Banner: Fixes gov banner link extending past text on hover.

### DIFF
--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -172,6 +172,8 @@
 
     &:hover {
       @include u-text("primary-darker");
+      // Underline added to inner text instead.
+      text-decoration: none;
     }
   }
 


### PR DESCRIPTION
## Description

A duplicate `text-decoration: underline` on the button was being set on hover.

Fixes #3394.

## Additional information

![image](https://user-images.githubusercontent.com/3385219/79871884-ab4f4780-83aa-11ea-80be-d86c98af9cc2.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
