### PR TITLE
USWDS-3401: Last dropdown gets cutoff.

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -168,6 +168,15 @@ $z-index-overlay: 400;
       width: auto;
     }
 
+    // Issue #3401: last dropdown gets cutoff.
+    .usa-nav__primary-item:last-of-type {
+      position: relative;
+
+      .usa-nav__submenu {
+        @include u-pin-right;
+      }
+    }
+
     .usa-search {
       top: 0;
     }
@@ -181,6 +190,12 @@ $z-index-overlay: 400;
         display: block;
         float: right;
         margin-top: units(-5);
+      }
+    }
+
+    .usa-nav__primary-item:last-of-type {
+      @include at-media($theme-header-min-width) {
+        position: static;
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes #3401. Pins basic header's last navigation item's dropdown to the right.

## Additional information

![image](https://user-images.githubusercontent.com/3385219/80615326-2943cc00-8a05-11ea-8f37-550715c765c1.png)

![image](https://user-images.githubusercontent.com/3385219/80615368-3660bb00-8a05-11ea-95ea-b69a86b2cf79.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
