### PR TITLE
Remove default styling from the usa-collection__calendar-date class a…

### DIFF
--- a/src/stylesheets/components/_collection.scss
+++ b/src/stylesheets/components/_collection.scss
@@ -72,8 +72,6 @@ $collection-thumb-margin: 2;
 }
 
 .usa-collection__calendar-date {
-  @include u-radius("sm");
-  border: 1px solid color("primary");
   text-decoration: none;
 }
 
@@ -91,11 +89,14 @@ $collection-thumb-margin: 2;
 }
 
 .usa-collection__calendar-date-month {
+  @include u-radius-top("sm");
   background-color: color("primary");
   color: color("white");
 }
 
 .usa-collection__calendar-date-day {
+  @include u-radius-bottom("sm");
+  border: 1px solid color("primary");
   color: color("primary");
 }
 


### PR DESCRIPTION
...and add styling to the spans below it

## Description
In the previous version of the fancy date collection, a white, 1px line was present between the background color and border of the month block at certain zoom settings. This update fixes that by removing the border from the month block and allowing the background color to fill to the edge.

Also instead of a single radius setting for the entire block, u-radius-top and u-radius-bottom mixins are now used to add rounded corners to the month and day block separately.

## Additional information
Before this update, a white line is present between the month background color and border:

![image](https://user-images.githubusercontent.com/19338309/103647187-e093c980-4f28-11eb-9e8c-749c23b75bff.png)

After this update, the white line is gone at any zoom level:

![image](https://user-images.githubusercontent.com/19338309/103647228-f2756c80-4f28-11eb-9dc1-2f012486f7bb.png)


## Federalist link
https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/accelerator/collection-improvements/components/detail/collection--fancy-date.html

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
