### PR TITLE
Icon list modifications

### DIFF
--- a/src/components/icon-list/icon-list.config.yml
+++ b/src/components/icon-list/icon-list.config.yml
@@ -22,32 +22,31 @@ variants:
   - name: rich
     label: Rich content
     context:
-      iconSize: sm
       items:
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Donate cash when possible.</h3>
-            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+            <h3 class="usa-icon-list__title">Donate cash when possible.</h3>
+            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Confirm what donations are needed.</h3>
-            <p class="margin-top-1">Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
+            <h3 class="usa-icon-list__title">Confirm what donations are needed.</h3>
+            <p>Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
 
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Talk to trusted organizations about volunteering.</h3>
-            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
-  - name: large-icon
+            <h3 class="usa-icon-list__title">Talk to trusted organizations about volunteering.</h3>
+            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+  - name: custom-size
     label: Custom size
     context:
       iconSize: lg
@@ -67,7 +66,7 @@ variants:
             color: ink
             utilities:
           content: Talk to trusted organizations about volunteering.
-  - name: rich-large
+  - name: custom-size-rich
     label: Custom size with rich content
     context:
       iconSize: lg
@@ -77,21 +76,21 @@ variants:
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Donate cash when possible.</h3>
-            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+            <h3 class="usa-icon-list__title">Donate cash when possible.</h3>
+            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Confirm what donations are needed.</h3>
-            <p class="margin-top-1">Unsolicited goods NOT needed burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
+            <h3 class="usa-icon-list__title">Confirm what donations are needed.</h3>
+            <p>Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
 
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Talk to trusted organizations about volunteering.</h3>
-            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+            <h3 class="usa-icon-list__title">Talk to trusted organizations about volunteering.</h3>
+            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>

--- a/src/components/icon-list/icon-list.config.yml
+++ b/src/components/icon-list/icon-list.config.yml
@@ -22,13 +22,14 @@ variants:
   - name: rich
     label: Rich content
     context:
+      iconSize: sm
       items:
         - icon:
             name: check_circle
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0 line-height-sans-3">Donate cash when possible.</h2>
+            <h3 class="margin-0">Donate cash when possible.</h3>
             <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
         - icon:
@@ -36,7 +37,7 @@ variants:
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0 line-height-sans-3">Confirm what donations are needed.</h3>
+            <h3 class="margin-0">Confirm what donations are needed.</h3>
             <p class="margin-top-1">Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
 
         - icon:
@@ -44,7 +45,7 @@ variants:
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0 line-height-sans-3">Talk to trusted organizations about volunteering.</h3>
+            <h3 class="margin-0">Talk to trusted organizations about volunteering.</h3>
             <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
   - name: large-icon
     label: Custom size
@@ -76,7 +77,7 @@ variants:
             color: ink
             utilities:
           content: |
-            <h3 class="margin-0">Donate cash when possible.</h2>
+            <h3 class="margin-0">Donate cash when possible.</h3>
             <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
         - icon:

--- a/src/components/icon-list/icon-list.config.yml
+++ b/src/components/icon-list/icon-list.config.yml
@@ -15,7 +15,7 @@ context:
       content: Confirm what donations are needed.
     - icon:
         name: cancel
-        color: secondary
+        color: red
       content: Don't just show up to a disaster area.
 
 variants:
@@ -52,18 +52,18 @@ variants:
       iconSize: lg
       items:
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: Donate cash when possible.
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: Confirm what donations are needed.
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: Talk to trusted organizations about volunteering.
   - name: custom-size-rich
@@ -72,24 +72,24 @@ variants:
       iconSize: lg
       items:
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: |
             <h3 class="usa-icon-list__title">Donate cash when possible.</h3>
             <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: |
             <h3 class="usa-icon-list__title">Confirm what donations are needed.</h3>
             <p>Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
 
         - icon:
-            name: check_circle
-            color: ink
+            name: check
+            color: green
             utilities:
           content: |
             <h3 class="usa-icon-list__title">Talk to trusted organizations about volunteering.</h3>

--- a/src/components/icon-list/icon-list.config.yml
+++ b/src/components/icon-list/icon-list.config.yml
@@ -19,6 +19,26 @@ context:
       content: Don't just show up to a disaster area.
 
 variants:
