### PR TITLE
USWDS - Banner: Fix media block in usa-banner.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3820,7 +3820,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -10551,7 +10552,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "lcid": {
@@ -19014,7 +19016,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -17,7 +17,7 @@
     </header>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance tablet:grid-col-6">
+        <div class="usa-banner__guidance usa-media-block tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
@@ -27,7 +27,7 @@
             </p>
           </div>
         </div>
-        <div class="usa-banner__guidance tablet:grid-col-6">
+        <div class="usa-banner__guidance usa-media-block tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" alt="Https">
           <div class="usa-media-block__body">
             <p>

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -17,7 +17,7 @@
     </header>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance usa-media-block tablet:grid-col-6">
+        <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
@@ -27,7 +27,7 @@
             </p>
           </div>
         </div>
-        <div class="usa-banner__guidance usa-media-block tablet:grid-col-6">
+        <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" alt="Https">
           <div class="usa-media-block__body">
             <p>

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -222,5 +222,5 @@
 }
 
 .usa-banner__icon {
-  width: units(5);
+  max-width: units(5);
 }

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -36,6 +36,8 @@
 }
 
 .usa-banner__guidance {
+  @include u-display("flex");
+  @include u-flex("align-start");
   padding-top: units(2);
 
   @include at-media("tablet") {

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -222,5 +222,5 @@
 }
 
 .usa-banner__icon {
-  max-width: units(5);
+  width: units(5);
 }

--- a/src/stylesheets/core/mixins/_media-block-img.scss
+++ b/src/stylesheets/core/mixins/_media-block-img.scss
@@ -1,3 +1,4 @@
 @mixin media-block-img($margin-right: units(1)) {
+  flex-shrink: 0;
   margin-right: $margin-right;
 }


### PR DESCRIPTION
## Description

Fixes issue #3502. The usa-media-block class is missing on the banner icons, which makes it collapse. There was also an issue in IE11 where the icon gets squished due to conflicts between `width` and `max-width`.

## Additional information

uswds-site will need to be updated as well.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
