### PR TITLE
Utilize $theme-font-weight-bold variable for customizing bold font-weight

### DIFF
--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -237,7 +237,7 @@ $system-properties: (
       "normal": normal,
       "medium": $theme-font-weight-medium,
       "semibold": $theme-font-weight-semibold,
-      "bold": bold,
+      "bold": $theme-font-weight-bold,
       "heavy": $theme-font-weight-heavy,
     ),
     extended: (


### PR DESCRIPTION
## Description

This addresses an issue where sites could not theme the weight value for "bold" using `$theme-font-weight-bold`.

[`"bold"` maps to `700`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#values). This is an issue if a site is using a custom font that is not part of the USWDS and has a non-standard weight value (like `550`). 

## Additional information

This was discovered why working a site that pretty heavily themes USWDS since it's a state govt website with their own unique branding. They utilize a variable font and "bold" is closer to `550`. 

In my Sass, I've set `$theme-global-content-styles: true` and `$theme-font-weight-bold: 550` however all of the headings still output `font-weight: bold`. I would expect them to output `font-weight: 550` instead. This change should enable that.

![image](https://user-images.githubusercontent.com/371943/98185615-f4945e00-1eda-11eb-9f33-429f02cc88c0.png)

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
