### PR TITLE
Add accent warm buttons

### DIFF
--- a/src/components/02-buttons/buttons.config.yml
+++ b/src/components/02-buttons/buttons.config.yml
@@ -14,6 +14,12 @@ variants:
       label: Accent cool buttons
       classes: "usa-button--accent-cool"
 
+  - name: accent-warm
+    context:
+      category: alternate
+      label: Accent warm buttons
+      classes: "usa-button--accent-warm"
+
   - name: base
     context:
       category: alternate

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -7,7 +7,6 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
 .usa-button {
   @include border-box-sizing;
   @include typeset($theme-button-font-family, null, 1);
-  @include add-knockout-font-smoothing;
   @include set-text-and-bg("primary");
   appearance: none;
   border: 0;
@@ -52,7 +51,6 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
 }
 
 .usa-button--accent-cool {
-  @include no-knockout-font-smoothing;
   @include set-text-and-bg("accent-cool");
 
   &:visited {
@@ -61,19 +59,34 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
 
   &:hover,
   &.usa-button--hover {
-    @include add-knockout-font-smoothing;
     @include set-text-and-bg("accent-cool-dark");
   }
 
   &:active,
   &.usa-button--active {
-    @include add-knockout-font-smoothing;
     @include set-text-and-bg("accent-cool-darker");
   }
 }
 
+.usa-button--accent-warm {
+  @include set-text-and-bg("accent-warm");
+
+  &:visited {
+    @include set-text-and-bg("accent-warm");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    @include set-text-and-bg("accent-warm-dark");
+  }
+
+  &:active,
+  &.usa-button--active {
+    @include set-text-and-bg("accent-warm-darker");
+  }
+}
+
 .usa-button--outline {
-  @include no-knockout-font-smoothing;
   background-color: color("transparent");
   box-shadow: $button-stroke color("primary");
   color: color("primary");


### PR DESCRIPTION
- Adds `accent-warm` button variant styling.
- Removes font smoothing rules and overrides and uses default smoothing for buttons

<img width="648" alt="Screen Shot 2020-09-14 at 3 51 24 PM" src="https://user-images.githubusercontent.com/11464021/93145879-4de1cd00-f6a2-11ea-816a-b8f2d64d726a.png">

**Note: This will get a docs PR once this work is merged into develop.**