### PR TITLE
USWDS - Card: Fix Card flag layout responsiveness

### DIFF
--- a/src/components/card/card--compare.njk
+++ b/src/components/card/card--compare.njk
@@ -91,7 +91,7 @@
 
 <h6 class="padding-bottom-2">Flag Layout</h6>
 <ul class="usa-card-group">
-  <li class="tablet:grid-col-6 usa-card usa-card--flag">
+  <li class="desktop:grid-col-6 usa-card usa-card--flag">
     <div class="usa-card__container">
       <header class="usa-card__header">
         <h2 class="usa-card__heading">Flag default</h2>
@@ -110,7 +110,7 @@
       </div>
     </div>
   </li>
-  <li class="tablet:grid-col-6 usa-card usa-card--flag usa-card--media-right">
+  <li class="desktop:grid-col-6 usa-card usa-card--flag usa-card--media-right">
     <div class="usa-card__container">
       <header class="usa-card__header">
         <h2 class="usa-card__heading">Flag media on right</h2>

--- a/src/components/card/card--test.njk
+++ b/src/components/card/card--test.njk
@@ -45,7 +45,7 @@
         </div>
       </div>
     </li>
-    <li class="usa-card usa-card--flag usa-card--header-first tablet:grid-col-12">
+    <li class="usa-card usa-card--flag usa-card--header-first desktop:grid-col-6">
       <div class="usa-card__container">
         <div class="usa-card__header">
           <h3 class="usa-card__heading">I hereunto append the result</h3>
@@ -65,7 +65,7 @@
         </div>
       </div>
     </li>
-    <li class="usa-card usa-card--media-right usa-card--flag tablet:grid-col-12">
+    <li class="usa-card usa-card--media-right usa-card--flag desktop:grid-col-6">
       <div class="usa-card__container border-primary-vivid">
         <div class="usa-card__header">
           <h3 class="usa-card__heading">My friend's friend</h3>

--- a/src/components/card/card.config.yml
+++ b/src/components/card/card.config.yml
@@ -133,14 +133,14 @@ variants:
     context:
       cards:
         - title: Default flag
-          classes: "usa-card--flag tablet:grid-col-6"
+          classes: "usa-card--flag desktop:grid-col-6"
           media: true
           media_classes: ""
           image_classes: ""
           content:
             - Lorem ipsum dolor sit amet consectetur adipisicing elit.
         - title: Flag media right inset
-          classes: "usa-card--flag usa-card--media-right tablet:grid-col-6"
+          classes: "usa-card--flag usa-card--media-right desktop:grid-col-6"
           media: true
           media_classes: "usa-card__media--inset"
           image_classes: ""


### PR DESCRIPTION

Addresses #3826 

##Description
Card component - Card Group sizing/responsiveness bug#3870 

The issue happens with the card flag layout variation.
For desktop, should be 2 cards per row, but for tablet and mobile it should fall in 1 card per row.
Samples have changed to reflect that.
