### PR TITLE
Modal: Fix modal aria-hidden for non-modal content after script load

### DIFF
--- a/spec/unit/modal/modal.spec.js
+++ b/spec/unit/modal/modal.spec.js
@@ -89,7 +89,7 @@ describe("Modal window", () => {
     });
 
     it("makes all other page content invisible to screen readers", () => {
-      const activeContent = document.querySelectorAll('body > :not([aria-hidden])');
+      const activeContent = document.querySelectorAll("body > :not([aria-hidden])");
       assert.strictEqual(activeContent.length, 1);
       assert.strictEqual(activeContent[0], modalWrapper);
     });
@@ -118,10 +118,10 @@ describe("Modal window", () => {
 
     it("restores other page content screen reader visibility", () => {
       closeButton.click();
-      const activeContent = document.querySelectorAll('body > :not([aria-hidden])');
-      const staysHidden = document.getElementById('stays-hidden');
+      const activeContent = document.querySelectorAll("body > :not([aria-hidden])");
+      const staysHidden = document.getElementById("stays-hidden");
       assert.strictEqual(activeContent.length, 4);
-      assert.strictEqual(staysHidden.hasAttribute('aria-hidden'), true);
+      assert.strictEqual(staysHidden.hasAttribute("aria-hidden"), true);
     });
   });
 });

--- a/spec/unit/modal/modal.spec.js
+++ b/spec/unit/modal/modal.spec.js
@@ -87,6 +87,12 @@ describe("Modal window", () => {
     it("focuses the modal window when opened", () => {
       assert.strictEqual(document.activeElement, modalWindow);
     });
+
+    it("makes all other page content invisible to screen readers", () => {
+      const activeContent = document.querySelectorAll('body > :not([aria-hidden])');
+      assert.strictEqual(activeContent.length, 1);
+      assert.strictEqual(activeContent[0], modalWrapper);
+    });
   });
 
   describe("When closing", () => {
@@ -108,6 +114,14 @@ describe("Modal window", () => {
     it("sends focus to the element that opened it", () => {
       closeButton.click();
       assert.strictEqual(document.activeElement, openButton2);
+    });
+
+    it("restores other page content screen reader visibility", () => {
+      closeButton.click();
+      const activeContent = document.querySelectorAll('body > :not([aria-hidden])');
+      const staysHidden = document.getElementById('stays-hidden');
+      assert.strictEqual(activeContent.length, 4);
+      assert.strictEqual(staysHidden.hasAttribute('aria-hidden'), true);
     });
   });
 });

--- a/spec/unit/modal/template.html
+++ b/spec/unit/modal/template.html
@@ -5,33 +5,29 @@
 <div id="other-content">
 </div>
 
-<div id="original-container">
-  <div>
-    <a id="open-button1" href="#modal" class="usa-button" aria-controls="modal" data-open-modal>Open modal</a>
-    <button id="open-button2" type="button" class="usa-button" aria-controls="modal" data-open-modal>Open modal</button>
-    <div class="usa-modal" id="modal" aria-labelledby="modalheading" aria-describedby="describe">
-      <div class="usa-modal__content">
-        <div class="usa-modal__main">
-          <h2 class="usa-modal__heading" id="modal-sm-heading">You have unsaved changes</h2>
-          <div id="describe" class="usa-prose">
-            <p>Your changes will be lost if you leave this page without saving. Are you sure you want to continue?</p>
-          </div>
+<a id="open-button1" href="#modal" class="usa-button" aria-controls="modal" data-open-modal>Open modal</a>
+<button id="open-button2" type="button" class="usa-button" aria-controls="modal" data-open-modal>Open modal</button>
+<div class="usa-modal" id="modal" aria-labelledby="modalheading" aria-describedby="describe">
+  <div class="usa-modal__content">
+    <div class="usa-modal__main">
+      <h2 class="usa-modal__heading" id="modal-sm-heading">You have unsaved changes</h2>
+      <div id="describe" class="usa-prose">
+        <p>Your changes will be lost if you leave this page without saving. Are you sure you want to continue?</p>
+      </div>
 
