### PR TITLE
Consistently use (avoid) browser prefixes for icon mask styling

### DIFF
--- a/src/stylesheets/core/mixins/_icon.scss
+++ b/src/stylesheets/core/mixins/_icon.scss
@@ -139,6 +139,7 @@
   @supports (mask: url("")) or (-webkit-mask: url("")) {
     background: none;
     background-color: color($color);
+    -webkit-mask: $image-props;
     mask: $image-props;
     @if $color-hover {
       &:hover {

--- a/src/stylesheets/core/mixins/_icon.scss
+++ b/src/stylesheets/core/mixins/_icon.scss
@@ -136,10 +136,9 @@
   }
 
   // Mask supportered styles
-  @supports (mask: url("")) or (-webkit-mask: url("")) {
+  @supports (mask: url("")) {
     background: none;
     background-color: color($color);
-    -webkit-mask: $image-props;
     mask: $image-props;
     @if $color-hover {
       &:hover {


### PR DESCRIPTION
## Description

The `add-color-icon` icon mixin uses an `@supports` test of `(mask: url("")) or (-webkit-mask: url(""))` in checking whether to add mask styling, but then only adds the styling using the unprefixed style `mask:`. The changes here seek to consistently use (avoid) the prefix.

## Additional information

In environments where autoprefixing is not configured, this can cause strange behaviors in Chrome (v87) where `-webkit-mask` is supported, but the unprefixed `mask` is not, and yet the styles will still be applied.

Because [the documentation](https://github.com/uswds/uswds#sass-compilation-requirements) claims that autoprefixing is a prerequisite in projects, the suggestion here is to remove the prefixed form in the `@supports` check. This way, the prefixing will be added by autoprefixer, but without autoprefixer, at least the styles would not be applied erroneously.

You can confirm using a tool like [Autoprefixer CSS online](https://autoprefixer.github.io/) that the prefixed form is added to a `@supports` directive:

```scss
.example {
  @supports (mask: url("")) {
    background: none;
    background-color: color($color);
    mask: $image-props;
    @if $color-hover {
      &:hover {
        background-color: color($color-hover);
      }
    }
  }
}
```

Without these changes, an autoprefixer would unnecessarily duplicate the vendor prefix:

```
@supports ((-webkit-mask: url("")) or (mask: url(""))) or (-webkit-mask: url("")) {
```
