### PR TITLE
Remove elem-dataset dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6704,11 +6704,6 @@
       "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig==",
       "dev": true
     },
-    "elem-dataset": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/elem-dataset/-/elem-dataset-2.0.0.tgz",
-      "integrity": "sha512-e7gieGopWw5dMdEgythH3lUS7nMizutPDTtkzfQW/q2gCvFnACyNnK3ytCncAXKxdBXQWcXeKaYTTODiMnp8mw=="
-    },
     "element-closest": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "classlist-polyfill": "^1.0.3",
     "del": "^6.0.0",
     "domready": "^1.0.8",
-    "elem-dataset": "^2.0.0",
     "object-assign": "^4.1.1",
     "receptor": "^1.0.0",
     "resolve-id-refs": "^0.1.0"

--- a/src/js/utils/validate-input.js
+++ b/src/js/utils/validate-input.js
@@ -1,13 +1,10 @@
-const dataset = require("elem-dataset");
-
 const { prefix: PREFIX } = require("../config");
 
 const CHECKED = "aria-checked";
 const CHECKED_CLASS = `${PREFIX}-checklist__item--checked`;
 
 module.exports = function validate(el) {
-  const data = dataset(el);
-  const id = data.validationElement;
+  const id = el.dataset.validationElement;
   const checkList =
     id.charAt(0) === "#"
       ? document.querySelector(id)
@@ -17,7 +14,7 @@ module.exports = function validate(el) {
     throw new Error(`No validation element found with id: "${id}"`);
   }
 
-  Object.entries(data).forEach(([key, value]) => {
+  Object.entries(el.dataset).forEach(([key, value]) => {
     if (key.startsWith("validate")) {
       const validatorName = key.substr("validate".length).toLowerCase();
       const validatorPattern = new RegExp(value);


### PR DESCRIPTION
## Description

Removes the `elem-dataset` dependency, substituting an equivalent implementation in the one instance of current usage.

## Additional information

Rationale:

- Consistency with other existing non-polyfilled references to `dataset`
   - Examples:
      - https://github.com/uswds/uswds/blob/4a0dfc7ec3fcba32f9999a5e0555f1796d3718bb/src/js/components/time-picker.js#L92
      - https://github.com/uswds/uswds/blob/4a0dfc7ec3fcba32f9999a5e0555f1796d3718bb/src/js/components/date-range-picker.js#L73
- Alignment to documented browser support, where `dataset` is available in all supported browsers ([browser support statement](https://designsystem.digital.gov/documentation/developers/#browser-support), [feature browser support](https://caniuse.com/dataset))
- Fewer dependencies to maintain
- Smaller bundle size
- Downstream projects that consume JavaScript from source don't need to transpile `elem-dataset`, which is published with modern JavaScript syntax in its `module` entrypoint ([source](https://unpkg.com/elem-dataset@2.0.0/index.js), [example](https://github.com/18F/identity-idp/blob/7f308cda8ec5eed824acd44603c741f87c58d148/config/webpack/environment.js#L13-L20))

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
