### PR TITLE
USWDS - CI: Show axe best-practices as warnings.

### DIFF
--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const assert = require("assert");
+const colors = require('ansi-colors');
 
 const AXE_JS = fs.readFileSync(`${__dirname}/../node_modules/axe-core/axe.js`);
 
@@ -13,26 +14,34 @@ const AXE_CONTEXT = JSON.stringify({
   ]
 });
 
-const AXE_OPTIONS = JSON.stringify({
+const AXE_OPTIONS = {
   runOnly: {
-    type: "tag",
+    type: 'tag',
     // @TODO Separate "best-practice" and use warn instead of fail. Issue #3333 on USWDS github
-    values: ["section508", "wcag2a", "wcag2aa"]
+    values: ['section508', 'wcag2a', 'wcag2aa'],
   },
   rules: {
     // Not all our examples need "skip to main content" links, so
     // ignore that rule.
     bypass: { enabled: false },
     // Nor do all our examples need main landmarks...
-    "landmark-one-main": { enabled: false },
+    'landmark-one-main': { enabled: false },
     // Not all content will be in a landmark region
     region: { enabled: false },
     // Not all examples have skip-link as a first element
-    "skip-link": { enabled: false },
+    'skip-link': { enabled: false },
     // Not all examples will need an h1, ex: links.
-    "page-has-heading-one": { enabled: false }
-  }
-});
+    'page-has-heading-one': { enabled: false },
+  },
+};
+
+const AXE_BEST_PRACTICES = {
+  ...AXE_OPTIONS,
+  runOnly: {
+    ...AXE_OPTIONS.runOnly.type,
+    values: ['best-practice'],
+  },
+}
 
 // This function is only here so it can be easily .toString()'d
 // and run in the context of a web page by Chrome. It will not
@@ -58,33 +67,49 @@ function load(cdp) {
   });
 }
 
