### PR TITLE
Refinements to breadcrumb

### DIFF
--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -48,11 +48,11 @@ $breadcrumb-back-icon-aspect: (
     3
   );
   @include set-text-and-bg($theme-breadcrumb-background-color);
-  @include u-padding-x($theme-breadcrumb-spacing-x);
+  @include u-padding-x($theme-breadcrumb-padding-x);
 
   @include at-media($theme-breadcrumb-min-width) {
-    @include u-padding-bottom($theme-breadcrumb-spacing-bottom);
-    @include u-padding-top($theme-breadcrumb-spacing-top);
+    @include u-padding-bottom($theme-breadcrumb-padding-bottom);
+    @include u-padding-top($theme-breadcrumb-padding-top);
   }
 
   &.usa-breadcrumb--wrap {
@@ -109,8 +109,8 @@ $breadcrumb-back-icon-aspect: (
         );
 
         @include u-display("inline-block");
-        @include u-padding-bottom($theme-breadcrumb-spacing-bottom);
-        @include u-padding-top($theme-breadcrumb-spacing-top);
+        @include u-padding-bottom($theme-breadcrumb-padding-bottom);
+        @include u-padding-top($theme-breadcrumb-padding-top);
       }
 
       // Override icon spacing from place-icon() with non-token value

--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -111,6 +111,13 @@ $breadcrumb-back-icon-aspect: (
         @include u-display("inline-block");
         @include u-padding-bottom($theme-breadcrumb-padding-bottom);
         @include u-padding-top($theme-breadcrumb-padding-top);
+
+        // Prevent underline that extends beyond text
+        @include u-text("no-underline");
+
+        span {
+          @include u-text("underline");
+        }
       }
 
       // Override icon spacing from place-icon() with non-token value
@@ -148,4 +155,11 @@ $breadcrumb-back-icon-aspect: (
     $theme-breadcrumb-link-color
   );
   @include u-display("inline");
+
+  // Prevent underline that extends beyond text
+  @include u-text("no-underline");
+
+  span {
+    @include u-text("underline");
+  }
 }

--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -113,8 +113,11 @@ $breadcrumb-back-icon-aspect: (
         @include u-padding-top($theme-breadcrumb-padding-top);
 
         // Prevent underline that extends beyond text
-        @include u-text("no-underline");
-
+        &,
+        &:hover,
+        &:active {
+          @include u-text("no-underline");
+        }
         span {
           @include u-text("underline");
         }

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -35,15 +35,15 @@ $theme-banner-link-color: default !default;
 $theme-banner-max-width: "desktop" !default;
 
 // Breadcrumb
-$theme-breadcrumb-background-color: "white" !default;
+$theme-breadcrumb-background-color: "ink" !default;
 $theme-breadcrumb-font-size: "sm" !default;
 $theme-breadcrumb-font-family: "body" !default;
 $theme-breadcrumb-link-color: default !default;
 $theme-breadcrumb-min-width: "mobile-lg" !default;
+$theme-breadcrumb-padding-bottom: 2 !default;
+$theme-breadcrumb-padding-top: 2 !default;
+$theme-breadcrumb-padding-x: 2 !default;
 $theme-breadcrumb-separator-color: "base" !default;
-$theme-breadcrumb-spacing-bottom: 2 !default;
-$theme-breadcrumb-spacing-top: 2 !default;
-$theme-breadcrumb-spacing-x: 1 !default;
 
 // Button
 $theme-button-font-family: "ui" !default;

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -35,14 +35,14 @@ $theme-banner-link-color: default !default;
 $theme-banner-max-width: "desktop" !default;
 
 // Breadcrumb
-$theme-breadcrumb-background-color: "ink" !default;
+$theme-breadcrumb-background-color: "white" !default;
 $theme-breadcrumb-font-size: "sm" !default;
 $theme-breadcrumb-font-family: "body" !default;
 $theme-breadcrumb-link-color: default !default;
 $theme-breadcrumb-min-width: "mobile-lg" !default;
 $theme-breadcrumb-padding-bottom: 2 !default;
 $theme-breadcrumb-padding-top: 2 !default;
-$theme-breadcrumb-padding-x: 2 !default;
+$theme-breadcrumb-padding-x: 0 !default;
 $theme-breadcrumb-separator-color: "base" !default;
 
 // Button

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -40,10 +40,10 @@ $theme-breadcrumb-font-size: "sm";
 $theme-breadcrumb-font-family: "body";
 $theme-breadcrumb-link-color: default;
 $theme-breadcrumb-min-width: "mobile-lg";
+$theme-breadcrumb-padding-bottom: 2;
+$theme-breadcrumb-padding-top: 2;
+$theme-breadcrumb-padding-x: 0;
 $theme-breadcrumb-separator-color: "base";
-$theme-breadcrumb-spacing-bottom: 2;
-$theme-breadcrumb-spacing-top: 2;
-$theme-breadcrumb-spacing-x: 1;
 
 // Button
 $theme-button-font-family: "ui";


### PR DESCRIPTION
- Prevent link underline from extending beyond text
- Use "padding" instead of "spacing" in settings
- Set `$theme-breadcrumb-padding-x` default to `0`