### PR TITLE
Improve combo box resizing

### DIFF
--- a/src/components/07-form/controls/combo-box--test.njk
+++ b/src/components/07-form/controls/combo-box--test.njk
@@ -1,22 +1,24 @@
 <div class="padding-2">
-  <form class="usa-form">
-    <h6>Standard combo box in a usa-form</h6>
-    {% render "@combo-box" %}
-    <h6>Overriding the combobox width</h6>
+  <form class="usa-form padding-2 bg-base-lightest radius-md">
+    {% render "@combo-box",
+      { comboBox: {
+          label: "Default combo box in a usa-form"
+        }
+      },
+      merge=true %}
     {% render "@combo-box",
       { comboBox: {
         utilities: "width-tablet maxw-none",
-          label: "Select some more fruit",
+          label: "Override combo box with utilities",
           name: "moar-fruit",
           id: "moar-fruit"
         }
       },
       merge=true %}
   </form>
-  <h6>Not in a usa-form element</h6>
   {% render "@combo-box",
     { comboBox: {
-        label: "Once again, select more fruit",
+        label: "Not in a usa-form element",
         name: "even-moar-fruit"
       }
     },
@@ -24,8 +26,8 @@
   {% render "@combo-box",
     { comboBox: {
         utilities: "width-full maxw-none",
-        label: "Once again, select more fruit",
-        name: "even-moar-fruit"
+        label: "Not in a usa-form element, custom width utilities",
+        name: "even-moar-moar-fruit"
       }
     },
     merge=true %}

--- a/src/components/07-form/controls/combo-box--test.njk
+++ b/src/components/07-form/controls/combo-box--test.njk
@@ -1,9 +1,11 @@
 <div class="padding-2">
   <form class="usa-form">
+    <h6>Standard combo box in a usa-form</h6>
     {% render "@combo-box" %}
+    <h6>Overriding the combobox width</h6>
     {% render "@combo-box",
       { comboBox: {
-          utilities: "width-tablet",
+        utilities: "width-tablet maxw-none",
           label: "Select some more fruit",
           name: "moar-fruit",
           id: "moar-fruit"
@@ -11,4 +13,20 @@
       },
       merge=true %}
   </form>
+  <h6>Not in a usa-form element</h6>
+  {% render "@combo-box",
+    { comboBox: {
+        label: "Once again, select more fruit",
+        name: "even-moar-fruit"
+      }
+    },
+    merge=true %}
+  {% render "@combo-box",
+    { comboBox: {
+        utilities: "width-full maxw-none",
+        label: "Once again, select more fruit",
+        name: "even-moar-fruit"
+      }
+    },
+    merge=true %}
 </div>

--- a/src/components/07-form/controls/combo-box--test.njk
+++ b/src/components/07-form/controls/combo-box--test.njk
@@ -1,5 +1,5 @@
 <div class="padding-2">
-  <form class="usa-form padding-2 bg-base-lightest radius-md">
+  <form class="usa-form padding-x-2 padding-bottom-2 padding-top-1px bg-base-lightest radius-md">
     {% render "@combo-box",
       { comboBox: {
           label: "Default combo box in a usa-form"

--- a/src/components/07-form/controls/combo-box--test.njk
+++ b/src/components/07-form/controls/combo-box--test.njk
@@ -1,6 +1,14 @@
 <div class="padding-2">
   <form class="usa-form">
     {% render "@combo-box" %}
-    {% render "@combo-box" %}
+    {% render "@combo-box",
+      { comboBox: {
+          utilities: "width-tablet",
+          label: "Select some more fruit",
+          name: "moar-fruit",
+          id: "moar-fruit"
+        }
+      },
+      merge=true %}
   </form>
 </div>

--- a/src/components/07-form/controls/combo-box--test.njk
+++ b/src/components/07-form/controls/combo-box--test.njk
@@ -1,0 +1,6 @@
+<div class="padding-2">
+  <form class="usa-form">
+    {% render "@combo-box" %}
+    {% render "@combo-box" %}
+  </form>
+</div>

--- a/src/components/07-form/controls/combo-box.config.yml
+++ b/src/components/07-form/controls/combo-box.config.yml
@@ -5,6 +5,10 @@ preview: "@uswds-framed"
 variants:
   - name: default
     label: Default
+    context:
+      comboBox:
+        label: "Select a fruit"
+        name: "fruit"
 
   - name: default-value
     label: Default Value

--- a/src/components/07-form/controls/combo-box.njk
+++ b/src/components/07-form/controls/combo-box.njk
@@ -1,12 +1,12 @@
-<label class="usa-label" for="fruit">Select a fruit</label>
-<div class="usa-combo-box"
+<label class="usa-label" for="{{ comboBox.name }}">{{ comboBox.label }}</label>
+<div class="usa-combo-box{% if comboBox.utilities %} {{ comboBox.utilities }}{% endif %}"
   {% if comboBox.defaultValue %} data-default-value="{{ comboBox.defaultValue }}"{% endif %}
   {% if comboBox.placeholder %} data-placeholder="{{ comboBox.placeholder }}"{% endif %}
 >
   <select
     class="usa-select"
-    name="fruit"
-    id="fruit"
+    name="{{ comboBox.name }}"
+    id="{% if comboBox.id %}{{ comboBox.id }}{% else %}{{ comboBox.name }}{% endif %}"
     {% if comboBox.disabled %} disabled{% endif %}
     {% if comboBox.required %} required{% endif %}
   >

--- a/src/components/07-form/controls/combo-box.njk
+++ b/src/components/07-form/controls/combo-box.njk
@@ -1,81 +1,79 @@
-<form class="usa-form">
-  <label class="usa-label" for="fruit">Select a fruit</label>
-  <div class="usa-combo-box"
-    {% if comboBox.defaultValue %} data-default-value="{{ comboBox.defaultValue }}"{% endif %}
-    {% if comboBox.placeholder %} data-placeholder="{{ comboBox.placeholder }}"{% endif %}
+<label class="usa-label" for="fruit">Select a fruit</label>
+<div class="usa-combo-box"
+  {% if comboBox.defaultValue %} data-default-value="{{ comboBox.defaultValue }}"{% endif %}
+  {% if comboBox.placeholder %} data-placeholder="{{ comboBox.placeholder }}"{% endif %}
+>
+  <select
+    class="usa-select"
+    name="fruit"
+    id="fruit"
+    {% if comboBox.disabled %} disabled{% endif %}
+    {% if comboBox.required %} required{% endif %}
   >
-    <select 
-      class="usa-select" 
-      name="fruit" 
-      id="fruit"
-      {% if comboBox.disabled %} disabled{% endif %}
-      {% if comboBox.required %} required{% endif %}
-    >
-      <option value>Select a fruit</option>
-      <option value="apple">Apple</option>
-      <option value="apricot">Apricot</option>
-      <option value="avocado">Avocado</option>
-      <option value="banana">Banana</option>
-      <option value="blackberry">Blackberry</option>
-      <option value="blood orange">Blood orange</option>
-      <option value="blueberry">Blueberry</option>
-      <option value="boysenberry">Boysenberry</option>
-      <option value="breadfruit">Breadfruit</option>
-      <option value="buddhas hand citron">Buddha's hand citron</option>
-      <option value="cantaloupe">Cantaloupe</option>
-      <option value="clementine">Clementine</option>
-      <option value="crab apple">Crab apple</option>
-      <option value="currant">Currant</option>
-      <option value="cherry">Cherry</option>
-      <option value="custard apple">Custard apple</option>
-      <option value="coconut">Coconut</option>
-      <option value="cranberry">Cranberry</option>
-      <option value="date">Date</option>
-      <option value="dragonfruit">Dragonfruit</option>
-      <option value="durian">Durian</option>
-      <option value="elderberry">Elderberry</option>
-      <option value="fig">Fig</option>
-      <option value="gooseberry">Gooseberry</option>
-      <option value="grape">Grape</option>
-      <option value="grapefruit">Grapefruit</option>
-      <option value="guava">Guava</option>
-      <option value="honeydew melon">Honeydew melon</option>
-      <option value="jackfruit">Jackfruit</option>
-      <option value="kiwifruit">Kiwifruit</option>
-      <option value="kumquat">Kumquat</option>
-      <option value="lemon">Lemon</option>
-      <option value="lime">Lime</option>
-      <option value="lychee">Lychee</option>
-      <option value="mandarine">Mandarine</option>
-      <option value="mango">Mango</option>
-      <option value="mangosteen">Mangosteen</option>
-      <option value="marionberry">Marionberry</option>
-      <option value="nectarine">Nectarine</option>
-      <option value="orange">Orange</option>
-      <option value="papaya">Papaya</option>
-      <option value="passionfruit">Passionfruit</option>
-      <option value="peach">Peach</option>
-      <option value="pear">Pear</option>
-      <option value="persimmon">Persimmon</option>
-      <option value="plantain">Plantain</option>
-      <option value="plum">Plum</option>
-      <option value="pineapple">Pineapple</option>
-      <option value="pluot">Pluot</option>
-      <option value="pomegranate">Pomegranate</option>
-      <option value="pomelo">Pomelo</option>
-      <option value="quince">Quince</option>
-      <option value="raspberry">Raspberry</option>
-      <option value="rambutan">Rambutan</option>
-      <option value="soursop">Soursop</option>
-      <option value="starfruit">Starfruit</option>
-      <option value="strawberry">Strawberry</option>
-      <option value="tamarind">Tamarind</option>
-      <option value="tangelo">Tangelo</option>
-      <option value="tangerine">Tangerine</option>
-      <option value="ugli fruit">Ugli fruit</option>
-      <option value="watermelon">Watermelon</option>
-      <option value="white currant">White currant</option>
-      <option value="yuzu">Yuzu</option>
-    </select>
-  </div>
-</form>
+    <option value>Select a fruit</option>
+    <option value="apple">Apple</option>
+    <option value="apricot">Apricot</option>
+    <option value="avocado">Avocado</option>
+    <option value="banana">Banana</option>
+    <option value="blackberry">Blackberry</option>
+    <option value="blood orange">Blood orange</option>
+    <option value="blueberry">Blueberry</option>
+    <option value="boysenberry">Boysenberry</option>
+    <option value="breadfruit">Breadfruit</option>
+    <option value="buddhas hand citron">Buddha's hand citron</option>
+    <option value="cantaloupe">Cantaloupe</option>
+    <option value="clementine">Clementine</option>
+    <option value="crab apple">Crab apple</option>
+    <option value="currant">Currant</option>
+    <option value="cherry">Cherry</option>
+    <option value="custard apple">Custard apple</option>
+    <option value="coconut">Coconut</option>
+    <option value="cranberry">Cranberry</option>
+    <option value="date">Date</option>
+    <option value="dragonfruit">Dragonfruit</option>
+    <option value="durian">Durian</option>
+    <option value="elderberry">Elderberry</option>
+    <option value="fig">Fig</option>
+    <option value="gooseberry">Gooseberry</option>
+    <option value="grape">Grape</option>
+    <option value="grapefruit">Grapefruit</option>
+    <option value="guava">Guava</option>
+    <option value="honeydew melon">Honeydew melon</option>
+    <option value="jackfruit">Jackfruit</option>
+    <option value="kiwifruit">Kiwifruit</option>
+    <option value="kumquat">Kumquat</option>
+    <option value="lemon">Lemon</option>
+    <option value="lime">Lime</option>
+    <option value="lychee">Lychee</option>
+    <option value="mandarine">Mandarine</option>
+    <option value="mango">Mango</option>
+    <option value="mangosteen">Mangosteen</option>
+    <option value="marionberry">Marionberry</option>
+    <option value="nectarine">Nectarine</option>
+    <option value="orange">Orange</option>
+    <option value="papaya">Papaya</option>
+    <option value="passionfruit">Passionfruit</option>
+    <option value="peach">Peach</option>
+    <option value="pear">Pear</option>
+    <option value="persimmon">Persimmon</option>
+    <option value="plantain">Plantain</option>
+    <option value="plum">Plum</option>
+    <option value="pineapple">Pineapple</option>
+    <option value="pluot">Pluot</option>
+    <option value="pomegranate">Pomegranate</option>
+    <option value="pomelo">Pomelo</option>
+    <option value="quince">Quince</option>
+    <option value="raspberry">Raspberry</option>
+    <option value="rambutan">Rambutan</option>
+    <option value="soursop">Soursop</option>
+    <option value="starfruit">Starfruit</option>
+    <option value="strawberry">Strawberry</option>
+    <option value="tamarind">Tamarind</option>
+    <option value="tangelo">Tangelo</option>
+    <option value="tangerine">Tangerine</option>
+    <option value="ugli fruit">Ugli fruit</option>
+    <option value="watermelon">Watermelon</option>
+    <option value="white currant">White currant</option>
+    <option value="yuzu">Yuzu</option>
+  </select>
+</div>

--- a/src/stylesheets/elements/form-controls/_combo-box.scss
+++ b/src/stylesheets/elements/form-controls/_combo-box.scss
@@ -1,4 +1,5 @@
 .usa-combo-box {
+  max-width: units($theme-input-max-width);
   position: relative;
 }
 
@@ -21,6 +22,7 @@
   @extend %block-input-styles;
   appearance: none;
   margin-bottom: 0;
+  max-width: none;
   padding-right: calc(2.5em + 3px);
 }
 

--- a/src/stylesheets/elements/form-controls/_global.scss
+++ b/src/stylesheets/elements/form-controls/_global.scss
@@ -63,8 +63,12 @@ $input-select-margin-right: 1.5;
 }
 
 .usa-label {
+  @include typeset(
+    $theme-form-font-family,
+    $theme-body-font-size,
+    $theme-input-line-height
+  );
   display: block;
-  line-height: line-height($theme-form-font-family, 2);
   margin-top: units(3);
   max-width: units($theme-input-max-width);
 }


### PR DESCRIPTION
**Improved combo box resizing.** We fixed a display bug with the combo box where custom combo box sizing wasn't reflected in its input.

- - -

[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/dw-combobox-max-width/components/preview/combo-box--test.html) →

This PR is based on an issue raised by @fafnirical in the USWDS Slack (https://1qhkw.csb.app/). There are a couple issues in that demo, a **z-index overlap** issue that we fixed in https://github.com/uswds/uswds/pull/3572 (thanks @Pharmasolin) and a **resizing issue** that's the focus of this work.

The basic issue was that the combo box input and combo box enhancements are subject to separate styling constraints — specifically that the `usa-input` has a max-width rule that the enhancements do not.

This PR shifts the max-width rule to the `usa-combo-box` element. Now the combo box displays with the same max-width as other form input elements, but any overrides to the combo box's width are reflected in both its input and its enhancements. I've also added a test into our library to assure that this is working properly.

<img width="1011" alt="Screen Shot 2020-08-13 at 1 28 03 PM" src="https://user-images.githubusercontent.com/11464021/90183731-d9e19b80-dd68-11ea-9523-dcddb8b6e4a0.png">

### Other work in this PR
- I updated the Nunjucks template to improve its ability to accept custom data and the component's ability to be used in different contexts. An implication of this change is that the default component no longer includes the wrapping `usa-form` element. If we want that `usa-form` to appear in the markup, we'll need to add it to the output markup on `usa-site`.
- I improved the reliability of input labels, by adding the proper typesetting to the `usa-label` as well as the `usa-form` so labels will display at the right size, even if they don't appear in a `usa-form`.
 