### PR TITLE
Checkbox / Radio Button: Improve HTML whitespace sensitivity

### DIFF
--- a/src/components/checkbox/checkbox--tile.njk
+++ b/src/components/checkbox/checkbox--tile.njk
@@ -3,7 +3,12 @@
     <legend class="usa-legend">Select any historical figure</legend>
     <div class="usa-checkbox">
       <input class="usa-checkbox__input usa-checkbox__input--tile" id="check-historical-truth-2" type="checkbox" name="historical-figures-2" value="sojourner-truth" checked>
-      <label class="usa-checkbox__label" for="check-historical-truth-2">Sojourner Truth <span class="usa-checkbox__label-description">This is optional text that can be used to describe the label in more detail.</span></label>
+      <label class="usa-checkbox__label" for="check-historical-truth-2">
+        Sojourner Truth
+        <span class="usa-checkbox__label-description">
+          This is optional text that can be used to describe the label in more detail.
+        </span>
+      </label>
     </div>
     <div class="usa-checkbox">
       <input class="usa-checkbox__input usa-checkbox__input--tile" id="check-historical-douglass-2" type="checkbox" name="historical-figures-2" value="frederick-douglass">

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -176,7 +176,7 @@
       padding: units(1.5) units(2) units(1.5) units(5);
 
       &:before {
-        left: units(5 - $input-select-margin-right - $theme-input-select-size);
+        left: units(5) - units($input-select-margin-right) - units($theme-input-select-size);
       }
     }
   }

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -174,6 +174,10 @@
       border-radius: radius($theme-input-tile-border-radius);
       margin-top: units(1);
       padding: units(1.5) units(2) units(1.5) units(5);
+
+      &:before {
+        left: units(5 - $input-select-margin-right - $theme-input-select-size);
+      }
     }
   }
 }
@@ -201,7 +205,6 @@
         background-image: none;
         background-color: color("white");
         content: url("#{$theme-image-path}/checkbox-check-print.svg");
-        text-indent: 0;
       }
     }
   }
@@ -215,18 +218,18 @@
   margin-top: units(1.5);
   padding-left: units($input-select-margin-right + $theme-input-select-size);
   position: relative;
-  text-indent: units(-$input-select-margin-right - $theme-input-select-size);
 
   &:before {
     content: " ";
-    display: inline-block;
-    left: units($theme-input-select-border-width);
-    line-height: units($theme-input-select-size);
-    margin-right: units($input-select-margin-right);
-    position: relative;
-    text-indent: 0;
-    vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
-    white-space: pre;
+    display: block;
+    left: 0;
+    margin-left: units($theme-input-select-border-width);
+    margin-top: (
+      line-height($theme-form-font-family, $theme-input-line-height) *
+      fs($theme-form-font-family, $theme-body-font-size) -
+      units($theme-input-select-size)
+    ) / 2;
+    position: absolute;
   }
 }
 
@@ -244,7 +247,6 @@
   display: block;
   font-size: size("ui", "2xs");
   margin-top: units(1);
-  text-indent: 0;
 }
 
 // Test code for scoped custom colors

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -226,7 +226,7 @@
     margin-left: units($theme-input-select-border-width);
     margin-top: (
       line-height($theme-form-font-family, $theme-input-line-height) *
-      fs($theme-form-font-family, $theme-body-font-size) -
+      font-size($theme-form-font-family, $theme-body-font-size) -
       units($theme-input-select-size)
     ) / 2;
     position: absolute;

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -212,11 +212,12 @@
 
 .usa-checkbox__label,
 .usa-radio__label {
+  @extend %block-input-general;
   cursor: pointer;
   display: inherit;
   font-weight: font-weight("normal");
   margin-top: units(1.5);
-  padding-left: units($input-select-margin-right + $theme-input-select-size);
+  padding-left: units($input-select-margin-right) + units($theme-input-select-size);
   position: relative;
 
   &:before {


### PR DESCRIPTION
## Description

This pull request seeks to maintain the existing visual appearance of the Checkbox and Radio Button components, while improving developer ergonomics regarding HTML whitespace sensitivity.

Context: https://github.com/18F/identity-idp/pull/5279#discussion_r686146591

## Additional information

Because the current implementation styles the icon pseudo-element and label text as adjacent inline elements, it suffers from a common issue with unintended whitespace between the elements (see [related blog post](https://css-tricks.com/fighting-the-space-between-inline-block-elements/)). For this reason, the code must be marked up very carefully to avoid additional whitespace within the label class (including newlines), as otherwise the text alignment between label and description is misplaced, seen in the screenshots below:

Before|After
---|---
![localhost_3000_components_preview_checkbox--tile (1)](https://user-images.githubusercontent.com/1779930/129046927-f6f90ef3-fc03-4358-8ad1-7812387a0f6c.png)|![localhost_3000_components_preview_checkbox--tile](https://user-images.githubusercontent.com/1779930/129046928-a78a8b86-df05-4b40-809f-91e3fdca1f98.png)

There are a few ways this could be addressed, including using Flexbox, though most of these alternative solutions would require backwards-incompatible changes to the component markup, such as the introduction of a new element to wrap the label text. A Flexbox approach can _almost_ work with the existing markup through a combination of `flex-wrap: wrap` and `flex-basis: 100%` on the description element, but unfortunately this implementation fails when the label text is especially long.

Positioning absolutely is mostly straight-forward, with one exception: Because it is no longer in line with the label text, the checkmark icon must be manually positioned to restore the appearance of vertical alignment. The proposed implementation here uses some extensive math to achieve this, tested in the demo samples with default font size and with an adjusted `$theme-body-font-size: "xl";`. Ideally there'd be a simpler solution to this, though I could not come up with one.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
