### PR TITLE
Button: Include explicit state classes in unstyled hover, active overrides

### DIFF
--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -26,4 +26,12 @@
   &.usa-button--disabled {
     color: color("disabled");
   }
+
+  &.usa-button--hover {
+    color: color($theme-link-hover-color);
+  }
+
+  &.usa-button--active {
+    color: color($theme-link-active-color);
+  }
 }

--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -13,7 +13,9 @@
   &:hover,
   &.usa-button--hover,
   &:active,
-  &.usa-button--active {
+  &.usa-button--active,
+  &:disabled,
+  &.usa-button--disabled {
     @include no-knockout-font-smoothing;
     background-color: transparent;
     box-shadow: none;

--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -11,7 +11,9 @@
   text-align: left;
 
   &:hover,
-  &:active {
+  &.usa-button--hover,
+  &:active,
+  &.usa-button--active {
     @include no-knockout-font-smoothing;
     background-color: transparent;
     box-shadow: none;

--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -21,4 +21,9 @@
     box-shadow: none;
     text-decoration: underline;
   }
+
+  &:disabled,
+  &.usa-button--disabled {
+    color: color("disabled");
+  }
 }

--- a/src/stylesheets/core/mixins/_button-unstyled.scss
+++ b/src/stylesheets/core/mixins/_button-unstyled.scss
@@ -12,8 +12,20 @@
 
   &:hover,
   &.usa-button--hover,
+  &:disabled:hover,
+  &:disabled.usa-button--hover,
+  &.usa-button--disabled:hover,
+  &.usa-button--disabled.usa-button--hover,
   &:active,
   &.usa-button--active,
+  &:disabled:active,
+  &:disabled.usa-button--active,
+  &.usa-button--disabled:active,
+  &.usa-button--disabled.usa-button--active,
+  &:disabled:focus,
+  &:disabled.usa-focus,
+  &.usa-button--disabled:focus,
+  &.usa-button--disabled.usa-focus,
   &:disabled,
   &.usa-button--disabled {
     @include no-knockout-font-smoothing;


### PR DESCRIPTION
## Description

The unstyled button mixin customizes the hover and active appearance of a button, but only applies this with the browser-native `:hover` and `:active` modifiers, and not with USWDS' explicit `usa-button--hover` and `usa-button--active` modifier classes.

## Additional information

Before these changes, if one would apply `usa-button--hover` to an unstyled button, the overrides in these styles would not be applied, most notably the background color. You can test this by adding `usa-button--hover` class to the "Unstyled button" example in the Buttons component page.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/110641966-8dd0cb00-8180-11eb-9900-a1b77b2ba8b6.png)|![after](https://user-images.githubusercontent.com/1779930/110642049-a3de8b80-8180-11eb-872f-7e0e2a19a220.png)

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
