### PR TITLE
USWDS - 3554: fix tooltip arrow position after resize

### DIFF
--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -32,7 +32,6 @@ const addListenerMulti = (element, eventNames, listener) => {
 * @param {HTMLElement} tooltipTrigger - the element that initializes the tooltip
 */
 const showToolTip = (tooltipBody, tooltipTrigger, position, wrapper) => {
-  let tooltipPosition = position;
 
   tooltipBody.setAttribute("aria-hidden", "false");
 

--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -63,8 +63,10 @@ const showToolTip = (tooltipBody, tooltipTrigger, position, wrapper) => {
   * @param {string} setPos - can be "top", "bottom", "right", "left"
   */
   const setPositionClass = setPos => {
-    tooltipBody.classList.remove(`${TOOLTIP_BODY_CLASS}--${tooltipPosition}`);
-    tooltipPosition = setPos;
+    tooltipBody.classList.remove(`${TOOLTIP_BODY_CLASS}--top`);
+    tooltipBody.classList.remove(`${TOOLTIP_BODY_CLASS}--bottom`);
+    tooltipBody.classList.remove(`${TOOLTIP_BODY_CLASS}--right`);
+    tooltipBody.classList.remove(`${TOOLTIP_BODY_CLASS}--left`);
     tooltipBody.classList.add(`${TOOLTIP_BODY_CLASS}--${setPos}`);
   }
 


### PR DESCRIPTION
## Description
Resolves: Resolves https://github.com/uswds/uswds/issues/3554

Screen recording of the fix in place:
![Screen Recording 2020-07-17 at 12 18 22 PM](https://user-images.githubusercontent.com/1094951/87808703-2d270380-c828-11ea-9eb0-b9b4974ce1f6.gif)


## Additional information

Include any of the following (as necessary): 

* Explicitly removes all positioning classes before applying correct class
* Removed unused variable

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
