### PR TITLE
2.11.0 bugfixes

### DIFF
--- a/src/components/input-prefix-suffix/input-prefix-suffix.njk
+++ b/src/components/input-prefix-suffix/input-prefix-suffix.njk
@@ -9,6 +9,16 @@
   <input type="text" id="example-input-prefix" class="usa-input" pattern="[0-9]*" inputmode="numeric">
 </div>
 
+<label class="usa-label" for="example-input-prefix-error">Credit card number (Error)</label>
+<div class="usa-input-group usa-input-group--error">
+  <div class="usa-input-prefix" aria-hidden="true">
+    <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../dist/img/sprite.svg#credit_card"></use>
+    </svg>
+  </div>
+  <input type="text" id="example-input-prefix-error" class="usa-input" pattern="[0-9]*" inputmode="numeric">
+</div>
+
 <label class="usa-label" for="example-input-suffix">Weight, in pounds</label>
 <div class="usa-input-group width-10">
   <input type="text" id="example-input-suffix" class="usa-input" pattern="[0-9]*" inputmode="numeric">

--- a/src/components/validation/validation.njk
+++ b/src/components/validation/validation.njk
@@ -1,6 +1,6 @@
 <form class="usa-form">
   <fieldset class="usa-fieldset">
-    <legend class="usa-legend">Enter a code</legend>
+    <legend class="usa-legend usa-legend--large">Enter a code</legend>
     <div class="usa-alert usa-alert--info usa-alert--validation">
       <div class="usa-alert__body">
         <h3 class="usa-alert__heading">Code requirements</h3>

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -26,7 +26,7 @@ $alert-icon-optical-padding: units($theme-alert-padding-x) -
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
     display: block;
-    height: units(7);
+    height: (2 * units($theme-alert-padding-y)) + units(3);
     // padding - optical spacing value
     left: $alert-icon-optical-padding;
     position: absolute;

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -122,11 +122,6 @@ $alert-padding-left: units($theme-alert-bar-width);
 }
 
 .usa-alert--validation {
-  &:before {
-    background-position: 0 units(1);
-    mask-position: 0 units(1);
-  }
-
   .usa-checklist {
     margin-top: units(2);
   }

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -14,18 +14,17 @@ $alert-icon-optical-padding: units($theme-alert-padding-x) -
   );
   &:before {
     @include add-color-icon($this-icon-object, $bgcolor);
-    // Position centered in the alert
-    bottom: 0;
     content: "";
     display: block;
+    height: units(7);
     // padding - optical spacing value
     left: $alert-icon-optical-padding;
     position: absolute;
-    height: auto;
     top: 0;
   }
   &.usa-alert--slim:before {
     background-size: $alert-slim-icon-size;
+    height: units(5);
     width: $alert-slim-icon-size;
     @supports (mask: url("")) {
       mask-size: $alert-slim-icon-size;

--- a/src/stylesheets/components/_alerts.scss
+++ b/src/stylesheets/components/_alerts.scss
@@ -3,6 +3,16 @@ $alert-icon-optical-factor: units($theme-alert-icon-size) / 6;
 $alert-icon-optical-padding: units($theme-alert-padding-x) -
   $alert-icon-optical-factor;
 
+@mixin add-slim-alert-icon {
+  &:before {
+    background-size: $alert-slim-icon-size;
+    height: units(5);
+    width: $alert-slim-icon-size;
+    @supports (mask: url("")) {
+      mask-size: $alert-slim-icon-size;
+    }
+  }
+}
 @mixin add-alert-icon($name, $color, $bgcolor) {
   $this-icon-object: map-merge(
     $icon-object,
@@ -22,13 +32,8 @@ $alert-icon-optical-padding: units($theme-alert-padding-x) -
     position: absolute;
     top: 0;
   }
-  &.usa-alert--slim:before {
-    background-size: $alert-slim-icon-size;
-    height: units(5);
-    width: $alert-slim-icon-size;
-    @supports (mask: url("")) {
-      mask-size: $alert-slim-icon-size;
-    }
+  &.usa-alert--slim {
+    @include add-slim-alert-icon;
   }
 }
 
@@ -79,14 +84,19 @@ $alert-padding-left: units($theme-alert-bar-width);
   }
 }
 
+.usa-alert__body {
+  @include u-padding-x($theme-alert-padding-x);
+}
+
 @each $name, $icon in $alert-icons {
   .usa-alert--#{$name} {
     @include alert-status-styles($name, $icon);
-  }
-}
 
