### PR TITLE
Try: Implement banner toggle as CSS-only accordion

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -12,43 +12,40 @@
         <div class="grid-col-auto">
           <img class="usa-banner__header-flag" src="{{ uswds.path }}/img/us_flag_small.png" alt="U.S. flag">
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
-          <p class="usa-banner__header-text">{{ banner.text }}</p>
-          <p class="usa-banner__header-action" aria-hidden="true">{{ banner.action }}</p>
+        <p class="usa-banner__header-text">{{ banner.text }}</p>
+        <input id="usa-banner-toggle" type="checkbox" role="button" aria-expanded="false" aria-controls="gov-banner" class="usa-banner__toggle">
+        <label for="usa-banner-toggle" class="usa-accordion__button usa-banner__button">
+          <span class="usa-banner__button-text">{{banner.action}}</span>
+        </label>
+        <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+          <div class="grid-row grid-gap-lg">
+            <div class="usa-banner__guidance tablet:grid-col-6">
+              <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
+              <div class="usa-media-block__body">
+                <p>
+                  <strong>
+                    {{ domain.heading | safe | replace(tld_text, domain.tld) -}}
+                  </strong>
+                  <br/>
+                  {{ domain.text | safe | replace(tld_text, domain.tld) }}
+                </p>
+              </div>
+            </div>
+            <div class="usa-banner__guidance tablet:grid-col-6">
+              <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
+              <div class="usa-media-block__body">
+                <p>
+                  <strong>
+                    {{ https.heading | safe | replace(tld_text, domain.tld) -}}
+                  </strong>
+                  <br/>
+                  {{ https.text | safe | replace(tld_text, domain.tld) | replace(lock_image, lock) }}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
-        <button class="usa-accordion__button usa-banner__button"
-          aria-expanded="false" aria-controls="gov-banner">
-          <span class="usa-banner__button-text">{{ banner.action }}</span>
-        </button>
+      </div>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-      <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
-          <div class="usa-media-block__body">
-            <p>
-              <strong>
-                {{ domain.heading | safe | replace(tld_text, domain.tld) -}}
-              </strong>
-              <br/>
-              {{ domain.text | safe | replace(tld_text, domain.tld) }}
-            </p>
-          </div>
-        </div>
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
-          <div class="usa-media-block__body">
-            <p>
-              <strong>
-                {{ https.heading | safe | replace(tld_text, domain.tld) -}}
-              </strong>
-              <br/>
-              {{ https.text | safe | replace(tld_text, domain.tld) | replace(lock_image, lock) }}
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 </section>

--- a/src/js/components/banner.js
+++ b/src/js/components/banner.js
@@ -5,8 +5,9 @@ const { prefix: PREFIX } = require("../config");
 const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
 
-const toggleBanner = function toggleEl(event) {
-  event.preventDefault();
+function toggleBanner(event) {
+  const checkbox = event.target;
+  checkbox.setAttribute('aria-expanded', checkbox.checked ? 'true' : 'false');
   this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
 };
 

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -51,14 +51,32 @@ $banner-icon-close: (
   @include set-text-from-bg($theme-banner-background-color);
 }
 
+.usa-banner__toggle {
+  @include u-pin-all;
+  height: 100%;
+  opacity: 0;
+  width: 100%;
+
+  @include at-media("tablet") {
+    @include add-sr-only;
+  }
+
+  &:focus + .usa-banner__button {
+    @include focus-outline;
+  }
+
+  &:not(:checked) ~ .usa-banner__content {
+    @include u-display("none");
+  }
+}
+
 .usa-banner__content {
-  @include grid-container($theme-banner-max-width);
-  @include add-responsive-site-margins;
   background-color: color("transparent");
   font-size: font-size($theme-banner-font-family, 4);
   overflow: hidden;
   padding-bottom: units(2);
-  padding-left: units($theme-site-margins-mobile-width - 1);
+  padding-left: units(0);
+  padding-right: units(0);
   padding-top: units(0.5);
   width: 100%;
 
@@ -193,9 +211,18 @@ $banner-icon-close: (
 
 .usa-banner__button {
   @include button-unstyled;
-  @include u-pin("left");
-  @include u-pin("y");
   @include u-text("primary", underline, baseline);
+  @include set-link-from-bg(
+    $theme-banner-background-color,
+    $theme-banner-link-color
+  );
+  @include place-icon(
+    $banner-icon-chevron,
+    "after",
+    2px,
+    middle,
+    $theme-banner-background-color
+  );
   @include set-link-from-bg(
     $theme-banner-background-color,
     $theme-banner-link-color
@@ -204,9 +231,10 @@ $banner-icon-close: (
   font-size: font-size($theme-banner-font-family, 1);
   height: auto;
   line-height: line-height($theme-banner-font-family, 2);
-  padding-top: units(0);
+  margin-left: units(3);
   padding-left: units(0);
-  text-decoration: none;
+  padding-top: units(0);
+  text-decoration: underline;
   width: auto;
 
   @include at-media-max("tablet") {
@@ -214,32 +242,16 @@ $banner-icon-close: (
   }
 
   @include at-media("tablet") {
-    @include place-icon(
-      $banner-icon-chevron,
-      "after",
-      2px,
-      middle,
-      $theme-banner-background-color
-    );
-    @include set-link-from-bg(
-      $theme-banner-background-color,
-      $theme-banner-link-color
-    );
-    @include u-pin("none");
     display: inline;
     margin-left: units(1);
-    position: relative;
-
-    &:hover {
-      // Underline added to inner text instead.
-      text-decoration: none;
-    }
   }
 
+  .usa-banner__toggle + &,
   &[aria-expanded="false"] {
     background-image: none;
   }
 
+  .usa-banner__toggle:checked + &,
   &[aria-expanded="true"] {
     background-image: none;
 
@@ -279,16 +291,12 @@ $banner-icon-close: (
       padding: units(0);
       position: relative;
     }
-  }
-}
 
-.usa-banner__button-text {
-  @include add-sr-only;
-  text-decoration: underline;
-
-  @include at-media("tablet") {
-    @include add-no-sr-only;
-    display: inline;
+    .usa-banner__button-text {
+      @include at-media-max("tablet") {
+        @include add-sr-only;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Closes #3092
Related: #3810

## Description

This pull request aims to explore a CSS-only alternative to the U.S. banner accordion toggle. It does so using a hidden checkbox and CSS adjacent sibling selectors.

## Additional information

The advantage to this approach is that the accordion toggle works in no-JavaScript environments, an enhancement to the experience for no-JS users, while still satisfying the objective of #3092.

In its current form, the pull request primarily serves as a proof-of-concept.

Further work needed:

- Accessibility audit
- Updates to test specifications
- Minor styling revisions to match current appearance (minor padding differences)
- Backward-compatibility story

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
