### PR TITLE
Subset files for packaging to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ spec/screenshots/metadata.js
 
 # ignore sassdoc build
 sassdoc/
+
+# ignore tarballs and gzipped files
+*.tgz
+*.gz

--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -16,17 +16,6 @@ gulp.task("clean-dist", (done) => {
   return del("dist");
 });
 
-gulp.task("docs", (done) => {
-  dutil.logMessage("docs", "Copying documentation dist dir");
-
-  const stream = gulp
-    .src(["README.md", "LICENSE.md", "CONTRIBUTING.md"])
-    .pipe(gulp.dest("dist"));
-
-  done();
-  return stream;
-});
-
 gulp.task(
   "build",
   gulp.series(
@@ -36,7 +25,6 @@ gulp.task(
       done();
     },
     "clean-dist",
-    "docs",
     gulp.parallel("sass", "javascript", "images", "fonts"),
     // We need to copy the Sass to dist *after* the sass task, to ensure
     // that vendor libraries have been copied to the Sass directory first.

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "/dist/js",
     "/dist/scss",
     "/src/js",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "SECURITY.md"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -130,5 +130,13 @@
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "yargs": "^16.0.3"
-  }
+  },
+  "files": [
+    "/dist/fonts",
+    "/dist/img",
+    "/dist/js",
+    "/dist/scss",
+    "/src/js",
+    "CONTRIBUTING.md"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "federalist": "npm install && gulp build && fractal build",
     "lint": "eslint src/js/**/*.js spec/**/*.js",
     "mocha": "mocha",
-    "prepare": "gulp build",
+    "prepare": "gulp build && fractal build",
     "preversion": "npm test",
     "release": "gulp release",
     "spec": "npm run mocha -- 'spec/**/*.spec.js'",
@@ -137,6 +137,7 @@
     "/dist/js",
     "/dist/scss",
     "/src/js",
+    "/build/components/render",
     "CONTRIBUTING.md",
     "SECURITY.md"
   ]


### PR DESCRIPTION
We only need to include files that teams will actually use in our release package (plus a couple docs that are important for reference). This includes
- fonts
- images
- Sass files
- rendered components (**only** used on uswds-site)
- compiled JavaScript (for many projects this is fine)
- JavaScript source (for projects that build _from_ our javascript source)
- README, LICENSE, and SECURITY, and CONTRIBUTING

Note that this does _not_ include compiled CSS. Teams should not be using a precompiled CSS file, instead compiling project-specific CSS from the distributed Sass files, using project-specific settings.

This pull request adds a `files` section to the `package.json` that specifies the files and directories included in the package. It also modified the build script to omit duplicating docs files from the project root inthe `dist` directory.

The file contents of the package are:
- `/dist/js`
- `/dist/scss`
- `/dist/img`
- `/dist/fonts`
- `/src/js`
- `build/components/render`
- `README.md`
- `LICENSE.md`
- `CONTRIBUTING.md`
- `SECURITY.md`
- `package.json`

Test this config by running `npm pack` locally.

**This may change as our project matures, but these contents are the current requirements.**