### PR TITLE
Replace unsplash links with a basic design system image

### DIFF
--- a/src/components/card/_card--basic.njk
+++ b/src/components/card/_card--basic.njk
@@ -6,7 +6,7 @@
   <div class="usa-card__media{% if card.media_classes %} {{ card.media_classes }}{% endif %}">
     <div class="usa-card__img{% if card.image_classes %} {{ card.image_classes }}{% endif %}">
       <img
-        src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+        src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
         alt="A placeholder image">
     </div>
   </div>

--- a/src/components/card/card--compare.njk
+++ b/src/components/card/card--compare.njk
@@ -20,7 +20,7 @@
       </header>
       <div class="usa-card__media">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
       <div class="usa-card__body">
@@ -38,7 +38,7 @@
       </header>
       <div class="usa-card__media">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
       <div class="usa-card__body">
@@ -56,7 +56,7 @@
       </header>
       <div class="usa-card__media usa-card__media--inset">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
 
@@ -75,7 +75,7 @@
       </header>
       <div class="usa-card__media usa-card__media--exdent">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
 
@@ -98,7 +98,7 @@
       </header>
       <div class="usa-card__media">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
 
@@ -117,7 +117,7 @@
       </header>
       <div class="usa-card__media">
         <div class="usa-card__img">
-          <img src="https://images.unsplash.com/photo-1579800070193-abe62433f737?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=610&fit=max&ixid=eyJhcHBfaWQiOjE0NTg5fQ" alt="A placeholder image">
+          <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
         </div>
       </div>
 

--- a/src/components/card/card--test.njk
+++ b/src/components/card/card--test.njk
@@ -11,7 +11,7 @@
         <div class="usa-card__media">
           <div class="usa-card__img add-aspect-16x9">
             <img
-              src="https://source.unsplash.com/featured/800x800/daily?cities"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="An image's description"
               class="pin-all"
             >
@@ -53,7 +53,7 @@
         <div class="usa-card__media usa-card__media--exdent">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x450/daily?patterns"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -73,7 +73,7 @@
         <div class="usa-card__media flex-align-center">
           <div class="usa-card__img circle-card margin-x-auto">
             <img
-              src="https://source.unsplash.com/featured/450x600/daily?human"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -93,7 +93,7 @@
         <div class="usa-card__media usa-card__media--exdent usa-card__media--fix-aspect add-aspect-1x1">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/450x600/daily?people"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -114,7 +114,7 @@
         <div class="usa-card__media usa-card__media--fix-aspect" aria-hidden="true">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x450/daily?architecture"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -137,7 +137,7 @@
         <div class="usa-card__media">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x600?geometric"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -157,7 +157,7 @@
         <div class="usa-card__media usa-card__media--inset">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x600?geometric"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>
@@ -177,7 +177,7 @@
         <div class="usa-card__media usa-card__media--inset">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x600?geometric"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="">
           </div>
         </div>

--- a/src/components/test/flex.njk
+++ b/src/components/test/flex.njk
@@ -280,7 +280,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
           <div class="usa-card__media usa-card__media--fix-aspect" aria-hidden="true">
             <div class="usa-card__img">
               <img
-                src="https://source.unsplash.com/featured/800x450/daily?architecture"
+                src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
                 alt=""
               />
             </div>
@@ -312,7 +312,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
         <div class="usa-card__media">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x600?geometric"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt=""
             />
           </div>
@@ -345,7 +345,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
         <div class="usa-card__media usa-card__media--inset">
           <div class="usa-card__img">
             <img
-              src="https://source.unsplash.com/featured/800x600?geometric"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt=""
             />
           </div>
@@ -386,7 +386,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
             <div class="usa-card__media">
               <div class="usa-card__img">
                 <img
-                  src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+                  src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
                   alt=""
                 />
               </div>
@@ -404,7 +404,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
             <div class="usa-card__media">
               <div class="usa-card__img">
                 <img
-                  src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+                  src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
                   alt=""
                 />
               </div>
@@ -422,7 +422,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
             <div class="usa-card__media">
               <div class="usa-card__img">
                 <img
-                  src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+                  src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
                   alt=""
                 />
               </div>
@@ -444,7 +444,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
         <div class="usa-card__media">
           <div class="usa-card__img">
             <img
-              src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="" />
           </div>
         </div>
@@ -461,7 +461,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
         <div class="usa-card__media">
           <div class="usa-card__img">
             <img
-              src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="" />
           </div>
         </div>
@@ -478,7 +478,7 @@ class="grid-col-auto border border-primary-light bg-primary-lighter padding-4"
         <div class="usa-card__media">
           <div class="usa-card__img">
             <img
-              src="https://images.unsplash.com/photo-1464132272316-b28740d26ad9?ixlib=rb-1.2.1&q=85&fm=jpg&crop=entropy&cs=srgb&ixid=eyJhcHBfaWQiOjE0NTg5fQ"
+              src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg"
               alt="" />
           </div>
         </div>


### PR DESCRIPTION
Let's use a basic design system image instead of pulling from unsplash. Not only is this more consistent, but it may fix some of our build timeout issues.