### PR TITLE
Add basic state palette to color utilities

### DIFF
--- a/src/stylesheets/core/_system-tokens.scss
+++ b/src/stylesheets/core/_system-tokens.scss
@@ -633,6 +633,11 @@ $tokens-color-basic: (
   "white-transparent": false,
 );
 
+$tokens-color-basic-state: (
+  "error": $theme-color-error,
+  "success": $theme-color-success,
+);
+
 //red-cool
 $color-red-cool-5: get-system-color("red-cool", 5);
 $color-red-cool-10: get-system-color("red-cool", 10);

--- a/src/stylesheets/utilities/palettes/_default-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_default-palettes.scss
@@ -22,6 +22,7 @@ $palettes-default: (
   "palette-color-default":
     map-collect(
       $tokens-color-basic,
+      $tokens-color-basic-state,
       $tokens-color-grayscale,
       $tokens-color-theme
     ),


### PR DESCRIPTION
Trying to address #4098, but I don't think I know enough about how to add in color utilities. Maybe someone can help get this working? Or if there's an easier way to do this in my theme, let me know.