### PR TITLE
Reinstate synk scan in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  snyk: snyk/snyk@0.0.8
+  snyk: snyk/snyk@0.0.12
 
 references:
   container: &container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  snyk: snyk/snyk@0.0.8
+
 references:
   container: &container
     docker:
@@ -28,6 +31,8 @@ jobs:
           paths:
             - node_modules
           key: v2-uswds-dependencies-{{ checksum "package-lock.json" }}
+      - snyk/scan:
+          organization: uswds
       - run:
           name: Run test
           command: npm run test:ci


### PR DESCRIPTION
Reinstates Synk scan into the Circle workflow, now that we've resolved the API issues with Snyk. We were always performing Snyk scans as part of any PR, but this puts it pack in the CI as well.