### PR TITLE
"Alt text" is bad alt text

### DIFF
--- a/src/components/collection/collection--media.njk
+++ b/src/components/collection/collection--media.njk
@@ -1,6 +1,6 @@
 <ul class="usa-collection">
   <li class="usa-collection__item">
-    <img class="usa-collection__img" src="https://www.performance.gov/img/GoG/gears-govt-presidents.png" alt="Alt text">
+    <img class="usa-collection__img" src="https://www.performance.gov/img/GoG/gears-govt-presidents.png" alt="Gears of Government Awards - President's Award">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
         <a class="usa-link" href="https://www.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
@@ -31,7 +31,7 @@
     </div>
   </li>
   <li class="usa-collection__item">
-    <img class="usa-collection__img" src="https://www.performance.gov/img/blog/wosb1.jpg" alt="Alt text">
+    <img class="usa-collection__img" src="https://www.performance.gov/img/blog/wosb1.jpg" alt="Woman Owned Small Business Federal Contracts">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
         <a class="usa-link" href="https://www.performance.gov/sba-wosb-dashboard/">Women-owned small business dashboard</a>
@@ -56,7 +56,7 @@
     </div>
   </li>
   <li class="usa-collection__item">
-    <img class="usa-collection__img" src="https://www.performance.gov/img/blog/sept-2020.png" alt="Alt text">
+    <img class="usa-collection__img" src="https://www.performance.gov/img/blog/sept-2020.png" alt="September 2020 Updates">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
         <a class="usa-link" href="https://www.performance.gov/September-2020-Updates-Show-Progress/">September 2020 updates show progress on cross-agency and agency priority goals</a>

--- a/src/components/graphic-list/graphic-list.njk
+++ b/src/components/graphic-list/graphic-list.njk
@@ -2,14 +2,14 @@
   <div class="grid-container">
     <div class="usa-graphic-list__row grid-row grid-gap">
       <div class="usa-media-block tablet:grid-col">
-        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="Alt text">
+        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="">
         <div class="usa-media-block__body">
           <h2 class="usa-graphic-list__heading">Graphic headings can vary.</h2>
           <p>Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.</p>
         </div>
       </div>
       <div class="usa-media-block tablet:grid-col">
-        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="Alt text">
+        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="">
         <div class="usa-media-block__body">
           <h2 class="usa-graphic-list__heading">Stick to 6 or fewer words.</h2>
           <p>Keep body text to about 30 words. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.</p>
@@ -18,14 +18,14 @@
     </div>
     <div class="usa-graphic-list__row grid-row grid-gap">
       <div class="usa-media-block tablet:grid-col">
-        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="Alt text">
+        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="">
         <div class="usa-media-block__body">
           <h2 class="usa-graphic-list__heading">Never highlight anything without a goal.</h2>
           <p>For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.</p>
         </div>
       </div>
       <div class="usa-media-block tablet:grid-col">
-        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="Alt text">
+        <img class="usa-media-block__img"  src="{{ uswds.path }}/img/circle-124.png" alt="">
         <div class="usa-media-block__body">
           <h2 class="usa-graphic-list__heading">Could also have 2 or 6.</h2>
           <p>In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.</p>

--- a/src/components/layouts/sign-in-partials/value-props.njk
+++ b/src/components/layouts/sign-in-partials/value-props.njk
@@ -8,7 +8,7 @@
           <img
             class="usa-media-block__img height-7 width-7"
             src="{{ uswds.path }}/img/{{ value.img }}"
-            alt="Alt text"
+            alt=""
           >
           <div class="usa-media-block__body">
             <p>{{ value.description | safe }}</p>
@@ -18,4 +18,3 @@
     </div>
   </section>
 </div>
-


### PR DESCRIPTION
## Have good examples for alt text

This is just an example, but good examples matter. Let's make sure that we have good alternative text in this.

`<img class="usa-collection__img" src="https://www.performance.gov/img/GoG/gears-govt-presidents.png" alt="Alt text">`

Is never appropriate.