### PR TITLE
USWDS - date-picker: Resolve chrome non-unique empty id warnings.

### DIFF
--- a/src/js/components/date-picker.js
+++ b/src/js/components/date-picker.js
@@ -877,7 +877,7 @@ const enhanceDatePicker = (el) => {
     "usa-sr-only",
     DATE_PICKER_INTERNAL_INPUT_CLASS
   );
-  internalInputEl.id = "";
+  internalInputEl.removeAttribute("id");
   internalInputEl.required = false;
 
   datePickerEl.appendChild(calendarWrapper);


### PR DESCRIPTION
## Description

The date picker component sets an id to "". 
Chrome gives a warning as it treats multiple empty ids as non-unique.

## Additional information

Visit a following page in Chrome withe more than 1 date picker, and see console warnings (ex. https://designsystem.digital.gov/components/date-range-picker/)

