### PR TITLE
Replace String#includes with browser-compatible indexOf

### DIFF
--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -214,7 +214,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
           const fileType = acceptedFiles[j];
           allFilesAllowed =
             file.name.indexOf(fileType) > 0 ||
-            file.type.includes(fileType.replace(/\*/g, ""));
+            file.type.indexOf(fileType.replace("*", "")) === 0;
           if (allFilesAllowed) break;
         }
       } else break;


### PR DESCRIPTION
This pull request seeks to replace code which would be incompatible if run in Internet Explorer with a browser-compatible variant.

## Additional information

`String#includes` is a feature of ECMAScript 2015 and isn't supported in Internet Explorer ([see browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#browser_compatibility)).

The intention of the code is to test whether the MIME type of an uploaded file matches an `accept` parameter, which can be in the format of either e.g. `image/png` or `image/*` ([see specification](https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file))). Therefore, it should be enough to use a `String#indexOf` to check to see that the MIME type of the file starts with the `accept` parameter type sans at most one `*`.

Note that it does not currently appear that this code is run in Internet Explorer due to a combination of the facts that only drop events are validated (#4053) and drag-and-drop doesn't appear to work in Internet Explorer (possibly a bug?).

An alternative here is to configure Babel to provide polyfills for these, by one of the following:

1. [`@babel/polyfill`](https://babeljs.io/docs/en/babel-polyfill/)
2. [`core-js`](https://github.com/zloirock/core-js)
3. [`@babel/preset-env`'s `useBuiltIns`](https://babeljs.io/docs/en/babel-preset-env#usebuiltins) option
   - This is most promising since the preset is already being used ([source](https://github.com/uswds/uswds/blob/1f9bb1cca8afdd1d00481f00bf32a38169790058/config/gulp/javascript.js#L27))