### PR TITLE
USWDS-3469 - Header: Fix mobile subnav in IE11.

### DIFF
--- a/src/stylesheets/components/_megamenu.scss
+++ b/src/stylesheets/components/_megamenu.scss
@@ -10,6 +10,7 @@
 .usa-megamenu {
   .usa-col {
     @include u-flex(1);
+    flex-basis: auto;
     @include at-media($theme-header-min-width) {
       // needs this round() to avoid a compile bug
       @include u-flex(round(12 / $theme-megamenu-columns));

--- a/src/stylesheets/components/_megamenu.scss
+++ b/src/stylesheets/components/_megamenu.scss
@@ -9,8 +9,10 @@
 
 .usa-megamenu {
   .usa-col {
-    @include u-flex(1);
-    flex-basis: auto;
+    // Flex grow to take up available width.
+    // Flex shrink so long nav lines don't extend beyond viewport.
+    // Finally `flex-basis: auto` for IE11.
+    flex: 1 1 auto;
     @include at-media($theme-header-min-width) {
       // needs this round() to avoid a compile bug
       @include u-flex(round(12 / $theme-megamenu-columns));


### PR DESCRIPTION
**Fixed IE11 display issue in mobile nav.** Now nav elements display as expected at mobile width on IE11.

##  Description
Fixes: https://github.com/uswds/uswds/issues/3469

Our old friend `flex-basis: 0`. This changes the value to `auto` so the
width is correctly rendered in IE11. There's also an issue I discovered
regarding long navigation links extending beyond viewport because of:

`flex: 1 0 0`

The flex-shrink value was making it stay the same width and it'd break out
of viewport. 

## Additional information

![image](https://user-images.githubusercontent.com/3385219/81863815-65148080-9531-11ea-890e-04298682acfc.png)


These values could be adjusted to make sure they don't shrink/grow
too much.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
