### PR TITLE
USWDS - Icons: Remove internal UMD code for SVG4Everybody polyfill.

### DIFF
--- a/src/js/polyfills/svg4everybody.js
+++ b/src/js/polyfills/svg4everybody.js
@@ -1,14 +1,18 @@
 /* eslint-disable */
-!function(root, factory) {
-  if(root === undefined) root = window; //*  THIS IS A HOTFIX FOR BABEL TRANSPILERS ADDING USING STRICT MODE CAUSING ROOT TO BE UNDEFINED. 
-  "function" == typeof define && define.amd ? // AMD. Register as an anonymous module unless amdModuleId is set
-  define([], function() {
-      return root.svg4everybody = factory();
-  }) : "object" == typeof module && module.exports ? // Node. Does not work with strict CommonJS, but
-  // only CommonJS-like environments that support module.exports,
-  // like Node.
-  module.exports = factory() : root.svg4everybody = factory();
-}(this, function() {
+!(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
   /*! svg4everybody v2.1.9 | github.com/jonathantneal/svg4everybody */
   function embed(parent, svg, target, use) {
       // if the target exists
@@ -40,16 +44,16 @@
               // get the cached html document
               var cachedDocument = xhr._cachedDocument;
               // ensure the cached html document based on the xhr response
-              cachedDocument || (cachedDocument = xhr._cachedDocument = document.implementation.createHTMLDocument(""), 
+              cachedDocument || (cachedDocument = xhr._cachedDocument = document.implementation.createHTMLDocument(""),
               cachedDocument.body.innerHTML = xhr.responseText, // ensure domains are the same, otherwise we'll have issues appending the
               // element in IE 11
-              cachedDocument.domain !== document.domain && (cachedDocument.domain = document.domain), 
+              cachedDocument.domain !== document.domain && (cachedDocument.domain = document.domain),
               xhr._cachedTarget = {}), // clear the xhr embeds list and embed each item
               xhr._embeds.splice(0).map(function(item) {
                   // get the cached target
                   var target = xhr._cachedTarget[item.id];
                   // ensure the cached target
-                  target || (target = xhr._cachedTarget[item.id] = cachedDocument.getElementById(item.id)), 
+                  target || (target = xhr._cachedTarget[item.id] = cachedDocument.getElementById(item.id)),
                   // embed the target into the svg
                   embed(item.parent, item.svg, target, use);
               });
@@ -72,7 +76,7 @@
           var index = 0; index < uses.length; ) {
               // get the current <use>
               var use = uses[index], parent = use.parentNode, svg = getSVGAncestor(parent), src = use.getAttribute("xlink:href") || use.getAttribute("href");
-              if (!src && opts.attributeName && (src = use.getAttribute(opts.attributeName)), 
+              if (!src && opts.attributeName && (src = use.getAttribute(opts.attributeName)),
               svg && src) {
                   if (polyfill) {
                       if (!opts.validate || opts.validate(src, svg, use)) {
@@ -85,7 +89,7 @@
                               // get the cached xhr request
                               var xhr = requests[url];
                               // ensure the xhr request exists
-                              xhr || (xhr = requests[url] = new XMLHttpRequest(), xhr.open("GET", url), xhr.send(), 
+                              xhr || (xhr = requests[url] = new XMLHttpRequest(), xhr.open("GET", url), xhr.send(),
                               xhr._embeds = []), // add the svg and id as an item to the xhr embeds list
                               xhr._embeds.push({
                                   parent: parent,
@@ -122,4 +126,4 @@
       return svg;
   }
   return svg4everybody;
-});
+}));

--- a/src/js/polyfills/svg4everybody.js
+++ b/src/js/polyfills/svg4everybody.js
@@ -1,18 +1,7 @@
 /* eslint-disable */
-!(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define([], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory();
-  } else {
-    // Browser globals (root is window)
-    root.returnExports = factory();
-  }
-}(typeof self !== 'undefined' ? self : this, function () {
+!function(factory) {
+  module.exports = factory();
+}(function() {
   /*! svg4everybody v2.1.9 | github.com/jonathantneal/svg4everybody */
   function embed(parent, svg, target, use) {
       // if the target exists
@@ -126,4 +115,4 @@
       return svg;
   }
   return svg4everybody;
-}));
+});


### PR DESCRIPTION
## Description

SVG4Everybody polyfill is used to convert SVG sprite icons to an embedded format so IE11 can render them. The code included to create a UMD module is causing conflicts when we pass it through Babel for older browsers. Removed it based on this [Slack  comment by Andrew Duthie](https://gsa-tts.slack.com/archives/C050HRGN7/p1614032336002600?thread_ts=1614014121.001300&cid=C050HRGN7)

**Modern browsers**
```html
<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
  <use xlink:href="../../dist/img/sprite.svg#add"></use>
</svg>
```

**IE11** (after SVG4E)
```html
<svg xmlns="http://www.w3.org/2000/svg" class="usa-icon" role="img" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
  <g>
    <path fill="none" d="M 0 0 h 24 v 24 H 0 Z" />
    <path d="M 19 13 h -6 v 6 h -2 v -6 H 5 v -2 h 6 V 5 h 2 v 6 h 6 v 2 Z" />
  </g>
</svg>
```

## Additional information

Now you should be able to use `uswds.js` or `uswds.min.js` in a React app without any problems.

Thanks to @aduth  for looking into this and providing a solution!

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
