### PR TITLE
Update CI processes to use main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,4 +75,4 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,7 @@ on:
     branches:
       [
         develop,
-        master,
+        main,
         v1-develop,
         v1-master,
         v2.10-beta--develop,
@@ -16,7 +16,7 @@ on:
     branches:
       [
         develop,
-        master,
+        main,
         v1-develop,
         v1-master,
         v2.10-beta--develop,


### PR DESCRIPTION
We've renamed our primary branch `main` from `master`. This PR updates references in the code.