-function run(cdp) {
+function handleError(reportDetails, showWarnings) {
+  const messageType = showWarnings ? warn : error;
+
+  return {
+    message: console.messageType(
+      `Unexpected result from aXe JS evaluation: ${JSON.stringify(
+        reportDetails.result,
+        null,
+        2
+      )}`
+    ),
+    summary: 'test'
+  };
+}
+
+/**
+ *
+ * @param { cdp, warn } - Run axe via Chrome Dev Protocol with a show warnings option to show axe bestPractice errors.
+ */
+function run({ cdp, warn = false } = {}) {
+  const AXE_SETTINGS = warn ? AXE_BEST_PRACTICES : AXE_OPTIONS;
   return cdp.Runtime.evaluate({
-    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${AXE_OPTIONS})`,
-    awaitPromise: true
-  }).then(details => {
-    if (details.result.type !== "string") {
-      return Promise.reject(
-        new Error(
-          `Unexpected result from aXe JS evaluation: ${JSON.stringify(
-            details.result,
-            null,
-            2
-          )}`
-        )
-      );
-    }
-    const viols = JSON.parse(details.result.value);
-    if (viols.length > 0) {
-      const errorMsg = `Found ${viols.length} aXe violations:
-        ${JSON.stringify(viols, null, 2)}
+    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${JSON.stringify(
+      AXE_SETTINGS
+    )})`,
+    awaitPromise: true,
+  }).then((details) => {
+    // if (details.result.type !== 'string') {
+    //   return Promise.reject(handleError.message(details.result, false));
+    // }
+    const violations = JSON.parse(details.result.value);
+    if (violations.length > 0) {
+      const errorMsg = `Found ${violations.length} aXe violations:
+        ${JSON.stringify(violations, null, 2)}
         To debug these violations, install aXe at:
         https://www.deque.com/products/axe/`;
-
-      return Promise.reject(new Error(errorMsg));
+      throw new Error(errorMsg);
     }
-    return Promise.resolve();
-  });
+  }).catch((error) => {
+    console.error(colors.red('Error 😰'));
+    console.error(colors.red(error));
+    // return Promise.reject(new Error(error));
+  })
 }
 
 module.exports = {

--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -17,7 +17,6 @@ const AXE_CONTEXT = JSON.stringify({
 const AXE_OPTIONS = {
   runOnly: {
     type: 'tag',
-    // @TODO Separate "best-practice" and use warn instead of fail. Issue #3333 on USWDS github
     values: ['section508', 'wcag2a', 'wcag2aa'],
   },
   rules: {

--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const assert = require("assert");
+const colors = require('ansi-colors');
 
 const AXE_JS = fs.readFileSync(`${__dirname}/../node_modules/axe-core/axe.js`);
 
@@ -13,26 +14,34 @@ const AXE_CONTEXT = JSON.stringify({
   ]
 });
 
-const AXE_OPTIONS = JSON.stringify({
+const AXE_OPTIONS = {
   runOnly: {
-    type: "tag",
+    type: 'tag',
     // @TODO Separate "best-practice" and use warn instead of fail. Issue #3333 on USWDS github
-    values: ["section508", "wcag2a", "wcag2aa"]
+    values: ['section508', 'wcag2a', 'wcag2aa'],
   },
   rules: {
     // Not all our examples need "skip to main content" links, so
     // ignore that rule.
     bypass: { enabled: false },
     // Nor do all our examples need main landmarks...
-    "landmark-one-main": { enabled: false },
+    'landmark-one-main': { enabled: false },
     // Not all content will be in a landmark region
     region: { enabled: false },
     // Not all examples have skip-link as a first element
-    "skip-link": { enabled: false },
+    'skip-link': { enabled: false },
     // Not all examples will need an h1, ex: links.
-    "page-has-heading-one": { enabled: false }
-  }
-});
+    'page-has-heading-one': { enabled: false },
+  },
+};
+
+const AXE_BEST_PRACTICES = {
+  ...AXE_OPTIONS,
+  runOnly: {
+    ...AXE_OPTIONS.runOnly.type,
+    values: ['best-practice'],
+  },
+}
 
 // This function is only here so it can be easily .toString()'d
 // and run in the context of a web page by Chrome. It will not

--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -82,22 +82,31 @@ function run({ cdp, warn = false } = {}) {
   })
   .then((details) => {
     const violations = JSON.parse(details.result.value);
-    const violations_formatted = JSON.stringify(violations, null, 2);
+    const violationsFormatted = JSON.stringify(violations, null, 2);
+
+    /**
+     * Reject and show an error if it's a 'section508', 'wcag2a', 'wcag2aa'
+     * violation. Otherwise, show a console warning.
+     */
+    const handleError = () => {
+      let errorMsg = `
+        Found ${violations.length} aXe ${warn ? 'warnings' : 'violations'}:
+        ${violationsFormatted}
+        To debug these violations, install aXe at:
+        https://www.deque.com/products/axe/`;
+
+      if (!warn) {
+        return Promise.reject(new Error(errorMsg));
+      } else {
+        /* eslint-disable-next-line no-console */
+        return console.log(colors.yellow(errorMsg));
+      }
+    };
 
     if (!violations.length) {
       return Promise.resolve();
     } else {
-      let errorMsg = `
-        Found ${violations.length} aXe ${warn ? 'warnings' : 'violations'}:
-        ${violations_formatted}
-        To debug these violations, install aXe at:
-        https://www.deque.com/products/axe/`;
-
-        if (!warn) {
-          return Promise.reject(new Error(errorMsg));
-        } else {
-          console.log(colors.yellow(errorMsg));
-        }
+      return handleError(violations);
     }
   });
 }

--- a/spec/axe-tester.js
+++ b/spec/axe-tester.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const assert = require("assert");
-const colors = require('ansi-colors');
 
 const AXE_JS = fs.readFileSync(`${__dirname}/../node_modules/axe-core/axe.js`);
 
@@ -14,34 +13,26 @@ const AXE_CONTEXT = JSON.stringify({
   ]
 });
 
