### PR TITLE
USWDS-3073 - Mobile nav: Fix `ESC` key not closing on IE11.

### DIFF
--- a/src/js/utils/focus-trap.js
+++ b/src/js/utils/focus-trap.js
@@ -38,9 +38,10 @@ const tabHandler = context => {
 
 module.exports = (context, additionalKeyBindings = {}) => {
   const tabEventHandler = tabHandler(context);
+  const bindings = additionalKeyBindings;
+  const { Esc, Escape } = bindings;
 
-  const { Esc, Escape } = additionalKeyBindings;
-  if (Escape && !Esc) additionalKeyBindings.Esc = Escape;
+  if (Escape && !Esc) bindings.Esc = Escape;
 
   //  TODO: In the future, loop over additional keybindings and pass an array
   // of functions, if necessary, to the map keys. Then people implementing

--- a/src/js/utils/focus-trap.js
+++ b/src/js/utils/focus-trap.js
@@ -39,6 +39,9 @@ const tabHandler = context => {
 module.exports = (context, additionalKeyBindings = {}) => {
   const tabEventHandler = tabHandler(context);
 
+  const { Esc, Escape } = additionalKeyBindings;
+  if (Escape && !Esc) additionalKeyBindings.Esc = Escape;
+
   //  TODO: In the future, loop over additional keybindings and pass an array
   // of functions, if necessary, to the map keys. Then people implementing
   // the focus trap could pass callbacks to fire when tabbing


### PR DESCRIPTION
**Allows mobile menus to be close with the `esc` key in IE11.** Now, the escape key will properly close mobile menus in IE11. Thanks @joncasey!

## Description

Fixes #3073 based on guidance in ticket.

## Additional information

Tested and working in IE11 on browserstack.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
