### PR TITLE
File Input - Add disabled styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "spec": "npm run mocha -- 'spec/**/*.spec.js'",
     "start": "fractal start --sync & npm run watch",
     "test": "snyk test && gulp eslint && gulp typecheck && gulp stylelint && fractal build && gulp test && gulp regression",
-    "test:ci": "gulp eslint && gulp typecheck && gulp stylelint && gulp test && gulp regression",
+    "test:ci": "gulp eslint && gulp typecheck && gulp stylelint && fractal build && gulp test && gulp regression",
     "test:unit": "gulp test",
     "test:visual": "node ./spec/visual-regression-tester.js test",
     "test:visual:update": " node ./spec/visual-regression-tester.js test --updateGolden",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release": "gulp release",
     "spec": "npm run mocha -- 'spec/**/*.spec.js'",
     "start": "fractal start --sync & npm run watch",
-    "test": "snyk test && gulp eslint && gulp typecheck && gulp stylelint && gulp test && gulp regression",
+    "test": "snyk test && gulp eslint && gulp typecheck && gulp stylelint && fractal build && gulp test && gulp regression",
     "test:ci": "gulp eslint && gulp typecheck && gulp stylelint && gulp test && gulp regression",
     "test:unit": "gulp test",
     "test:visual": "node ./spec/visual-regression-tester.js test",

--- a/spec/unit/file-input/file-input-disabled.spec.js
+++ b/spec/unit/file-input/file-input-disabled.spec.js
@@ -9,7 +9,6 @@ describe("file input is disabled", () => {
  const { body } = document;
 
  let component;
- let inputEl;
 
  beforeEach(() => {
    body.innerHTML = TEMPLATE;

--- a/spec/unit/file-input/file-input-disabled.spec.js
+++ b/spec/unit/file-input/file-input-disabled.spec.js
@@ -3,28 +3,33 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const TEMPLATE = fs.readFileSync(path.join(__dirname, "/file-input-disabled.template.html"));
+const RENDER = "../../../build/components/render/";
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, RENDER, "file-input--disabled.html")
+);
 
 describe("file input is disabled", () => {
- const { body } = document;
+  const { body } = document;
 
- let component;
+  let component;
 
- beforeEach(() => {
-   body.innerHTML = TEMPLATE;
-   fileInput.on();
-   component = body.querySelector(".usa-file-input");
-   fileInput.on(body);
- });
+  beforeEach(() => {
+    body.innerHTML = TEMPLATE;
+    fileInput.on();
+    component = body.querySelector(".usa-file-input");
+    fileInput.on(body);
+  });
 
- afterEach(() => {
-   body.innerHTML = "";
-   fileInput.off(body);
- });
+  afterEach(() => {
+    body.innerHTML = "";
+    fileInput.off(body);
+  });
 
- it('has disabled styling', () => {
-   const expectedClass = "usa-file-input--disabled";  
-   assert.strictEqual(component.getAttribute("class").includes(expectedClass), true);
- });
-
-})
+  it("has disabled styling", () => {
+    const expectedClass = "usa-file-input--disabled";
+    assert.strictEqual(
+      component.getAttribute("class").includes(expectedClass),
+      true
+    );
+  });
+});

--- a/spec/unit/file-input/file-input-disabled.spec.js
+++ b/spec/unit/file-input/file-input-disabled.spec.js
@@ -1,0 +1,31 @@
+const assert = require("assert");
+const fileInput = require("../../../src/js/components/file-input");
+const fs = require("fs");
+const path = require("path");
+
+const TEMPLATE = fs.readFileSync(path.join(__dirname, "/file-input-disabled.template.html"));
+
+describe("file input is disabled", () => {
+ const { body } = document;
+
+ let component;
+ let inputEl;
+
+ beforeEach(() => {
+   body.innerHTML = TEMPLATE;
+   fileInput.on();
+   component = body.querySelector(".usa-file-input");
+   fileInput.on(body);
+ });
+
+ afterEach(() => {
+   body.innerHTML = "";
+   fileInput.off(body);
+ });
+
+ it('has disabled styling', () => {
+   const expectedClass = "usa-file-input--disabled";  
+   assert.strictEqual(component.getAttribute("class").includes(expectedClass), true);
+ });
+
+})

