### PR TITLE
Include DAP script with agency and subagency params

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -41,7 +41,11 @@ web.theme(
     // display context data in YAML
     format: "yaml",
     // which panels to show
-    panels: ["html", "notes", "view", "context", "resources", "info"]
+    panels: ["html", "notes", "view", "context", "resources", "info"],
+    scripts: [
+      "default",
+      "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS"
+    ]
   })
 );
 


### PR DESCRIPTION
This adds DAP with appropriate agency and subagency parameters to the Fractal site. 