### PR TITLE
USWDS - Navigation - vertically center search when there are no secondary links.

### DIFF
--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -212,11 +212,19 @@ $nav-link-arrow-icon-size: 2;
   }
 
   .usa-search {
-    margin-top: units(2);
     width: 100%;
+    bottom: units("05");
 
     @include at-media($theme-header-min-width) {
       margin-left: 0;
+    }
+  }
+
+  .usa-nav__secondary-links ~ .usa-search {
+    bottom: 0;
+    margin-top: units(2);
+
+    @include at-media($theme-header-min-width) {
       margin-top: units(1);
     }
   }

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -213,9 +213,9 @@ $nav-link-arrow-icon-size: 2;
 
   .usa-search {
     width: 100%;
-    bottom: units("05");
 
     @include at-media($theme-header-min-width) {
+      bottom: 7.5px; // Magic Number to vertically center when .usa-nav__secondary-links is not a sibling.
       margin-left: 0;
     }
   }


### PR DESCRIPTION
For https://github.com/uswds/uswds/issues/2835

## Description

When `.usa-search` exists inside of `.usa-nav__secondary` alone, it was not vertically centered. This styling fix makes the assumption that `.usa-search` should vertically center by way of absolute positioning by default and then reset back to bottom: 0 when it's the sibling of `.usa-nav__secondary-links`. Another approach might be the target the vertical centering for `.nav__secondary form:only-child` assuming the case where the search form is the only form that should appear in this part of the DOM, but that seems both prescriptive and less clear in intent.

The current layout of the header and navigation for complex variants looks like it would be prohibitive to use flex or other nice auto-centering techniques, there's a lot of absolute positioning going on.