### PR TITLE
Remove deprecated mixin targeting aria-hidden

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -105,8 +105,6 @@ $accordion-border: units($theme-accordion-border-width) solid
   > *:last-child {
     margin-bottom: 0;
   }
-
-  @include accessibly-hidden;
 }
 
 .usa-accordion__button {

--- a/src/stylesheets/core/mixins/_screen-reader.scss
+++ b/src/stylesheets/core/mixins/_screen-reader.scss
@@ -21,10 +21,3 @@
 @mixin add-no-sr-only {
   position: static;
 }
-
-// Aria hidden helper
-@mixin accessibly-hidden {
-  &[aria-hidden="true"] {
-    display: none;
-  }
-}


### PR DESCRIPTION
We shouldn't provide a mixin that visually styles `aria-hidden`. Since the only component that uses that mixin is the accordion, and the accordion no longer uses `aria-hidden` in its markup/functionality, this mixin is vestigial and can be deprecated.

Fixes https://github.com/uswds/uswds/issues/1513