### PR TITLE
Fix file input bugs

### DIFF
--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -4,7 +4,7 @@
 
 <label class="usa-label" for="input-multiple">Multiple files</label>
 <span class="usa-hint" id="input-multiple-hit">Any file type</span>
-<input id="input-multiple" accept=".pdf" class="usa-file-input"  type="file" name="input-multiple" aria-describedby="input-multiple-hit" multiple />
+<input id="input-multiple" class="usa-file-input"  type="file" name="input-multiple" aria-describedby="input-multiple-hit" multiple />
 
 <div class="usa-form-group usa-form-group--error">
   <label class="usa-label usa-label--error" for="file-input-error">Error example</label>

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -4,7 +4,7 @@
 
 <label class="usa-label" for="input-multiple">Multiple files</label>
 <span class="usa-hint" id="input-multiple-hit">Any file type</span>
-<input id="input-multiple" class="usa-file-input"  type="file" name="input-multiple" aria-describedby="input-multiple-hit" multiple />
+<input id="input-multiple" accept=".pdf" class="usa-file-input"  type="file" name="input-multiple" aria-describedby="input-multiple-hit" multiple />
 
 <div class="usa-form-group usa-form-group--error">
   <label class="usa-label usa-label--error" for="file-input-error">Error example</label>

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -93,10 +93,17 @@ const buildFileInput = fileInputEl => {
 const removeOldPreviews = (dropTarget, instructions) => {
   const filePreviews = dropTarget.querySelectorAll(`.${PREVIEW_CLASS}`);
   const currentPreviewHeading = dropTarget.querySelector(`.${PREVIEW_HEADING_CLASS}`)
+  const currentErrorMessage = dropTarget.querySelector(`.${ACCEPTED_FILE_MESSAGE_CLASS}`);
 
   // Remove the heading above the previews
   if (currentPreviewHeading) {
     currentPreviewHeading.outerHTML = "";
+  }
+
+  // Remove existing error messages
+  if (currentErrorMessage) {
+    currentErrorMessage.outerHTML = "";
+    dropTarget.classList.remove(INVALID_FILE_CLASS);
   }
 
   // Get rid of existing previews if they exist, show instructions
@@ -127,12 +134,6 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
   // Runs if only specific files are accepted
   if (acceptedFiles) {
     const errorMessage = document.createElement('div');
-    const currentErrorMessage = dropTarget.querySelector(`.${ACCEPTED_FILE_MESSAGE_CLASS}`);
-
-    // Remove existing error messages
-    if (currentErrorMessage) {
-      currentErrorMessage.outerHTML = "";
-    }
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
     let allFilesAllowed = true;

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -141,6 +141,9 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       const file = e.dataTransfer.files[i];
       if (allFilesAllowed) {
         allFilesAllowed = file.name.indexOf(acceptedFiles)
+        if (allFilesAllowed < 0) {
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This fixes two bugs in the file input, both dealing with the `accept` attribute. We'll use pdf for these descriptions:

**1) If a user drags a non-pdf into a file input. An error message appears. Then, if user selects a pdf from the file browser (not by drag), the error message remains.**


![](https://p100.p0.n0.cdn.getcloudapp.com/items/04uYRv2j/Screen%20Shot%202020-07-08%20at%2010.02.01%20PM.png)


**2) If a user drags a group of files, some being non-pfd, but the last file in the list is a pdf, the files are accepted.**
![Screen Recording 2020-07-08 at 11 38 24 PM](https://user-images.githubusercontent.com/1094951/86994376-38b56300-c174-11ea-947e-880b2bd380a2.gif)


## Additional information

Fix for issue 1:
![](https://user-images.githubusercontent.com/1094951/86991305-c0976f00-c16c-11ea-9ea8-ea1b8e35e014.gif)

Fix for issue 2:
![Screen Recording 2020-07-08 at 11 40 10 PM](https://user-images.githubusercontent.com/1094951/86994484-7adea480-c174-11ea-9504-b8522fce789c.gif)



Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
