### PR TITLE
USWDS Spacing Tokens - Resolves sass error: 'neg-4' is not a valid USWDS margin-horizontal token

### DIFF
--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -393,6 +393,7 @@ $system-properties: (
         map-get($system-spacing, "small-negative"),
         map-get($system-spacing, "smaller"),
         map-get($system-spacing, "small"),
+        map-get($system-spacing, "medium-negative"),      
         map-get($system-spacing, "medium"),
         map-get($system-spacing-em, "small"),
         map-get($partial-values, "zero-zero")
@@ -406,6 +407,7 @@ $system-properties: (
         map-get($system-spacing, "small"),
         map-get($system-spacing, "smaller-negative"),
         map-get($system-spacing, "small-negative"),
+        map-get($system-spacing, "medium-negative"),
         map-get($system-spacing, "medium"),
         map-get($system-spacing, "large"),
         map-get($system-spacing-em, "small"),
@@ -421,6 +423,7 @@ $system-properties: (
         map-get($system-spacing, "small"),
         map-get($system-spacing, "smaller-negative"),
         map-get($system-spacing, "small-negative"),
+        map-get($system-spacing, "medium-negative"),
         map-get($system-spacing, "medium"),
         map-get($system-spacing-em, "small"),
         map-get($partial-values, "zero-zero"),

--- a/src/stylesheets/utilities/palettes/_spacing-palettes.scss
+++ b/src/stylesheets/utilities/palettes/_spacing-palettes.scss
@@ -69,6 +69,7 @@ $palettes-units: (
     map-collect(
       map-get($system-spacing, small-negative),
       map-get($system-spacing, smaller-negative),
+      map-get($system-spacing, medium-negative),
       map-get($system-spacing, smaller),
       map-get($system-spacing, small),
       map-get($system-spacing, medium),
@@ -100,6 +101,8 @@ $palettes-units: (
     map-get($system-spacing, smaller-negative),
   "palette-units-system-negative-small":
     map-get($system-spacing, small-negative),
+  "palette-units-system-negative-medium":
+    map-get($system-spacing, medium-negative),
   "palette-units-system-breakpoints":
     map-collect(
       map-get($system-spacing, large),
@@ -122,6 +125,7 @@ $palettes-units-misc: (
       map-get($system-spacing, smaller-negative),
       map-get($system-spacing, smaller),
       map-get($system-spacing, small),
+      map-get($system-spacing, medium-negative),
       map-get($system-spacing, medium),
       map-get($system-spacing, large),
       map-get($system-spacing, larger),


### PR DESCRIPTION
## Description

Resolves issue #4142 by adding the medium-negative system-tokens to `_spacing-tokens.scss` as well as `_properties.scss`.

## Additional information

Input before:

`@include u-margin-x("neg-4");`

left unexpected output: 
`    messageOriginal: "'neg-4' is not a valid USWDS margin-horizontal token. Valid tokens: 1px, 2px, 05, 1, 105, 2, 205, 3, neg-1px, neg-2px, neg-05, neg-1, neg-105, neg-2, neg-205, neg-3, 4, 5, 6, 7, 8, 9, 10, 15, card, card-lg, mobile, 05em, 1em, 105em, 2em, 0, auto"
   ╷
57 │     @return uswds-error(
   │ ┌───────────^
58 │ │     "'#{$token}' is not a valid USWDS #{$type} token.#{$valid-token-message}"
59 │ │   );
   │ └───^
`

The error does not occur with this build..


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ x ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ x ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ x ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
