### PR TITLE
USWDS - Side navigation: Fix incorrect padding-left applied to anchors in usa-sidenav__sublist

### DIFF
--- a/src/stylesheets/core/mixins/_nav-list.scss
+++ b/src/stylesheets/core/mixins/_nav-list.scss
@@ -78,17 +78,17 @@ $sidenav-level-4-inset: 8;
   }
 
   // level 2+
-  a {
+  a:not(.usa-button) {
     padding-left: units($sidenav-level-2-inset);
   }
 
   // level 3+
-  & & a {
+  & & a:not(.usa-button) {
     padding-left: units($sidenav-level-3-inset);
   }
 
   // level 4+
-  & & & a {
+  & & & a:not(.usa-button) {
     content: "foobar";
     padding-left: units($sidenav-level-4-inset);
   }


### PR DESCRIPTION
Issue uswds#3944

Addresses  https://github.com/uswds/uswds/issues/3944

## Description

When using a standard anchor tag, incorrect padding-left is applied for sublists.
