### PR TITLE
USWDS - Forms: Update form alerts.

### DIFF
--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -12,7 +12,7 @@
     class="usa-file-input"
     type="file"
     name="{{ name }}-{{ id }}"
-    {% if hint -%}aria-describedby="{{ name }}-{{ id }}-hint {{ name }}-{{ id }}-alert"{%- endif -%}
+    {% if hint or error -%}aria-describedby="{% if hint -%}{{ name }}-{{ id }}-hint{%- endif -%}{% if error %} {{ name }}-{{ id }}-alert"{%- endif -%}{%- endif -%}
     {% if accept -%}accept="{{ accept }}"{%- endif -%}
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled -%} disabled{%- endif -%} />

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -12,7 +12,7 @@
     class="usa-file-input"
     type="file"
     name="{{ name }}-{{ id }}"
-    {% if hint or error -%}aria-describedby="{% if hint -%}{{ name }}-{{ id }}-hint{%- endif -%}{% if error %} {{ name }}-{{ id }}-alert"{%- endif -%}{%- endif -%}
+    {% if hint or error -%}aria-describedby="{% if hint -%}{{ name }}-{{ id }}-hint{%- endif -%}{% if error %} {{ name }}-{{ id }}-alert{%- endif -%}"{%- endif -%}
     {% if accept -%}accept="{{ accept }}"{%- endif -%}
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled -%} disabled{%- endif -%} />

--- a/src/components/07-form/controls/file-input.njk
+++ b/src/components/07-form/controls/file-input.njk
@@ -6,13 +6,13 @@
   <span class="usa-hint" id="{{ name }}-{{ id }}-hint">{{ hint }}</span>
   {%- endif -%}
   {%- if error %}
-  <span class="usa-error-message" id="{{ name }}-{{ id }}-alert" role="alert">{{ errorMessage }}</span>
+  <span class="usa-error-message" id="{{ name }}-{{ id }}-alert">{{ errorMessage }}</span>
   {%- endif %}
   <input id="{{ name }}-{{ id }}"
     class="usa-file-input"
     type="file"
     name="{{ name }}-{{ id }}"
-    {% if hint -%}aria-describedby="{{ name }}-{{ id }}-hint"{%- endif -%}
+    {% if hint -%}aria-describedby="{{ name }}-{{ id }}-hint {{ name }}-{{ id }}-alert"{%- endif -%}
     {% if accept -%}accept="{{ accept }}"{%- endif -%}
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled -%} disabled{%- endif -%} />

--- a/src/components/07-form/controls/text-input.njk
+++ b/src/components/07-form/controls/text-input.njk
@@ -7,7 +7,7 @@
 
   <div class="usa-form-group usa-form-group--error">
     <label class="usa-label usa-label--error" for="input-error">Text input error</label>
-    <span class="usa-error-message" id="input-error-message" role="alert">Helpful error message</span>
+    <span class="usa-error-message" id="input-error-message">Helpful error message</span>
     <input class="usa-input usa-input--error" id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
   </div>
 

--- a/src/components/test/input-alerts.njk
+++ b/src/components/test/input-alerts.njk
@@ -1,0 +1,56 @@
+<main class="grid-container">
+  <h1>Testing alerts on inputs - <small><a href="https://github.com/uswds/uswds/issues/3788">issue #3788</a></small></h1>
+  <p class="measure-3">
+    Alerts on form inputs aren't being read on voiceover. These are tests with current problem and possible solution. Originally tested on Voiceover Safari Version 14.0 (15610.1.28.1.9, 15610)
+  </p>
+  <div class="grid-row grid-gap-6 margin-top-4">
+    <div class="tablet:grid-col-6">
+      <h2>Current</h2>
+      <!-- Text w/ error -->
+      <div class="usa-form-group usa-form-group--error">
+        <label class="usa-label usa-label--error" for="input-error">Text input error</label>
+        <span class="usa-error-message" id="input-error-message" role="alert">Helpful error message</span>
+        <input class="usa-input usa-input--error" id="input-error" name="input-error" type="text"
+          aria-describedby="input-error-message">
+      </div>
+
+      <!-- File input w/ error -->
+      <div class="usa-form-group usa-form-group--error">
+        <label class="usa-label usa-label--error" for="file-input-error">Input has an error</label>
+        <span class="usa-hint" id="file-input-error-hint">Select any valid file</span>
+        <span class="usa-error-message" id="file-input-error-alert" role="alert">Display a helpful error message</span>
+        <input id="file-input-error" class="usa-file-input" type="file" name="file-input-error"
+          aria-describedby="file-input-error-hint">
+      </div>
+    </div>
+    <div class="tablet:grid-col-6">
+      <h2>Proposed</h2>
+      <p>Removing role attribute from spans in alert. Gov.uk does something like this in their <a href="https://design-system.service.gov.uk/components/file-upload/error/index.html">file input →</a></p>
+      <!-- Text w/ error -->
+      <div class="usa-form-group usa-form-group--error">
+        <label class="usa-label usa-label--error" for="input-error-2">Text input error</label>
+        <span class="usa-error-message" id="input-error-message-2">Helpful error message</span>
+        <input class="usa-input usa-input--error" id="input-error-2" name="input-error-2" type="text"
+          aria-describedby="input-error-message-2">
+      </div>
+
+      <!-- File input w/ error -->
+      <div class="usa-form-group usa-form-group--error">
+        <label class="usa-label usa-label--error" for="file-input-error-2">
+          Input has an error
+        </label>
+        <span class="usa-hint" id="file-input-error-hint-2">
+          Select any valid file
+        </span>
+        <span class="usa-error-message" id="file-input-error-alert-2">
+          Display a helpful error message
+        </span>
+        <input id="file-input-error" class="usa-file-input" type="file" name="file-input-error-2"
+          aria-describedby="file-input-error-alert-2 file-input-error-hint-2" />
+        <p>
+          Here we removed the role and updated the aria-describedby attribute.
+        </p>
+      </div>
+    </div>
+  </div>
+</main>

--- a/src/components/test/input-alerts.njk
+++ b/src/components/test/input-alerts.njk
@@ -45,7 +45,7 @@
         <span class="usa-error-message" id="file-input-error-alert-2">
           Display a helpful error message
         </span>
-        <input id="file-input-error" class="usa-file-input" type="file" name="file-input-error-2"
+        <input id="file-input-error-2" class="usa-file-input" type="file" name="file-input-error-2"
           aria-describedby="file-input-error-alert-2 file-input-error-hint-2" />
         <p>
           Here we removed the role and updated the aria-describedby attribute.


### PR DESCRIPTION
## Preview
[Test page →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-form-alerts-voiceover/components/preview/input-alerts.html)

## Description

Fixes #3788

## Additional information

Voiceover isn't reading error alerts. This removes `role="alert"` from Input alerts. Similar to [Gov.uk](https://design-system.service.gov.uk/components/file-upload/error/index.html).

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
