### PR TITLE
USWDS - Footer: Move social icon images into their own element.

### DIFF
--- a/src/components/footer/footer--big.njk
+++ b/src/components/footer/footer--big.njk
@@ -2,7 +2,7 @@
 
 {% set contact_info = {
   'heading': secondary_section.contact_links.heading | e,
-  'phone':  secondary_section.contact_links.address.phone | e ,
+  'phone':  secondary_section.contact_links.address.phone | e,
   'email': secondary_section.contact_links.address.email | e
 } %}
 
@@ -68,7 +68,7 @@
             {% for item in secondary_section.contact_links.social_nav %}
               <div class="grid-col-auto">
                 <a class="usa-social-link usa-social-link--{{ item | lower }}" href="javascript:void(0);">
-                  <span>{{ item }}</span>
+                  <span class="usa-social-icon usa-social-icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
                 </a>
               </div>
             {% endfor %}

--- a/src/components/footer/footer--big.njk
+++ b/src/components/footer/footer--big.njk
@@ -67,8 +67,11 @@
           <div class="usa-footer__social-links grid-row grid-gap-1">
             {% for item in secondary_section.contact_links.social_nav %}
               <div class="grid-col-auto">
-                <a class="usa-social-link usa-social-link--{{ item | lower }}" href="javascript:void(0);">
-                  <span class="usa-social-link__icon usa-social-link__icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
+                <a class="usa-social-link" href="javascript:void(0);">
+                  <img class="usa-social-link__icon"
+                    src="{{ uswds.path }}/img/usa-icons/{% if item.icon %}{{ item.icon }}{% else %}{{ item.name | lower }}{% endif %}.svg"
+                    alt="{{ item.name }}"
+                  />
                 </a>
               </div>
             {% endfor %}

--- a/src/components/footer/footer--big.njk
+++ b/src/components/footer/footer--big.njk
@@ -68,7 +68,7 @@
             {% for item in secondary_section.contact_links.social_nav %}
               <div class="grid-col-auto">
                 <a class="usa-social-link usa-social-link--{{ item | lower }}" href="javascript:void(0);">
-                  <span class="usa-social-icon usa-social-icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
+                  <span class="usa-social-link__icon usa-social-link__icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
                 </a>
               </div>
             {% endfor %}

--- a/src/components/footer/footer.config.yml
+++ b/src/components/footer/footer.config.yml
@@ -18,11 +18,12 @@ context:
       agency_name: <Name of Agency>
     contact_links:
       social_nav:
-        - Facebook
-        - Twitter
-        - YouTube
-        - Instagram
-        - RSS
+        - name: Facebook
+        - name: Twitter
+        - name: YouTube
+        - name: Instagram
+        - name: RSS
+          icon: rss_feed
       heading: <Agency Contact Center>
       address:
         phone: <(800) 555-GOVT>

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -42,7 +42,10 @@
             {% for item in secondary_section.contact_links.social_nav %}
               <div class="grid-col-auto">
                 <a class="usa-social-link" href="javascript:void(0);">
-                  <span class="usa-social-link__icon usa-social-link__icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
+                  <img class="usa-social-link__icon"
+                    src="{{ uswds.path }}/img/usa-icons/{% if item.icon %}{{ item.icon }}{% else %}{{ item.name | lower }}{% endif %}.svg"
+                    alt="{{ item.name }}"
+                  />
                 </a>
               </div>
             {% endfor %}

--- a/src/components/footer/footer.njk
+++ b/src/components/footer/footer.njk
@@ -2,7 +2,7 @@
 
 {% set contact_info = {
   'heading': secondary_section.contact_links.heading | e,
-  'phone':  secondary_section.contact_links.address.phone | e ,
+  'phone':  secondary_section.contact_links.address.phone | e,
   'email': secondary_section.contact_links.address.email | e
 } %}
 
@@ -41,8 +41,8 @@
           <div class="usa-footer__social-links grid-row grid-gap-1">
             {% for item in secondary_section.contact_links.social_nav %}
               <div class="grid-col-auto">
