### PR TITLE
3352 Combo Box cross browser navigation

### DIFF
--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -415,7 +415,9 @@ const comboBox = behavior(
     keydown: {
       [COMBO_BOX]: keymap({
         ArrowUp: handleUp,
+        Up: handleUp,
         ArrowDown: handleDown,
+        Down: handleDown,
         Escape: handleEscape,
         Enter: handleEnter
       })


### PR DESCRIPTION
Adds the keymap values for cross browser compatibility.

<img width="675" alt="Screenshot 2020-05-04 18 08 50" src="https://user-images.githubusercontent.com/1385752/81022405-2268ef00-8e33-11ea-8417-8aa2cbe8434a.png">
