### PR TITLE
[4194] Adds component JS files to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   ],
   "module": "./dist/js/uswds.min.js",
   "exports": {
-    "import": "./dist/js/uswds.min.js",
-    "default": "./dist/js/uswds.min.js"
+    ".": {
+      "import": "./dist/js/uswds.min.js",
+      "default": "./dist/js/uswds.min.js"
+    },
+    "./src/js/components": "./src/js/components/index.js",
+    "./src/js/components/*": "./src/js/components/*.js"
   },
   "types": "./index.d.ts",
   "main": "dist/js/uswds.min.js",


### PR DESCRIPTION
Resolves #4194 . Adds individual components to package.json exports so that they can be imported with Webpack 5.

e.g.
```
import accordion from 'uswds/src/js/components/accordion';
accordion.on(document.body);
```
