### PR TITLE
Links: Use add-color-icon mixin with currentColor for external link

### DIFF
--- a/src/img/usa-icons-bg/launch--blue-60v.svg
+++ b/src/img/usa-icons-bg/launch--blue-60v.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#005ea2" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/img/usa-icons-bg/launch--blue-70v.svg
+++ b/src/img/usa-icons-bg/launch--blue-70v.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#0b4778" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/img/usa-icons-bg/launch--gray-5.svg
+++ b/src/img/usa-icons-bg/launch--gray-5.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#f0f0f0" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/img/usa-icons-bg/launch--white.svg
+++ b/src/img/usa-icons-bg/launch--white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/img/usa-icons-bg/launch--white.svg
+++ b/src/img/usa-icons-bg/launch--white.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/stylesheets/core/mixins/_external-link.scss
+++ b/src/stylesheets/core/mixins/_external-link.scss
@@ -1,16 +1,16 @@
+$external-link-size: 1.75ex;
+
+$icon-object: (
+  "name": "launch",
+  "color": currentColor,
+  "height": $external-link-size,
+  "svg-height": 24,
+  "svg-width": 24,
+);
+
 @mixin external-link($contrast-bg: "default") {
   &::after {
-    $external-link-size: 1.75ex;
-    @include add-color-icon(
-      (
-        "name": "launch",
-        "color": currentColor,
-        "height": $external-link-size,
-        "svg-height": 24,
-        "svg-width": 24,
-      ),
-      $contrast-bg
-    );
+    @include add-color-icon($icon-object, $contrast-bg);
     content: "";
     height: $external-link-size;
     margin-left: units(2px);

--- a/src/stylesheets/core/mixins/_external-link.scss
+++ b/src/stylesheets/core/mixins/_external-link.scss
@@ -1,13 +1,16 @@
-@mixin external-link(
-  $external-link,
-  $external-link-hover,
-  $image-path: $theme-image-path
-) {
+@mixin external-link($contrast-bg: "default") {
   &::after {
     $external-link-size: 1.75ex;
-    background-image: url("#{$image-path}/#{$external-link}.svg");
-    background-repeat: no-repeat;
-    background-size: 100%;
+    @include add-color-icon(
+      (
+        "name": "launch",
+        "color": currentColor,
+        "height": $external-link-size,
+        "svg-height": 24,
+        "svg-width": 24,
+      ),
+      $contrast-bg
+    );
     content: "";
     height: $external-link-size;
     margin-left: units(2px);
@@ -16,9 +19,5 @@
     display: inline;
     padding-left: $external-link-size;
     vertical-align: middle;
-  }
-
-  &:hover::after {
-    @include add-background-svg("#{$external-link-hover}", $image-path);
   }
 }

--- a/src/stylesheets/core/mixins/_icon.scss
+++ b/src/stylesheets/core/mixins/_icon.scss
@@ -139,7 +139,7 @@
   // Mask supported styles
   @supports (mask: url("")) {
     background: none;
-    background-color: color($color);
+    background-color: if($color == currentColor, $color, color($color));
     mask: $mask-props;
     @if $color-hover {
       &:hover {

--- a/src/stylesheets/elements/typography/_links.scss
+++ b/src/stylesheets/elements/typography/_links.scss
@@ -10,6 +10,6 @@
   @include external-link();
 
   &.usa-link--alt {
-    @include external-link("base-darker");
+    @include external-link($contrast-bg: "base-darker");
   }
 }

--- a/src/stylesheets/elements/typography/_links.scss
+++ b/src/stylesheets/elements/typography/_links.scss
@@ -7,15 +7,9 @@
 // [href^='https:']:not([href*='my-domain.com'])
 
 .usa-link--external {
-  @include external-link(
-    usa-icons-bg/launch--blue-60v,
-    usa-icons-bg/launch--blue-70v
-  );
+  @include external-link();
 
   &.usa-link--alt {
-    @include external-link(
-      usa-icons-bg/launch--gray-5,
-      usa-icons-bg/launch--white
-    );
+    @include external-link("base-darker");
   }
 }


### PR DESCRIPTION
## Description

Refactors external link styling to use `add-color-icon` mixin, using [`currentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword) to match link text, avoiding the need for multiple color variations of the icon, and resolving an issue with visited links where the icon color does not match the color of the link (previously reported at #2185).

## Additional information

Open question: Should the existing SVG files should be kept around for backward-compatibility, or is it reasonable to remove them since they're now unused in the project?

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
