### PR TITLE
USWDS - Identifier: Update Performance reports link text.

### DIFF
--- a/src/components/identifier/identifier.config.yml
+++ b/src/components/identifier/identifier.config.yml
@@ -83,8 +83,8 @@ context:
           es: javascript:void(0);
       performance:
         content:
-          en: Performance reports
-          es: Informes de desempeño
+          en: Budget and Performance
+          es: Presupuesto y Desempeño
         url:
           en: javascript:void(0);
           es: javascript:void(0);


### PR DESCRIPTION
## Issue #3869: Update required link text to read Budget and Performance.


## Description

According to #3869, https://digital.gov/resources/required-web-content-and-links/ requires the link text to read `Budget and Performance` rather than `Performance reports`.