### PR TITLE
USWDS - Header: Fix header secondary links positioning on Safari.

### DIFF
--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -37,8 +37,8 @@ $z-index-overlay: 400;
     @include at-media($theme-header-min-width) {
       float: right;
       max-width: calc(
-        #{$theme-search-min-width} + #{units($theme-button-small-width)}
-      );
+        #{$theme-search-min-width + 1} + #{units($theme-button-small-width)}
+      ); // + 1 fixes Safari quirk.
       width: 100%;
     }
   }


### PR DESCRIPTION
Addresses #3805 

## Description

Fixes secondary link examples mis-positioned on Safari.
