### PR TITLE
Add a clearer outside link section for collection

### DIFF
--- a/src/components/collection/collection--only-headers.njk
+++ b/src/components/collection/collection--only-headers.njk
@@ -3,7 +3,7 @@
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
+        <a class="usa-link" href="https://digital.gov/guides/mobile-principles/?dg">The eight principles of mobile-friendliness</a>
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
@@ -18,7 +18,7 @@
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/sba-wosb-dashboard/">Women-owned small business dashboard</a>
+        <a class="usa-link" href="https://designsystem.digital.gov/maturity-model/">The USWDS maturity model</a>
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
@@ -33,29 +33,14 @@
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/September-2020-Updates-Show-Progress/">September 2020 updates show progress on cross-agency and agency priority goals</a>
+        <a class="usa-link" href="#">A news item that’s on our own site</a>
       </h3>
     </div>
   </li>
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/a-11-update/">Integrating components of the GPRA Modernization Act and Evidence Act to improve organizational performance</a>
-      </h3>
-      <ul class="usa-collection__meta" aria-label="More information">
-        <li class="usa-collection__meta-item position-relative">
-          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
-            <use xlink:href="../../dist/img/sprite.svg#public"></use>
-          </svg>
-          Performance.gov
-        </li>
-      </ul>
-    </div>
-  </li>
-  <li class="usa-collection__item">
-    <div class="usa-collection__body">
-      <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/sharing-services-memo-release/">Sharing quality services</a>
+        <a class="usa-link" href="https://18f.gsa.gov/2020/11/24/the-key-role-of-product-owners-in-federated-data-projects/">The key role of product owners in federated data projects</a>
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
@@ -63,6 +48,21 @@
             <use xlink:href="../../dist/img/sprite.svg#public"></use>
           </svg>
           18F
+        </li>
+      </ul>
+    </div>
+  </li>
+  <li class="usa-collection__item">
+    <div class="usa-collection__body">
+      <h3 class="usa-collection__heading">
+        <a class="usa-link" href="https://www.performance.gov/September-2020-Updates-Show-Progress/">Progress on Cross-Agency Priority (CAP) goals and Agency Priority Goals (APGs)</a>
+      </h3>
+      <ul class="usa-collection__meta" aria-label="More information">
+        <li class="usa-collection__meta-item position-relative">
+          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
+            <use xlink:href="../../dist/img/sprite.svg#public"></use>
+          </svg>
+          Performance.gov
         </li>
       </ul>
     </div>

--- a/src/components/collection/collection--only-headers.njk
+++ b/src/components/collection/collection--only-headers.njk
@@ -8,9 +8,9 @@
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
           <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
-            <use xlink:href="../../dist/img/sprite.svg#launch"></use>
+            <use xlink:href="../../dist/img/sprite.svg#public"></use>
           </svg>
-          digital.gov
+          Digital.gov
         </li>
       </ul>
     </div>
@@ -23,9 +23,9 @@
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
           <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
-            <use xlink:href="../../dist/img/sprite.svg#launch"></use>
+            <use xlink:href="../../dist/img/sprite.svg#public"></use>
           </svg>
-          designsystem.digital.gov
+          U.S. Web Design System
         </li>
       </ul>
     </div>
@@ -45,9 +45,9 @@
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
           <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
-            <use xlink:href="../../dist/img/sprite.svg#launch"></use>
+            <use xlink:href="../../dist/img/sprite.svg#public"></use>
           </svg>
-          performance.gov
+          Performance.gov
         </li>
       </ul>
     </div>
@@ -60,9 +60,9 @@
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
           <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
-            <use xlink:href="../../dist/img/sprite.svg#launch"></use>
+            <use xlink:href="../../dist/img/sprite.svg#public"></use>
           </svg>
-          performance.gov
+          18F
         </li>
       </ul>
     </div>


### PR DESCRIPTION
[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/dw-collection-outside-link/components/detail/collection--only-headers.html) → 

- Use globe instead of outside-link icon
- Use the name of the source and not its URL
- Use a more diverse range of sources

<img width="613" alt="Screen Shot 2020-12-14 at 3 36 31 PM" src="https://user-images.githubusercontent.com/11464021/102148915-3097d880-3e22-11eb-92d7-dc21cecdb1e6.png">
