### PR TITLE
USWDS: Breadcrumb - Changes negative margin from shorthand to left/right

### DIFF
--- a/src/stylesheets/components/_breadcrumb.scss
+++ b/src/stylesheets/components/_breadcrumb.scss
@@ -74,7 +74,8 @@ $breadcrumb-back-icon-aspect: (
   @include unstyled-list;
   @include u-display("block");
   @include u-padding($theme-focus-width);
-  margin: units($theme-focus-width) * -1;
+  margin-left: units($theme-focus-width) * -1;
+  margin-right: units($theme-focus-width) * -1;
 }
 
 .usa-breadcrumb__list-item {


### PR DESCRIPTION
## Resolves #4240 

## Description

Uses @mejiaj 's solution to fix negative margin overlap error by changing `margin: units($theme-focus-width) * -1;` to
```
margin-left: units($theme-focus-width) * -1;
margin-right: units($theme-focus-width) * -1;
```


## Additional information

**Before**

![image](https://user-images.githubusercontent.com/25211650/124187297-9fb9df00-da8b-11eb-9ddc-717cc1780d23.png)

**After**

![image](https://user-images.githubusercontent.com/25211650/124187734-3eded680-da8c-11eb-9956-cafb383968eb.png)




Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ x ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ x ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ x ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
