### PR TITLE
USWDS - Navigation: Close actions.

### DIFF
--- a/config/gulp/test.js
+++ b/config/gulp/test.js
@@ -15,9 +15,7 @@ gulp.task("cover", () =>
   gulp.src("spec/unit/**/*.spec.js").pipe(
     mocha(
       mochaConfig,
-      Object.assign({
-        nyc: true,
-      })
+      {nyc: true}
     )
   )
 );

--- a/spec/unit/modal/modal.spec.js
+++ b/spec/unit/modal/modal.spec.js
@@ -16,7 +16,7 @@ describe("Modal window", () => {
   let openButton2;
   let overlay;
 
-  const isVisible = el => el.classList.contains("is-visible");
+  const isVisible = (el) => el.classList.contains("is-visible");
 
   beforeEach(() => {
     body.innerHTML = TEMPLATE;
@@ -36,8 +36,7 @@ describe("Modal window", () => {
   });
 
   describe("Builds the modal HTML", () => {
-
-    it('creates new parent elements', () => {
+    it("creates new parent elements", () => {
       assert.ok(modalWindow, "creates inner div");
       assert.ok(overlay, "creates the overlay");
       assert.ok(modalWrapper, "creates the outer div");
@@ -47,32 +46,35 @@ describe("Modal window", () => {
       assert.strictEqual(modalWrapper.getAttribute("role"), "dialog");
     });
 
-    it('moves aria-lableledby, aria-describedby, and id to the parent', () => {
+    it("moves aria-labelledby, aria-describedby, and id to the parent", () => {
       assert.strictEqual(modalWindow.hasAttribute("aria-describedby"), false);
       assert.strictEqual(modalWindow.hasAttribute("aria-labelledby"), false);
       assert.strictEqual(modalWindow.hasAttribute("id"), false);
       assert.strictEqual(modalWrapper.hasAttribute("aria-describedby"), true);
       assert.strictEqual(modalWrapper.hasAttribute("aria-labelledby"), true);
       assert.strictEqual(modalWrapper.getAttribute("id"), "modal");
-    })
+    });
 
     it('sets tabindex="-1" to the modal window', () => {
       assert.strictEqual(modalWindow.getAttribute("tabindex"), "-1");
     });
 
-    it('moves the modal to the bottom of the DOM', () => {
-      assert.strictEqual(body.lastElementChild.classList.contains("usa-modal-wrapper"), true);
+    it("moves the modal to the bottom of the DOM", () => {
+      assert.strictEqual(
+        body.lastElementChild.classList.contains("usa-modal-wrapper"),
+        true
+      );
     });
 
     it('adds role="button" to any <a> opener, but not <button>', () => {
       assert.strictEqual(openButton1.getAttribute("role"), "button");
       assert.strictEqual(openButton2.hasAttribute("role"), false);
-    })
+    });
 
-    it('adds aria-controls to each opener', () => {
+    it("adds aria-controls to each opener", () => {
       assert.strictEqual(openButton1.getAttribute("aria-controls"), "modal");
       assert.strictEqual(openButton2.getAttribute("aria-controls"), "modal");
-    })
+    });
   });
 
   describe("When opened", () => {
@@ -89,14 +91,16 @@ describe("Modal window", () => {
     });
 
     it("makes all other page content invisible to screen readers", () => {
-      const activeContent = document.querySelectorAll("body > :not([aria-hidden])");
+      const activeContent = document.querySelectorAll(
+        "body > :not([aria-hidden])"
+      );
+
       assert.strictEqual(activeContent.length, 1);
       assert.strictEqual(activeContent[0], modalWrapper);
     });
   });
 
   describe("When closing", () => {
-
     beforeEach(() => {
       openButton2.click();
     });
@@ -118,7 +122,9 @@ describe("Modal window", () => {
 
     it("restores other page content screen reader visibility", () => {
       closeButton.click();
-      const activeContent = document.querySelectorAll("body > :not([aria-hidden])");
+      const activeContent = document.querySelectorAll(
+        "body > :not([aria-hidden])"
+      );
       const staysHidden = document.getElementById("stays-hidden");
       assert.strictEqual(activeContent.length, 4);
       assert.strictEqual(staysHidden.hasAttribute("aria-hidden"), true);

--- a/spec/unit/modal/template.html
+++ b/spec/unit/modal/template.html
@@ -2,28 +2,38 @@
   Needs to stay set to aria-hidden="true" when modals are toggled
 </div>
 
-<div id="other-content">
-</div>
+<div id="other-content"></div>
 
-<a id="open-button1" href="#modal" class="usa-button" aria-controls="modal" data-open-modal>Open modal</a>
-<button id="open-button2" type="button" class="usa-button" aria-controls="modal" data-open-modal>Open modal</button>
-<div class="usa-modal" id="modal" aria-labelledby="modalheading" aria-describedby="describe">
+<a id="open-button1" href="#modal" class="usa-button" aria-controls="modal" data-open-modal>
+  Open modal
+</a>
+<button id="open-button2" type="button" class="usa-button" aria-controls="modal" data-open-modal>
+  Open modal
+</button>
+<div class="usa-modal" id="modal" aria-labelledby="modal-sm-heading" aria-describedby="describe">
   <div class="usa-modal__content">
     <div class="usa-modal__main">
-      <h2 class="usa-modal__heading" id="modal-sm-heading">You have unsaved changes</h2>
+      <h2 class="usa-modal__heading" id="modal-sm-heading">
+        You have unsaved changes
+      </h2>
       <div id="describe" class="usa-prose">
-        <p>Your changes will be lost if you leave this page without saving. Are you sure you want to continue?</p>
+        <p>
+          Your changes will be lost if you leave this page without saving. Are
+          you sure you want to continue?
+        </p>
       </div>
 
       <div class="usa-modal__footer">
         <ul class="usa-button-group">
           <li class="usa-button-group__item">
-            <button type="button" class="usa-button" data-close-modal>Continue</button>
+            <button type="button" class="usa-button" data-close-modal>
+              Continue
+            </button>
           </li>
         </ul>
       </div>
     </div>
-    <button id="close-button" class="usa-button usa-modal__close" aria-label="close this window"  data-close-modal>
+    <button id="close-button" class="usa-button usa-modal__close" aria-label="close this window" data-close-modal>
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
         <use xlink:href="{{ uswds.path }}/img/sprite.svg#close"></use>
       </svg>

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -97,12 +97,6 @@ describe("navigation toggle", () => {
     assert.strictEqual(isVisible(nav), false);
   });
 
-  it("hides the nav when the Escape key is hit", () => {
-    menuButton.click();
-    EVENTS.escape(body);
-    assert.strictEqual(isVisible(nav), false);
-  });
-
   it("focuses the close button when the menu button is clicked", () => {
     menuButton.click();
     assert.strictEqual(document.activeElement, closeButton);
@@ -136,6 +130,12 @@ describe("navigation toggle", () => {
   it("collapses accordions when a nav link is clicked", () => {
     accordionButton.click();
     navLink.click();
+    assert.strictEqual(accordionButton.getAttribute("aria-expanded"), "false");
+  });
+
+  it("collapses dropdowns when the Escape key is hit", () => {
+    accordionButton.click();
+    EVENTS.escape(accordionButton);
     assert.strictEqual(accordionButton.getAttribute("aria-expanded"), "false");
   });
 

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -7,6 +7,13 @@ const accordion = require("../../../src/js/components/accordion");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "template.html"));
 
+const escKey = (el) => {
+  el.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Escape",
+    bubbles: true
+  }));
+};
+
 describe("navigation toggle", () => {
   const { body } = document;
 
@@ -76,6 +83,12 @@ describe("navigation toggle", () => {
     menuButton.click();
     navLink.click();
     assert.strictEqual(isVisible(nav), false);
+  });
+
+  it("hides the nav when the Escape key is hit", () => {
+    menuButton.click();
+    escKey(body);
+    assert.strictEqual(isVisible(nav), false)
   });
 
   it("focuses the close button when the menu button is clicked", () => {

--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -7,11 +7,23 @@ const accordion = require("../../../src/js/components/accordion");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "template.html"));
 
-const escKey = (el) => {
-  el.dispatchEvent(new KeyboardEvent("keydown", {
-    key: "Escape",
-    bubbles: true
-  }));
+const EVENTS = {
+  escape(el) {
+    const escapeKeyEvent = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true
+    });
+
+    el.dispatchEvent(escapeKeyEvent);
+  },
+  focusOut(el) {
+    const focusOutEvent = new Event("focusout", {
+      bubbles: true,
+      cancelable: true
+    });
+
+    el.dispatchEvent(focusOutEvent);
+  }
 };
 
 describe("navigation toggle", () => {
@@ -87,8 +99,8 @@ describe("navigation toggle", () => {
 
   it("hides the nav when the Escape key is hit", () => {
     menuButton.click();
-    escKey(body);
-    assert.strictEqual(isVisible(nav), false)
+    EVENTS.escape(body);
+    assert.strictEqual(isVisible(nav), false);
   });
 
   it("focuses the close button when the menu button is clicked", () => {
@@ -125,6 +137,13 @@ describe("navigation toggle", () => {
     accordionButton.click();
     navLink.click();
     assert.strictEqual(accordionButton.getAttribute("aria-expanded"), "false");
+  });
+
+  it("collapses dropdowns when focus leaves nav", () => {
+    menuButton.click();
+    navLink.click();
+    EVENTS.focusOut(navLink);
+    assert.strictEqual(isVisible(nav), false);
   });
 
   describe("off()", () => {

--- a/spec/unit/navigation/template.html
+++ b/spec/unit/navigation/template.html
@@ -1,54 +1,74 @@
 <div class="usa-overlay"></div>
-<header class="usa-header usa-header--basic" role="banner">
-    <div class="usa-nav-container">
-        <div class="usa-navbar">
-            <div class="usa-logo" id="basic-logo">
-                <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">Project title</a></em>
-            </div>
-            <button class="usa-menu-btn">Menu</button>
-        </div>
-        <nav role="navigation" class="usa-nav">
-            <button class="usa-nav__close"><img src="../../dist/img/close.svg" alt="close"></button>
-            <ul class="usa-nav__primary usa-accordion">
-                <li class="usa-nav__primary-item">
-                    <button class="usa-accordion__button usa-nav__link  usa-current" aria-expanded="false" aria-controls="basic-nav-section-one"><span>Current section</span></button>
-                    <ul id="basic-nav-section-one" class="usa-nav__submenu">
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                    </ul>
-                </li>
-                <li class="usa-nav__primary-item">
-                    <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="basic-nav-section-two"><span>Section</span></button>
-                    <ul id="basic-nav-section-two" class="usa-nav__submenu">
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                        <li class="usa-nav__submenu-item">
-                            <a href="#">Navigation link</a>
-                        </li>
-                    </ul>
-                </li>
-                <li class="usa-nav__primary-item">
-                    <a class="usa-nav__link" href="javascript:void(0)"><span>Simple link</span></a>
-                </li>
-            </ul>
-            <form class="usa-search usa-search--small ">
-                <div role="search">
-                    <label class="usa-sr-only" for="basic-search-field-small">Search small</label>
-                    <input class="usa-input" id="basic-search-field-small" type="search" name="search">
-                    <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
-                </div>
-            </form>
-        </nav>
+<header class="usa-header usa-header--basic">
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <div class="usa-logo" id="basic-logo">
+        <em class="usa-logo__text">
+          <a href="/" title="Home" aria-label="Home">Project title</a>
+        </em>
+      </div>
+      <button class="usa-menu-btn">Menu</button>
     </div>
+    <nav class="usa-nav">
+      <button class="usa-nav__close">
+        <img src="../../dist/img/close.svg" alt="close">
+      </button>
+      <ul class="usa-nav__primary usa-accordion">
+        <li class="usa-nav__primary-item">
+          <button
+            class="usa-accordion__button usa-nav__link  usa-current"
+            aria-expanded="false"
+            aria-controls="basic-nav-section-one">
+            <span>Current section</span>
+          </button>
+          <ul id="basic-nav-section-one" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button
+            class="usa-accordion__button usa-nav__link"
+            aria-expanded="false"
+            aria-controls="basic-nav-section-two">
+            <span>Section</span>
+          </button>
+          <ul id="basic-nav-section-two" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="#">Navigation link</a>
+            </li>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="javascript:void(0)">
+            <span>Simple link</span>
+          </a>
+        </li>
+      </ul>
+      <form class="usa-search usa-search--small ">
+        <div role="search">
+          <label class="usa-sr-only" for="basic-search-field-small">
+            Search small
+          </label>
+          <input class="usa-input" id="basic-search-field-small" type="search" name="search">
+          <button class="usa-button" type="submit">
+            <span class="usa-sr-only">Search</span>
+          </button>
+        </div>
+      </form>
+    </nav>
+  </div>
 </header>

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -34,9 +34,9 @@ const INITIAL_PADDING = window
   .getComputedStyle(document.body)
   .getPropertyValue("padding-right");
 const TEMPORARY_PADDING =
-  parseInt(INITIAL_PADDING.replace(/px/, ""), 10) +
-  parseInt(SCROLLBAR_WIDTH.replace(/px/, ""), 10) +
-  "px";
+  `${parseInt(INITIAL_PADDING.replace(/px/, ""), 10) +
+  parseInt(SCROLLBAR_WIDTH.replace(/px/, ""), 10)
+  }px`;
 
 /**
  *  Is bound to escape key, closes modal when
@@ -108,7 +108,6 @@ function toggleModal(event) {
     }
   }
 
-  // Active class shares same as navigation
   body.classList.toggle(ACTIVE_CLASS, safeActive);
   targetModal.classList.toggle(VISIBLE_CLASS, safeActive);
   targetModal.classList.toggle(HIDDEN_CLASS, !safeActive);

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -1,3 +1,4 @@
+const keymap = require("receptor/keymap");
 const behavior = require("../utils/behavior");
 const select = require("../utils/select");
 const toggle = require("../utils/toggle");
@@ -26,8 +27,13 @@ let navActive;
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 const SCROLLBAR_WIDTH = ScrollBarWidth();
-const INITIAL_PADDING = window.getComputedStyle(document.body).getPropertyValue('padding-right');
-const TEMPORARY_PADDING = parseInt(INITIAL_PADDING.replace(/px/,""), 10) + parseInt(SCROLLBAR_WIDTH.replace(/px/,""), 10) + "px";
+const INITIAL_PADDING = window
+  .getComputedStyle(document.body)
+  .getPropertyValue("padding-right");
+const TEMPORARY_PADDING = `${
+  parseInt(INITIAL_PADDING.replace(/px/, ""), 10) +
+  parseInt(SCROLLBAR_WIDTH.replace(/px/, ""), 10)
+}px`;
 
 const toggleNav = (active) => {
   const { body } = document;
@@ -43,8 +49,11 @@ const toggleNav = (active) => {
 
   const closeButton = body.querySelector(CLOSE_BUTTON);
   const menuButton = body.querySelector(OPENERS);
-  
-  body.style.paddingRight = body.style.paddingRight === TEMPORARY_PADDING ? INITIAL_PADDING : TEMPORARY_PADDING;
+
+  body.style.paddingRight =
+    body.style.paddingRight === TEMPORARY_PADDING
+      ? INITIAL_PADDING
+      : TEMPORARY_PADDING;
 
   if (safeActive && closeButton) {
     // The mobile nav was just activated, so focus on the close button,
@@ -79,6 +88,10 @@ const resize = () => {
 
 const onMenuClose = () => navigation.toggleNav.call(navigation, false);
 const hideActiveNavDropdown = () => {
+  if (!navActive) {
+    return;
+  }
+
   toggle(navActive, false);
   navActive = null;
 };
@@ -88,14 +101,12 @@ navigation = behavior(
     [CLICK]: {
       [NAV_CONTROL]() {
         // If another nav is open, close it
-        if (navActive && navActive !== this) {
+        if (navActive !== this) {
           hideActiveNavDropdown();
         }
         // store a reference to the last clicked nav link element, so we
         // can hide the dropdown if another element on the page is clicked
-        if (navActive) {
-          hideActiveNavDropdown();
-        } else {
+        if (!navActive) {
           navActive = this;
           toggle(navActive, true);
         }
@@ -103,11 +114,7 @@ navigation = behavior(
         // Do this so the event handler on the body doesn't fire
         return false;
       },
-      [BODY]() {
-        if (navActive) {
-          hideActiveNavDropdown();
-        }
-      },
+      [BODY]: hideActiveNavDropdown,
       [OPENERS]: toggleNav,
       [CLOSERS]: toggleNav,
       [NAV_LINKS]() {
@@ -128,6 +135,9 @@ navigation = behavior(
           navigation.toggleNav.call(navigation, false);
         }
       },
+    },
+    keydown: {
+      [BODY]: keymap({ Escape: hideActiveNavDropdown }),
     },
   },
   {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -13,6 +13,7 @@ const BODY = "body";
 const NAV = `.${PREFIX}-nav`;
 const NAV_LINKS = `${NAV} a`;
 const NAV_CONTROL = `button.${PREFIX}-nav__link`;
+const NAV_PRIMARY = `.${PREFIX}-nav__primary`;
 const OPENERS = `.${PREFIX}-menu-btn`;
 const CLOSE_BUTTON = `.${PREFIX}-nav__close`;
 const OVERLAY = `.${PREFIX}-overlay`;
@@ -139,6 +140,15 @@ navigation = behavior(
     keydown: {
       [BODY]: keymap({ Escape: hideActiveNavDropdown }),
     },
+    focusout: {
+      [NAV_PRIMARY](event) {
+        const nav = event.target.closest(NAV_PRIMARY);
+
+        if (!nav.contains(event.relatedTarget)) {
+          hideActiveNavDropdown();
+        }
+      }
+    }
   },
   {
     init(root) {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -11,9 +11,10 @@ const { prefix: PREFIX } = require("../config");
 
 const BODY = "body";
 const NAV = `.${PREFIX}-nav`;
-const NAV_LINKS = `${NAV} a`;
-const NAV_CONTROL = `button.${PREFIX}-nav__link`;
 const NAV_PRIMARY = `.${PREFIX}-nav__primary`;
+const NAV_PRIMARY_ITEM = `.${PREFIX}-nav__primary-item`;
+const NAV_CONTROL = `button.${PREFIX}-nav__link`;
+const NAV_LINKS = `${NAV} a`;
 const OPENERS = `.${PREFIX}-menu-btn`;
 const CLOSE_BUTTON = `.${PREFIX}-nav__close`;
 const OVERLAY = `.${PREFIX}-overlay`;
@@ -88,6 +89,7 @@ const resize = () => {
 };
 
 const onMenuClose = () => navigation.toggleNav.call(navigation, false);
+
 const hideActiveNavDropdown = () => {
   if (!navActive) {
     return;
@@ -96,6 +98,20 @@ const hideActiveNavDropdown = () => {
   toggle(navActive, false);
   navActive = null;
 };
+
+const focusNavButton = (event) => {
+  const parentNavItem = event.target.closest(NAV_PRIMARY_ITEM);
+
+  // Only shift focus if within dropdown
+  if (!event.target.matches(NAV_CONTROL)) {
+    parentNavItem.querySelector(NAV_CONTROL).focus();
+  }
+}
+
+const handleEscape = (event) => {
+  hideActiveNavDropdown();
+  focusNavButton(event);
+}
 
 navigation = behavior(
   {
@@ -138,7 +154,7 @@ navigation = behavior(
       },
     },
     keydown: {
-      [NAV_PRIMARY]: keymap({ Escape: hideActiveNavDropdown }),
+      [NAV_PRIMARY]: keymap({ Escape: handleEscape }),
     },
     focusout: {
       [NAV_PRIMARY](event) {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -138,7 +138,7 @@ navigation = behavior(
       },
     },
     keydown: {
-      [BODY]: keymap({ Escape: hideActiveNavDropdown }),
+      [NAV_PRIMARY]: keymap({ Escape: hideActiveNavDropdown }),
     },
     focusout: {
       [NAV_PRIMARY](event) {

--- a/src/stylesheets/core/_properties.scss
+++ b/src/stylesheets/core/_properties.scss
@@ -393,7 +393,7 @@ $system-properties: (
         map-get($system-spacing, "small-negative"),
         map-get($system-spacing, "smaller"),
         map-get($system-spacing, "small"),
-        map-get($system-spacing, "medium-negative"),      
+        map-get($system-spacing, "medium-negative"),
         map-get($system-spacing, "medium"),
         map-get($system-spacing-em, "small"),
         map-get($partial-values, "zero-zero")


### PR DESCRIPTION
## Preview
[Header preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-nav-actions/components/detail/header--default.html)

## Description

**Close navigation with escape key.** Mobile menu closes and resets on escape key. On larger screen sizes escape closes any active dropdowns. Closes #3396.

**Dropdowns close on focusout.** Tabbing away from primary navigation now closes any active dropdown. Closes #3528.

## Additional information

- Added test cases in navigation.spec.js
- Updated navigation.js to accept `Esc` key to close nav and dropdowns
- Updated navigation.js to close active dropdown on focusout

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
