### PR TITLE
Add missing default to pending text setting

### DIFF
--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -122,7 +122,7 @@ $theme-step-indicator-segment-color-complete: "primary-darker" !default;
 $theme-step-indicator-segment-color-current: "primary" !default;
 $theme-step-indicator-segment-gap: 2px !default;
 $theme-step-indicator-segment-height: 1 !default;
-$theme-step-indicator-text-pending: "base-dark";
+$theme-step-indicator-text-pending: "base-dark" !default;
 
 // Tooltips
 $theme-tooltip-background-color: "ink" !default;


### PR DESCRIPTION
Adds a `!default` flag to `$theme-step-indicator-text-pending: "base-dark" !default;`