### PR TITLE
USWDS: Breadcrumb - Checkbox/radio components don't work if label class doesn't end with `usa-checkbox__label` or `usa-radio__label`

### DIFF
--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -1,11 +1,11 @@
 @mixin format-input {
-  & + [class$="__label"]::before {
+  & + [class*="__label"]::before {
     @content;
   }
 }
 
 @mixin format-label {
-  & + [class$="__label"] {
+  & + [class*="__label"] {
     @content;
   }
 }


### PR DESCRIPTION
 Fixes #4251.

## Description
Resolves a Sass selector issue where checkbox and radio components were only being styled if the `usa-*__label` was the last CSS class. One would expect this should work if the CSS class is present within the element regardless of position, due to modifiers and application-specific overrides or expansions.


## Additional information
See #4251 for the original report and suggested fix.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [] Run `npm test` and make sure the tests for the files you have changed have passed.
- [] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [X] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
