### PR TITLE
Add more resilience to decorative SVGs

### DIFF
--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -14,7 +14,7 @@
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{{ banner.text }}</p>
-          <p class="usa-banner__header-action" alt="" aria-hidden="true">{{ banner.action }}</p>
+          <p class="usa-banner__header-action" aria-hidden="true">{{ banner.action }}</p>
         </div>
         <button class="usa-accordion__button usa-banner__button"
           aria-expanded="false" aria-controls="gov-banner">

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -37,7 +37,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" aria-hidden="true">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             <p>
               <strong>

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -14,7 +14,7 @@
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{{ banner.text }}</p>
-          <p class="usa-banner__header-action" aria-hidden="true">{{ banner.action }}</p>
+          <p class="usa-banner__header-action" alt="" aria-hidden="true">{{ banner.action }}</p>
         </div>
         <button class="usa-accordion__button usa-banner__button"
           aria-expanded="false" aria-controls="gov-banner">
@@ -25,7 +25,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" aria-hidden="true">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             <p>
               <strong>

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -1,7 +1,7 @@
 {% set tld_text = "$TLD" %}
 {% set lock_image = "$LOCK_IMG" %}
 {% set lock %}
-<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false"><title id="banner-lock-title">Lock</title><desc id="banner-lock-description">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/></svg></span>
 {% endset %}
 
 

--- a/src/components/banner/banner.njk
+++ b/src/components/banner/banner.njk
@@ -25,7 +25,7 @@
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" alt="">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-dot-gov.svg" role="img" aria-hidden="true">
           <div class="usa-media-block__body">
             <p>
               <strong>
@@ -37,7 +37,7 @@
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" alt="">
+          <img class="usa-banner__icon usa-media-block__img" src="{{ uswds.path }}/img/icon-https.svg" role="img" aria-hidden="true">
           <div class="usa-media-block__body">
             <p>
               <strong>

--- a/src/components/icons/icons--sizes.njk
+++ b/src/components/icons/icons--sizes.njk
@@ -1,14 +1,14 @@
 <div>
   <p class="font-sans-2xl line-height-body-1 text-bold margin-y-0">
   An icon relative to font size
-    <svg class="usa-icon bottom-neg-05" aria-hidden="true" role="img">
+    <svg class="usa-icon bottom-neg-05" aria-hidden="true" focusable="false" role="img">
       <use xlink:href="../../dist/img/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
 
   <p class="">
   An icon relative to font size
-    <svg class="usa-icon bottom-neg-2px" aria-hidden="true" role="img">
+    <svg class="usa-icon bottom-neg-2px" aria-hidden="true" focusable="false" role="img">
       <use xlink:href="../../dist/img/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
@@ -26,7 +26,7 @@
     <tr>
       <th><code>.usa-icon--size-{{item.units}}</code></th>
       <td>
-        <svg class="usa-icon usa-icon--size-{{item.units}}" aria-hidden="true" role="img">
+        <svg class="usa-icon usa-icon--size-{{item.units}}" aria-hidden="true" focusable="false" role="img">
           <use xlink:href="../../dist/img/sprite.svg#accessibility_new"></use>
         </svg>
       </td>

--- a/src/components/icons/icons.config.yml
+++ b/src/components/icons/icons.config.yml
@@ -19,7 +19,7 @@ context:
         pixels: "64px"
       - units: "9"
         pixels: "72px"
-    items: 
+    items:
       - name: accessibility_new
         meta: "accessible"
       - name: accessible_forward
@@ -350,8 +350,10 @@ context:
         meta: "occupancy"
       - name: remove_red_eye
         meta: "visibility"
+      - name: remove
+        meta: "minus collapse"
       - name: report
-        meta: "exlamation danger stop"
+        meta: "exclamation danger stop"
       - name: restaurant
         meta: "dining food"
       - name: rss_feed

--- a/src/components/icons/icons.njk
+++ b/src/components/icons/icons.njk
@@ -7,9 +7,9 @@
 {% for item in icons.items %}
   <div role="region" aria-atomic="true" class="font-sans-xl position-relative icon-example border-1px border-base-lighter hover:text-white hover:bg-primary-vivid hover:border-primary-darker " data-meta="{{ item.name }} {{ item.meta }}" aria-label="{{ item.name }} icon.">
     <button type="button" onclick="copyHTML(this)" class="bg-transparent cursor-pointer text-no-underline text-black display-flex width-card height-card flex-align-center flex-align-center border-0 flex-column flex-justify-center padding-2  hover:text-white" aria-label="Copy to clipboard" style="-webkit-user-select: text; -moz-user-select: text; -ms-user-select: text; user-select: text;">
-      <svg class="usa-icon" aria-hidden="true" role="img">
-        <use xlink:href="{{ uswds.path }}/img/sprite.svg#{{ item.name }}"></use>
-      </svg>
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use xlink:href="{{ uswds.path }}/img/sprite.svg#{{ item.name }}"></use>
+</svg>
       <span class="font-sans-3xs margin-top-2 display-block" aria-hidden="true">{{ item.name }}</span>
     </button>
     <span aria-live="assertive" style="pointer-events:none" class="message-holder bottom-1 position-absolute font-sans-3xs text-bold display-block text-center left-0 width-full" aria-label="{{ item.name }}"></span>
@@ -40,7 +40,7 @@ function copyHTML(el){
   oldCopyNotice = document.getElementById("icon-copy-notice");
 
   if (oldCopyNotice) { oldCopyNotice.remove(); }
-  
+
   message = document.createElement("span");
   message.setAttribute("id", "icon-copy-notice");
   message.setAttribute("aria-live", "assertive");


### PR DESCRIPTION
### **Use the `aria-hidden="true"` property on decorative images (`<img>`) whose source is an SVG.**

Adding `role="img"` fixes a webkit bug that causes images with an SVG source be be announced as a group, not an image. However, adding `role="img"` and `alt=""` result in an object that's selectable by AT but not announced (at least in our testing on VoiceOver and Chrome). Adding `aria-hidden="true"` results in a properly hidden element. 

Adding `aria-hidden="true"` only would be equally effective (it renders `role="img"` moot) but we choose to add all three to be as consistent as possible with `<img>`, even if it is redundant. Thus, each of the following can always be true for `<img>`:
- Use `alt=""` for decorative image
- Use `role="img"` for images with an SVG source
- Use `aria-hidden="true"` for decorative images with an SVG source

### **Add `focusable="false"` to `<svg>` elements meant to be images (ie not text/data).** 

This prevents an IE11 bug that could allow the `Tab` key to navigate into the SVG. 

For decorative SVGs, use `role="img"` and `aria-hidden="true"` as above. Using both allows us the following consistent rules for the `<svg>` element:

- Use `role="img"` and `focusable="false"` for SVGs meant to be images (ie don't contain text/data)
- Use `aria-hidden="true"` for decorative SVGs
- Use `aria-label="[accessible name]"` or `aria-labelledby="[id list]"` for SVGs that convey information and need an accessible description

Source: https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html