### PR TITLE
Try: Implement banner toggle as substituted noscript markup

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -23,32 +23,34 @@
       </div>
     </header>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-      <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
-          <div class="usa-media-block__body">
-            <p>
-              <strong>
-                {{ domain.heading | safe | replace(tld_text, domain.tld) -}}
-              </strong>
-              <br/>
-              {{ domain.text | safe | replace(tld_text, domain.tld) }}
-            </p>
+      <noscript>
+        <div class="grid-row grid-gap-lg">
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
+            <div class="usa-media-block__body">
+              <p>
+                <strong>
+                  {{ domain.heading | safe | replace(tld_text, domain.tld) -}}
+                </strong>
+                <br/>
+                {{ domain.text | safe | replace(tld_text, domain.tld) }}
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
+            <div class="usa-media-block__body">
+              <p>
+                <strong>
+                  {{ https.heading | safe | replace(tld_text, domain.tld) -}}
+                </strong>
+                <br/>
+                {{ https.text | safe | replace(tld_text, domain.tld) | replace(lock_image, lock) }}
+              </p>
+            </div>
           </div>
         </div>
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
-          <div class="usa-media-block__body">
-            <p>
-              <strong>
-                {{ https.heading | safe | replace(tld_text, domain.tld) -}}
-              </strong>
-              <br/>
-              {{ https.text | safe | replace(tld_text, domain.tld) | replace(lock_image, lock) }}
-            </p>
-          </div>
-        </div>
-      </div>
+      </noscript>
     </div>
   </div>
 </section>

--- a/src/js/components/banner.js
+++ b/src/js/components/banner.js
@@ -1,17 +1,33 @@
+const select = require("../utils/select");
 const behavior = require("../utils/behavior");
 const { CLICK } = require("../events");
 const { prefix: PREFIX } = require("../config");
 
 const HEADER = `.${PREFIX}-banner__header`;
+const CONTENT = `.${PREFIX}-banner__content`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
+const JS_ENABLED_CLASS = `${PREFIX}-banner--js-enabled`;
 
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
   this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
 };
 
-module.exports = behavior({
-  [CLICK]: {
-    [`${HEADER} [aria-controls]`]: toggleBanner,
+function replaceNoScript(content) {
+  content.classList.add(JS_ENABLED_CLASS);
+  const noscript = content.querySelector("noscript");
+  if (noscript) noscript.outerHTML = noscript.textContent;
+}
+
+module.exports = behavior(
+  {
+    [CLICK]: {
+      [`${HEADER} [aria-controls]`]: toggleBanner,
+    },
   },
-});
+  {
+    init(root) {
+      select(CONTENT, root).forEach(replaceNoScript);
+    },
+  }
+);


### PR DESCRIPTION
Closes #3092
Related: #3809

## Description

This pull request aims to explore an approach to #3092 based on @eddietejeda suggestion at https://github.com/uswds/uswds/issues/3092#issuecomment-533674613 to use a `noscript` container to show banner contents for no-JavaScript environments. In JavaScript environments, the container is replaced with its children's markup. This approach avoids the need for multiple copies of the banner content.

## Additional information

In its current form, the pull request primarily serves as a proof-of-concept.

Further work needed:

- Security audit (`outerHTML` substitution)
- Browser testing (I've read [some indication](https://stackoverflow.com/a/620955) that the contents of a `noscript` tag will be empty in some browsers in JavaScript-capable environments?)

An advantage to this over #3809 is that it can be considered an enhancement to opt-in to, and will not conflict with existing banner markup.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
