### PR TITLE
Fix Unhandled rejection Parsing error

### DIFF
--- a/src/stylesheets/utilities/utility-fonts.scss
+++ b/src/stylesheets/utilities/utility-fonts.scss
@@ -13,7 +13,7 @@ $if-important: "";
 
 @each $face, $stack in $project-font-stacks {
   @if $stack {
-    [class*="#{ns("utility")}font-#{$face}-"] {
+    [class*="#{ns('utility')}font-#{$face}-"] {
       font-family: #{$stack}#{$if-important};
     }
   }


### PR DESCRIPTION
## Description

While attempting to pull some sass variables into javascript using https://github.com/jgranstrom/sass-extract, I encountered the following error:
```
Unhandled rejection Parsing error: Please check validity of the block starting from line #16

14 | @each $face, $stack in $project-font-stacks {
15 |   @if $stack {
16*|     [class*="#{ns("utility")}font-#{$face}-"] {
17 |       font-family: #{$stack}#{$if-important};
18 |     }
```
It looks like using two sets of double quotes (line 16) causes the parser to have an error. This PR switches the innermost to single quotes. This resolves the error and allows the sass to be interpreted correctly. 
