### PR TITLE
POAM | CVE-2020-7729

### DIFF
--- a/examples/grunt/package.json
+++ b/examples/grunt/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "uswds": "^2.12.0"
+    "uswds": "^2.11.2"
   },
   "scripts": {
     "build": "grunt js sass",

--- a/examples/grunt/package.json
+++ b/examples/grunt/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "uswds": "^1.1.0"
+    "uswds": "^2.12.0"
   },
   "scripts": {
     "build": "grunt js sass",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "babel-preset-env": "^1.7.0",
     "babelify": "^7.3.0",
-    "grunt": "~1.0.1",
+    "grunt": ">=1.3.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-sass": "^1.2.1",


### PR DESCRIPTION
# CVE-2020-7729

## Description

Updates package to resolve the alert.

## Additional information

We should reconsider the value of the examples directory here.  

Are folks using it? 
Could be outdated recommendations for node dependencies here? (ie, node-sass)

We might consider removing the directory and revisit the need for including an updated "recommended approach" dir in future `library` updates.