+  - name: simple
+    label: Simple content
+    context:
+      items:
+        - icon:
+            name: check
+            color: green
+            utilities:
+          content: <span class="text-bold">Use cash.</span> Donate cash when possible.
+        - icon:
+            name: check
+            color: green
+            utilities:
+          content: <span class="text-bold">Check first.</span> Confirm what donations are needed.
+        - icon:
+            name: check
+            color: green
+            utilities:
+          content: <span class="text-bold">Volunteer.</span> Talk to trusted organizations about volunteering.
+
   - name: rich
     label: Rich content
     context:
@@ -55,17 +75,17 @@ variants:
             name: check
             color: green
             utilities:
-          content: Donate cash when possible.
+          content: <span class="text-bold">Use cash.</span> Donate cash when possible.
         - icon:
             name: check
             color: green
             utilities:
-          content: Confirm what donations are needed.
+          content: <span class="text-bold">Check first.</span> Confirm what donations are needed.
         - icon:
             name: check
             color: green
             utilities:
-          content: Talk to trusted organizations about volunteering.
+          content: <span class="text-bold">Volunteer.</span> Talk to trusted organizations about volunteering.
   - name: custom-size-rich
     label: Custom size with rich content
     context:

--- a/src/components/icon-list/icon-list.config.yml
+++ b/src/components/icon-list/icon-list.config.yml
@@ -19,91 +19,78 @@ context:
       content: Don't just show up to a disaster area.
 
 variants:
-  - name: large-icon
-    label: Large icon
+  - name: rich
+    label: Rich content
     context:
-      iconSize: lg
       items:
         - icon:
-            name: attach_money
-            color: primary
-            utilities: bottom-0
+            name: check_circle
+            color: ink
+            utilities:
           content: |
-            <p class="usa-icon-list__title">Donate cash when possible.</p>
-        - icon:
-            name: mail
-            color: primary
-            utilities: bottom-0
-          content: |
-            <p class="usa-icon-list__title">Confirm what donations are needed.</p>
-        - icon:
-            name: chat
-            color: primary
-            utilities: bottom-0
-          content: |
-            <p class="usa-icon-list__title">Talk to trusted organizations about volunteering.</p>
-  - name: complex-list
-    label: Default with title and description
-    context:
-      iconSize: sm
-      items:
-        - icon:
-            name: attach_money
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Donate cash when possible.</h2>
-            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
-        - icon:
-            name: mail
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Confirm what donations are needed.</h2>
-            <p>Unsolicited goods NOT needed burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
-            <p>Critical needs change rapidly. Confirm with trusted organizations what items are needed BEFORE collecting. Remember to:</p>
-            <ul>
-              <li>Pack and label carefully</li>
-              <li>Confirm delivery locations</li>
-              <li>Arrange transportation</li>
-            </ul>
-        - icon:
-            name: chat
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Talk to trusted organizations about volunteering.</h2>
-            <p>Don’t self-deploy to disaster areas. Trusted organizations operating in the affected area know where volunteers are needed and can ensure appropriate volunteer safety, training and housing.</p>
-  - name: complex-list2
-    label: Large with title and description
-    context:
-      iconSize: lg
-      items:
-        - icon:
-            name: attach_money
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Donate cash when possible.</h2>
-            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
-        - icon:
-            name: mail
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Confirm what donations are needed.</h2>
-            <p>Unsolicited goods NOT needed burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
-            <p>Critical needs change rapidly. Confirm with trusted organizations what items are needed BEFORE collecting. Remember to:</p>
-            <ul>
-              <li>Pack and label carefully</li>
-              <li>Confirm delivery locations</li>
-              <li>Arrange transportation</li>
-            </ul>
-        - icon:
-            name: chat
-            color: primary
-            utilities: bottom-0
-          content: |
-            <h2 class="usa-icon-list__title">Talk to trusted organizations about volunteering.</h2>
-            <p>Don’t self-deploy to disaster areas. Trusted organizations operating in the affected area know where volunteers are needed and can ensure appropriate volunteer safety, training and housing.</p>
+            <h3 class="margin-0 line-height-sans-3">Donate cash when possible.</h2>
+            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
 
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: |
+            <h3 class="margin-0 line-height-sans-3">Confirm what donations are needed.</h3>
+            <p class="margin-top-1">Unneeded and unsolicited goods burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
+
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: |
+            <h3 class="margin-0 line-height-sans-3">Talk to trusted organizations about volunteering.</h3>
+            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+  - name: large-icon
+    label: Custom size
+    context:
+      iconSize: lg
+      items:
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: Donate cash when possible.
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: Confirm what donations are needed.
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: Talk to trusted organizations about volunteering.
+  - name: rich-large
+    label: Custom size with rich content
+    context:
+      iconSize: lg
+      items:
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: |
+            <h3 class="margin-0">Donate cash when possible.</h2>
+            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
+
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: |
+            <h3 class="margin-0">Confirm what donations are needed.</h3>
+            <p class="margin-top-1">Unsolicited goods NOT needed burden local organizations’ ability to meet survivors’ confirmed needs, drawing away valuable volunteer labor, transportation and warehouse space.</p>
+
+        - icon:
+            name: check_circle
+            color: ink
+            utilities:
+          content: |
+            <h3 class="margin-0">Talk to trusted organizations about volunteering.</h3>
+            <p class="margin-top-1">Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -5,7 +5,7 @@ $icon-list-icon-size-factor: 1.75;
 // Center the icon to the title text, works for all size variants
 $icon-list-icon-margin-top: -8%;
 // Fine tune the space between the icon and content with this factor