--- a/spec/unit/file-input/file-input-disabled.template.html
+++ b/spec/unit/file-input/file-input-disabled.template.html
@@ -1,0 +1,2 @@
+<label class="usa-label" for="input-drop3">Label</label>
+<input disabled id="input-drop3" accept=".pdf" class="usa-file-input" multiple  type="file" name="" />

--- a/spec/unit/file-input/file-input-disabled.template.html
+++ b/spec/unit/file-input/file-input-disabled.template.html
@@ -1,2 +1,0 @@
-<label class="usa-label" for="input-drop3">Label</label>
-<input disabled id="input-drop3" accept=".pdf" class="usa-file-input" multiple  type="file" name="" />

--- a/spec/unit/file-input/file-input.spec.js
+++ b/spec/unit/file-input/file-input.spec.js
@@ -3,51 +3,56 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const TEMPLATE = fs.readFileSync(path.join(__dirname, "/file-input.template.html"));
+const RENDER = "../../../build/components/render/";
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, RENDER, "file-input--multiple.html")
+);
 
 describe("file input component builds successfully", () => {
- const { body } = document;
+  const { body } = document;
 
- let dropZone;
- let instructions;
- let inputEl;
- let dragText;
- let box;
+  let dropZone;
+  let instructions;
+  let inputEl;
+  let dragText;
+  let box;
 
- beforeEach(() => {
-   body.innerHTML = TEMPLATE;
-   fileInput.on();
-   dropZone = body.querySelector(".usa-file-input__target");
-   instructions = body.querySelector(".usa-file-input__instructions");
-   inputEl = body.querySelector(".usa-file-input__input");
-   box = body.querySelector(".usa-file-input__box");
-   dragText = body.querySelector(".usa-file-input__drag-text")
-   fileInput.on(body);
- });
+  beforeEach(() => {
+    body.innerHTML = TEMPLATE;
+    fileInput.on();
+    dropZone = body.querySelector(".usa-file-input__target");
+    instructions = body.querySelector(".usa-file-input__instructions");
+    inputEl = body.querySelector(".usa-file-input__input");
+    box = body.querySelector(".usa-file-input__box");
+    dragText = body.querySelector(".usa-file-input__drag-text");
+    fileInput.on(body);
+  });
 
- afterEach(() => {
-   body.innerHTML = "";
-   fileInput.off(body);
- });
+  afterEach(() => {
+    body.innerHTML = "";
+    fileInput.off(body);
+  });
 
- it('instructions are created', () => {
-   assert.equal(instructions.getAttribute("class"), "usa-file-input__instructions");
- });
+  it("instructions are created", () => {
+    assert.equal(
+      instructions.getAttribute("class"),
+      "usa-file-input__instructions"
+    );
+  });
 
- it('target ui is created', () => {
-   assert.equal(dropZone.getAttribute("class"), "usa-file-input__target");
- });
+  it("target ui is created", () => {
+    assert.equal(dropZone.getAttribute("class"), "usa-file-input__target");
+  });
 
- it('input gets new class', () => {
-   assert.equal(inputEl.getAttribute("class"), "usa-file-input__input");
- });
+  it("input gets new class", () => {
+    assert.equal(inputEl.getAttribute("class"), "usa-file-input__input");
+  });
 
- it('box is created', () => {
-   assert.equal(box.getAttribute("class"), "usa-file-input__box");
- });
+  it("box is created", () => {
+    assert.equal(box.getAttribute("class"), "usa-file-input__box");
+  });
 
- it('pluralizes "files" if there is a "multiple" attribute', () => {
-   assert.equal(dragText.innerHTML, "Drag files here or ")
- });
-
-})
+  it('pluralizes "files" if there is a "multiple" attribute', () => {
+    assert.equal(dragText.innerHTML, "Drag files here or ");
+  });
+});

