### PR TITLE
Allow custom prefix separator

### DIFF
--- a/src/stylesheets/components/_icon-list.scss
+++ b/src/stylesheets/components/_icon-list.scss
@@ -104,7 +104,7 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
   }
   // Or the standard prefix if the breakpoint is output
   @else if map-get($theme-utility-breakpoints, $mq-key) {
-    $prefix: "#{$mq-key}\\:";
+    $prefix: "#{$mq-key}#{$separator}";
   }
 
   @include at-media($mq-key) {

--- a/src/stylesheets/core/_variables.scss
+++ b/src/stylesheets/core/_variables.scss
@@ -33,6 +33,14 @@ $ns-grid: ns("grid");
 
 /*
 ----------------------------------------
+Separator
+----------------------------------------
+*/
+
+$separator: $theme-prefix-separator;
+
+/*
+----------------------------------------
 Spacing
 ----------------------------------------
 All spacing values that can be called

--- a/src/stylesheets/core/mixins/_utility-builder.scss
+++ b/src/stylesheets/core/mixins/_utility-builder.scss
@@ -21,7 +21,7 @@ loop
   $important: if($utilities-use-important, " !important", null);
   $this-mq: null;
 
-  .#{$media-prefix}#{$pseudoclass}\:#{ns("utility")}#{$selector}:#{$pseudoclass} {
+  .#{$media-prefix}#{$pseudoclass}#{$separator}#{ns("utility")}#{$selector}:#{$pseudoclass} {
     @each $this-property in $property {
       #{$this-property}: unquote("#{$value}#{$important}");
     }
@@ -63,7 +63,7 @@ future version of Sass' warning.
   $value-is-map: if(type-of($val-props) == "map", true, false);
 
   @if $media-key {
-    $media-prefix: #{$media-key}\:;
+    $media-prefix: #{$media-key}#{$separator};
   }
 
   .#{$media-prefix}#{ns("utility")}#{$selector} {

--- a/src/stylesheets/elements/_layout-grid.scss
+++ b/src/stylesheets/elements/_layout-grid.scss
@@ -20,14 +20,14 @@ $namespace-grid: ns("grid");
 @each $mq-key, $mq-value in $system-breakpoints {
   @if map-get($theme-utility-breakpoints, $mq-key) {
     @include at-media($mq-key) {
-      .#{$mq-key}\:#{$namespace-grid}container {
+      .#{$mq-key}#{$separator}#{$namespace-grid}container {
         $props: append-important($grid-global, desktop);
         @include grid-container($props);
       }
 
       // ...with custom widths
       @each $width-key, $width-value in $system-breakpoints {
-        .#{$mq-key}\:#{$namespace-grid}container-#{$width-key} {
+        .#{$mq-key}#{$separator}#{$namespace-grid}container-#{$width-key} {
           $props: append-important($grid-global, $width-key);
           @include grid-container($props);
         }
@@ -58,7 +58,7 @@ $namespace-grid: ns("grid");
         @each $gap-key,
           $gap-val in map-deep-get($system-properties, gap, standard)
         {
-          &.#{$mq-key}\:#{$namespace-grid}gap-#{$gap-key} {
+          &.#{$mq-key}#{$separator}#{$namespace-grid}gap-#{$gap-key} {
             $props: append-important($grid-global, $gap-key);
             @include grid-gap($props);
           }
@@ -102,21 +102,21 @@ $namespace-grid: ns("grid");
 @each $mq-key, $mq-value in $system-breakpoints {
   @if map-get($theme-utility-breakpoints, $mq-key) {
     @include at-media($mq-key) {
-      .#{$mq-key}\:#{$namespace-grid}col {
+      .#{$mq-key}#{$separator}#{$namespace-grid}col {
         $props: append-important($grid-global, fill);
         @include grid-col($props);
       }
-      .#{$mq-key}\:#{$namespace-grid}col-fill {
+      .#{$mq-key}#{$separator}#{$namespace-grid}col-fill {
         $props: append-important($grid-global, fill);
         @include grid-col($props);
       }
-      .#{$mq-key}\:#{$namespace-grid}col-auto {
+      .#{$mq-key}#{$separator}#{$namespace-grid}col-auto {
         $props: append-important($grid-global, auto);
         @include grid-col($props);
       }
 
       @each $width-key, $width-value in $system-layout-grid-widths {
-        .#{$mq-key}\:#{$namespace-grid}col-#{$width-key} {
+        .#{$mq-key}#{$separator}#{$namespace-grid}col-#{$width-key} {
           $props: append-important($grid-global, $width-key);
           @include grid-col($props);
         }
@@ -142,14 +142,14 @@ $namespace-grid: ns("grid");
   @if map-get($theme-utility-breakpoints, $mq-key) {
     @each $width-key, $width-value in $system-layout-grid-widths {
       @include at-media($mq-key) {
-        .#{$mq-key}\:#{$namespace-grid}offset-#{$width-key} {
+        .#{$mq-key}#{$separator}#{$namespace-grid}offset-#{$width-key} {
           $props: append-important($grid-global, $width-key);
           @include grid-offset($props);
         }
       }
     }
     @include at-media($mq-key) {
-      .#{$mq-key}\:#{$namespace-grid}offset-none {
+      .#{$mq-key}#{$separator}#{$namespace-grid}offset-none {
         $props: append-important($grid-global, none);
         @include grid-offset($props);
       }

--- a/src/stylesheets/settings/_settings-general.scss
+++ b/src/stylesheets/settings/_settings-general.scss
@@ -60,6 +60,22 @@ $theme-namespace: (
 
 /*
 ----------------------------------------
+Prefix separator
+----------------------------------------
+Set the character the separates
+responsive and state prefixes from the
+main class name.
+
+The default (":") needs to be preceded
+by two backslashes to be properly
+escaped.
+----------------------------------------
+*/
+
+$theme-prefix-separator: "\\:" !default;
+
+/*
+----------------------------------------
 Layout grid
 ----------------------------------------
 Should the layout grid classes output

--- a/src/stylesheets/theme/_uswds-theme-general.scss
+++ b/src/stylesheets/theme/_uswds-theme-general.scss
@@ -19,7 +19,7 @@ https://designsystem.digital.gov/design-tokens
 
 /*
 ----------------------------------------
-Image Path
+Image path
 ----------------------------------------
 Relative image file path
 ----------------------------------------
@@ -60,6 +60,22 @@ $theme-namespace: (
 
 /*
 ----------------------------------------
+Prefix separator
+----------------------------------------
+Set the character the separates
+responsive and state prefixes from the
+main class name.
+
+The default (":") needs to be preceded
+by two backslashes to be properly
+escaped.
+----------------------------------------
+*/
+
+$theme-prefix-separator: "\\:";
+
+/*
+----------------------------------------
 Layout grid
 ----------------------------------------
 Should the layout grid classes output
@@ -67,7 +83,7 @@ with !important
 ----------------------------------------
 */
 
-$theme-layout-grid-use-important: false !default;
+$theme-layout-grid-use-important: false;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
**Now you can use a custom prefix separator.** Some systems don't parse the `:` separator character in the default USWDS responsive and state prefixes like `tablet:margin-x-2`. Now you can set the value of `$theme-prefix-separator` to output any character or string between the prefix and the main class.

Note that the default needs two `\` characters to properly output the escaped `:` character in the final CSS.

```
$theme-prefix-separator: "\\:",
ex: .tablet\:margin-x-2
      <div class="margin:x-2">

$theme-prefix-separator: "--",
ex: .tablet--margin-x-2
      <div class="margin--x-2">

```

Fixes #3045 