### PR TITLE
found a hotfix for babel transpiler issue with svg4everybody, this is…

### DIFF
--- a/src/js/polyfills/svg4everybody.js
+++ b/src/js/polyfills/svg4everybody.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 !function(root, factory) {
+  if(root === undefined) root = window; //*  THIS IS A HOTFIX FOR BABEL TRANSPILERS ADDING USING STRICT MODE CAUSING ROOT TO BE UNDEFINED. 
   "function" == typeof define && define.amd ? // AMD. Register as an anonymous module unless amdModuleId is set
   define([], function() {
       return root.svg4everybody = factory();


### PR DESCRIPTION
Babel compilers that add 'strict-mode' to all files will have issues transpiling this, unless users add special loaders. root object will become undefined using the polyfill. This hotfix set's the root object = window if it comes in undefined. This will work for those who are using default create-react-app webpacks and unable to eject them to add special loader logic.

- [x ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