--- a/spec/unit/file-input/file-input.template.html
+++ b/spec/unit/file-input/file-input.template.html
@@ -1,2 +1,0 @@
-<label class="usa-label" for="input-drop3">Label</label>
-<input id="input-drop3" accept=".pdf" class="usa-file-input" multiple  type="file" name="" />

--- a/spec/unit/file-input/single-file-input.spec.js
+++ b/spec/unit/file-input/single-file-input.spec.js
@@ -3,27 +3,29 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const TEMPLATE = fs.readFileSync(path.join(__dirname, "/single-file-input.template.html"));
+const RENDER = "../../../build/components/render/";
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, RENDER, "file-input--default.html")
+);
 
 describe("file input: single file input", () => {
- const { body } = document;
+  const { body } = document;
 
- let dragText;
+  let dragText;
 
- beforeEach(() => {
-   body.innerHTML = TEMPLATE;
-   fileInput.on();
-   dragText = body.querySelector(".usa-file-input__drag-text")
-   fileInput.on(body);
- });
+  beforeEach(() => {
+    body.innerHTML = TEMPLATE;
+    fileInput.on();
+    dragText = body.querySelector(".usa-file-input__drag-text");
+    fileInput.on(body);
+  });
 
- afterEach(() => {
-   body.innerHTML = "";
-   fileInput.off(body);
- });
+  afterEach(() => {
+    body.innerHTML = "";
+    fileInput.off(body);
+  });
 
- it('uses singular "file" if there is not a "multiple" attribute', () => {
-   assert.equal(dragText.innerHTML, "Drag file here or ")
- });
-
-})
+  it('uses singular "file" if there is not a "multiple" attribute', () => {
+    assert.equal(dragText.innerHTML, "Drag file here or ");
+  });
+});

--- a/spec/unit/file-input/single-file-input.template.html
+++ b/spec/unit/file-input/single-file-input.template.html
@@ -1,2 +1,0 @@
-<label class="usa-label" for="input-drop3">Label</label>
-<input id="input-drop3" accept=".pdf" class="usa-file-input" type="file" name="" />

--- a/src/components/07-form/controls/file-input.config.yml
+++ b/src/components/07-form/controls/file-input.config.yml
@@ -1,0 +1,37 @@
+label: File input
+status: ready
+
+variants:
+  - name: default
+    context:
+      id: single
+      label: Input a single file
+
+  - name: specific
+    context:
+      id: specific
+      label: Accept only specific filetypes
+      hint: Add only PDF or TXT files
+      accept:
+        - .pdf
+        - .txt
+
+  - name: multiple
+    context:
+      label: File input with multiple files
+      id: multiple
+      hint: Add one or more files
+      multiple: true
+
+  - name: error
+    context:
+      id: error
+      label: File input with error
+      error: true
+      errorMessage: A helpful error message
+
+  - name: disabled
+    context:
+      id: disabled
+      label: Disabled file input
+      disabled: true

--- a/src/components/07-form/controls/file-input.config.yml
+++ b/src/components/07-form/controls/file-input.config.yml
@@ -6,34 +6,34 @@ variants:
   - name: default
     context:
       id: single
-      label: Input a single file
+      label: Input accepts a single file
 
   - name: specific
     context:
       id: specific
-      label: Input only specific file types
-      hint: Attach PDF or TXT files
+      label: Input accepts only specific file types
+      hint: Select PDF or TXT files
       accept:
         - .pdf
         - .txt
 
   - name: multiple
     context:
-      label: Input multiple files
+      label: Input accepts multiple files
       id: multiple
-      hint: Attach one or more files
+      hint: Select one or more files
       multiple: true
 
   - name: error
     context:
       id: error
-      label: Input with an error
-      hint: Attach any valid file
+      label: Input has an error
+      hint: Select any valid file
       error: true
       errorMessage: Display a helpful error message
 
   - name: disabled
     context:
       id: disabled
-      label: Disabled input
+      label: Input in a disabled state
       disabled: true

