### PR TITLE
USWDS - Combobox: Set matching label on ul and label.

### DIFF
--- a/spec/unit/time-picker/time-picker.template.html
+++ b/spec/unit/time-picker/time-picker.template.html
@@ -1,5 +1,6 @@
 <form class="usa-form">
-  <label class="usa-label" for="combobox"
+  <!-- Label `for` attribute must match input ID -->
+  <label class="usa-label" for="appointment-time"
     >Your preferred programming language:
   </label>
   <div class="usa-time-picker">

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -154,7 +154,9 @@ const enhanceComboBox = (_comboBoxEl) => {
   }
 
   const selectId = selectEl.id;
+  const selectLabel = document.querySelector(`label[for="${selectId}"]`);
   const listId = `${selectId}--list`;
+  const listIdLabel = `${selectId}-label`;
   const assistiveHintID = `${selectId}--assistiveHint`;
   const additionalAttributes = [];
   const defaultValue = comboBoxEl.dataset.defaultValue;
@@ -176,6 +178,7 @@ const enhanceComboBox = (_comboBoxEl) => {
     }
   }
 
+  selectLabel.setAttribute("id", listIdLabel);
   selectEl.setAttribute("aria-hidden", "true");
   selectEl.setAttribute("tabindex", "-1");
   selectEl.classList.add("usa-sr-only", SELECT_CLASS);
@@ -218,6 +221,7 @@ const enhanceComboBox = (_comboBoxEl) => {
         id="${listId}"
         class="${LIST_CLASS}"
         role="listbox"
+        aria-labelledby="${listIdLabel}"
         hidden>
       </ul>`,
       `<div class="${STATUS_CLASS} usa-sr-only" role="status"></div>`,

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -154,7 +154,7 @@ const enhanceComboBox = (_comboBoxEl) => {
   }
 
   const selectId = selectEl.id;
-  const selectLabel = document.querySelector(`label[for="${selectId}"]`);
+  const selectLabel = comboBoxEl.previousElementSibling;
   const listId = `${selectId}--list`;
   const listIdLabel = `${selectId}-label`;
   const assistiveHintID = `${selectId}--assistiveHint`;
@@ -176,6 +176,18 @@ const enhanceComboBox = (_comboBoxEl) => {
         break;
       }
     }
+  }
+
+  /**
+   * Throw error if combobox is missing a label or label is missing
+   * `for` attribute. Otherwise, set the ID to match the <ul> aria-labelledby
+   */
+  if (!selectLabel || !selectLabel.matches(`label[for="${selectId}"]`)) {
+    throw new Error(
+      `${COMBO_BOX} for ${selectId} is missing a label or a "for" attribute`
+    );
+  } else {
+    selectLabel.setAttribute("id", listIdLabel);
   }
 
   selectLabel.setAttribute("id", listIdLabel);

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -154,7 +154,8 @@ const enhanceComboBox = (_comboBoxEl) => {
   }
 
   const selectId = selectEl.id;
-  const selectLabel = comboBoxEl.previousElementSibling;
+  const selectParent = comboBoxEl.parentElement;
+  const selectLabel = selectParent.querySelector("label");
   const listId = `${selectId}--list`;
   const listIdLabel = `${selectId}-label`;
   const assistiveHintID = `${selectId}--assistiveHint`;
@@ -184,7 +185,7 @@ const enhanceComboBox = (_comboBoxEl) => {
    */
   if (!selectLabel || !selectLabel.matches(`label[for="${selectId}"]`)) {
     throw new Error(
-      `${COMBO_BOX} for ${selectId} is missing a label or a "for" attribute`
+      `${COMBO_BOX} for ${selectId} is either missing a label or a "for" attribute`
     );
   } else {
     selectLabel.setAttribute("id", listIdLabel);


### PR DESCRIPTION
## Description

Closes #3900. Sets `aria-lablledby` on `ul` and matching id on the combobox label.


## Additional information

If there's no element before combobox (label) and that element's `for` attribute doesn't match the `selectId`, then it will throw an error because either the label is missing or the `for` attribute doesn't match.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
