### PR TITLE
Search: Prevent flexbox shrink on search component

### DIFF
--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -18,6 +18,7 @@
   // ...or if the component has a separate <div[role="search"]> (<=2.4.0)
   [role="search"] {
     display: flex;
+    flex-shrink: 0;
   }
 
   [type="submit"] {


### PR DESCRIPTION
Resolves an issue where `.usa-search` will shrink itself when flex is assigned on form, and form is a sibling of lengthy navigation in header navigation.

In testing, this doesn't appear to affect all browsers. Notably, this is not currently an issue in Chrome (macOS, 87.0), but is an issue on Safari (Safari 14, iOS 14.2).

Open questions:

- Should shrinkage be allowed at larger viewports? (i.e. scope `flex-shrink` with `at-media` or `at-media-max`)
- Should styles only apply from within context of header navigation (`_navigation.scss`)? This is slightly more cumbersome due to how `display: flex;` is applied on many selectors for backward-compatibility.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/104197495-16d2bc80-53f3-11eb-90c6-8b6c94578691.png)|![after](https://user-images.githubusercontent.com/1779930/104197381-f1de4980-53f2-11eb-8e98-da526dcff10e.png)
