### PR TITLE
USWDS-3472 Remove colon from Combo Box example

### DIFF
--- a/src/components/07-form/controls/combo-box.njk
+++ b/src/components/07-form/controls/combo-box.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <label class="usa-label" for="fruit">Select your desired fruit</label>
+  <label class="usa-label" for="fruit">Select a fruit</label>
   <div class="usa-combo-box">
     <select class="usa-select usa-combo-box__select" name="fruit" id="fruit" required>
       <option value>Select a fruit</option>

--- a/src/components/07-form/controls/combo-box.njk
+++ b/src/components/07-form/controls/combo-box.njk
@@ -1,5 +1,5 @@
 <form class="usa-form">
-  <label class="usa-label" for="fruit">Select your desired fruit:</label>
+  <label class="usa-label" for="fruit">Select your desired fruit</label>
   <div class="usa-combo-box">
     <select class="usa-select usa-combo-box__select" name="fruit" id="fruit" required>
       <option value>Select a fruit</option>


### PR DESCRIPTION
closes #3472 

Removes the colon from the Combo Box Example

![Screenshot 2020-05-18 13 59 36](https://user-images.githubusercontent.com/1385752/82249668-d7a9a580-990f-11ea-8ba9-837baeabe41e.png)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
