### PR TITLE
USWDS - Breadcrumb: Safari overflowing instead of wrapping.

### DIFF
--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -59,12 +59,6 @@ $breadcrumb-back-icon-aspect: (
     @include u-padding-top($theme-breadcrumb-padding-top);
   }
 
-  &.usa-breadcrumb--wrap {
-    @include at-media($theme-breadcrumb-min-width) {
-      @include u-line-height($theme-breadcrumb-font-family, 4);
-    }
-  }
-
   &:not(.usa-breadcrumb--wrap) {
     .usa-breadcrumb__list {
       @include at-media($theme-breadcrumb-min-width) {
@@ -183,4 +177,7 @@ $breadcrumb-back-icon-aspect: (
     @include u-line-height($theme-breadcrumb-font-family, 4);
   }
 
+  .usa-breadcrumb__list-item {
+    @include u-display("inline-block");
+  }
 }

--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -172,3 +172,15 @@ $breadcrumb-back-icon-aspect: (
     @include u-text("underline");
   }
 }
+
+// ---------------------------------
+// Variations
+// ---------------------------------
+
+// Breadcrumb wrap
+.usa-breadcrumb--wrap {
+  @include at-media($theme-breadcrumb-min-width) {
+    @include u-line-height($theme-breadcrumb-font-family, 4);
+  }
+
+}


### PR DESCRIPTION
## Preview
[Breadcrumb wrap →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-breadcrumb-wrapping/components/detail/breadcrumb--wrap.html)

## Description

Closes #3997. Safari 14.0.3 isn't wrapping as expected and overflows outside of the viewport.

## Additional information

I was able to pull down and verify https://github.com/brandonlenz/test-uswds-app — thanks @brandonlenz! This safari only quirk seems to be happening with minified HTML.

I added `inline-block` to `usa-breadcrumb__list-item` for wrapped variation (inline still required for default). I've tested in all major browsers for Windows and OSX and found no issues. Even IE11 still behaves as expected.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
