### PR TITLE
USWDS-3316: Add `role="img"` to component SVGs.

### DIFF
--- a/src/components/08-navigation/_nav-primary.njk
+++ b/src/components/08-navigation/_nav-primary.njk
@@ -1,4 +1,4 @@
-<button class="usa-nav__close"><img src="{{ uswds.path }}/img/close.svg" alt="close"></button>
+<button class="usa-nav__close"><img src="{{ uswds.path }}/img/close.svg" role="img" alt="close"></button>
 <ul class="usa-nav__primary usa-accordion">
   {%- for link in nav.links -%}
   <li class="usa-nav__primary-item">

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -18,7 +18,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" alt="Dot gov">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
               <strong>The .gov means it’s official.</strong>
@@ -28,7 +28,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" alt="Https">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>
               <strong>The site is secure.</strong>


### PR DESCRIPTION
## Description

Added `role="img"` to close icon in nav and banner icons so Voiceover can correctly identify them as images instead of groups.

It makes sense to add them in this case because the images have alt text.

Resoves: https://github.com/uswds/uswds/issues/3316

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
