### PR TITLE
Add a white variant of the expand icon for dark bgs

### DIFF
--- a/src/img/usa-icons-bg/expand_more--white.svg
+++ b/src/img/usa-icons-bg/expand_more--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>


### PR DESCRIPTION
Adds a `expand_more--white.svg` icon to `usa-icons-bg` so there's an option available for projects that use the top nav with a dark background