### PR TITLE
Update `success-dark` to vivid variant

### DIFF
--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -106,7 +106,7 @@ $theme-color-success-lighter: "green-cool-5" !default;
 $theme-color-success-light: "green-cool-20v" !default;
 $theme-color-success: "green-cool-40v" !default;
 $theme-color-success-dark: "green-cool-50v" !default;
-$theme-color-success-darker: "green-cool-60" !default;
+$theme-color-success-darker: "green-cool-60v" !default;
 
 // Info colors
 $theme-color-info-family: "cyan" !default;

--- a/src/stylesheets/settings/_settings-color.scss
+++ b/src/stylesheets/settings/_settings-color.scss
@@ -105,7 +105,7 @@ $theme-color-success-family: "green-cool" !default;
 $theme-color-success-lighter: "green-cool-5" !default;
 $theme-color-success-light: "green-cool-20v" !default;
 $theme-color-success: "green-cool-40v" !default;
-$theme-color-success-dark: "green-cool-50" !default;
+$theme-color-success-dark: "green-cool-50v" !default;
 $theme-color-success-darker: "green-cool-60" !default;
 
 // Info colors

--- a/src/stylesheets/theme/_uswds-theme-color.scss
+++ b/src/stylesheets/theme/_uswds-theme-color.scss
@@ -103,8 +103,8 @@ $theme-color-success-family: "green-cool";
 $theme-color-success-lighter: "green-cool-5";
 $theme-color-success-light: "green-cool-20v";
 $theme-color-success: "green-cool-40v";
-$theme-color-success-dark: "green-cool-50";
-$theme-color-success-darker: "green-cool-60";
+$theme-color-success-dark: "green-cool-50v";
+$theme-color-success-darker: "green-cool-60v";
 
 // Info colors
 $theme-color-info-family: "cyan";


### PR DESCRIPTION
Needed for light text on a `success` background, for example: status tags. The current one is drab and doesn't look like a state color and this is more similar to the `success` token.

[Brought up in Slack in 2019](https://gsa-tts.slack.com/archives/C3F14AHSQ/p1576013330201600?thread_ts=1576012784.201200&cid=C3F14AHSQ)