### PR TITLE
USWDS - Range: add ARIA attribute.

### DIFF
--- a/src/components/range-slider/range-slider.njk
+++ b/src/components/range-slider/range-slider.njk
@@ -1,2 +1,15 @@
 <label class="usa-label" for="usa-range">Range slider</label>
-<input id="usa-range" class="usa-range" type="range" min="0" max="100" step="10" value="20">
+<input
+  id="usa-range"
+  class="usa-range"
+  type="range"
+  min="0"
+  max="100"
+  step="10"
+  value="20"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-valuenow="20"
+  role="slider"
+>
+<output for="usa-range" class="usa-output" id="usa-range-value">20</output>

--- a/src/components/range-slider/range-slider.njk
+++ b/src/components/range-slider/range-slider.njk
@@ -12,4 +12,3 @@
   aria-valuenow="20"
   role="slider"
 >
-<output for="usa-range" class="usa-output" id="usa-range-value">20</output>


### PR DESCRIPTION
## Preview
[Range slider →
](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-range-add-aria/components/detail/range-slider.html)


## Description

Fixes #4265; add missing range attributes.

Added the last four values.

```html
<label class="usa-label" for="usa-range">Range slider</label>
<input
  id="usa-range"
  class="usa-range"
  type="range"
  min="0"
  max="100"
  step="10"
  value="20"
  aria-valuemin="0"
  aria-valuemax="100"
  aria-valuenow="20"
  role="slider"
>
```

## Additional information

Alternatively, we could enhance the component by adding an `output` element after: [example →
](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-range-add-output/components/detail/range-slider.html)

This uses `nextElementSibling` to select the output element. We could improve it further if we changed the markup. Something like:

```html
<div class="usa-range">
  <label for="" class="usa-range__label usa-label">Range input</label>
  <input type="range" class="usa-range__input" value="20">
  <output class="usa-range__output">20</output>
</div>
```

But this would be a breaking change.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
