### PR TITLE
Add external link examples and improve external link icon display

### DIFF
--- a/src/components/type/links.njk
+++ b/src/components/type/links.njk
@@ -2,6 +2,9 @@
 
 <p>This is <a class="usa-link usa-color-text-visited" href="javascript:void(0);">a visited link</a>.</p>
 
+<p>This is a link that goes to an <a class="usa-link usa-link--external" href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">external website</a>.</p>
+
 <div class="usa-dark-background padding-1 display-inline-block">
   <p>This is <a class="usa-link" href="javascript:void(0);">a text link on a dark background</a>.</p>
+  <p><a class="usa-link usa-link--alt usa-link--external" href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">This</a> is an alternate external text link on a dark background.</p>
 </div>

--- a/src/stylesheets/core/mixins/_external-link.scss
+++ b/src/stylesheets/core/mixins/_external-link.scss
@@ -9,11 +9,13 @@
     background-repeat: no-repeat;
     background-size: 100%;
     content: "";
-    display: inline-block;
     height: $external-link-size;
     margin-left: units(2px);
+    // Use following inline styling to prevent icon splitting over line breaks
+    display: inline;
     vertical-align: middle;
-    width: $external-link-size;
+    padding-left: $external-link-size;
+    background-position: center;
   }
 
   &:hover::after {

--- a/src/stylesheets/core/mixins/_external-link.scss
+++ b/src/stylesheets/core/mixins/_external-link.scss
@@ -4,15 +4,16 @@
   $image-path: $theme-image-path
 ) {
   &::after {
-    $icon-size: 0.65em;
+    $external-link-size: 1.75ex;
     background-image: url("#{$image-path}/#{$external-link}.svg");
-    background-position: 50% 60%;
     background-repeat: no-repeat;
     background-size: 100%;
     content: "";
-    display: inline;
+    display: inline-block;
+    height: $external-link-size;
     margin-left: units(2px);
-    padding-left: $icon-size;
+    vertical-align: middle;
+    width: $external-link-size;
   }
 
   &:hover::after {

--- a/src/stylesheets/core/mixins/_external-link.scss
+++ b/src/stylesheets/core/mixins/_external-link.scss
@@ -12,10 +12,10 @@
     height: $external-link-size;
     margin-left: units(2px);
     // Use following inline styling to prevent icon splitting over line breaks
-    display: inline;
-    vertical-align: middle;
-    padding-left: $external-link-size;
     background-position: center;
+    display: inline;
+    padding-left: $external-link-size;
+    vertical-align: middle;
   }
 
   &:hover::after {


### PR DESCRIPTION
This PR adds external link code examples and makes some small stylistic changes to the appearance of the external link icon — making it a little bigger and better aligned with the link text.