-const AXE_OPTIONS = {
+const AXE_OPTIONS = JSON.stringify({
   runOnly: {
-    type: 'tag',
+    type: "tag",
     // @TODO Separate "best-practice" and use warn instead of fail. Issue #3333 on USWDS github
-    values: ['section508', 'wcag2a', 'wcag2aa'],
+    values: ["section508", "wcag2a", "wcag2aa"]
   },
   rules: {
     // Not all our examples need "skip to main content" links, so
     // ignore that rule.
     bypass: { enabled: false },
     // Nor do all our examples need main landmarks...
-    'landmark-one-main': { enabled: false },
+    "landmark-one-main": { enabled: false },
     // Not all content will be in a landmark region
     region: { enabled: false },
     // Not all examples have skip-link as a first element
-    'skip-link': { enabled: false },
+    "skip-link": { enabled: false },
     // Not all examples will need an h1, ex: links.
-    'page-has-heading-one': { enabled: false },
-  },
-};
-
-const AXE_BEST_PRACTICES = {
-  ...AXE_OPTIONS,
-  runOnly: {
-    ...AXE_OPTIONS.runOnly.type,
-    values: ['best-practice'],
-  },
-}
+    "page-has-heading-one": { enabled: false }
+  }
+});
 
 // This function is only here so it can be easily .toString()'d
 // and run in the context of a web page by Chrome. It will not
@@ -67,49 +58,33 @@ function load(cdp) {
   });
 }
 
