### PR TITLE
Restore deleted variant icons

### DIFF
--- a/src/img/usa-icons-bg/add--white.svg
+++ b/src/img/usa-icons-bg/add--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>

--- a/src/img/usa-icons-bg/check_circle--white.svg
+++ b/src/img/usa-icons-bg/check_circle--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#fff" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>

--- a/src/img/usa-icons-bg/error--white.svg
+++ b/src/img/usa-icons-bg/error--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#fff" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>

--- a/src/img/usa-icons-bg/expand_more--white.svg
+++ b/src/img/usa-icons-bg/expand_more--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>

--- a/src/img/usa-icons-bg/info--white.svg
+++ b/src/img/usa-icons-bg/info--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#fff" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>

--- a/src/img/usa-icons-bg/remove--white.svg
+++ b/src/img/usa-icons-bg/remove--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 13H5v-2h14v2z" fill="#FFFFFF" /></svg>

--- a/src/img/usa-icons-bg/warning--white.svg
+++ b/src/img/usa-icons-bg/warning--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#fff" d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>


### PR DESCRIPTION
This restores seven white variant icons mistakenly removed from the `usa-icons-bg`:
- `add--white.svg`
- `check_circle--white.svg`
- `error--white.svg`
- `expand_more--white.svg`
- `info--white.svg`
- `remove--white.svg`
- `warning--white.svg`