### PR TITLE
Improve font stack logic

### DIFF
--- a/src/stylesheets/core/_functions.scss
+++ b/src/stylesheets/core/_functions.scss
@@ -626,18 +626,22 @@ role-based font token.
     @if map-has-key($this-typeface-data, "system-font") {
       $output-display-name: false;
     }
-    // If there's a custom stack, use it and output the display name
+    // If there's a custom stack, use it and output the display name...
     @if map-get($this-font-map, "custom-stack") {
       $this-stack: map-get($this-font-map, "custom-stack");
       $output-display-name: true;
     }
-    // Otherwise, just get the token's default stack
-    @else {
+    // If the token has an existing stack, use that...
+    @else if map-deep-get($all-typeface-tokens, $this-font-token, "stack") {
       $this-stack: map-deep-get(
         $all-typeface-tokens,
         $this-font-token,
         "stack"
       );
+    }
+    // Otherwise, get the type token's default stack.
+    @else {
+      $this-stack: map-get($system-font-stacks, $type-token);
     }
     // If the typeface has no display name (system fonts), don't output the display name
     @if map-get($this-typeface-data, "display-name") == null {

--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -171,6 +171,12 @@ $font-stack-helvetica: "Helvetica Neue", "Helvetica", "Roboto", "Arial",
 $font-stack-monospace: "Bitstream Vera Sans Mono", "Consolas", "Courier",
   monospace;
 
+$system-font-stacks: (
+  "mono": $font-stack-monospace,
+  "sans": $font-stack-system,
+  "serif": $font-stack-georgia,
+);
+
 /*
 ----------------------------------------
 Typeface


### PR DESCRIPTION
This PR improves the logic we use to assign font stacks to type tokens. Now every font will get a stack, even if it has no defined stack.

1. First we look for a custom stack and use it if it exists.
2. Then we look to see if the font has an existing stack defined in its metadata, and use that if it exists.
3. If neither of those exist, we use a predefined default stack for that font type.

I created a new map to hold our new default stacks, using the system stack as our `sans` default, the Georgia stack as our `serif` default, and the Bitstream Vera Sans Mono stack as our `mono` default.

Before:
```
font-family:Foo Sans,;
```

After:
```
font-family:Foo Sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
  Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
  "Segoe UI Symbol";
```

Fixes #4048 