### PR TITLE
USWDS - Build: Update dist SCSS paths so they match current stable structure.

### DIFF
--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -25,9 +25,9 @@ module.exports = {
   copySass: function() {
 
     return mergeStream(
-      src('src/patterns/components/**/*.scss').pipe(
-        dest('dist/scss/components')
-      ),
+      src('src/patterns/components/**/*.scss')
+        .pipe(replace(/(..\/..\/stylesheets)/g, '../stylesheets'))
+        .pipe(dest('dist/scss/components')),
       src('src/patterns/stylesheets/**/*.scss')
         .pipe(replace(/(..\/..\/components)/g, '../components'))
         .pipe(dest('dist/scss'))

--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -26,7 +26,7 @@ module.exports = {
 
     return mergeStream(
       src('src/patterns/components/**/*.scss')
-        .pipe(replace(/(..\/..\/stylesheets)/g, '../stylesheets'))
+        .pipe(replace(/(..\/..\/stylesheets)/g, '../..'))
         .pipe(dest('dist/scss/components')),
       src('src/patterns/stylesheets/**/*.scss')
         .pipe(replace(/(..\/..\/components)/g, '../components'))

--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const GulpClient = require('gulp');
 // Include gulp
 const { src, dest } = require('gulp');
 
@@ -7,6 +8,7 @@ const { src, dest } = require('gulp');
 const filter = require("gulp-filter");
 const rename = require('gulp-rename');
 const mergeStream = require('merge-stream');
+const replace = require('gulp-replace');
 
 // Export our tasks.
 module.exports = {
@@ -21,12 +23,15 @@ module.exports = {
 
   // Copy Sass to dist folder
   copySass: function() {
+
     return mergeStream(
-      src('src/patterns/components/**/*.scss')
-        .pipe(dest('dist/scss/components')),
+      src('src/patterns/components/**/*.scss').pipe(
+        dest('dist/scss/components')
+      ),
       src('src/patterns/stylesheets/**/*.scss')
+        .pipe(replace(/(..\/..\/components)/g, '../components'))
         .pipe(dest('dist/scss'))
-    )
+    );
   },
 
   // Copy Images to dist folder

--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -6,6 +6,7 @@ const { src, dest } = require('gulp');
 // Include Our Plugins
 const filter = require("gulp-filter");
 const rename = require('gulp-rename');
+const mergeStream = require('merge-stream');
 
 // Export our tasks.
 module.exports = {
@@ -20,8 +21,12 @@ module.exports = {
 
   // Copy Sass to dist folder
   copySass: function() {
-    return src('src/patterns/**/**/*.scss')
-      .pipe(dest('dist/scss'));
+    return mergeStream(
+      src('src/patterns/components/**/*.scss')
+        .pipe(dest('dist/scss/components')),
+      src('src/patterns/stylesheets/**/*.scss')
+        .pipe(dest('dist/scss'))
+    )
   },
 
   // Copy Images to dist folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds",
-  "version": "2.10.0-beta.0",
+  "version": "2.10.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15378,6 +15378,12 @@
       "requires": {
         "is-plain-obj": "^1.1"
       }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "handlebars-helpers": "^0.10.0",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
+    "merge-stream": "^2.0.0",
     "mocha": "^8.1.3",
     "normalize.css": "^8.0.1",
     "nyc": "^15.1.0",


### PR DESCRIPTION
- Add merge-stream plugin to handle different sources
- Update copySass task

### Previous structure
```
dist/scss
├── stylesheets
│   ├── utilities
│   ├── uswds.scss
│   ├── theme
│   ├── packages
│   ├── lib
│   ├── helpers
│   ├── elements
│   ├── core
│   └── _uswds-package.scss
└── components
```

### New
```
dist/scss
├── utilities
├── theme
├── packages
├── lib
├── helpers
├── elements
├── core
├── components
├── uswds.scss
└── _uswds-package.scss
```

---

### Testing
1. Install USWDS branch via `npm i "uswds/uswds#jm-update-sass-dist"`
1. If you're using `uswds-gulp` run `gulp build-sass`
1. Should compile without errors