-$icon-list-icon-padding-left-factor: 0.6;
+$icon-list-icon-padding-left-factor: 0.5;
 // Fine tune the title top padding given a line height of 2
 $icon-list-title-padding-top: 0.2em;
 
@@ -19,83 +19,13 @@ $icon-list-font-sizes: (
   "3xl" $theme-type-scale-3xl
 );
 
+$type-scale: font-size($theme-icon-list-font-family, $theme-body-font-size);
+
 @include override-prose {
   .usa-icon-list {
     @include typeset($theme-icon-list-font-family);
     @include unstyled-list;
     @include u-measure(5);
-
-    @each $color, $grades in $all-project-colors {
-      @each $grade, $value in $grades {
-        @if $value {
-          $prefix: if($grade != "default", #{$color}-#{$grade}, #{$color});
-          &--#{$prefix} {
-            .usa-icon-list__icon {
-              color: color($prefix);
-            }
-          }
-        }
-      }
-    }
-  }
-  // Generate responsive variants
-  // Create a map for looping that includes a default or no-breakpoint version
-  $this-null: (
-    "none": null,
-  );
-  $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
-  @each $mq-key, $mq-value in $icon-list-breakpoints {
-    @each $token, $val in $icon-list-font-sizes {
-      // Set the prefix
-      // An empty string if "none"
-      $prefix: false;
-      @if $mq-key == "none" {
-        $prefix: "";
-      }
-      // Or the standard prefix if the break[pint is output
-      @else if map-get($theme-utility-breakpoints, $mq-key) {
-        $prefix: "#{$mq-key}\\:";
-      }
-      @if $prefix {
-        $type-scale: font-size($theme-icon-list-font-family, $token);
-        @include at-media($mq-key) {
-          .#{$prefix}usa-icon-list--size-#{$token} {
-            .usa-icon-list__icon {
-              .usa-icon {
-                // Set the height and width of the icon based on the size variant and factor
-                height: $type-scale * $icon-list-icon-size-factor;
-                margin-top: $icon-list-icon-margin-top;
-                width: $type-scale * $icon-list-icon-size-factor;
-              }
-            }
-
-            .usa-icon-list__content {
-              // Calculate the space between the icon and content based on the size variant and factor
-              padding-left: $type-scale * $icon-list-icon-padding-left-factor;
-              // Resize simple (un-marked up) content
-              font-size: size($theme-icon-list-font-family, $token);
-
-              // But don't resize any element inside content
-              p,
-              h1,
-              h2,
-              h3,
-              h4,
-              h5,
-              h6,
-              ul,
-              ol {
-                font-size: initial;
-              }
-
-              .usa-icon-list__title {
-                font-size: size($theme-icon-list-font-family, $token);
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   .usa-icon-list__item {
@@ -107,41 +37,108 @@ $icon-list-font-sizes: (
       padding-top: units(1.5);
     }
   }
+}
 
-  $type-scale: font-size($theme-icon-list-font-family, $theme-body-font-size);
-  .usa-icon-list__icon {
-    .usa-icon {
-      // Set the height and width of the icon based on the size variant and factor
-      display: block;
-      height: $type-scale * $icon-list-icon-size-factor;
-      margin-top: $icon-list-icon-margin-top;
-      position: relative;
-      width: $type-scale * $icon-list-icon-size-factor;
+// Allow setting icon color on the icon-list element
+.usa-icon-list {
+  @each $color, $grades in $all-project-colors {
+    @each $grade, $value in $grades {
+      @if $value {
+        $prefix: if($grade != "default", #{$color}-#{$grade}, #{$color});
+        &--#{$prefix} {
+          .usa-icon-list__icon {
+            color: color($prefix);
+          }
+        }
+      }
     }
   }
+}
 
-  .usa-icon-list__content {
-    padding-left: $type-scale * $icon-list-icon-padding-left-factor;
-    font-size: $type-scale;
-    > *:first-child {
-      margin-top: 0;
-    }
-    > *:last-child {
-      margin-bottom: 0;
-    }
+.usa-icon-list__icon {
+  .usa-icon {
+    // Set the height and width of the icon based on the size variant and factor
+    display: block;
+    height: $type-scale * $icon-list-icon-size-factor;
+    margin-top: $icon-list-icon-margin-top;
+    position: relative;
+    width: $type-scale * $icon-list-icon-size-factor;
+  }
+}
 
-    ul li {
-      list-style-type: disc;
+// Generate responsive variants
+// Create a map for looping that includes a default or no-breakpoint version
+$this-null: (
+  "none": null,
+);
+$icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
+@each $mq-key, $mq-value in $icon-list-breakpoints {
+  @each $token, $val in $icon-list-font-sizes {
+    // Set the prefix
+    // An empty string if "none"
+    $prefix: false;
+    @if $mq-key == "none" {
+      $prefix: "";
+    }
+    // Or the standard prefix if the break[pint is output
+    @else if map-get($theme-utility-breakpoints, $mq-key) {
+      $prefix: "#{$mq-key}\\:";
+    }
+    @if $prefix {
+      $this-type-scale: font-size($theme-icon-list-font-family, $token);
+      @include at-media($mq-key) {
+        .#{$prefix}usa-icon-list--size-#{$token} {
+          .usa-icon-list__icon {
+            .usa-icon {
+              // Set the height and width of the icon based on the size variant and factor
+              height: $this-type-scale * $icon-list-icon-size-factor;
+              margin-top: $icon-list-icon-margin-top;
+              width: $this-type-scale * $icon-list-icon-size-factor;
+            }
+          }
+
+          .usa-icon-list__content {
+            // Calculate the space between the icon and content based on the size variant and factor
+            padding-left: $this-type-scale * $icon-list-icon-padding-left-factor;
+            // Resize simple (un-marked up) content
+            font-size: size($theme-icon-list-font-family, $token);
+
+            // But don't resize any element inside content
+            > * {
+              font-size: initial;
+            }
+
+            .usa-icon-list__title {
+              font-size: size($theme-icon-list-font-family, $token);
+            }
+          }
+        }
+      }
     }
   }
+}
 
-  .usa-icon-list__title {
-    font-size: size($theme-icon-list-font-family, $theme-body-font-size);
-    line-height: lh($theme-icon-list-font-family, $theme-heading-line-height);
-    margin-bottom: units(0);
-    padding-top: $icon-list-title-padding-top;
-    & + * {
-      margin-top: units(1);
-    }
+.usa-icon-list__title {
+  font-size: size($theme-icon-list-font-family, $theme-body-font-size);
+  line-height: lh($theme-icon-list-font-family, $theme-heading-line-height);
+  margin-bottom: units(0);
+  padding-top: $icon-list-title-padding-top;
+  & + * {
+    margin-top: units(1);
+  }
+}
+
+.usa-icon-list__content {
+  padding-left: $type-scale * $icon-list-icon-padding-left-factor;
+  font-size: $type-scale;
+  > *:first-child {
+    margin-top: 0;
+  }
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  ul li {
+    list-style-type: disc;
   }
 }

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -104,7 +104,15 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
             font-size: size($theme-icon-list-font-family, $token);
 
             // But don't resize any element inside content
-            > * {
+            > p,
+            > h2,
+            > h3,
+            > h4,
+            > h5,
+            > h6,
+            > ul,
+            > ol,
+            > div {
               font-size: initial;
             }
 

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -103,7 +103,7 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
             // Resize simple (un-marked up) content
             font-size: size($theme-icon-list-font-family, $token);
 
-            // But don't resize any element inside content
+            // But don't resize any block-level element inside content
             > p,
             > h2,
             > h3,

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -39,6 +39,10 @@ $icon-list-font-sizes: (
     // Set default title font size if no size variant class is present
     .usa-icon-list__title {
       font-size: size($theme-icon-list-font-family, "lg");
+      margin-bottom: units(0);
+      & + * {
+        margin-top: units(1);
+      }
     }
   }
 

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -40,27 +40,50 @@ $icon-list-font-sizes: (
     .usa-icon-list__title {
       font-size: size($theme-icon-list-font-family, "lg");
     }
+  }
 
+  // Generate responsive variants
+  // Create a map for looping that includes a default or no-breakpoint version
+  $this-null: (
+    "none": null,
+  );
+  $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
+  @each $mq-key, $mq-value in $icon-list-breakpoints {
     @each $token, $val in $icon-list-font-sizes {
-      &--size-#{$token} {
-        .usa-icon-list__icon {
-          .usa-icon {
-            // Set the height and width of the icon based on the size variant and factor
-            height: system-type-scale($val) * $icon-list-icon-size-factor;
-            margin-top: $icon-list-icon-margin-top;
-            width: system-type-scale($val) * $icon-list-icon-size-factor;
+      // Set the prefix
+      // An empty string if "none"
+      $prefix: false;
+      @if $mq-key == "none" {
+        $prefix: "";
+      }
+      // Or the standard prefix if the break[pint is output
+      @else if map-get($theme-utility-breakpoints, $mq-key) {
+        $prefix: "#{$mq-key}\\:";
+      }
+      @if $prefix {
+        @include at-media($mq-key) {
+          .#{$prefix}usa-icon-list--size-#{$token} {
+            .usa-icon-list__icon {
+              .usa-icon {
+                // Set the height and width of the icon based on the size variant and factor
+                height: system-type-scale($val) * $icon-list-icon-size-factor;
+                margin-top: $icon-list-icon-margin-top;
+                width: system-type-scale($val) * $icon-list-icon-size-factor;
+              }
+            }
+            .usa-icon-list__content {
+              // Calculate the space between the icon and content based on the size variant and factor
+              padding-left: system-type-scale($val) *
+                $icon-list-icon-padding-left-factor;
+
+              // Resize the content unless a manual class is set
+              &:not(.usa-icon-list__content--manual),
+              &:not(.usa-icon-list__content--manual) * {
+                font-size: size($theme-icon-list-font-family, $token);
+                margin-bottom: 0;
+              }
+            }
           }
-        }
-        .usa-icon-list__title {
-          font-size: size($theme-icon-list-font-family, $token);
-          margin-bottom: 0;
-          & + p {
-            margin-top: units(0.5);
-          }
-        }
-        .usa-icon-list__content {
-          // Calculate the space between the icon and content based on the size variant and factor
-          padding-left: system-type-scale($val) * $icon-list-icon-padding-left-factor;
         }
       }
     }
@@ -89,6 +112,9 @@ $icon-list-font-sizes: (
     padding-left: 0.5rem;
     > *:first-child {
       margin-top: 0;
+    }
+    > *:last-child {
+      margin-bottom: 0;
     }
 
     ul li {

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -6,6 +6,8 @@ $icon-list-icon-size-factor: 1.75;
 $icon-list-icon-margin-top: -8%;
 // Fine tune the space between the icon and content with this factor
 $icon-list-icon-padding-left-factor: 0.6;
+// Fine tune the title top padding given a line height of 2
+$icon-list-title-padding-top: 0.2em;
 
 $icon-list-font-sizes: (
   "xs" $theme-type-scale-xs,
@@ -70,9 +72,10 @@ $icon-list-font-sizes: (
             .usa-icon-list__content {
               // Calculate the space between the icon and content based on the size variant and factor
               padding-left: $type-scale * $icon-list-icon-padding-left-factor;
+              // Resize simple (un-marked up) content
               font-size: size($theme-icon-list-font-family, $token);
 
-              // Resize the content unless a manual class is set
+              // But don't resize any element inside content
               p,
               h1,
               h2,
@@ -108,8 +111,8 @@ $icon-list-font-sizes: (
   $type-scale: font-size($theme-icon-list-font-family, $theme-body-font-size);
   .usa-icon-list__icon {
     .usa-icon {
-      display: block;
       // Set the height and width of the icon based on the size variant and factor
+      display: block;
       height: $type-scale * $icon-list-icon-size-factor;
       margin-top: $icon-list-icon-margin-top;
       position: relative;
@@ -136,7 +139,7 @@ $icon-list-font-sizes: (
     font-size: size($theme-icon-list-font-family, $theme-body-font-size);
     line-height: lh($theme-icon-list-font-family, $theme-heading-line-height);
     margin-bottom: units(0);
-    padding-top: 0.25em;
+    padding-top: $icon-list-title-padding-top;
     & + * {
       margin-top: units(1);
     }

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -29,8 +29,8 @@ $type-scale: font-size($theme-icon-list-font-family, $theme-body-font-size);
   }
 
   .usa-icon-list__item {
-    font-size: size($theme-icon-list-font-family, $theme-icon-list-font-size);
     display: flex;
+    font-size: size($theme-icon-list-font-family, $theme-icon-list-font-size);
     position: relative;
 
     & + .usa-icon-list__item {
@@ -98,10 +98,10 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
           }
 
           .usa-icon-list__content {
-            // Calculate the space between the icon and content based on the size variant and factor
-            padding-left: $this-type-scale * $icon-list-icon-padding-left-factor;
             // Resize simple (un-marked up) content
             font-size: size($theme-icon-list-font-family, $token);
+            // Calculate the space between the icon and content based on the size variant and factor
+            padding-left: $this-type-scale * $icon-list-icon-padding-left-factor;
 
             // But don't resize any block-level element inside content
             > p,
@@ -137,8 +137,8 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
 }
 
 .usa-icon-list__content {
-  padding-left: $type-scale * $icon-list-icon-padding-left-factor;
   font-size: $type-scale;
+  padding-left: $type-scale * $icon-list-icon-padding-left-factor;
   > *:first-child {
     margin-top: 0;
   }

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -1,11 +1,11 @@
 // Variables
 
 // Size icons based on the theme-type-scale-[size] number and this factor
-$icon-list-icon-size-factor: 1.75;
+$icon-list-icon-size-factor: 1.5;
 // Center the icon to the title text, works for all size variants
-$icon-list-icon-margin-top: -8%;
+$icon-list-icon-margin-top: -1.5%;
 // Fine tune the space between the icon and content with this factor
-$icon-list-icon-padding-left-factor: 0.5;
+$icon-list-icon-padding-left-factor: 0.4;
 // Fine tune the title top padding given a line height of 2
 $icon-list-title-padding-top: 0.2em;
 

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -77,8 +77,7 @@ $icon-list-font-sizes: (
                 $icon-list-icon-padding-left-factor;
 
               // Resize the content unless a manual class is set
-              &:not(.usa-icon-list__content--manual),
-              &:not(.usa-icon-list__content--manual) * {
+              > *:not(p, h1, h2, h3, h4, h5, h6) {
                 font-size: size($theme-icon-list-font-family, $token);
                 margin-bottom: 0;
               }

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -1,7 +1,7 @@
 // Variables
 
 // Size icons based on the theme-type-scale-[size] number and this factor
-$icon-list-icon-size-factor: 2;
+$icon-list-icon-size-factor: 1.75;
 // Center the icon to the title text, works for all size variants
 $icon-list-icon-margin-top: -8%;
 // Fine tune the space between the icon and content with this factor
@@ -55,28 +55,37 @@ $icon-list-font-sizes: (
         $prefix: "#{$mq-key}\\:";
       }
       @if $prefix {
+        $type-scale: font-size($theme-icon-list-font-family, $token);
         @include at-media($mq-key) {
           .#{$prefix}usa-icon-list--size-#{$token} {
             .usa-icon-list__icon {
               .usa-icon {
                 // Set the height and width of the icon based on the size variant and factor
-                height: system-type-scale($val) * $icon-list-icon-size-factor;
+                height: $type-scale * $icon-list-icon-size-factor;
                 margin-top: $icon-list-icon-margin-top;
-                width: system-type-scale($val) * $icon-list-icon-size-factor;
+                width: $type-scale * $icon-list-icon-size-factor;
               }
-            }
-
-            .usa-icon-list__title {
-              font-size: size($theme-icon-list-font-family, $token);
             }
 
             .usa-icon-list__content {
               // Calculate the space between the icon and content based on the size variant and factor
-              padding-left: system-type-scale($val) *
-                $icon-list-icon-padding-left-factor;
+              padding-left: $type-scale * $icon-list-icon-padding-left-factor;
+              font-size: size($theme-icon-list-font-family, $token);
 
               // Resize the content unless a manual class is set
-              > *:not(p, h1, h2, h3, h4, h5, h6, ul, ol) {
+              p,
+              h1,
+              h2,
+              h3,
+              h4,
+              h5,
+              h6,
+              ul,
+              ol {
+                font-size: initial;
+              }
+
+              .usa-icon-list__title {
                 font-size: size($theme-icon-list-font-family, $token);
               }
             }
@@ -96,17 +105,21 @@ $icon-list-font-sizes: (
     }
   }
 
+  $type-scale: font-size($theme-icon-list-font-family, $theme-body-font-size);
   .usa-icon-list__icon {
     .usa-icon {
       display: block;
-      height: 1.5em;
+      // Set the height and width of the icon based on the size variant and factor
+      height: $type-scale * $icon-list-icon-size-factor;
+      margin-top: $icon-list-icon-margin-top;
       position: relative;
-      width: 1.5em;
+      width: $type-scale * $icon-list-icon-size-factor;
     }
   }
 
   .usa-icon-list__content {
-    padding-left: 0.5rem;
+    padding-left: $type-scale * $icon-list-icon-padding-left-factor;
+    font-size: $type-scale;
     > *:first-child {
       margin-top: 0;
     }
@@ -120,7 +133,7 @@ $icon-list-font-sizes: (
   }
 
   .usa-icon-list__title {
-    font-size: size($theme-icon-list-font-family, "lg");
+    font-size: size($theme-icon-list-font-family, $theme-body-font-size);
     line-height: lh($theme-icon-list-font-family, $theme-heading-line-height);
     margin-bottom: units(0);
     padding-top: 0.25em;

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -35,17 +35,7 @@ $icon-list-font-sizes: (
         }
       }
     }
-
-    // Set default title font size if no size variant class is present
-    .usa-icon-list__title {
-      font-size: size($theme-icon-list-font-family, "lg");
-      margin-bottom: units(0);
-      & + * {
-        margin-top: units(1);
-      }
-    }
   }
-
   // Generate responsive variants
   // Create a map for looping that includes a default or no-breakpoint version
   $this-null: (
@@ -75,15 +65,19 @@ $icon-list-font-sizes: (
                 width: system-type-scale($val) * $icon-list-icon-size-factor;
               }
             }
+
+            .usa-icon-list__title {
+              font-size: size($theme-icon-list-font-family, $token);
+            }
+
             .usa-icon-list__content {
               // Calculate the space between the icon and content based on the size variant and factor
               padding-left: system-type-scale($val) *
                 $icon-list-icon-padding-left-factor;
 
               // Resize the content unless a manual class is set
-              > *:not(p, h1, h2, h3, h4, h5, h6) {
+              > *:not(p, h1, h2, h3, h4, h5, h6, ul, ol) {
                 font-size: size($theme-icon-list-font-family, $token);
-                margin-bottom: 0;
               }
             }
           }
@@ -122,6 +116,16 @@ $icon-list-font-sizes: (
 
     ul li {
       list-style-type: disc;
+    }
+  }
+
+  .usa-icon-list__title {
+    font-size: size($theme-icon-list-font-family, "lg");
+    line-height: lh($theme-icon-list-font-family, $theme-heading-line-height);
+    margin-bottom: units(0);
+    padding-top: 0.25em;
+    & + * {
+      margin-top: units(1);
     }
   }
 }

--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -80,7 +80,7 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
     @if $mq-key == "none" {
       $prefix: "";
     }
-    // Or the standard prefix if the break[pint is output
+    // Or the standard prefix if the breakpoint is output
     @else if map-get($theme-utility-breakpoints, $mq-key) {
       $prefix: "#{$mq-key}\\:";
     }

--- a/src/stylesheets/core/mixins/_at-media.scss
+++ b/src/stylesheets/core/mixins/_at-media.scss
@@ -3,17 +3,19 @@
 @mixin at-media($bp) {
   $quoted-bp: smart-quote($bp);
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
-  @if map-has-key($our-breakpoints, $quoted-bp) {
+  @if $quoted-bp == "none" {
+    @content;
+  } @else if map-has-key($our-breakpoints, $quoted-bp) {
     @if $theme-respect-user-font-size {
       $bp: rem-to-user-em(map-get($our-breakpoints, $quoted-bp));
     } @else {
       $bp: rem-to-px(map-get($our-breakpoints, $quoted-bp));
     }
+    @media all and (min-width: #{$bp}) {
+      @content;
+    }
   } @else {
     @warn '`#{$bp}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}';
-  }
-  @media all and (min-width: #{$bp}) {
-    @content;
   }
 }
 


### PR DESCRIPTION
[Preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/dw-icon-list-modifications/components/detail/icon-list--custom-size-rich.html) → 

This PR makes a few modifications to (hopefully!) streamline and improve the functionality of the icon list.

First, I'd like to focus the icon list a use case that's closer in spirit to a conventional unordered list, except using an icon instead of a bullet. This means building for shorter lists, with only a few words or sentences per list item, or a slightly more robust list item, with a title and some accompanying text:

### Default list
<img width="681" alt="Screen Shot 2021-02-10 at 3 12 38 PM" src="https://user-images.githubusercontent.com/11464021/107585376-fc872c80-6bb2-11eb-9975-a7b785849631.png">

### List with rich text
<img width="684" alt="Screen Shot 2021-02-10 at 3 12 51 PM" src="https://user-images.githubusercontent.com/11464021/107585382-001ab380-6bb3-11eb-8ca4-25166b4b9bef.png">

Next, I wanted to simplify the implementation for lists that use a custom size. I liked how you could pass a size variant into the list and it would update the icon and the text — but I didn't like the extra step of adding the `usa-icon-list--title` class. This PR changes the behavior, so that content inside of `usa-icon-list--content` gets the custom sizing. For example:

### Default
<img width="678" alt="Screen Shot 2021-02-10 at 3 23 41 PM" src="https://user-images.githubusercontent.com/11464021/107586016-08bfb980-6bb4-11eb-8991-6135853c8670.png">

```
<ul class="usa-icon-list">
    <li class="usa-icon-list__item">
        <div class="usa-icon-list__icon text-green"> ... </div>
        <div class="usa-icon-list__content">
            Donate cash when possible.
        </div>
    </li>
    ...
</ul>
```

### Large variant
<img width="682" alt="Screen Shot 2021-02-10 at 3 23 53 PM" src="https://user-images.githubusercontent.com/11464021/107586021-0b221380-6bb4-11eb-8a32-0b23f782527b.png">

```
<ul class="usa-icon-list usa-icon-list--size-lg">
    <li class="usa-icon-list__item">
        <div class="usa-icon-list__icon text-green"> ... </div>
        <div class="usa-icon-list__content">
            Donate cash when possible.
        </div>
    </li>
    ...
</ul>
```

This custom sizing only applies to text directly inside the `usa-icon-list__content` element. Any block-level _child_ of `usa-icon-list__content` gets `initial` styling. So, if you want to have custom styled text inside content, just put it in a `p`, `h3`, `div`, or whatever. You can add the `usa-icon-list__title` class to a block-level heading that _should_ get the custom sizing:

<img width="681" alt="Screen Shot 2021-02-10 at 3 38 25 PM" src="https://user-images.githubusercontent.com/11464021/107587103-0c544000-6bb6-11eb-8574-f2d6abd08707.png">

```
<ul class="usa-icon-list usa-icon-list--size-lg">
    <li class="usa-icon-list__item">
        <div class="usa-icon-list__icon text-green"> ... </div>
        <div class="usa-icon-list__content">
            <h3 class="usa-icon-list__title">Donate cash when possible.</h3>
            <p>Financial contributions to recognized disaster relief organizations are the fastest, most flexible and most effective method of donating. Organizations on the ground know what items and quantities are needed, often buy in bulk with discounts and, if possible, purchase through businesses local to the disaster, which supports economic recovery.</p>
        </div>
    </li>
    ...
</ul>
```

Styling controlled with `span`, `em`, `strong`, etc works as expected:

<img width="683" alt="Screen Shot 2021-02-10 at 3 41 53 PM" src="https://user-images.githubusercontent.com/11464021/107587386-85ec2e00-6bb6-11eb-83cb-6ab19b3019df.png">

```
<ul class="usa-icon-list usa-icon-list--size-lg">
    <li class="usa-icon-list__item">
        <div class="usa-icon-list__icon text-green"> ... </div>
        <div class="usa-icon-list__content">
            <strong class="text-bold">Use cash.</strong> Donate cash when possible.
        </div>
    </li>
    ...
</ul>
```

- - -

# Other changes

### Responsive variants
Added responsive prefixing to the size variant. Larger sizes would be impractical for narrow widths, but devs should be able to access them when they're appropriate. So now you can add something like `tablet:usa-icon-list--size-lg`.

https://user-images.githubusercontent.com/11464021/107587859-69042a80-6bb7-11eb-9efe-db6a700de005.mp4

### Rem sizing
I rebuilt some of the sizing and spacing Sass to use rem instead of px. This will help with responsiveness and accessibility, especially if users have custom font sizing set in their browser.

### Size and spacing adjustments
I reduced the size and padding of the icons a bit, and reduced the size of the default title to the same as the text size, except bold. 