### PR TITLE
USWDS - Radio Buttons: Style Disabled Radio Buttons

### DIFF
--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -99,8 +99,10 @@
   @include focus-outline(null, null, null, 0.5);
 }
 
-.usa-checkbox__input:disabled + .usa-checkbox__label {
+.usa-checkbox__input:disabled + .usa-checkbox__label,
+.usa-radio__input:disabled + .usa-radio__label {
   color: color("disabled");
+  cursor: not-allowed;
 }
 
 .usa-checkbox__input:focus + .usa-checkbox__label::before {


### PR DESCRIPTION
## [Style Disabled Radio Buttons]: Gray out disabled radio button label

## Description

This PR styles a disabled radio button's label to the standard disabled gray.  It also adds a `not-allowed` cursor to both the disabled radio button label and disabled checkbox label. Fixes #3610.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