--- a/src/components/07-form/controls/file-input.config.yml
+++ b/src/components/07-form/controls/file-input.config.yml
@@ -1,5 +1,6 @@
 label: File input
 status: ready
+collated: true
 
 variants:
   - name: default
@@ -10,29 +11,29 @@ variants:
   - name: specific
     context:
       id: specific
-      label: Accept only specific filetypes
-      hint: Add only PDF or TXT files
+      label: Input only specific file types
+      hint: Attach PDF or TXT files
       accept:
         - .pdf
         - .txt
 
   - name: multiple
     context:
-      label: File input with multiple files
+      label: Input multiple files
       id: multiple
-      hint: Add one or more files
+      hint: Attach one or more files
       multiple: true
 
   - name: error
     context:
       id: error
-      label: File input with error
-      hint: Add any valid file
+      label: Input with an error
+      hint: Attach any valid file
       error: true
-      errorMessage: Add a helpful error message
+      errorMessage: Display a helpful error message
 
   - name: disabled
     context:
       id: disabled
-      label: Disabled file input
+      label: Disabled input
       disabled: true

--- a/src/components/07-form/controls/file-input.config.yml
+++ b/src/components/07-form/controls/file-input.config.yml
@@ -27,8 +27,9 @@ variants:
     context:
       id: error
       label: File input with error
+      hint: Add any valid file
       error: true
-      errorMessage: A helpful error message
+      errorMessage: Add a helpful error message
 
   - name: disabled
     context:

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -8,7 +8,7 @@
   {%- if error %}
   <span class="usa-error-message" id="{{ name }}-{{ id }}-alert" role="alert">{{ errorMessage }}</span>
   {%- endif %}
-  <input id="input-{{ id }}"
+  <input id="{{ name }}-{{ id }}"
     class="usa-file-input"
     type="file"
     name="{{ name }}-{{ id }}"

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -1,13 +1,15 @@
-<label class="usa-label" for="input-single">Single file</label>
-<span class="usa-hint" id="input-single-hint">Must be a PDF</span>
-<input id="input-single" class="usa-file-input" type="file" name="input-single" accept=".pdf" aria-describedby="input-single-hint" />
-
-<label class="usa-label" for="input-multiple">Multiple files</label>
-<span class="usa-hint" id="input-multiple-hit">Any file type</span>
-<input id="input-multiple" class="usa-file-input"  type="file" name="input-multiple" aria-describedby="input-multiple-hit" multiple />
-
-<div class="usa-form-group usa-form-group--error">
-  <label class="usa-label usa-label--error" for="file-input-error">Error example</label>
-  <span class="usa-error-message" id="file-input-error-message" role="alert">Helpful error message</span>
-  <input id="file-input-error" class="usa-file-input" multiple type="file" name="file-input-error" aria-describedby="file-input-error-message"/>
+<div class="usa-form-group{% if error %} usa-form-group--error{% endif %}">
+  <label class="usa-label{% if error %} usa-label--error{% endif %}" for="input-{{ id }}">{{ label }} </label>
+  <span class="usa-hint" id="input-{{ id }}-hint">{{ hint }}</span>
+  {% if error %}
+  <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">Helpful error message</span>
+  {% endif %}
+  <input id="input-{{ id }}"
+    class="usa-file-input"
+    type="file"
+    name="input-{{ id }}"
+    accept="{{ accept }}"
+    aria-describedby="input-{{ id }}-hint"
+    {% if multiple %} multiple{% endif %}
+    {% if disabled %} disabled{% endif %} />
 </div>

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -1,16 +1,18 @@
+{% set name = "file-input" %}
+
 <div class="usa-form-group{% if error %} usa-form-group--error{% endif %}">
-  <label class="usa-label{% if error %} usa-label--error{% endif %}" for="input-{{ id }}">{{ label }}</label>
+  <label class="usa-label{% if error %} usa-label--error{% endif %}" for="{{ name }}-{{ id }}">{{ label }}</label>
   {%- if hint %}
-  <span class="usa-hint" id="input-{{ id }}-hint">{{ hint }}</span>
+  <span class="usa-hint" id="{{ name }}-{{ id }}-hint">{{ hint }}</span>
   {%- endif -%}
   {%- if error %}
