### PR TITLE
USWDS Disable focus outline on drag

### DIFF
--- a/src/stylesheets/elements/form-controls/_combo-box.scss
+++ b/src/stylesheets/elements/form-controls/_combo-box.scss
@@ -88,6 +88,10 @@ button.usa-combo-box__clear-input {
   position: absolute;
   width: 100%;
   z-index: z-index(100);
+
+  &:focus {
+    outline: 0;
+  }
 }
 
 .usa-combo-box__list-option {


### PR DESCRIPTION
[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/10x-forms/disable-focus-outline-on-list/components/preview/combo-box.html) →

Disable the outline on focus in the list when dragging.

![Screenshot 2020-06-16 16 15 25](https://user-images.githubusercontent.com/1385752/84829208-fe312e00-afec-11ea-8bf8-8db7cea3deab.png)