### PR TITLE
USWDS - Collection: Removed href from fancy-date divs. Resolves #4285

### DIFF
--- a/src/components/collection/collection--fancy-date.njk
+++ b/src/components/collection/collection--fancy-date.njk
@@ -1,6 +1,6 @@
 <ul class="usa-collection">
   <li class="usa-collection__item">
-    <div class="usa-collection__calendar-date" href="https://www.performance.gov/presidents-winners-press-release/">
+    <div class="usa-collection__calendar-date">
       <time datetime="2020-09-30T12:00:00+01:00">
         <span class="usa-collection__calendar-date-month">SEP</span>
         <span class="usa-collection__calendar-date-day">30</span>
@@ -14,7 +14,7 @@
     </div>
   </li>
   <li class="usa-collection__item">
-    <div class="usa-collection__calendar-date" href="https://www.performance.gov/sba-wosb-dashboard/">
+    <div class="usa-collection__calendar-date">
       <time datetime="2020-09-30T12:00:00+01:00">
         <span class="usa-collection__calendar-date-month">SEP</span>
         <span class="usa-collection__calendar-date-day">30</span>
@@ -28,7 +28,7 @@
     </div>
   </li>
   <li class="usa-collection__item">
-    <div class="usa-collection__calendar-date" href="https://www.performance.gov/September-2020-Updates-Show-Progress/">
+    <div class="usa-collection__calendar-date">
       <time datetime="2020-09-17T12:00:00+01:00">
         <span class="usa-collection__calendar-date-month">SEP</span>
         <span class="usa-collection__calendar-date-day">17</span>


### PR DESCRIPTION
## Description

As #4285 points out, div elements within the calendar collection component contained href values which fail to create working links.

## Additional information

**Before**
![image](https://user-images.githubusercontent.com/25211650/131735483-bab335ca-e737-4fb6-aa63-cd356c07daa2.png)
(from #4285)

**After**
![image](https://user-images.githubusercontent.com/25211650/131735831-8ce93135-8372-4d8d-b89f-9913e0da8d4d.png)

