### PR TITLE
Add proper data and references for search ids

### DIFF
--- a/src/components/08-navigation/_nav-secondary.njk
+++ b/src/components/08-navigation/_nav-secondary.njk
@@ -7,6 +7,6 @@
     {%- endfor -%}
   </ul>
   {%- if nav.search -%}
-    {% render '@search--header', {search: nav.search, search_js: false, id_prefix: id_prefix} %}
+    {% render '@search--header', {search: nav.search, search_js: false, id_prefix: nav.id_prefix} %}
   {%- endif -%}
 </div>

--- a/src/components/09-header/header.config.yml
+++ b/src/components/09-header/header.config.yml
@@ -32,6 +32,7 @@ variants:
           id_prefix: extended-
         secondary:
           search: true
+          id_prefix: extended-
 
   - name: extended-mega
     label: Extended with mega-menu
@@ -43,3 +44,4 @@ variants:
           mega: true
         secondary:
           search: true
+          id_prefix: extended-mega-


### PR DESCRIPTION
A continuation of the work in https://github.com/uswds/uswds/pull/3077

This just makes sure each search element in the header has a unique id. It doesn't matter in most instances except the example where all the header are on the same page.

[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-subnav-on-tablet/components/preview/header--default.html)→ 