### PR TITLE
Alert: Utilize $theme-alert-icon-size variable for setting the alert icon size

### DIFF
--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -17,7 +17,7 @@ $alert-padding-left: units($theme-alert-padding-x) +
   background-color: color("base-lightest");
   background-position: $alert-padding-left units($theme-alert-padding-x - 1);
   background-repeat: no-repeat;
-  background-size: units(5);
+  background-size: units($theme-alert-icon-size);
   padding-bottom: units(2);
   padding-left: $alert-padding-left;
   padding-right: units($theme-alert-padding-x);

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -25,7 +25,7 @@ $theme-accordion-font-family: "body" !default;
 // Alert
 $theme-alert-bar-width: 1 !default;
 $theme-alert-font-family: "ui" !default;
-$theme-alert-icon-size: 4 !default;
+$theme-alert-icon-size: 5 !default;
 $theme-alert-padding-x: 2.5 !default;
 
 // Banner

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -25,7 +25,7 @@ $theme-accordion-font-family: "body";
 // Alert
 $theme-alert-bar-width: 1;
 $theme-alert-font-family: "ui";
-$theme-alert-icon-size: 4;
+$theme-alert-icon-size: 5;
 $theme-alert-padding-x: 2.5;
 
 // Banner


### PR DESCRIPTION
## Description

- Update Alert component so that its background size is set by the `$theme-alert-icon-size` variable, rather than being hard-coded.

## Additional information

This makes the behavior of the design system match with what is in the documentation:

![image](https://user-images.githubusercontent.com/371943/104385353-19bbd300-5501-11eb-9371-cd5fd1d1a60b.png)

The Alert background size was increased in https://github.com/uswds/uswds/commit/92c7be5bc54fabedbc23bddf70aeeede6f0bee65 which causes issues for projects that have themed the design system and are utilizing their own icon files.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
