### PR TITLE
USWDS - Combobox: Use more specific JS selector.

### DIFF
--- a/src/components/templates/address-form.njk
+++ b/src/components/templates/address-form.njk
@@ -7,7 +7,7 @@
     <label class="usa-label" for="mailing-address-1">
       Street address <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
-    <input class="usa-input" id="mailing-address-1" name="mailing-address-1" type="text">
+    <input class="usa-input" id="mailing-address-1" name="mailing-address-1" type="text" required>
 
     <div class="grid-row grid-gap">
       <div class="mobile-lg:grid-col-8">
@@ -51,11 +51,11 @@
     </div>
 
     <label class="usa-label" for="city">City <abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
-    <input class="usa-input" id="city" name="city" type="text">
+    <input class="usa-input" id="city" name="city" type="text" required>
 
     <label class="usa-label" for="state">State <abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
     <div class="usa-combo-box">
-      <select class="usa-select" id="state" name="state">
+      <select class="usa-select" id="state" name="state" required>
         <option value>- Select -</option>
         <option value="AL">AL - Alabama</option>
         <option value="AK">AK - Alaska</option>
@@ -124,6 +124,6 @@
     </div>
 
     <label class="usa-label" for="zip">ZIP code <abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
-    <input class="usa-input usa-input--medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?">
+    <input class="usa-input usa-input--medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" required>
   </fieldset>
 </form>

--- a/src/components/templates/address-form.njk
+++ b/src/components/templates/address-form.njk
@@ -14,33 +14,33 @@
         <label class="usa-label" for="apt-suite-other">Unit type</label>
         <div class="usa-combo-box">
           <select class="usa-select" id="apt-suite-other" name="apt-suite-other">
-              <option value>- Select -</option>
-              <option value="APT">APT - Apartment</option>
-              <option value="BSMT">BSMT - Basement</option>
-              <option value="BLDG">BLDG - Building</option>
-              <option value="DEPT">DEPT - Department</option>
-              <option value="FL">FL - Floor</option>
-              <option value="FRNT">FRNT - Front</option>
-              <option value="HNGR">HNGR - Hanger</option>
-              <option value="KEY">KEY - Key</option>
-              <option value="LBBY">LBBY - Lobby</option>
-              <option value="LOT">LOT - Lot</option>
-              <option value="LOWR">LOWR - Lower</option>
-              <option value="OFC">OFC - Office</option>
-              <option value="OTHER">Other</option>
-              <option value="PH">PH - Penthouse</option>
-              <option value="PIER">PIER - Pier</option>
-              <option value="REAR">REAR - Rear</option>
-              <option value="RM">RM - Room</option>
-              <option value="SIDE">SIDE - Side</option>
-              <option value="SLIP">SLIP - Slip</option>
-              <option value="SPC">SPC - Space</option>
-              <option value="STOP">STOP - Stop</option>
-              <option value="STE">STE - Suite</option>
-              <option value="TRLR">TRLR - Trailer</option>
-              <option value="UNAVAILABLE">Unable to determine</option>
-              <option value="UNIT">UNIT - Unit</option>
-              <option value="UPPR">UPPR - Upper</option>
+            <option value>- Select -</option>
+            <option value="APT">APT - Apartment</option>
+            <option value="BSMT">BSMT - Basement</option>
+            <option value="BLDG">BLDG - Building</option>
+            <option value="DEPT">DEPT - Department</option>
+            <option value="FL">FL - Floor</option>
+            <option value="FRNT">FRNT - Front</option>
+            <option value="HNGR">HNGR - Hanger</option>
+            <option value="KEY">KEY - Key</option>
+            <option value="LBBY">LBBY - Lobby</option>
+            <option value="LOT">LOT - Lot</option>
+            <option value="LOWR">LOWR - Lower</option>
+            <option value="OFC">OFC - Office</option>
+            <option value="OTHER">Other</option>
+            <option value="PH">PH - Penthouse</option>
+            <option value="PIER">PIER - Pier</option>
+            <option value="REAR">REAR - Rear</option>
+            <option value="RM">RM - Room</option>
+            <option value="SIDE">SIDE - Side</option>
+            <option value="SLIP">SLIP - Slip</option>
+            <option value="SPC">SPC - Space</option>
+            <option value="STOP">STOP - Stop</option>
+            <option value="STE">STE - Suite</option>
+            <option value="TRLR">TRLR - Trailer</option>
+            <option value="UNAVAILABLE">Unable to determine</option>
+            <option value="UNIT">UNIT - Unit</option>
+            <option value="UPPR">UPPR - Upper</option>
           </select>
         </div>
       </div>

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -154,8 +154,7 @@ const enhanceComboBox = (_comboBoxEl) => {
   }
 
   const selectId = selectEl.id;
-  const selectParent = comboBoxEl.parentElement;
-  const selectLabel = selectParent.querySelector("label");
+  const selectLabel = document.querySelector(`label[for="${selectId}"]`);
   const listId = `${selectId}--list`;
   const listIdLabel = `${selectId}-label`;
   const assistiveHintID = `${selectId}--assistiveHint`;


### PR DESCRIPTION
## Description

Closes #3989. Previous work done for #3900 had a selector which found the combo label based on it's parent. This skips that step and selects the label directly based on the `selectId`.

## Additional information
This also adds `required` to some Address form inputs.

Test following templates:
- [Address form template](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-patch-combobox/components/preview/address-form.html)
- [Timepicker](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-patch-combobox/components/preview/time-picker.html)
- [Combobox](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-patch-combobox/components/detail/combo-box--default.html)

Combobox default and test have label `for` values, but the others in that folder don't. Should we add them?

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
