### PR TITLE
Fix template to improve code render on uswds-site

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -28,8 +28,10 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
-              <strong>{{ domain.heading | safe | replace(tld_text, domain.tld) }}</strong>
-              <br>
+              <strong>
+                {{ domain.heading | safe | replace(tld_text, domain.tld) -}}
+              </strong>
+              <br/>
               {{ domain.text | safe | replace(tld_text, domain.tld) }}
             </p>
           </div>
@@ -38,8 +40,10 @@
           <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>
-              <strong>{{ https.heading | safe | replace(tld_text, domain.tld) }}</strong>
-              <br>
+              <strong>
+                {{ https.heading | safe | replace(tld_text, domain.tld) -}}
+              </strong>
+              <br/>
               {{ https.text | safe | replace(tld_text, domain.tld) | replace(lock_image, lock) }}
             </p>
           </div>


### PR DESCRIPTION
This just makes some small tweaks to the template markup to improve how the code renders on `uswds-site`

Trying to prevent this bad line break and indentation coming out of Fractal (which is unreliable about this kind of thing):

<img width="678" alt="Screen Shot 2020-07-08 at 1 31 43 PM" src="https://user-images.githubusercontent.com/11464021/86967412-7340e080-c11f-11ea-8f57-bc3b70e454c9.png">
