### PR TITLE
USWDS - File input: Correct file input image preview BEM class name.

### DIFF
--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -18,7 +18,7 @@ const DRAG_CLASS = `${PREFIX}-file-input--drag`;
 const LOADING_CLASS = 'is-loading';
 const HIDDEN_CLASS = 'display-none';
 const INVALID_FILE_CLASS = 'has-invalid-file';
-const GENERIC_PREVIEW_CLASS_NAME = `${PREFIX}-file-input__preview__image`;
+const GENERIC_PREVIEW_CLASS_NAME = `${PREFIX}-file-input__preview-image`;
 const GENERIC_PREVIEW_CLASS = `${GENERIC_PREVIEW_CLASS_NAME}--generic`;
 const PDF_PREVIEW_CLASS = `${GENERIC_PREVIEW_CLASS_NAME}--pdf`;
 const WORD_PREVIEW_CLASS = `${GENERIC_PREVIEW_CLASS_NAME}--word`;
@@ -71,7 +71,7 @@ const buildFileInput = fileInputEl => {
   fileInputEl.parentNode.insertBefore(instructions, fileInputEl);
   fileInputEl.parentNode.insertBefore(box, fileInputEl);
 
-  // Disabled styling 
+  // Disabled styling
   if (disabled) {
     fileInputParent.classList.add(DISABLED_CLASS);
     fileInputParent.setAttribute('aria-disabled', 'true');
@@ -193,7 +193,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
      // Starts with a loading image while preview is created
      reader.onloadstart = function createLoadingImage() {
        const imageId = makeSafeForID(fileName);
-       const previewImage = `<img id="${imageId}" src="${SPACER_GIF}" alt="" class="usa-file-input__preview__image  ${LOADING_CLASS}"/>`;
+       const previewImage = `<img id="${imageId}" src="${SPACER_GIF}" alt="" class="${GENERIC_PREVIEW_CLASS_NAME} ${LOADING_CLASS}"/>`;
 
        instructions.insertAdjacentHTML('afterend', `<div class="${PREVIEW_CLASS}" aria-hidden="true">${previewImage}${fileName}<div>`);
      }

--- a/src/stylesheets/elements/form-controls/_file-input.scss
+++ b/src/stylesheets/elements/form-controls/_file-input.scss
@@ -129,7 +129,7 @@
   }
 }
 
-.usa-file-input__preview__image {
+.usa-file-input__preview-image {
   border: none;
   display: block;
   height: units(5);
@@ -138,40 +138,40 @@
   width: units(5);
 }
 
-.usa-file-input__preview__image.is-loading {
+.usa-file-input__preview-image.is-loading {
   @include add-background-svg("loader");
   background-position: center center;
   background-repeat: no-repeat;
   background-size: units(4);
 }
 
-.usa-file-input__preview__image--generic,
-.usa-file-input__preview__image--pdf,
-.usa-file-input__preview__image--word,
-.usa-file-input__preview__image--excel,
-.usa-file-input__preview__image--video {
+.usa-file-input__preview-image--generic,
+.usa-file-input__preview-image--pdf,
+.usa-file-input__preview-image--word,
+.usa-file-input__preview-image--excel,
+.usa-file-input__preview-image--video {
   background-position: center center;
   background-repeat: no-repeat;
   background-size: units(3);
 }
 
-.usa-file-input__preview__image--pdf {
+.usa-file-input__preview-image--pdf {
   @include add-background-svg("file-pdf");
 }
 
-.usa-file-input__preview__image--generic {
+.usa-file-input__preview-image--generic {
   @include add-background-svg("file");
 }
 
-.usa-file-input__preview__image--word {
+.usa-file-input__preview-image--word {
   @include add-background-svg("file-word");
 }
 
-.usa-file-input__preview__image--excel {
+.usa-file-input__preview-image--excel {
   @include add-background-svg("file-excel");
 }
 
-.usa-file-input__preview__image--video {
+.usa-file-input__preview-image--video {
   @include add-background-svg("file-video");
 }
 


### PR DESCRIPTION
## Description

Resolves #3573

Updates BEM class name for file input preview image. Thanks a lot @aduth!

```
usa-file-input__preview__image--generic → usa-file-input__preview-image--generic
```

`file-input.js:196 - const previewImage` now takes the updated constant
`GENERIC_PREVIEW_CLASS_NAME` instead of the old written out `usa-file-input__preview__image`.

## Additional information

Include any of the following (as necessary): 

![image](https://user-images.githubusercontent.com/3385219/89457406-f65b5380-d72a-11ea-9f8f-28c6402b6c41.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
