### PR TITLE
USWDS-3578 Elevate Focused Element

### DIFF
--- a/src/stylesheets/elements/form-controls/_combo-box.scss
+++ b/src/stylesheets/elements/form-controls/_combo-box.scss
@@ -21,6 +21,7 @@
   @extend %block-input-styles;
   appearance: none;
   margin-bottom: 0;
+  max-width: none;
   padding-right: calc(2.5em + 3px);
 }
 
@@ -102,6 +103,8 @@ button.usa-combo-box__clear-input {
 
   &--focused {
     @include focus-outline($width: 2px, $offset: -2px, $color: "blue-warm-80v");
+    position: relative;
+    z-index: z-index(100);
 
     &:focus {
       outline-offset: -4px;

--- a/src/stylesheets/elements/form-controls/_combo-box.scss
+++ b/src/stylesheets/elements/form-controls/_combo-box.scss
@@ -21,7 +21,6 @@
   @extend %block-input-styles;
   appearance: none;
   margin-bottom: 0;
-  max-width: none;
   padding-right: calc(2.5em + 3px);
 }
 

--- a/src/stylesheets/elements/form-controls/_date-picker.scss
+++ b/src/stylesheets/elements/form-controls/_date-picker.scss
@@ -146,6 +146,8 @@
 
   &--focused {
     @include focus-outline($width: 2px, $offset: -2px, $color: "blue-warm-80v");
+    position: relative;
+    z-index: z-index(100);
   }
 
   &--next-month:not([disabled]),
@@ -235,6 +237,8 @@
 
   &--focused {
     @include focus-outline($width: 2px, $offset: -2px, $color: "blue-warm-80v");
+    position: relative;
+    z-index: z-index(100);
   }
 
   &--selected {
@@ -291,6 +295,8 @@
 
   &--focused {
     @include focus-outline($width: 2px, $offset: -2px, $color: "blue-warm-80v");
+    position: relative;
+    z-index: z-index(100);
   }
 
   &--selected {


### PR DESCRIPTION
## Description

updates the z-index of the focused item to allow for the outline to not be cut off on ie11.

<img width="390" alt="Screen Shot 2020-08-10 at 12 18 08 AM" src="https://user-images.githubusercontent.com/1385752/89753830-5fcac180-da9f-11ea-9c68-f3e6092f83e7.png">

<img width="626" alt="Screen Shot 2020-08-10 at 12 32 04 AM" src="https://user-images.githubusercontent.com/1385752/89754293-f5b31c00-daa0-11ea-9296-9f63d70671d0.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
