### PR TITLE
docs: update links to markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We’re glad you’d like to use the design system — here’s how you can get 
 
 How you implement the design system depends on the needs of your project and your workstyle. We recommend implementing the design system with `npm`, but we also provide a direct download if `npm` will not work for you or your project.
 
-- **[Download the design system](#download)** if you are not familiar with `npm` and package management.
+- **[Download the design system](#download-and-install)** if you are not familiar with `npm` and package management.
 
 - **[Use the design system `npm` package](#install-using-npm)** if you are familiar with using `npm` and package management.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is for the design system code itself. We maintain [another repos
 - [Recent updates](#recent-updates)
 - [Getting started](#getting-started)
 - [Using the design system](#using-the-design-system)
-  - [Download](#download)
+  - [Download and install](#download-and-install)
   - [Install using `npm`](#install-using-npm)
     - [Using the USWDS package](#using-the-uswds-package)
     - [Sass and theme settings](#sass-and-theme-settings)


### PR DESCRIPTION
current link https://github.com/uswds/uswds#download does not match section id https://github.com/uswds/uswds#download-and-install