### PR TITLE
Align secondary nav and search with flex to prevent a Safari display bug

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -197,8 +197,9 @@ $nav-link-arrow-icon-size: 1;
   margin-top: units(2);
 
   @include at-media($theme-header-min-width) {
-    // Note: Previius calc() couldn't work. don't hardcode rem vals
+    @include u-flex("column", "align-end");
     bottom: units(8); // XXX magic number
+    display: flex;
     font-size: font-size($theme-navigation-font-family, "2xs");
     margin-top: units(1);
     min-width: calc(


### PR DESCRIPTION
[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/dw-secondary-nav-safari/components/preview/header--extended.html) → 

This builds on the work done in https://github.com/uswds/uswds/pull/3960 to fix a display bug. The flex display will assure that the elements always appear in the proper relationship.

Before:
<img width="1024" alt="Screen Shot 2021-01-26 at 2 21 57 PM" src="https://user-images.githubusercontent.com/11464021/105913714-171dab00-5fe2-11eb-9765-1e874791078e.png">

After:
<img width="1002" alt="Screen Shot 2021-01-26 at 2 22 06 PM" src="https://user-images.githubusercontent.com/11464021/105913736-1dac2280-5fe2-11eb-9680-5c77c07a145d.png">
