### PR TITLE
Button: Remove pointer-events styling from disabled buttons

### DIFF
--- a/src/stylesheets/core/mixins/_button-disabled.scss
+++ b/src/stylesheets/core/mixins/_button-disabled.scss
@@ -2,7 +2,6 @@
   @include add-knockout-font-smoothing;
   background-color: color("disabled");
   color: color("white");
-  pointer-events: none;
 
   &:hover,
   &.usa-button--hover,

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -200,7 +200,6 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
 .usa-button--outline-inverse:disabled,
 .usa-button--outline-inverse:disabled {
   background-color: color("transparent");
-  pointer-events: none;
 
   &:hover,
   &.usa-button--hover,


### PR DESCRIPTION
Closes #4122

## Description

Removes `pointer-events: none` styling from disabled buttons.

## Additional information

See #4122 for additional context.

Developers who wish to disable interactivity on disabled buttons should apply [a `disabled` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled), as this is its intended purpose. At worst, using `pointer-events: none;` could give developers a false sense of confidence that their buttons are non-interactive, when in-fact this is not true (see #4122).

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
