### PR TITLE
USWDS-3450 - Autoprefixer: Add browserslist settings.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Supported browsers
+> 2%
+last 2 versions
+IE 11
+not dead

--- a/README.md
+++ b/README.md
@@ -217,10 +217,13 @@ scss
 
 The design system requires **autoprefixing** to work properly. This is included in the [`uswds-gulp`](https://github.com/uswds/uswds-gulp) package.
 
-**Autoprefixing** uses a service like [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) to automatically add vendor prefixes to the precompiled stylesheets. Don't add vendor prefixes to your custom styles manually — it is more reliable to use autoprefixing. We use the following autoprefixer settings:
+**Autoprefixing** uses a service like [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) to automatically add vendor prefixes to the precompiled stylesheets. Don't add vendor prefixes to your custom styles manually — it is more reliable to use autoprefixing. We use the following autoprefixer settings via `.browserslistrc` config:
 
 ```
-'> 2%','Last 2 versions', 'IE 11'
+> 2%
+last 2 versions
+IE 11
+not dead
 ```
 
 > Note: **media query sorting** is no longer required as of USWDS 2.5.0. We stopped sorting media queries with [csso](https://github.com/css/csso) in USWDS 2.5.1 because it wasn't outputting as expected. While both the minified and unminified CSS files are modestly larger as a result: `268 KB` unsorted vs. `259 KB` sorted, our testing indicates that once the files are compressed server side with gzip, the unsorted CSS is actually smaller: `36 KB` unsorted and gzipped vs. `38 KB` sorted and gzipped. As a result, we recommend that teams do not use media query sorting at this time.

--- a/config/gulp/browsers.js
+++ b/config/gulp/browsers.js
@@ -1,1 +1,0 @@
-module.exports = ["> 2%", "Last 2 versions", "IE 11"];

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -11,7 +11,6 @@ const rename = require("gulp-rename");
 const sass = require("gulp-sass");
 const sourcemaps = require("gulp-sourcemaps");
 const changed = require("gulp-changed");
-const autoprefixerOptions = require("./browsers");
 const dutil = require("./doc-util");
 const pkg = require("../../package.json");
 
@@ -90,7 +89,7 @@ gulp.task(
     dutil.logMessage(task, "Compiling Sass");
     const pluginsProcess = [
       discardComments(),
-      autoprefixer(autoprefixerOptions)
+      autoprefixer()
     ];
     const pluginsMinify = [csso({ forceMediaMerge: false })];
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "mocha": {
     "config": "spec/.mocharc.json"
   },
+  "browserslist": [
+    "> 2%",
+    "last 2 versions",
+    "ie 11",
+    "not dead"
+  ],
   "scripts": {
     "build": "gulp build",
     "build:css": "gulp sass",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,6 @@
   "mocha": {
     "config": "spec/.mocharc.json"
   },
-  "browserslist": [
-    "> 2%",
-    "last 2 versions",
-    "ie 11",
-    "not dead"
-  ],
   "scripts": {
     "build": "gulp build",
     "build:css": "gulp sass",


### PR DESCRIPTION
**Improved our Autoprefixer and Browserlist settings.** We added `not dead` to our autoprefixer settings and now use a `.browserslistrc` file to enumerate these options. This gets us more in line with Autoprefixer and Browserslist best practices.

## Description

Resolves #3450

- Add browserslist settings in package.json
- Remove browsers.js and reference in sass.js

Related issues:
https://github.com/uswds/uswds-gulp/pull/16

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
