### PR TITLE
[internal] USWDS - Footer: Change the markup tag for logo-heading from an h3 to a p.

### DIFF
--- a/src/components/footer/footer--big.njk
+++ b/src/components/footer/footer--big.njk
@@ -76,7 +76,7 @@
             <img class="usa-footer__logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
           </div>
           <div class="mobile-lg:grid-col-auto">
-            <h3 class="usa-footer__logo-heading">Name of Agency</h3>
+            <p class="usa-footer__logo-heading">Name of Agency</p>
           </div>
         </div>
         <div class="usa-footer__contact-links mobile-lg:grid-col-6">

--- a/src/components/footer/footer--slim.njk
+++ b/src/components/footer/footer--slim.njk
@@ -47,7 +47,7 @@
           <img class="usa-footer__logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
         </div>
         <div class="grid-col-auto">
-          <h3 class="usa-footer__logo-heading">Name of Agency</h3>
+          <p class="usa-footer__logo-heading">Name of Agency</p>
         </div>
       </div>
     </div>

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -32,7 +32,7 @@
             <img class="usa-footer__logo-img" src="{{ uswds.path }}/img/logo-img.png" alt="">
           </div>
           <div class="mobile-lg:grid-col-auto">
-            <h3 class="usa-footer__logo-heading">Name of Agency</h3>
+            <p class="usa-footer__logo-heading">Name of Agency</p>
           </div>
         </div>
         <div class="usa-footer__contact-links mobile-lg:grid-col-6">

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -162,6 +162,7 @@
 
 .usa-footer__logo-heading {
   @include typeset($theme-footer-font-family, $theme-h3-font-size, 1);
+  @include u-font-weight("bold");
   @include u-margin-y(1);
 }
 


### PR DESCRIPTION
Internal version of https://github.com/uswds/uswds/pull/3923

- - -

## Adjust markup in footer for logo header: Issue #3904 points out that this markup should not be an `<h3>`.

## Description

As mentioned in #3904, the heading element for `.usa-footer__logo-heading` contains no siblings and effectively creates an empty section. While I wasn't able to find any documentation in the HTML spec saying this was specifically not allowed, it still seems like a good practice to swap to a `<p>` tag.

## Additional Information

This change likely needs some input about whether the class name should be changed since it is no longer a heading.