### PR TITLE
Use smaller heading margin-top on mobile

### DIFF
--- a/src/stylesheets/components/_step-indicator.scss
+++ b/src/stylesheets/components/_step-indicator.scss
@@ -1,5 +1,7 @@
 $step-indicator-label-margin-top: 1;
 $step-indicator-margin-bottom: 4;
+$step-indicator-header-margin-top: 4;
+$step-indicator-header-margin-top-mobile: 2;
 $step-indicator-segment-height-mobile: 1;
 $step-indicator-counter-size: 5;
 $step-indicator-counter-size-sm: 3;
@@ -108,12 +110,13 @@ $step-indicator-counter-size-sm: 3;
     $theme-step-indicator-heading-font-size-small
   );
   font-weight: font-weight("bold");
-  margin: units(4) 0 0;
+  margin: units($step-indicator-header-margin-top-mobile) 0 0;
   @include at-media($theme-step-indicator-min-width) {
     font-size: size(
       $theme-step-indicator-heading-font-family,
       $theme-step-indicator-heading-font-size
     );
+    margin-top: units($step-indicator-header-margin-top);
   }
 }
 

--- a/src/stylesheets/components/_step-indicator.scss
+++ b/src/stylesheets/components/_step-indicator.scss
@@ -417,4 +417,25 @@ $step-indicator-counter-size-sm: 3;
       }
     }
   }
+
+  &.usa-step-indicator--counters-sm {
+    .usa-step-indicator__segment {
+      &:before {
+        @if $theme-step-indicator-counter-gap == 0 {
+          left: calc(50% - ((#{units($step-indicator-counter-size-sm)}) / 2));
+        } @else {
+          left: calc(
+            50% -
+              (
+                (
+                    #{units($step-indicator-counter-size-sm)} +
+                      #{units($theme-step-indicator-counter-gap)}
+                  ) /
+                  2
+              )
+          );
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Use a 2 unit margin-top for the heading to better connect it to the indicator bar
- Fix centering with small counters