-.usa-alert__body {
-  @include u-padding-x($theme-alert-padding-x);
+    .usa-alert__body {
+      padding-left: units($theme-alert-icon-size) +
+        (2 * $alert-icon-optical-padding);
+    }
+  }
 }
 
 .usa-alert__heading {

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -224,7 +224,7 @@ $banner-icon-close: (
     @include place-icon(
       $banner-icon-chevron,
       "after",
-      0,
+      "2px",
       middle,
       $theme-banner-background-color
     );
@@ -237,6 +237,10 @@ $banner-icon-close: (
     display: inline;
     margin-left: units(1);
     position: relative;
+
+    &:after {
+      position: absolute;
+    }
 
     &:hover {
       // Underline added to inner text instead.
@@ -260,7 +264,7 @@ $banner-icon-close: (
         "base-lighter"
       );
 
-      &::before {
+      &:before {
         @include u-pin("y");
         @include u-pin("right");
         background-color: color("base-lighter");
@@ -269,7 +273,7 @@ $banner-icon-close: (
         height: units($size-touch-target);
         width: units($size-touch-target);
       }
-      &::after {
+      &:after {
         @include u-pin("y");
         @include u-pin("right");
       }
@@ -279,13 +283,17 @@ $banner-icon-close: (
       @include place-icon(
         $banner-icon-chevron-up,
         "after",
-        0,
+        "2px",
         middle,
         $theme-banner-background-color
       );
       height: auto;
       padding: units(0);
       position: relative;
+
+      &:after {
+        position: absolute;
+      }
     }
   }
 }

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -34,16 +34,16 @@
     }
     &--md,
     &--medium {
-      max-width: 20ex;
+      max-width: 15ex;
     }
     &--lg {
-      max-width: 30ex;
+      max-width: 25ex;
     }
     &--xl {
       max-width: 40ex;
     }
     &--2xl {
-      max-width: 50ex;
+      max-width: 60ex;
     }
   }
 

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -34,16 +34,16 @@
     }
     &--md,
     &--medium {
-      max-width: 15ex;
+      max-width: 20ex;
     }
     &--lg {
-      max-width: 25ex;
+      max-width: 30ex;
     }
     &--xl {
       max-width: 40ex;
     }
     &--2xl {
-      max-width: 60ex;
+      max-width: 50ex;
     }
   }
 

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -20,34 +20,30 @@
     max-width: none;
   }
 
