### PR TITLE
USWDS - Media Block: Use flexbox instead of floats.

### DIFF
--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,6 +1,6 @@
 .usa-media-block {
   @include u-display("flex");
-  @include u-align-items("flex-align-start");
+  @include u-align-items("align-start");
 
   .usa-media-block__img {
     @include media-block-img;

--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,6 +1,6 @@
 .usa-media-block {
-  @include u-display("flex");
   @include u-align-items("align-start");
+  @include u-display("flex");
 
   .usa-media-block__img {
     @include media-block-img;

--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,12 +1,12 @@
 .usa-media-block {
   @include u-align-items("align-start");
   @include u-display("flex");
+}
 
-  .usa-media-block__img {
-    @include media-block-img;
-  }
+.usa-media-block__img {
+  @include media-block-img;
+}
 
-  .usa-media-block__body {
-    @include u-flex(1);
-  }
+.usa-media-block__body {
+  @include u-flex(1);
 }

--- a/src/stylesheets/components/_media-block.scss
+++ b/src/stylesheets/components/_media-block.scss
@@ -1,7 +1,12 @@
-.usa-media-block__img {
-  @include media-block-img;
-}
+.usa-media-block {
+  @include u-display("flex");
+  @include u-align-items("flex-align-start");
 
-.usa-media-block__body {
-  overflow: hidden;
+  .usa-media-block__img {
+    @include media-block-img;
+  }
+
+  .usa-media-block__body {
+    @include u-flex(1);
+  }
 }

--- a/src/stylesheets/core/mixins/_media-block-img.scss
+++ b/src/stylesheets/core/mixins/_media-block-img.scss
@@ -1,4 +1,3 @@
 @mixin media-block-img($margin-right: units(1)) {
-  float: left;
   margin-right: $margin-right;
 }


### PR DESCRIPTION
**Improve display of media block in IE11.** Text in a media block is no longer cut occasionally cut off at the end of a line in IE11. Thanks @maya! 

## Description
Resolves #3425. 

## Additional information

Based on:
https://philipwalton.github.io/solved-by-flexbox/demos/media-object/


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
