### PR TITLE
USWDS - Radio + Checkbox: Fix focus outline on FF.

### DIFF
--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -61,6 +61,7 @@
   box-shadow: 0 0 0 units($theme-input-select-border-width) color("base");
   line-height: units($theme-input-select-size);
   margin-right: units($input-select-margin-right);
+  text-indent: 0;
 }
 
 .usa-checkbox__input:checked + .usa-checkbox__label::before,


### PR DESCRIPTION
## Preview
[Radio ➡](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-ff-input-focus/components/detail/radio-buttons--default.html)
[Checkbox ➡](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-ff-input-focus/components/detail/checkboxes--default.html)

## Description

Closes #3916.

## Additional information

Removes text indent from custom checkbox and radio input. This was causing a wider focus outline than intended on Firefox only.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