-  <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">{{ errorMessage }}</span>
+  <span class="usa-error-message" id="{{ name }}-{{ id }}-alert" role="alert">{{ errorMessage }}</span>
   {%- endif %}
   <input id="input-{{ id }}"
     class="usa-file-input"
     type="file"
-    name="input-{{ id }}"
-    {% if hint %}aria-describedby="input-{{ id }}-hint"{% endif %}
+    name="{{ name }}-{{ id }}"
+    {% if hint %}aria-describedby="{{ name }}-{{ id }}-hint"{% endif %}
     {% if accept %}accept="{{ accept }}"{% endif %}
     {% if multiple %} multiple{% endif %}
     {% if disabled %} disabled{% endif %} />

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -4,7 +4,7 @@
   <span class="usa-hint" id="input-{{ id }}-hint">{{ hint }}</span>
   {%- endif -%}
   {%- if error %}
-  <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">Helpful error message</span>
+  <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">{{ errorMessage }}</span>
   {%- endif %}
   <input id="input-{{ id }}"
     class="usa-file-input"

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -1,11 +1,11 @@
 <div class="usa-form-group{% if error %} usa-form-group--error{% endif %}">
   <label class="usa-label{% if error %} usa-label--error{% endif %}" for="input-{{ id }}">{{ label }}</label>
-  {%- if hint -%}
+  {%- if hint %}
   <span class="usa-hint" id="input-{{ id }}-hint">{{ hint }}</span>
   {%- endif -%}
-  {%- if error -%}
+  {%- if error %}
   <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">Helpful error message</span>
-  {%- endif -%}
+  {%- endif %}
   <input id="input-{{ id }}"
     class="usa-file-input"
     type="file"

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -1,15 +1,17 @@
 <div class="usa-form-group{% if error %} usa-form-group--error{% endif %}">
-  <label class="usa-label{% if error %} usa-label--error{% endif %}" for="input-{{ id }}">{{ label }} </label>
+  <label class="usa-label{% if error %} usa-label--error{% endif %}" for="input-{{ id }}">{{ label }}</label>
+  {%- if hint -%}
   <span class="usa-hint" id="input-{{ id }}-hint">{{ hint }}</span>
-  {% if error %}
+  {%- endif -%}
+  {%- if error -%}
   <span class="usa-error-message" id="file-input-{{ id }}-alert" role="alert">Helpful error message</span>
-  {% endif %}
+  {%- endif -%}
   <input id="input-{{ id }}"
     class="usa-file-input"
     type="file"
     name="input-{{ id }}"
-    accept="{{ accept }}"
     aria-describedby="input-{{ id }}-hint"
+    {% if accept %}accept="{{ accept }}"{% endif %}
     {% if multiple %} multiple{% endif %}
     {% if disabled %} disabled{% endif %} />
 </div>

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -12,8 +12,8 @@
     class="usa-file-input"
     type="file"
     name="{{ name }}-{{ id }}"
-    {% if hint %}aria-describedby="{{ name }}-{{ id }}-hint"{% endif %}
-    {% if accept %}accept="{{ accept }}"{% endif %}
-    {% if multiple %} multiple{% endif %}
-    {% if disabled %} disabled{% endif %} />
+    {% if hint -%}aria-describedby="{{ name }}-{{ id }}-hint"{%- endif -%}
+    {% if accept -%}accept="{{ accept }}"{%- endif -%}
+    {% if multiple -%} multiple{%- endif -%}
+    {% if disabled -%} disabled{%- endif -%} />
 </div>

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -10,7 +10,7 @@
     class="usa-file-input"
     type="file"
     name="input-{{ id }}"
