### PR TITLE
Use descriptive suffixes in indicator settings

### DIFF
--- a/src/stylesheets/components/_step-indicator.scss
+++ b/src/stylesheets/components/_step-indicator.scss
@@ -71,7 +71,7 @@ $step-indicator-segment-height-mobile: 1;
           color($theme-step-indicator-segment-color-pending),
         0 0 0 units($theme-step-indicator-counter-gap)
           color($step-indicator-background-color);
-      color: color($theme-step-indicator-text-pending);
+      color: color($theme-step-indicator-text-pending-color);
       content: counter(usa-step-indicator);
       display: block;
       font-weight: fw("bold");
@@ -158,7 +158,7 @@ $step-indicator-segment-height-mobile: 1;
   display: none;
   // Show labels only at the min-width
   @include at-media($theme-step-indicator-min-width) {
-    color: color($theme-step-indicator-text-pending);
+    color: color($theme-step-indicator-text-pending-color);
     display: block;
     font-size: size(
       $theme-step-indicator-font-family,

--- a/src/stylesheets/components/_step-indicator.scss
+++ b/src/stylesheets/components/_step-indicator.scss
@@ -67,7 +67,7 @@ $step-indicator-segment-height-mobile: 1;
       @include u-circle($theme-step-indicator-counter-size);
       @include u-text("tabular");
       background-color: color($step-indicator-background-color);
-      box-shadow: inset 0 0 0 units($theme-step-indicator-counter-border)
+      box-shadow: inset 0 0 0 units($theme-step-indicator-counter-border-width)
           color($theme-step-indicator-segment-color-pending),
         0 0 0 units($theme-step-indicator-counter-gap)
           color($step-indicator-background-color);

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -122,7 +122,7 @@ $theme-step-indicator-segment-color-complete: "primary-darker" !default;
 $theme-step-indicator-segment-color-current: "primary" !default;
 $theme-step-indicator-segment-gap: 2px !default;
 $theme-step-indicator-segment-height: 1 !default;
-$theme-step-indicator-text-pending: "base-dark" !default;
+$theme-step-indicator-text-pending-color: "base-dark" !default;
 
 // Tooltips
 $theme-tooltip-background-color: "ink" !default;

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -108,7 +108,7 @@ $theme-sidenav-font-family: "ui" !default;
 // Step indicator
 $step-indicator-background-color: "white" !default;
 $theme-step-indicator-counter-gap: 0.5 !default;
-$theme-step-indicator-counter-border: 0.5 !default;
+$theme-step-indicator-counter-border-width: 0.5 !default;
 $theme-step-indicator-counter-size: 5 !default;
 $theme-step-indicator-font-family: "ui" !default;
 $theme-step-indicator-heading-color: "ink" !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -122,7 +122,7 @@ $theme-step-indicator-segment-color-complete: "primary-darker";
 $theme-step-indicator-segment-color-current: "primary";
 $theme-step-indicator-segment-gap: 2px;
 $theme-step-indicator-segment-height: 1;
-$theme-step-indicator-text-pending: "base-dark";
+$theme-step-indicator-text-pending-color: "base-dark";
 
 // Tooltips
 $theme-tooltip-background-color: "ink";

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -108,7 +108,7 @@ $theme-sidenav-font-family: "ui";
 // Step indicator
 $step-indicator-background-color: "white";
 $theme-step-indicator-counter-gap: 0.5;
-$theme-step-indicator-counter-border: 0.5;
+$theme-step-indicator-counter-border-width: 0.5;
 $theme-step-indicator-counter-size: 5;
 $theme-step-indicator-font-family: "ui";
 $theme-step-indicator-heading-color: "ink";


### PR DESCRIPTION
`$theme-step-indicator-text-pending` → `$theme-step-indicator-text-pending-color`
`$theme-step-indicator-counter-border` → `$theme-step-indicator-counter-border-width`