### PR TITLE
USWDS-3355 Date Picker Default Value Attribute

### DIFF
--- a/spec/unit/date-picker/date-picker-default-value.spec.js
+++ b/spec/unit/date-picker/date-picker-default-value.spec.js
@@ -1,0 +1,50 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const EVENTS = require("./events");
+const DatePicker = require("../../../src/js/components/date-picker");
+
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, "/date-picker-default-value.template.html")
+);
+
+describe("date picker component with default date", () => {
+  const { body } = document;
+
+  let root;
+  let input;
+  let button;
+  const getCalendarEl = query =>
+    root.querySelector(
+      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
+    );
+
+  beforeEach(() => {
+    body.innerHTML = TEMPLATE;
+    DatePicker.on();
+    root = body.querySelector(".usa-date-picker");
+    input = root.querySelector(".usa-date-picker__external-input");
+    button = root.querySelector(".usa-date-picker__button");
+  });
+
+  afterEach(() => {
+    window.onerror = null;
+    body.textContent = "";
+    DatePicker.off(body);
+  });
+
+  it("should set the input date of the calendar", () => {
+    assert.equal(input.value, "05/22/2020", "updates the calendar value");
+  });
+
+  it("should display the selected date when the calendar is opened", () => {
+    EVENTS.click(button);
+
+    assert.equal(getCalendarEl().hidden, false, "The calendar is shown");
+    assert.equal(
+      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+      "2020-05-22",
+      "focuses correct date"
+    );
+  });
+});

--- a/spec/unit/date-picker/date-picker-default-value.template.html
+++ b/spec/unit/date-picker/date-picker-default-value.template.html
@@ -1,0 +1,13 @@
+<div>
+  <div class="usa-form-group">
+    <label class="usa-label" for="input-dates-of-use">Dates of use</label>
+    <div class="usa-date-picker" data-default-value="2020-05-22">
+      <input
+        class="usa-input"
+        id="input-dates-of-use"
+        name="input-dates-of-use"
+        type="text"
+      />
+    </div>
+  </div>
+</div>

--- a/src/components/07-form/controls/date-picker.njk
+++ b/src/components/07-form/controls/date-picker.njk
@@ -1,6 +1,6 @@
 <form class="usa-form">
   <div class="usa-form-group">
-    <label class="usa-label" id="appointment-date-label" for="appointment-date">Appointment Date</label>
+    <label class="usa-label" id="appointment-date-label" for="appointment-date">Appointment date</label>
     <div class="usa-hint" id="appointment-date-hint">mm/dd/yyyy</div>
     <div class="usa-date-picker">
       <input class="usa-input" id="appointment-date" name="appointment-date" type="text" aria-describedby="appointment-date-label appointment-date-hint">

--- a/src/components/07-form/controls/date-range-picker.njk
+++ b/src/components/07-form/controls/date-range-picker.njk
@@ -1,18 +1,18 @@
 <form class="usa-form">
   <div class="usa-date-range-picker">
     <div class="usa-form-group">
-      <label class="usa-label" id="appointment-date-start-label" for="appointment-date-start">Appointment Date Start</label>
-      <div class="usa-hint" id="appointment-date-start-hint">mm/dd/yyyy</div>
+      <label class="usa-label" id="event-date-start-label" for="event-date-start">Event start date</label>
+      <div class="usa-hint" id="event-date-start-hint">mm/dd/yyyy</div>
       <div class="usa-date-picker">
-        <input class="usa-input" id="appointment-date-start" name="appointment-date-start" type="text" aria-describedby="appointment-date-start-label appointment-date-start-hint">
+        <input class="usa-input" id="event-date-start" name="event-date-start" type="text" aria-describedby="event-date-start-label event-date-start-hint">
       </div>
     </div>
 
     <div class="usa-form-group">
-      <label class="usa-label" id="appointment-date-end-label" for="appointment-date-end">Appointment Date End</label>
-      <div class="usa-hint" id="appointment-date-end-hint">mm/dd/yyyy</div>
+      <label class="usa-label" id="event-date-end-label" for="event-date-end">Event end date</label>
+      <div class="usa-hint" id="event-date-end-hint">mm/dd/yyyy</div>
       <div class="usa-date-picker">
-        <input class="usa-input" id="appointment-date-end" name="appointment-date-end" type="text" aria-describedby="appointment-date-end-label appointment-date-end-hint">
+        <input class="usa-input" id="event-date-end" name="event-date-end" type="text" aria-describedby="event-date-end-label event-date-end-hint">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Allow a default value to be set via data attribute

A default was available to be set but the value would need set as the element value in MM/DD/YYYY format. This aligns to use a data attribute similar to the combo box component and uses the internal ISO-8601 which is consistent with other data attributes.

![Screenshot 2020-07-07 14 55 02](https://user-images.githubusercontent.com/1385752/86835533-e2f09600-c061-11ea-929e-c65c74396b33.png)
![Screenshot 2020-07-07 14 54 52](https://user-images.githubusercontent.com/1385752/86835537-e3892c80-c061-11ea-8bf4-80a92c5820d4.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
