### PR TITLE
2.10.0-alpha.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
     <<: *container
     steps:
       - checkout
-      - run:
-          name: Install codeclimate
-          command: sudo npm install -g codeclimate-test-reporter
       - restore_cache:
           keys:
             - v2-uswds-dependencies-{{ checksum "package-lock.json" }}
@@ -36,16 +33,6 @@ jobs:
       - run:
           name: Run test
           command: npm run test:ci
-      - run:
-          name: Run code coverage report
-          command: npm run cover
-      - run:
-          name: Checking build
-          command: |
-            if [[ $(echo "$CIRCLE_BRANCH" | grep -c "pull") -le 0 ]]; then
-              ls -agolf dist/
-              codeclimate-test-reporter < coverage/lcov.info
-            fi
 
   deploy:
     <<: *container
@@ -58,12 +45,42 @@ jobs:
       - run: npm rebuild node-sass
       - run:
           name: Build the USWDS package
-          command: npm run release
+          command: npm run build
       - run:
           name: Publish to NPM
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
             npm publish
+
+  deploy-alpha:
+    <<: *container
+    steps:
+      - checkout
+      - run: npm install --ignore-scripts
+      - run: npm rebuild node-sass
+      - run:
+          name: Build the USWDS package
+          command: npm run build
+      - run:
+          name: Publish to NPM with `alpha` tag
+          command: |
+            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+            npm publish --tag alpha
+
+  deploy-beta:
+    <<: *container
+    steps:
+      - checkout
+      - run: npm install --ignore-scripts
+      - run: npm rebuild node-sass
+      - run:
+          name: Build the USWDS package
+          command: npm run build
+      - run:
+          name: Publish to NPM with `beta` tag
+          command: |
+            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+            npm publish --tag beta
 
 workflows:
   version: 2
@@ -76,3 +93,9 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-alpha:
+          requires:
+            - build
+          filters:
+            branches:
+              only: v2.10-beta--main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.9.0",
+  "version": "2.10.0-alpha.0",
   "description": "Open source UI components and visual style guide for U.S. government websites",
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
This will publish the first draft of our Sass modules work to npm as `2.10.0-alpha.0` with an `alpha` tag.