-                <a class="usa-social-link usa-social-link--{{ item | lower }}" href="javascript:void(0);">
-                  <span>{{ item }}</span>
+                <a class="usa-social-link" href="javascript:void(0);">
+                  <span class="usa-social-link__icon usa-social-link__icon--{{ item | lower }}" role="img" aria-label="{{ item }}"></span>
                 </a>
               </div>
             {% endfor %}

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -206,6 +206,10 @@
   background-color: color("black-transparent-10");
   display: inline-block;
   padding: units(0.5);
+
+  &:hover {
+    background-color: color("white");
+  }
 }
 
 .usa-social-link__icon {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -202,36 +202,32 @@
 }
 
 .usa-social-link {
-  $background-height: units(4); // Height of icon within hit area.
   @include u-square($size-touch-target);
-  background-position: center center;
-  background-size: auto $background-height;
   background-color: color("black-transparent-10");
   display: inline-block;
+}
 
-  span {
-    @include sr-only();
+.usa-social-link__icon {
+  $background-height: units(4); // Height of icon within hit area.
+  background-position: center center;
+  background-size: auto $background-height;
+  display: inline-block;
+  height: inherit;
+  width: inherit;
+}
+
+$social-networks: (
+  "facebook": "usa-icons/facebook",
+  "twitter": "usa-icons/twitter",
+  "youtube": "usa-icons/youtube",
+  "instagram": "usa-icons/instagram",
+  "rss": "usa-icons/rss_feed",
+);
+
+@each $network, $icon in $social-networks {
+  .usa-social-link__icon--#{$network} {
+    @include add-background-svg(#{$icon});
   }
-}
-
-.usa-social-link--facebook {
-  @include add-background-svg("usa-icons/facebook");
-}
-
-.usa-social-link--twitter {
-  @include add-background-svg("usa-icons/twitter");
-}
-
-.usa-social-link--youtube {
-  @include add-background-svg("usa-icons/youtube");
-}
-
-.usa-social-link--instagram {
-  @include add-background-svg("usa-icons/instagram");
-}
-
-.usa-social-link--rss {
-  @include add-background-svg("usa-icons/rss_feed");
 }
 
 .usa-footer__address {

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -205,29 +205,13 @@
   @include u-square($size-touch-target);
   background-color: color("black-transparent-10");
   display: inline-block;
+  padding: units(0.5);
 }
 
 .usa-social-link__icon {
-  $background-height: units(4); // Height of icon within hit area.
-  background-position: center center;
-  background-size: auto $background-height;
-  display: inline-block;
-  height: inherit;
-  width: inherit;
-}
-
-$social-networks: (
-  "facebook": "usa-icons/facebook",
-  "twitter": "usa-icons/twitter",
-  "youtube": "usa-icons/youtube",
-  "instagram": "usa-icons/instagram",
-  "rss": "usa-icons/rss_feed",
-);
-
-@each $network, $icon in $social-networks {
-  .usa-social-link__icon--#{$network} {
-    @include add-background-svg(#{$icon});
-  }
+  display: block;
+  height: auto;
+  width: 100%;
 }
 
 .usa-footer__address {


### PR DESCRIPTION
## Description

Fixes issue #4207. 

**Improved accessibility of USA Footer's social nav.** Social icons were converted to inline images with `alt` text to ensure there's a meaningful text alternative.

⚠ Requires a manual change to Footer's social navigation.

**New markup**
```html
<a class="usa-social-link" href="{{ social-network-link }}">
  <img class="usa-social-link__icon" src="path-to-usa-icons/usa-icons/facebook.svg" alt="Facebook">
</a>
```

**Old markup**
```html
<a class="usa-social-link usa-social-link--facebook" href="{{ social-network-link }}">
  <span>Facebook</span>
</a>
```


### Preview links
[Footer (default) →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-footer-bg-images/components/preview/footer--default.html)
[Footer Big →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-footer-bg-images/components/preview/footer--big.html)

## Additional information

The reported ANDI issue USWDS <= 2.12.0.
![image](https://user-images.githubusercontent.com/3385219/126394308-c5eeeff7-b2e4-43e3-9768-2443d764d874.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