-  .usa-input--2xs {
-    max-width: 4ex;
-  }
-
-  .usa-input--xs {
-    max-width: 7ex;
-  }
-
-  .usa-input--small,
-  .usa-input--sm {
-    max-width: 10ex;
-  }
-
-  .usa-input--medium,
-  .usa-input--md {
-    max-width: 20ex;
-  }
-
-  .usa-input--lg {
-    max-width: 30ex;
-  }
-
-  .usa-input--xl {
-    max-width: 40ex;
-  }
-
-  .usa-input--2xl {
-    max-width: 50ex;
+  .usa-input {
+    &--2xs {
+      max-width: 4ex;
+    }
+    &--xs {
+      max-width: 7ex;
+    }
+    &--sm,
+    &--small {
+      max-width: 10ex;
+    }
+    &--md,
+    &--medium {
+      max-width: 20ex;
+    }
+    &--lg {
+      max-width: 30ex;
+    }
+    &--xl {
+      max-width: 40ex;
+    }
+    &--2xl {
+      max-width: 50ex;
+    }
   }
 
   .usa-button {

--- a/src/stylesheets/components/_forms.scss
+++ b/src/stylesheets/components/_forms.scss
@@ -20,7 +20,8 @@
     max-width: none;
   }
 
-  .usa-input {
+  .usa-input,
+  .usa-input-group {
     &--2xs {
       max-width: 4ex;
     }

--- a/src/stylesheets/components/_site-alert.scss
+++ b/src/stylesheets/components/_site-alert.scss
@@ -40,7 +40,6 @@ $alert-icons: (
   .usa-site-alert--#{$name} {
     $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
     @include set-text-and-bg($bgcolor);
-    background-color: yellow;
 
     .usa-alert {
       @include alert-status-styles($name, $icon);
@@ -64,10 +63,15 @@ $alert-icons: (
 
 .usa-site-alert--no-icon {
   .usa-alert {
-    background-image: none;
+    &:before {
+      display: none;
+    }
 
     .usa-alert__body {
-      padding-left: 0;
+      padding-left: units($theme-site-margins-mobile-width);
+      @include at-media($theme-site-margins-breakpoint) {
+        padding-left: units($theme-site-margins-width);
+      }
     }
   }
 }
@@ -84,13 +88,5 @@ $alert-icons: (
       padding-left: units($theme-site-margins-width) + $alert-slim-icon-size +
         units(1.5);
     }
-  }
-}
-
-.usa-site-alert--no-heading {
-  .usa-alert {
-    background-position-y: calc(
-      #{units($theme-alert-padding-x)} - #{units(0.5)}
-    );
   }
 }

--- a/src/stylesheets/components/_site-alert.scss
+++ b/src/stylesheets/components/_site-alert.scss
@@ -18,12 +18,12 @@ $alert-icons: (
   background-color: color("base-lightest");
 
   .usa-alert {
-    @include grid-container($theme-site-alert-max-width);
     @include site-alert-icon-margin;
+    @include u-margin-x("auto");
+    @include u-maxw($theme-site-alert-max-width);
 
-    &::before {
-      display: none;
-    }
+    // Don't show the left bar
+    border-left: none;
 
     > .usa-list,
     .usa-alert__body > .usa-list {

--- a/src/stylesheets/components/_site-alert.scss
+++ b/src/stylesheets/components/_site-alert.scss
@@ -5,11 +5,12 @@ $alert-icons: (
   emergency: "error",
 );
 
-@mixin site-alert-icon-margin {
-  background-position-x: units($theme-site-margins-mobile-width);
-
-  @include at-media($theme-site-margins-breakpoint) {
-    background-position-x: units($theme-site-margins-width);
+@mixin site-alert-margins {
+  &:before {
+    left: units($theme-site-margins-mobile-width);
+    @include at-media($theme-site-margins-breakpoint) {
+      left: units($theme-site-margins-width);
+    }
   }
 }
 
@@ -18,7 +19,6 @@ $alert-icons: (
   background-color: color("base-lightest");
 
   .usa-alert {
-    @include site-alert-icon-margin;
     @include u-margin-x("auto");
     @include u-maxw($theme-site-alert-max-width);
 
@@ -32,11 +32,7 @@ $alert-icons: (
   }
 
   .usa-alert__body {
-    display: block;
-
-    @include at-media("tablet") {
-      position: relative;
-    }
+    @include add-responsive-site-margins;
   }
 }
 
@@ -44,9 +40,24 @@ $alert-icons: (
   .usa-site-alert--#{$name} {
     $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
     @include set-text-and-bg($bgcolor);
+    background-color: yellow;
 
     .usa-alert {
       @include alert-status-styles($name, $icon);
+      @include site-alert-margins;
+    }
+
+    .usa-alert__body {
+      padding-right: units($theme-site-margins-mobile-width);
+      padding-left: units($theme-site-margins-mobile-width) +
+        units($theme-alert-icon-size) +
+        units(1.5);
+
+      @include at-media($theme-site-margins-breakpoint) {
+        padding-right: units($theme-site-margins-width);
+        padding-left: units($theme-site-margins-width) +
+          units($theme-alert-icon-size) + units(1.5);
+      }
     }
   }
 }
@@ -63,8 +74,16 @@ $alert-icons: (
 
 .usa-site-alert--slim {
   .usa-alert {
-    @include alert-slim-styles;
-    @include site-alert-icon-margin;
+    @include add-slim-alert-icon;
+    @include u-padding-y(1);
+  }
+  .usa-alert__body {
+    padding-left: units($theme-site-margins-mobile-width) +
+      $alert-slim-icon-size + units(1.5);
+    @include at-media($theme-site-margins-breakpoint) {
+      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size +
+        units(1.5);
+    }
   }
 }
 

--- a/src/stylesheets/core/mixins/_alert-slim-styles.scss
+++ b/src/stylesheets/core/mixins/_alert-slim-styles.scss
@@ -1,8 +1,6 @@
 @mixin alert-slim-styles {
   @include u-padding-y(1);
   .usa-alert__body {
-    padding-left: calc(
-      #{$alert-slim-icon-size} + (2 * #{$alert-icon-optical-padding})
-    );
+    padding-left: $alert-slim-icon-size + (2 * $alert-icon-optical-padding);
   }
 }

--- a/src/stylesheets/core/mixins/_alert-status-styles.scss
+++ b/src/stylesheets/core/mixins/_alert-status-styles.scss
@@ -12,11 +12,6 @@
   border-left-color: color($name);
   color: color($banner-text-color-token);
 
-  .usa-alert__body {
-    padding-left: units($theme-alert-icon-size) +
-      (2 * $alert-icon-optical-padding);
-  }
-
   .usa-link {
     @include set-link-from-bg(
       $bgcolor,

--- a/src/stylesheets/core/placeholders/_table.scss
+++ b/src/stylesheets/core/placeholders/_table.scss
@@ -152,7 +152,7 @@ $table-sorted-stripe-text-color: color(
       fill: color($theme-table-unsorted-icon-color);
     }
     &:hover .usa-icon > g.unsorted {
-      fill: $table-sorted-header-text-color;
+      fill: $table-header-text-color;
     }
   }
 

--- a/src/stylesheets/core/placeholders/_table.scss
+++ b/src/stylesheets/core/placeholders/_table.scss
@@ -343,7 +343,6 @@ $table-sorted-stripe-text-color: color(
     margin: 0;
   }
 
-  th,
   td {
     white-space: nowrap;
   }

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -18,7 +18,9 @@
   @extend %block-input-general;
   @extend %block-input-styles;
   align-items: center;
+  background-color: color("white");
   display: flex;
+  overflow: hidden;
   padding: 0;
 
   &.is-focused {

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -19,9 +19,8 @@
   @extend %block-input-styles;
   align-items: center;
   background-color: color("white");
-  display: inline-flex;
+  display: flex;
   padding: 0;
-  width: auto;
 
   &.is-focused {
     @include focus-outline();

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -19,8 +19,9 @@
   @extend %block-input-styles;
   align-items: center;
   background-color: color("white");
-  display: flex;
+  display: inline-flex;
   padding: 0;
+  width: auto;
 
   &.is-focused {
     @include focus-outline();

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -55,17 +55,3 @@
     @include u-square(3);
   }
 }
-
-.usa-input-prefix {
-  padding-right: 0;
-  .usa-icon {
-    margin-right: units(1);
-  }
-}
-
-.usa-input-suffix {
-  padding-left: 0;
-  .usa-icon {
-    margin-left: units(1);
-  }
-}

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -20,7 +20,6 @@
   align-items: center;
   background-color: color("white");
   display: flex;
-  overflow: hidden;
   padding: 0;
 
   &.is-focused {
@@ -49,15 +48,20 @@
   white-space: nowrap;
 
   .usa-icon {
-    height: units(3);
-    width: units(3);
+    @include u-square(3);
   }
 }
 
 .usa-input-prefix {
   padding-right: 0;
+  .usa-icon {
+    margin-right: units(1);
+  }
 }
 
 .usa-input-suffix {
   padding-left: 0;
+  .usa-icon {
+    margin-left: units(1);
+  }
 }

--- a/src/stylesheets/elements/form-controls/_text-input.scss
+++ b/src/stylesheets/elements/form-controls/_text-input.scss
@@ -26,6 +26,10 @@
     @include focus-outline();
   }
 
+  &--error {
+    @include u-border($theme-input-state-border-width, "error-dark");
+  }
+
   input {
     border: 0;
     height: 100%;

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -25,7 +25,7 @@ $theme-accordion-font-family: "body" !default;
 // Alert
 $theme-alert-bar-width: 1 !default;
 $theme-alert-font-family: "ui" !default;
-$theme-alert-icon-size: 5 !default;
+$theme-alert-icon-size: 4 !default;
 $theme-alert-padding-x: 2.5 !default;
 $theme-alert-padding-y: 2 !default;
 $theme-alert-text-color: default !default;

--- a/src/stylesheets/theme/_uswds-theme-components.scss
+++ b/src/stylesheets/theme/_uswds-theme-components.scss
@@ -25,7 +25,7 @@ $theme-accordion-font-family: "body";
 // Alert
 $theme-alert-bar-width: 1;
 $theme-alert-font-family: "ui";
-$theme-alert-icon-size: 5;
+$theme-alert-icon-size: 4;
 $theme-alert-padding-x: 2.5;
 $theme-alert-padding-y: 2;
 $theme-alert-text-color: default;


### PR DESCRIPTION
## Alert icon position
The icon position in site alert regressed when we implemented color icon in alerts. This updates the padding and margin in the various site alert variants.

This also reverts the icon alignment to top and reduces its size to be more like the previous icon size.

Before:
<img width="993" alt="Screen Shot 2021-03-15 at 3 45 19 PM" src="https://user-images.githubusercontent.com/11464021/111230849-7db45380-85a5-11eb-91aa-791e2ac6b70b.png">

After:
<img width="995" alt="Screen Shot 2021-03-15 at 3 45 01 PM" src="https://user-images.githubusercontent.com/11464021/111230868-86a52500-85a5-11eb-9630-a0665637764a.png">

## Sortable table button hover
Fixed the hover state on the sortable indicator to fill the icon with the header text color, not the sorted header text color

## Input prefix and suffix
- Set an explicit white background for inputs on non-white backgrounds
- Give more padding around prefix or suffix to accommodate dynamically colored backgrounds
- **Note:** Input suffix and prefix doesn't support dynamic background colors, like the background color set by autofill values in webkit
- Added `--error` and ``--[size]` variants to `input-group` just as we have them for `input`

Example of dynamic color background (autofill in chrome) and prefix:
<img width="551" alt="Screen Shot 2021-03-16 at 2 22 21 PM" src="https://user-images.githubusercontent.com/11464021/111381523-0cd37100-8663-11eb-8099-3858c7ac26a0.png">

## Banner
Fixed an alignment issue with the `Here's how you know` button. _Note the button has moved down slightly to the text baseline._

Before:
<img width="719" alt="Screen Shot 2021-03-16 at 2 25 41 PM" src="https://user-images.githubusercontent.com/11464021/111381884-8a977c80-8663-11eb-8b85-6fa1a83e2933.png">

After:
<img width="719" alt="Screen Shot 2021-03-16 at 2 25 51 PM" src="https://user-images.githubusercontent.com/11464021/111381895-8e2b0380-8663-11eb-9d2e-76e268a6c02a.png">

