### PR TITLE
Radio / Checkbox: Add support for themeable tile input background color

### DIFF
--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -127,6 +127,7 @@
 // Checkboxes and radios with tap-friendly targets
 .usa-checkbox__input--tile + .usa-checkbox__label,
 .usa-radio__input--tile + .usa-radio__label {
+  background-color: color($theme-input-tile-background-color);
   border: units($theme-input-tile-border-width) solid
     color($theme-input-tile-border-color);
   border-radius: radius($theme-input-tile-border-radius);

--- a/src/stylesheets/settings/_settings-components.scss
+++ b/src/stylesheets/settings/_settings-components.scss
@@ -85,6 +85,7 @@ $theme-input-max-width: "mobile-lg" !default;
 $theme-input-select-border-width: 2px !default;
 $theme-input-select-size: 2.5 !default;
 $theme-input-state-border-width: 0.5 !default;
+$theme-input-tile-background-color: "transparent" !default;
 $theme-input-tile-background-color-selected: "primary-lighter" !default;
 $theme-input-tile-border-radius: "md" !default;
 $theme-input-tile-border-width: 2px !default;


### PR DESCRIPTION
## Description

Allows for a theme to customize the default background color of the tile [radio button](https://designsystem.digital.gov/components/radio-buttons/) or [checkbox](https://designsystem.digital.gov/components/checkbox/) components.

## Additional information

As implemented, this is entirely backward compatible and preserves the existing behavior of assigning a transparent background color, while allowing downstream projects to override this to customize the default background color of the tile inputs.

This improves consistency with selected input background color, which is already customizable. It also better supports assignment of background color in cases of e.g. desiring a white tile input background when within a container with a colored background, rather than default transparent.

For example, adding a background color (`bg-secondary-lighter` in this example) to the [component preview](https://designsystem.digital.gov/components/radio-buttons/) reveals that the tile inputs can be hard to distinguish:

![image](https://user-images.githubusercontent.com/1779930/116714500-d6984980-a9a3-11eb-9cd9-035fff04aafe.png)

With this change, one could override the background to improve the legibility. In this example with `'white'`:

![image](https://user-images.githubusercontent.com/1779930/116714716-0cd5c900-a9a4-11eb-9b41-97e291d48b3d.png)

An alternative or complementary improvement could be to change the default to always apply a white background color to tile inputs if it's naturally assumed to be shown with a white background (in current examples leveraging the container's lack of background color).

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