-function handleError(reportDetails, showWarnings) {
-  const messageType = showWarnings ? warn : error;
-
-  return {
-    message: console.messageType(
-      `Unexpected result from aXe JS evaluation: ${JSON.stringify(
-        reportDetails.result,
-        null,
-        2
-      )}`
-    ),
-    summary: 'test'
-  };
-}
-
-/**
- *
- * @param { cdp, warn } - Run axe via Chrome Dev Protocol with a show warnings option to show axe bestPractice errors.
- */
-function run({ cdp, warn = false } = {}) {
-  const AXE_SETTINGS = warn ? AXE_BEST_PRACTICES : AXE_OPTIONS;
+function run(cdp) {
   return cdp.Runtime.evaluate({
-    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${JSON.stringify(
-      AXE_SETTINGS
-    )})`,
-    awaitPromise: true,
-  }).then((details) => {
-    // if (details.result.type !== 'string') {
-    //   return Promise.reject(handleError.message(details.result, false));
-    // }
-    const violations = JSON.parse(details.result.value);
-    if (violations.length > 0) {
-      const errorMsg = `Found ${violations.length} aXe violations:
-        ${JSON.stringify(violations, null, 2)}
+    expression: `(${RUN_AXE_FUNC_JS})(${AXE_CONTEXT}, ${AXE_OPTIONS})`,
+    awaitPromise: true
+  }).then(details => {
+    if (details.result.type !== "string") {
+      return Promise.reject(
+        new Error(
+          `Unexpected result from aXe JS evaluation: ${JSON.stringify(
+            details.result,
+            null,
+            2
+          )}`
+        )
+      );
+    }
+    const viols = JSON.parse(details.result.value);
+    if (viols.length > 0) {
+      const errorMsg = `Found ${viols.length} aXe violations:
+        ${JSON.stringify(viols, null, 2)}
         To debug these violations, install aXe at:
         https://www.deque.com/products/axe/`;
-      throw new Error(errorMsg);
+
+      return Promise.reject(new Error(errorMsg));
     }
-  }).catch((error) => {
-    console.error(colors.red('Error 😰'));
-    console.error(colors.red(error));
-    // return Promise.reject(new Error(error));
-  })
+    return Promise.resolve();
+  });
 }
 
 module.exports = {

--- a/spec/headless-chrome.js
+++ b/spec/headless-chrome.js
@@ -101,7 +101,8 @@ fractalLoad.then(() => {
               cdp.Emulation.setDeviceMetricsOverride(device.metrics)
             );
 
-            it("has no aXe violations", () => axeTester.run(cdp));
+            it('has no aXe violations', () => axeTester.run({ cdp }));
+            it('shows aXe warnings', () => axeTester.run({ cdp, warn: true }));
 
             if (process.env.ENABLE_SCREENSHOTS) {
               const vrt = new VisualRegressionTester({ handle, device });

--- a/spec/headless-chrome.js
+++ b/spec/headless-chrome.js
@@ -101,7 +101,19 @@ fractalLoad.then(() => {
               cdp.Emulation.setDeviceMetricsOverride(device.metrics)
             );
 
-            it("has no aXe violations", () => axeTester.run(cdp));
+            // it('has no aXe violations', () => axeTester.run({ cdp }));
+            it('has no aXe violations', () => axeTester.run({ cdp, warn: true }));
+            // it('has no aXe warnings', () => {
+            //   axeTester.run({cdp, warn: true}).then(response => {
+            //     // console.log("\x1b[33m", response);
+            //   }).catch(
+            //     error => {
+            //       // console.warn(error);
+            //       // console.log(new Error(error));
+            //       // console.log('******************************');
+            //     }
+            //   )
+            // });
 
             if (process.env.ENABLE_SCREENSHOTS) {
               const vrt = new VisualRegressionTester({ handle, device });

--- a/spec/headless-chrome.js
+++ b/spec/headless-chrome.js
@@ -101,19 +101,7 @@ fractalLoad.then(() => {
               cdp.Emulation.setDeviceMetricsOverride(device.metrics)
             );
 
-            // it('has no aXe violations', () => axeTester.run({ cdp }));
-            it('has no aXe violations', () => axeTester.run({ cdp, warn: true }));
-            // it('has no aXe warnings', () => {
-            //   axeTester.run({cdp, warn: true}).then(response => {
-            //     // console.log("\x1b[33m", response);
-            //   }).catch(
-            //     error => {
-            //       // console.warn(error);
-            //       // console.log(new Error(error));
-            //       // console.log('******************************');
-            //     }
-            //   )
-            // });
+            it("has no aXe violations", () => axeTester.run(cdp));
 
             if (process.env.ENABLE_SCREENSHOTS) {
               const vrt = new VisualRegressionTester({ handle, device });


### PR DESCRIPTION
Resolves #3333 

## Description

This PR allows us to see axe's `best-practice` rule violations as warnings, instead of fails. Previously, if we checked against all of the rules at the same time, best-practices would cause the tests to fail — we just want them as a recommendation.

Now you should be able to run `gulp regression` and see warnings instead of errors for best-practice violations.

### No warnings or violations
```bash
   "breadcrumb"
      on small-desktop (412x732)
        ✓ has no aXe violations
        ✓ shows aXe warnings
      on large-desktop (1280x732)
        ✓ has no aXe violations
        ✓ shows aXe warnings
```

### Warning, no violation

```bash
"card"
      on small-desktop (412x732)
        ✓ has no aXe violations (39ms)

        Found 2 aXe warnings:
        [
  {
    "id": "landmark-no-duplicate-banner",
    "impact": "moderate",
    "tags": [
      "cat.semantics",
      "best-practice"
    ],
    "description": "Ensures the document has at most one banner landmark",
    "help": "Document must not have more than one banner landmark",
    "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-banner?application=axeAPI",
   …
```

### Violations
Same as before.

## Additional information
I tried to re-use as much of the previous code as possible, so as to prevent a re-write. Because we're using mocha, if we pass the warnings the same way as _real_ violations it will still cause the test to fail.

That's why we run the test twice in

```js
// headless-chrome.js
it('has no aXe violations', () => axeTester.run({ cdp }));
it('shows aXe warnings', () => axeTester.run({ cdp, warn: true }));
```

Also it seems that neither mocha nor axe support a "warning" state at the moment.

The following might look funny, but 

```js
// axe-tester.js:98if (!warn) {
  return Promise.reject(new Error(errorMsg));
} else {
  console.log(colors.yellow(errorMsg));
}
```

Rejecting the promise for warnings would cause an error message to be shown and might cause confusion. I wanted a clear separation between warnings and proper errors. I'm also using the `colors` library we've used in other scripts to style.


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
