### PR TITLE
USWDS - Identifier: Set font weight fallbacks for Identifier.

### DIFF
--- a/src/stylesheets/components/_identifier.scss
+++ b/src/stylesheets/components/_identifier.scss
@@ -4,6 +4,8 @@ $identifier-section-margin-y-small: 1;
 $identifier-link-gap: 1.5;
 $identifier-link-gap-desktop: 1;
 $identifier-links-gap: 4 !default;
+$identifier-thin-weight: if($theme-font-weight-light, "light", "normal");
+$identifier-bold-weight: if($theme-font-weight-bold, "bold", "normal");
 
 @mixin identifier-secondary-link {
   @include set-link-from-bg(
@@ -75,11 +77,11 @@ $identifier-links-gap: 4 !default;
 }
 
 .usa-identifier__identity-domain {
-  @include u-text("light", $theme-identifier-identity-domain-color);
+  @include u-text($identifier-thin-weight, $theme-identifier-identity-domain-color);
 }
 
 .usa-identifier__identity-disclaimer {
-  @include u-text("bold");
+  @include u-text($identifier-bold-weight);
 
   a {
     @include set-link-from-bg($theme-identifier-background-color);
@@ -130,7 +132,7 @@ $identifier-links-gap: 4 !default;
 
 .usa-identifier__section--usagov a {
   @include set-link-from-bg($theme-identifier-background-color);
-  @include u-text("bold");
+  @include u-text($identifier-bold-weight);
   display: inline-block;
   margin-top: units(1);
 

--- a/src/stylesheets/components/_identifier.scss
+++ b/src/stylesheets/components/_identifier.scss
@@ -4,8 +4,6 @@ $identifier-section-margin-y-small: 1;
 $identifier-link-gap: 1.5;
 $identifier-link-gap-desktop: 1;
 $identifier-links-gap: 4 !default;
-$identifier-thin-weight: if($theme-font-weight-light, "light", "normal");
-$identifier-bold-weight: if($theme-font-weight-bold, "bold", "normal");
 
 @mixin identifier-secondary-link {
   @include set-link-from-bg(
@@ -77,14 +75,11 @@ $identifier-bold-weight: if($theme-font-weight-bold, "bold", "normal");
 }
 
 .usa-identifier__identity-domain {
-  @include u-text(
-    $identifier-thin-weight,
-    $theme-identifier-identity-domain-color
-  );
+  @include u-text($theme-identifier-identity-domain-color);
 }
 
 .usa-identifier__identity-disclaimer {
-  @include u-text($identifier-bold-weight);
+  @include u-text("bold");
 
   a {
     @include set-link-from-bg($theme-identifier-background-color);
@@ -135,7 +130,7 @@ $identifier-bold-weight: if($theme-font-weight-bold, "bold", "normal");
 
 .usa-identifier__section--usagov a {
   @include set-link-from-bg($theme-identifier-background-color);
-  @include u-text($identifier-bold-weight);
+  @include u-text("bold");
   display: inline-block;
   margin-top: units(1);
 

--- a/src/stylesheets/components/_identifier.scss
+++ b/src/stylesheets/components/_identifier.scss
@@ -77,7 +77,10 @@ $identifier-bold-weight: if($theme-font-weight-bold, "bold", "normal");
 }
 
 .usa-identifier__identity-domain {
-  @include u-text($identifier-thin-weight, $theme-identifier-identity-domain-color);
+  @include u-text(
+    $identifier-thin-weight,
+    $theme-identifier-identity-domain-color
+  );
 }
 
 .usa-identifier__identity-disclaimer {


### PR DESCRIPTION
Fixes #3653

## Description

Sets identifier thin and bold font-weights to "normal" if either are disabled.

## Additional information

You have to set the following variables to false and then go see the identifier.
```scss
// _uswds-theme-typography.scss
$theme-font-weight-light: false;
$theme-font-weight-bold: false;
```


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
