### PR TITLE
USWDS-3490 Combo Box Mouseover Selection

### DIFF
--- a/spec/unit/combo-box/combo-box-change-event.spec.js
+++ b/spec/unit/combo-box/combo-box-change-event.spec.js
@@ -102,6 +102,18 @@ EVENTS.keydownArrowDown = el => {
   el.dispatchEvent(evt);
 };
 
+/**
+ * send a keydown Tab event
+ * @param {HTMLElement} el the element to sent the event to
+ */
+EVENTS.keydownTab = el => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: "Tab"
+  });
+  el.dispatchEvent(evt);
+};
+
 describe("combo box component change event dispatch", () => {
   const { body } = document;
 
@@ -172,6 +184,7 @@ describe("combo box component change event dispatch", () => {
     EVENTS.keyupA(input);
     assert.ok(!list.hidden, "should display the option list");
 
+    EVENTS.keydownTab(input);
     EVENTS.focusout(input);
 
     assert.equal(select.value, "", "should clear the value on the select");
@@ -224,6 +237,7 @@ describe("combo box component change event dispatch", () => {
     EVENTS.keyupO(input);
     assert.ok(!list.hidden, "should display the option list");
 
+    EVENTS.keydownTab(input);
     EVENTS.focusout(input);
 
     assert.equal(

--- a/spec/unit/combo-box/combo-box.spec.js
+++ b/spec/unit/combo-box/combo-box.spec.js
@@ -112,6 +112,18 @@ EVENTS.keydownArrowUp = (el) => {
   el.dispatchEvent(evt);
 };
 
+/**
+ * send a keydown Tab event
+ * @param {HTMLElement} el the element to sent the event to
+ */
+EVENTS.keydownTab = (el) => {
+  const evt = new KeyboardEvent('keydown', {
+    bubbles: true,
+    key: 'Tab',
+  });
+  el.dispatchEvent(evt);
+};
+
 describe('combo box component', () => {
   const { body } = document;
 
@@ -230,12 +242,13 @@ describe('combo box component', () => {
     assert.equal(list.children.length, 10, 'should filter the item by the string being present in the option');
   });
 
-  it('should clear input values when an incomplete item is remaining on blur', () => {
+  it('should clear input values when an incomplete item is remaining on tab/blur', () => {
     select.value = 'value-ActionScript';
     input.value = 'a';
 
     EVENTS.keyupA(input);
     assert.ok(!list.hidden, 'should display the option list');
+    EVENTS.keydownTab(input);
     EVENTS.focusout(input);
 
     assert.ok(list.hidden, 'should hide the option list');
@@ -280,12 +293,13 @@ describe('combo box component', () => {
     assert.equal(input.value, 'a', 'should not change the value in the input');
   });
 
-  it('should set the input value when a complete selection is submitted by clicking away', () => {
+  it('should set the input value when a complete selection is left on tab/blur from the input element', () => {
     select.value = 'value-ActionScript';
     input.value = 'go';
 
     EVENTS.keyupO(input);
     assert.ok(!list.hidden, 'should display the option list');
+    EVENTS.keydownTab(input);
     EVENTS.focusout(input);
 
     assert.ok(list.hidden, 'should hide the option list');

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -45,7 +45,7 @@ const isPrintableKeyCode = keyCode => {
  * @property {HTMLInputElement} inputEl
  * @property {HTMLUListElement} listEl
  * @property {HTMLDivElement} statusEl
- * @property {HTMLOptionElement} focusedOptionEl
+ * @property {HTMLLIElement} focusedOptionEl
  */
 
 /**
@@ -224,8 +224,8 @@ const hideList = el => {
   inputEl.setAttribute("aria-expanded", "false");
   inputEl.setAttribute("aria-activedescendant", "");
 
-  listEl.innerHTML = "";
   listEl.hidden = true;
+  listEl.innerHTML = "";
 };
 
 /**
@@ -236,7 +236,7 @@ const hideList = el => {
 const selectItem = listOptionEl => {
   const { comboBoxEl, selectEl, inputEl } = getComboBoxElements(listOptionEl);
 
-  selectEl.value = listOptionEl.getAttribute("data-option-value");
+  selectEl.value = listOptionEl.dataset.optionValue;
   inputEl.value = listOptionEl.textContent;
   hideList(comboBoxEl);
   inputEl.focus();
@@ -258,7 +258,7 @@ const completeSelection = el => {
   statusEl.textContent = "";
 
   if (focusedOptionEl) {
-    selectEl.value = focusedOptionEl.getAttribute("data-option-value");
+    selectEl.value = focusedOptionEl.dataset.optionValue;
     inputEl.value = focusedOptionEl.textContent;
     return;
   }
@@ -290,8 +290,9 @@ const completeSelection = el => {
  * @param {HTMLElement} el An element within the combo box component
  * @param {HTMLElement} currentEl An element within the combo box component
  * @param {HTMLElement} nextEl An element within the combo box component
+ * @param {boolean} preventScroll should skip procedure to scroll to element
  */
-const highlightOption = (el, currentEl, nextEl) => {
+const highlightOption = (el, currentEl, nextEl, preventScroll) => {
   const { inputEl, listEl } = getComboBoxElements(el);
 
   if (currentEl) {
@@ -304,17 +305,20 @@ const highlightOption = (el, currentEl, nextEl) => {
     nextEl.setAttribute("aria-selected", "true");
     nextEl.classList.add(LIST_OPTION_FOCUSED_CLASS);
 
-    const optionBottom = nextEl.offsetTop + nextEl.offsetHeight;
-    const currentBottom = listEl.scrollTop + listEl.offsetHeight;
+    if (!preventScroll) {
+      const optionBottom = nextEl.offsetTop + nextEl.offsetHeight;
+      const currentBottom = listEl.scrollTop + listEl.offsetHeight;
 
-    if (optionBottom > currentBottom) {
-      listEl.scrollTop = optionBottom - listEl.offsetHeight;
+      if (optionBottom > currentBottom) {
+        listEl.scrollTop = optionBottom - listEl.offsetHeight;
+      }
+
+      if (nextEl.offsetTop < listEl.scrollTop) {
+        listEl.scrollTop = nextEl.offsetTop;
+      }
     }
 
-    if (nextEl.offsetTop < listEl.scrollTop) {
-      listEl.scrollTop = nextEl.offsetTop;
-    }
-    nextEl.focus();
+    nextEl.focus({ preventScroll });
   } else {
     inputEl.setAttribute("aria-activedescendant", "");
     inputEl.focus();
@@ -322,25 +326,7 @@ const highlightOption = (el, currentEl, nextEl) => {
 };
 
 /**
- * Handle the enter event within the combo box component.
- *
- * @param {KeyboardEvent} event An event within the combo box component
- */
-const handleEnter = event => {
-  const { comboBoxEl, inputEl, listEl } = getComboBoxElements(event.target);
-  const listShown = !listEl.hidden;
-
-  completeSelection(comboBoxEl);
-
-  if (listShown) {
-    hideList(comboBoxEl);
-    inputEl.focus();
-    event.preventDefault();
-  }
-};
-
-/**
- * Handle the down event within the combo box component.
+ * Handle the escape event within the combo box component.
  *
  * @param {KeyboardEvent} event An event within the combo box component
  */
@@ -349,29 +335,6 @@ const handleEscape = event => {
 
   hideList(comboBoxEl);
   inputEl.focus();
-};
-
-/**
- * Handle the up event within the combo box component.
- *
- * @param {KeyboardEvent} event An event within the combo box component
- */
-const handleUp = event => {
-  const { comboBoxEl, listEl, focusedOptionEl } = getComboBoxElements(
-    event.target
-  );
-  const nextOptionEl = focusedOptionEl && focusedOptionEl.previousSibling;
-  const listShown = !listEl.hidden;
-
-  highlightOption(comboBoxEl, focusedOptionEl, nextOptionEl);
-
-  if (listShown) {
-    event.preventDefault();
-  }
-
-  if (!nextOptionEl) {
-    hideList(comboBoxEl);
-  }
 };
 
 /**
@@ -399,6 +362,84 @@ const handleDown = event => {
   event.preventDefault();
 };
 
+/**
+ * Handle the enter event from an input element within the combo box component.
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleEnterFromInput = event => {
+  const { comboBoxEl, listEl } = getComboBoxElements(event.target);
+  const listShown = !listEl.hidden;
+
+  completeSelection(comboBoxEl);
+
+  if (listShown) {
+    hideList(comboBoxEl);
+    event.preventDefault();
+  }
+};
+
+/**
+ * Handle the enter event from an input element within the combo box component.
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleTabFromInput = event => {
+  completeSelection(event.target);
+};
+
+
+/**
+ * Handle the enter event from list option within the combo box component.
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleEnterFromListOption = event => {
+  selectItem(event.target);
+  event.preventDefault();
+};
+
+/**
+ * Handle the up event from list option within the combo box component.
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleUpFromListOption = event => {
+  const { comboBoxEl, listEl, focusedOptionEl } = getComboBoxElements(
+    event.target
+  );
+  const nextOptionEl = focusedOptionEl && focusedOptionEl.previousSibling;
+  const listShown = !listEl.hidden;
+
+  highlightOption(comboBoxEl, focusedOptionEl, nextOptionEl);
+
+  if (listShown) {
+    event.preventDefault();
+  }
+
+  if (!nextOptionEl) {
+    hideList(comboBoxEl);
+  }
+};
+
+/**
+ * Select list option on the mousemove event.
+ *
+ * @param {MouseEvent} event The mousemove event
+ * @param {HTMLLIElement} listOptionEl An element within the combo box component
+ */
+const handleMousemove = listOptionEl => {
+  const isCurrentlyFocused = listOptionEl.classList.contains(
+    LIST_OPTION_FOCUSED_CLASS
+  );
+
+  if (isCurrentlyFocused) return;
+
+  const { comboBoxEl, focusedOptionEl } = getComboBoxElements(listOptionEl);
+
+  highlightOption(comboBoxEl, focusedOptionEl, listOptionEl, true);
+};
+
 const comboBox = behavior(
   {
     [CLICK]: {
@@ -413,19 +454,25 @@ const comboBox = behavior(
       [COMBO_BOX](event) {
         const { comboBoxEl } = getComboBoxElements(event.target);
         if (!comboBoxEl.contains(event.relatedTarget)) {
-          completeSelection(comboBoxEl);
           hideList(comboBoxEl);
         }
       }
     },
     keydown: {
-      [COMBO_BOX]: keymap({
-        ArrowUp: handleUp,
-        Up: handleUp,
+      [INPUT]: keymap({
         ArrowDown: handleDown,
         Down: handleDown,
         Escape: handleEscape,
-        Enter: handleEnter
+        Enter: handleEnterFromInput,
+        Tab: handleTabFromInput
+      }),
+      [LIST_OPTION]: keymap({
+        ArrowUp: handleUpFromListOption,
+        Up: handleUpFromListOption,
+        ArrowDown: handleDown,
+        Down: handleDown,
+        Escape: handleEscape,
+        Enter: handleEnterFromListOption
       })
     },
     keyup: {
@@ -433,6 +480,11 @@ const comboBox = behavior(
         if (isPrintableKeyCode(event.keyCode)) {
           displayList(this);
         }
+      }
+    },
+    mousemove: {
+      [LIST_OPTION]() {
+        handleMousemove(this);
       }
     }
   },

--- a/src/stylesheets/elements/form-controls/_combo-box.scss
+++ b/src/stylesheets/elements/form-controls/_combo-box.scss
@@ -36,15 +36,14 @@
   display: block;
   padding: units(1);
 
-  &--focused:focus {
-    outline-offset: -4px;
-  }
-
-  &:hover,
   &--focused {
     background-color: color("primary");
     border-color: color("primary");
     color: color("white");
+
+    &:focus {
+      outline-offset: -4px;
+    }
   }
 }
 


### PR DESCRIPTION
Adds hover focus for combo box list items.

closes #3490 

[Current Implementation](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/10x-forms/3490-mouseover-selection/components/preview/combo-box.html)

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
