### PR TITLE
USWDS - Color: Add state color tokens to default palettes.

### DIFF
--- a/src/components/test/state-color/state-color.config.yml
+++ b/src/components/test/state-color/state-color.config.yml
@@ -1,0 +1,30 @@
+label: State color utils
+
+context:
+  # $tokens-color-state in _variables.scss
+  state_colors:
+    - error-lighter
+    - error-light
+    - error
+    - error-dark
+    - error-darker
+    - warning-lighter
+    - warning-light
+    - warning
+    - warning-dark
+    - warning-darker
+    - success-lighter
+    - success-light
+    - success
+    - success-dark
+    - success-darker
+    - info-lighter
+    - info-light
+    - info
+    - info-dark
+    - info-darker
+    - disabled-light
+    - disabled
+    - disabled-dark
+    - emergency
+    - emergency-dark

--- a/src/components/test/state-color/state-color.njk
+++ b/src/components/test/state-color/state-color.njk
@@ -1,0 +1,14 @@
+<div class="padding-2 maxw-desktop">
+  {% for color in state_colors %}
+    <div class="grid-row flex-align-center">
+      <div class="tablet:grid-col-2">
+        <div>
+          {{ color }}
+        </div>
+      </div>
+      <div class="tablet:grid-col-10">
+        <div class="bg-{{ color }} util-test padding-205"></div>
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/src/stylesheets/utilities/palettes/_default-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_default-palettes.scss
@@ -23,7 +23,8 @@ $palettes-default: (
     map-collect(
       $tokens-color-basic,
       $tokens-color-grayscale,
-      $tokens-color-theme
+      $tokens-color-theme,
+      $tokens-color-state
     ),
   "palette-cursor-default": get-standard-values(cursor),
   "palette-display-default": get-standard-values(display),


### PR DESCRIPTION
## Description

Resolves #4098. Adds state colors to utilities.

### Preview
[State color utils test →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-state-color-utils/components/preview/state-color.html)

## Additional information
Adds `$tokens-color-state` to `$palettes-default`.

| File                 | Old size | New size |
| --------------- | -------- | --------- |
| uswds.css        | 464 KB | 488 KB   |
| uswds.min.css | 363 KB | 379 KB   |


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
