### PR TITLE
Remove redundant rule that affects specificity

### DIFF
--- a/src/stylesheets/components/_step-indicator.scss
+++ b/src/stylesheets/components/_step-indicator.scss
@@ -309,8 +309,7 @@ $step-indicator-segment-height-mobile: 1;
   }
 
   &.usa-step-indicator--no-counters,
-  &.usa-step-indicator--no-labels,
-  &.usa-step-indicator--centered {
+  &.usa-step-indicator--no-labels {
     .usa-step-indicator__segment {
       // Use full-width segments
       &:first-child {


### PR DESCRIPTION
Removes a redundant rule in the step indicator that prevented the segments from resizing properly:

before:
<img width="953" alt="Screen Shot 2020-09-15 at 11 51 23 PM" src="https://user-images.githubusercontent.com/11464021/93302171-650de100-f7ae-11ea-8249-2a078f8f4f1b.png">

after:
<img width="976" alt="Screen Shot 2020-09-15 at 11 51 00 PM" src="https://user-images.githubusercontent.com/11464021/93302178-6939fe80-f7ae-11ea-8f7e-51fc9a35f7e9.png">
