### PR TITLE
Footer: Switch to matchMedia for viewport-specific JavaScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12326,11 +12326,6 @@
       "integrity": "sha1-v+Bczn5RWzEokl1jYhOEIL1iSRA=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -13696,6 +13691,12 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
+    "mq-polyfill": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/mq-polyfill/-/mq-polyfill-1.1.8.tgz",
+      "integrity": "sha1-wUQZCyEhS/jYsJnn405soriI3BQ=",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "del": "^6.0.0",
     "domready": "^1.0.8",
     "elem-dataset": "^2.0.0",
-    "lodash.debounce": "^4.0.7",
     "object-assign": "^4.1.1",
     "receptor": "^1.0.0",
     "resolve-id-refs": "^0.1.0"
@@ -131,6 +130,7 @@
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^8.2.1",
+    "mq-polyfill": "^1.1.8",
     "node-notifier": "^9.0.0",
     "normalize.css": "^8.0.1",
     "nswatch": "^0.2.0",

--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -1,11 +1,11 @@
 const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
+const { default: matchMediaPolyfill } = require("mq-polyfill");
 const behavior = require("../../../src/js/components/footer");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "/template.html"));
 
-const { DEBOUNCE_RATE } = behavior;
 const HIDDEN = "hidden";
 const PRIMARY_CONTENT_SELECTOR =
   ".usa-footer--big .usa-footer__primary-content--collapsible";
@@ -24,9 +24,9 @@ const resizeTo = width =>
   new Promise(resolve => {
     if (width !== window.innerWidth) {
       window.innerWidth = width;
-      window.dispatchEvent(new CustomEvent("resize"));
+      window.dispatchEvent(new window.Event("resize"));
     }
-    setTimeout(resolve, DEBOUNCE_RATE + 10);
+    resolve();
   });
 
 const assertHidden = (el, hidden) => {
@@ -41,6 +41,10 @@ describe("big footer accordion", () => {
   const { body } = document;
   let buttons;
   let lists;
+
+  before(() => {
+    matchMediaPolyfill(window);
+  });
 
   beforeEach(() => {
     body.innerHTML = TEMPLATE;

--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -1,4 +1,3 @@
-const debounce = require("lodash.debounce");
 const behavior = require("../utils/behavior");
 const select = require("../utils/select");
 const { CLICK } = require("../events");
@@ -11,7 +10,6 @@ const BUTTON = `${NAV} .${PREFIX}-footer__primary-link`;
 const COLLAPSIBLE = `.${PREFIX}-footer__primary-content--collapsible`;
 
 const HIDE_MAX_WIDTH = 480;
-const DEBOUNCE_RATE = 180;
 
 function showPanel() {
   if (window.innerWidth < HIDE_MAX_WIDTH) {
@@ -30,14 +28,10 @@ function showPanel() {
   }
 }
 
-let lastInnerWidth;
+const toggleHidden = (isHidden) =>
+  select(COLLAPSIBLE).forEach((list) => list.classList.toggle(HIDDEN, isHidden));
 
-const resize = debounce(() => {
-  if (lastInnerWidth === window.innerWidth) return;
-  lastInnerWidth = window.innerWidth;
-  const hidden = window.innerWidth < HIDE_MAX_WIDTH;
-  select(COLLAPSIBLE).forEach((list) => list.classList.toggle(HIDDEN, hidden));
-}, DEBOUNCE_RATE);
+const resize = (event) => toggleHidden(event.matches);
 
 module.exports = behavior(
   {
@@ -48,15 +42,15 @@ module.exports = behavior(
   {
     // export for use elsewhere
     HIDE_MAX_WIDTH,
-    DEBOUNCE_RATE,
 
     init() {
-      resize();
-      window.addEventListener("resize", resize);
+      toggleHidden(window.innerWidth < HIDE_MAX_WIDTH);
+      this.mediaQueryList = window.matchMedia(`(max-width: ${HIDE_MAX_WIDTH}px)`);
+      this.mediaQueryList.addListener(resize);
     },
 
     teardown() {
-      window.removeEventListener("resize", resize);
+      this.mediaQueryList.removeListener(resize);
     },
   }
 );


### PR DESCRIPTION
Changes from responding to resize event with conditions on current viewport size, to event-based matchMedia.

Why:

- Fewer runtime dependencies, reducing bundle size ([~2kb](https://bundlephobia.com/result?p=lodash.debounce@4.0.8)) and maintenance overhead.
- Faster response time of viewport changes, since viewport-specific logic is run immediately, without a debounce delay.
- Simpler tests, due to the absence of timer scheduling accounting for debounce.
- Less computationally-intensive, since resize events are no longer handled, regardless whether they're debounced.

Browser support is good, supporting IE10 and newer ([reference](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)).

---

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
