### PR TITLE
USWDS - Search: Use inline image for Search icon

### DIFF
--- a/src/components/search/search.njk
+++ b/src/components/search/search.njk
@@ -1,7 +1,6 @@
 {%
   set search_attrs = {
     'input_modifier': (id_prefix if id_prefix) ~ 'search-field-' ~ (input_modifier if input_modifier else 'search-field'),
-    'button_class': 'usa-search__submit-text' if modifier !== 'usa-search--small' else 'usa-sr-only',
     'search_class': 'usa-search' ~ (' ' ~ modifier if modifier) ~ (' js-search-form' if search_js)
   }
 %}
@@ -16,8 +15,14 @@
     </label>
     <input class="usa-input" id="{{ search_attrs.input_modifier }}" type="search" name="search">
     <button class="usa-button" type="submit">
-      {# `usa-search__submit-text` is the default, but small variation requires a different class #}
-      <span class="{{ search_attrs.button_class }}">{{ text }}</span>
+      {% if modifier !== 'usa-search--small' %}
+        <span class="usa-search__submit-text">{{ text }}</span>
+      {% endif %}
+      <img
+          src="{{ uswds.path }}/img/usa-icons-bg/search--white.svg"
+          class="usa-search__submit-icon"
+          alt="{{ text }}"
+      >
     </button>
   </form>
 {% if not search_header %}

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -1,10 +1,3 @@
-// TODO: abstract and integrate
-@mixin search-icon {
-  @include add-background-svg("usa-icons-bg/search--white");
-  background-position: center center;
-  background-size: units(3);
-}
-
 .usa-search {
   @include border-box-sizing;
   @include clearfix;
@@ -21,7 +14,6 @@
   }
 
   [type="submit"] {
-    @include search-icon;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
     height: units(4);
@@ -31,8 +23,13 @@
 
     @include at-media("mobile-lg") {
       @include u-padding-x(2);
-      background-image: none;
       width: auto;
+    }
+  }
+
+  &__submit-icon {
+    @include at-media("mobile-lg") {
+      display: none;
     }
   }
 }
@@ -62,10 +59,13 @@
 .usa-search--small {
   [type="submit"],
   .usa-search__submit {
-    @include at-media("mobile-lg") {
-      @include search-icon;
-      width: units($theme-button-small-width);
-    }
+    @include u-padding-x(1.5);
+    width: units($theme-button-small-width);
+  }
+
+  .usa-search__submit-icon {
+    @include u-square(3);
+    display: block;
   }
 }
 
@@ -90,9 +90,9 @@ input[type="search"] {
 }
 
 .usa-search__submit-text {
-  @include sr-only;
+  display: none;
 
   @include at-media("mobile-lg") {
-    @include not-sr-only;
+    display: block;
   }
 }


### PR DESCRIPTION
## Preview
- [Search small](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-a11y-search-icon/components/detail/search--small.html)
- [Search in header](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-a11y-search-icon/components/detail/header--default.html)


## Description

Fixes #4272. The search icon has been converted from a background to an inline image. This is to ensure there's a text alternative should images fail to load.

⚠ Requires a markup change to Search component and/or header.

### New markup

The new addition is the inline image for the search icon.
```html
<img src="usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search">
```

**Default & Big search**
```html
<button class="usa-button" type="submit">    
  <span class="usa-search__submit-text">Search</span>    
  <img src="usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search">
</button>
```

**Small search**
```html
<button class="usa-button" type="submit">    
  <img src="usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search">
</button>
```

## Additional information

Related to issue #4207.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
