### PR TITLE
[USWDS] COMBOBOX | Fix textContent combobox

### DIFF
--- a/spec/unit/combo-box/combo-box.spec.js
+++ b/spec/unit/combo-box/combo-box.spec.js
@@ -127,7 +127,7 @@ describe("combo box component", () => {
 
   it("should set up the list items for accessibility", () => {
     let i = 0;
-    let len = list.children.length;
+    const len = list.children.length;
     EVENTS.click(input);
 
     assert.strictEqual(
@@ -199,7 +199,7 @@ describe("combo box component", () => {
     assert.ok(!list.hidden, "should display the option list");
     assert.strictEqual(
       list.children.length,
-      43,
+      44,
       "should filter the item by the string being present in the option"
     );
   });
@@ -499,5 +499,21 @@ describe("combo box component", () => {
 
     assert.ok(list.hidden, "should hide the option list");
     assert.strictEqual(document.activeElement, input, "should focus the input");
+  });
+
+  it("should not allow for innerHTML of child elements ", () => {
+    input.value = "apricot";
+
+    EVENTS.input(input);
+    assert.ok(!list.hidden, "should display the option list");
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < list.children.length; i++) {
+      assert.strictEqual(
+        list.children[i].children.innerHTML,
+        undefined,
+        "should not contain child HTML"
+      );
+    }
   });
 });

--- a/spec/unit/combo-box/combo-box.spec.js
+++ b/spec/unit/combo-box/combo-box.spec.js
@@ -507,13 +507,10 @@ describe("combo box component", () => {
     EVENTS.input(input);
     assert.ok(!list.hidden, "should display the option list");
 
-    // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < list.children.length; i++) {
-      assert.strictEqual(
-        list.children[i].children.innerHTML,
-        undefined,
-        "should not contain child HTML"
-      );
-    }
+    Array.from(list.children).forEach((listItem) => {
+      Array.from(listItem.children).forEach((childNode) => {
+        assert.strictEqual(childNode, Node.TEXT_NODE);
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box.spec.js
+++ b/spec/unit/combo-box/combo-box.spec.js
@@ -506,10 +506,9 @@ describe("combo box component", () => {
 
     EVENTS.input(input);
     assert.ok(!list.hidden, "should display the option list");
-
     Array.from(list.children).forEach((listItem) => {
-      Array.from(listItem.children).forEach((childNode) => {
-        assert.strictEqual(childNode, Node.TEXT_NODE);
+      Array.from(listItem.childNodes).forEach((childNode) => {
+        assert.strictEqual(childNode.nodeType, Node.TEXT_NODE);
       });
     });
   });

--- a/spec/unit/combo-box/combo-box.template.html
+++ b/spec/unit/combo-box/combo-box.template.html
@@ -5,6 +5,7 @@
       <option value>Select a fruit</option>
       <option value="apple">Apple</option>
       <option value="apricot">Apricot</option>
+      <option value="apricot test">Apricot &lt;img src='' onerror=alert('ouch')&gt;</option>
       <option value="avocado">Avocado</option>
       <option value="banana">Banana</option>
       <option value="blackberry">Blackberry</option>

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -404,17 +404,19 @@ const displayList = (el) => {
         tabindex = "0";
       }
 
-      return `<li
-          aria-selected="false"
-          aria-setsize="${options.length}"
-          aria-posinset="${index + 1}"
-          aria-selected="${ariaSelected}"
-          id="${optionId}"
-          class="${classes.join(" ")}"
-          tabindex="${tabindex}"
-          role="option"
-          data-value="${option.value}"
-        >${option.text}</li>`;
+      const li = document.createElement("li");
+
+      li.setAttribute("aria-setsize", options.length)
+      li.setAttribute("aria-posinset", index + 1)
+      li.setAttribute("aria-selected", ariaSelected)
+      li.setAttribute("id", optionId)
+      li.setAttribute("class", classes.join(" "))
+      li.setAttribute("tabindex", tabindex)
+      li.setAttribute("role", "option")
+      li.setAttribute("data-value", option.value)
+      li.textContent = option.text
+
+      return li.outerHTML;
     })
     .join("");
 


### PR DESCRIPTION
## Manually creates `li` and includes `option.text` as the safer `li.textContent`

includes a new test to check for potentially rendered `innerHtml` of list child elements.


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