-    aria-describedby="input-{{ id }}-hint"
+    {% if hint %}aria-describedby="input-{{ id }}-hint"{% endif %}
     {% if accept %}accept="{{ accept }}"{% endif %}
     {% if multiple %} multiple{% endif %}
     {% if disabled %} disabled{% endif %} />

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -74,6 +74,7 @@ const buildFileInput = fileInputEl => {
   // Disabled styling 
   if (disabled) {
     fileInputParent.classList.add(DISABLED_CLASS);
+    fileInputParent.setAttribute('aria-disabled', 'true');
   }
 
   // Sets instruction test based on whether or not multipe files are accepted

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -10,6 +10,7 @@ const BOX_CLASS = `${PREFIX}-file-input__box`;
 const INSTRUCTIONS_CLASS = `${PREFIX}-file-input__instructions`;
 const PREVIEW_CLASS = `${PREFIX}-file-input__preview`;
 const PREVIEW_HEADING_CLASS = `${PREFIX}-file-input__preview-heading`;
+const DISABLED_CLASS = `${PREFIX}-file-input--disabled`;
 const CHOOSE_CLASS = `${PREFIX}-file-input__choose`;
 const ACCEPTED_FILE_MESSAGE_CLASS = `${PREFIX}-file-input__accepted-files-message`;
 const DRAG_TEXT_CLASS = `${PREFIX}-file-input__drag-text`;
@@ -51,6 +52,7 @@ const buildFileInput = fileInputEl => {
   const dropTarget = document.createElement('div');
   const box = document.createElement('div');
   const instructions = document.createElement('div');
+  const disabled = fileInputEl.hasAttribute('disabled');
 
   // Adds class names and other attributes
   fileInputEl.classList.remove(DROPZONE_CLASS);
@@ -68,6 +70,11 @@ const buildFileInput = fileInputEl => {
   fileInputParent.appendChild(dropTarget);
   fileInputEl.parentNode.insertBefore(instructions, fileInputEl);
   fileInputEl.parentNode.insertBefore(box, fileInputEl);
+
+  // Disabled styling 
+  if (disabled) {
+    fileInputParent.classList.add(DISABLED_CLASS);
+  }
 
   // Sets instruction test based on whether or not multipe files are accepted
   if (acceptsMultiple) {

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -159,7 +159,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ''; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
-      errorMessage.innerHTML = `Please attach only ${acceptedFiles} files`;
+      errorMessage.innerHTML = `This is not a valid file type.`;
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       e.preventDefault();

--- a/src/stylesheets/elements/form-controls/_file-input.scss
+++ b/src/stylesheets/elements/form-controls/_file-input.scss
@@ -2,7 +2,7 @@
   border: none;
   margin-top: units(1);
   padding-left: 0;
-  padding-top: 0.2rem; // keeps input vertially centered on error state
+  padding-top: 0.2rem; // keeps input vertically centered on error state
 }
 
 .usa-file-input {
@@ -186,7 +186,7 @@
   pointer-events: none;
 
   .usa-file-input__instructions {
-    opacity: .5;
+    opacity: 0.5;
   }
 
   .usa-file-input__box {
@@ -197,4 +197,3 @@
     cursor: default;
   }
 }
-

--- a/src/stylesheets/elements/form-controls/_file-input.scss
+++ b/src/stylesheets/elements/form-controls/_file-input.scss
@@ -180,3 +180,21 @@
   border-color: color("secondary-dark");
   border-width: 2px;
 }
+
+// Disabled state
+.usa-file-input--disabled {
+  pointer-events: none;
+
+  .usa-file-input__instructions {
+    opacity: .5;
+  }
+
+  .usa-file-input__box {
+    background-color: color($theme-color-disabled-light);
+  }
+
+  .usa-file-input__input[type] {
+    cursor: default;
+  }
+}
+


### PR DESCRIPTION
## Description

Resolves issue #3556 

## Additional information

Adds disabled styling for file input. 
<img width="570" alt="Screen Shot 2020-07-21 at 2 24 21 PM" src="https://user-images.githubusercontent.com/1094951/88092481-8c558280-cb5e-11ea-9e5c-f6e21c2a6ce7.png">

Includes unit test to ensure parent element has disabled variant class.

Disabled styling is handled by CSS only, so file inputs can reliably be toggled between enabled and disabled without require any other javascript events.


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