-          <div class="usa-modal__footer">
-            <ul class="usa-button-group">
-              <li class="usa-button-group__item">
-                <button type="button" class="usa-button" data-close-modal>Continue</button>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <button id="close-button" class="usa-button usa-modal__close" aria-label="close this window"  data-close-modal>
-          <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-            <use xlink:href="{{ uswds.path }}/img/sprite.svg#close"></use>
-          </svg>
-          Close
-        </button>
+      <div class="usa-modal__footer">
+        <ul class="usa-button-group">
+          <li class="usa-button-group__item">
+            <button type="button" class="usa-button" data-close-modal>Continue</button>
+          </li>
+        </ul>
       </div>
     </div>
+    <button id="close-button" class="usa-button usa-modal__close" aria-label="close this window"  data-close-modal>
+      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlink:href="{{ uswds.path }}/img/sprite.svg#close"></use>
+      </svg>
+      Close
+    </button>
   </div>
 </div>

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -12,20 +12,19 @@ const WRAPPER_CLASSNAME = `${MODAL_CLASSNAME}-wrapper`;
 const OPENER_ATTRIBUTE = "data-open-modal";
 const CLOSER_ATTRIBUTE = "data-close-modal";
 const FORCE_ACTION_ATTRIBUTE = "data-force-action";
+const NON_MODAL_HIDDEN_ATTRIBUTE = `data-modal-hidden`;
 const MODAL = `.${MODAL_CLASSNAME}`;
 const INITIAL_FOCUS = `.${WRAPPER_CLASSNAME} *[data-focus]`;
 const CLOSE_BUTTON = `${WRAPPER_CLASSNAME} *[${CLOSER_ATTRIBUTE}]`;
 const OPENERS = `*[${OPENER_ATTRIBUTE}][aria-controls]`;
 const CLOSERS = `${CLOSE_BUTTON}, .${OVERLAY_CLASSNAME}:not([${FORCE_ACTION_ATTRIBUTE}])`;
+const NON_MODALS = `body > *:not(.${WRAPPER_CLASSNAME}):not([aria-hidden])`;
+const NON_MODALS_HIDDEN = `[${NON_MODAL_HIDDEN_ATTRIBUTE}]`;
 
 const ACTIVE_CLASS = "usa-js-modal--active";
 const PREVENT_CLICK_CLASS = "usa-js-no-click";
 const VISIBLE_CLASS = "is-visible";
 const HIDDEN_CLASS = "is-hidden";
-
-const nonModals = document.querySelectorAll(
-  `body > *:not(${MODAL}):not([aria-hidden])`
-);
 
 let modal;
 
@@ -148,15 +147,17 @@ function toggleModal(event) {
     openFocusEl.focus();
 
     // Hides everything that is not the modal from screen readers
-    for (let i = 0; i < nonModals.length; i += 1) {
-      nonModals[i].setAttribute("aria-hidden", "true");
-    }
+    document.querySelectorAll(NON_MODALS).forEach((nonModal) => {
+      nonModal.setAttribute("aria-hidden", "true");
+      nonModal.setAttribute(NON_MODAL_HIDDEN_ATTRIBUTE, "");
+    });
   } else if (!safeActive && menuButton && returnFocus) {
     // The modal window is closed.
     // Non-modals now accesible to screen reader
-    for (let i = 0; i < nonModals.length; i += 1) {
-      nonModals[i].removeAttribute("aria-hidden");
-    }
+    document.querySelectorAll(NON_MODALS_HIDDEN).forEach((nonModal) => {
+      nonModal.removeAttribute("aria-hidden");
+      nonModal.removeAttribute(NON_MODAL_HIDDEN_ATTRIBUTE);
+    });
 
     // Focus is returned to the opener
     returnFocus.focus();


### PR DESCRIPTION
## Description

Accounts for cases where page content changes after initial script load, including:

- If USWDS script is loaded early in page content, all server-rendered content to follow will not be counted as non-modal content ([demo](https://codepen.io/aduth/pen/PommWEK))
- If any JavaScript alters the page after load, this will not be counted as non-modal content ([demo](https://codepen.io/aduth/pen/GRmJaZe))

## Additional information

Because `nonModals` was assigned only once at script load, it would not include anything from the above scenarios.

Notably, this means that users navigating page content using assistive technology can often escape the modal, which is not the intended behavior.

The newly-added test cases will fail on the `develop` branch, because this issue is also present in the tests.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
