### PR TITLE
Reference "disabled-light" color by token name in File Input styles

### DIFF
--- a/src/stylesheets/elements/form-controls/_file-input.scss
+++ b/src/stylesheets/elements/form-controls/_file-input.scss
@@ -190,7 +190,7 @@
   }
 
   .usa-file-input__box {
-    background-color: color($theme-color-disabled-light);
+    background-color: color("disabled-light");
   }
 
   .usa-file-input__input[type] {


### PR DESCRIPTION
## Description

This pull request seeks to resolve an error which can occur when assigning a non-token value for the `$theme-color-disabled-light` variable, as described in the [USWDS v2.4.0 release notes](https://designsystem.digital.gov/about/releases/#version-240).

>Now, teams can add non-token colors to theme color settings like `$theme-color-primary: #f00`. This new non-token value of `'primary'` will apply anywhere the `'primary'` token is used: functions, mixins, settings, and utilities.

If a developer assigns the variable value...

```
$theme-color-disabled-light: #f00;
```

... an error occurs during build:

```
Error in plugin "gulp-sass"
Message:
    node_modules/uswds/dist/scss/core/_functions.scss
Error: Only use quoted color tokens in USWDS functions and mixins. See v2.designsystem.digital.gov/style-tokens/color for more information.
        on line 130 of node_modules/uswds/dist/scss/core/_functions.scss, in function `smart-quote`
        from line 924 of node_modules/uswds/dist/scss/core/_functions.scss, in function `color`
        from line 291 of node_modules/uswds/dist/scss/core/_variables.scss
        from line 28 of node_modules/uswds/dist/scss/uswds.scss
        from line 11 of src/scss/styles.scss
>>     @error 'Only use quoted color tokens in USWDS functions and mixins. '

   ----^
```

## Additional information

Exploring the [underlying `color` function source](https://github.com/uswds/uswds/blob/0c35004aa4b81ec94cca03d96a55ba5691524869/src/stylesheets/core/_functions.scss#L1271-L1334), `$value` is only allowed to be passed as a color value in combination with the `set-theme` flag, as is done in [the `_variables.scss` initialization file](https://github.com/uswds/uswds/blob/0c35004aa4b81ec94cca03d96a55ba5691524869/src/stylesheets/core/_variables.scss#L377). By referencing this variable directly without accompanying flags, the build will fail.

To allow for theme overrides to take effect, it would seem the most obvious fix is to pass the token name, rather than to reference the variable directly. It appears this is the only file in the repository outside `_variables.scss` which calls the `color` function with a `$theme-color-`-prefixed variable.

Originally observed at: https://github.com/18F/identity-style-guide/pull/159