### PR TITLE
USWDS - Banner: Remove alt from decorative banner images.

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -25,7 +25,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="">
           <div class="usa-media-block__body">
             <p>
               <strong>
@@ -37,7 +37,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="Https">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="">
           <div class="usa-media-block__body">
             <p>
               <strong>


### PR DESCRIPTION
## Preview
[Banner default →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-banner-a11y/components/detail/banner--default.html)

## Description

Closes #3689. Banner images are decorative and should not get a descriptive `alt`.

## Additional information

Need to update banners on:

- [x] USWDS Site https://github.com/uswds/uswds-site/pull/1102
- [x] Public Sans https://github.com/uswds/public-sans/pull/180

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
