### PR TITLE
USWDS - File Input: Creates unique ID per upload. Fixes #4144

### DIFF
--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -106,7 +106,6 @@ const makeSafeForID = (name) => name.replace(/[^a-z0-9]/g, replaceName);
 
 const createUniqueID = (name) => `${name}-${Math.floor(Date.now().toString() / 1000)}`;
 
-
 /**
  * Builds full file input comonent
  * @param {HTMLElement} fileInputEl - original file input on page

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -104,6 +104,9 @@ const replaceName = (s) => {
  */
 const makeSafeForID = (name) => name.replace(/[^a-z0-9]/g, replaceName);
 
+const createUniqueID = (name) => `${name}-${Math.floor(Date.now().toString() / 1000)}`;
+
+
 /**
  * Builds full file input comonent
  * @param {HTMLElement} fileInputEl - original file input on page
@@ -221,7 +224,8 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
     // Starts with a loading image while preview is created
     reader.onloadstart = function createLoadingImage() {
-      const imageId = makeSafeForID(fileName);
+      const imageId = createUniqueID(makeSafeForID(fileName));
+      console.log(imageId);
       const previewImage = `<img id="${imageId}" src="${SPACER_GIF}" alt="" class="${GENERIC_PREVIEW_CLASS_NAME} ${LOADING_CLASS}"/>`;
 
       instructions.insertAdjacentHTML(
@@ -232,7 +236,8 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
     // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
-      const imageId = makeSafeForID(fileName);
+      const imageId = createUniqueID(makeSafeForID(fileName));
+      console.log(imageId);
       const previewImage = document.getElementById(imageId);
       if (fileName.indexOf(".pdf") > 0) {
         previewImage.setAttribute(

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -104,6 +104,7 @@ const replaceName = (s) => {
  */
 const makeSafeForID = (name) => name.replace(/[^a-z0-9]/g, replaceName);
 
+// Creates a unique ID based on upload time. Here we devide by 1000 and use mathfloor to get rid of the milliseconds.
 const createUniqueID = (name) => `${name}-${Math.floor(Date.now().toString() / 1000)}`;
 
 /**
@@ -236,7 +237,6 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
     // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
       const imageId = createUniqueID(makeSafeForID(fileName));
-      console.log(imageId);
       const previewImage = document.getElementById(imageId);
       if (fileName.indexOf(".pdf") > 0) {
         previewImage.setAttribute(


### PR DESCRIPTION
## Description

#4144 pointed out that if a file with the same name is uploaded in two separate file input fields the preview spinner would spin indefinitely. After some research, I found this is because the two documents would share the same ID and the function that would replace the spinner would _only_ select the first ID on the page. By implementing a function that assigns each upload an individual ID, an image preview properly loads.

The function used uses the date and time down to the second to assign an ID.

## Steps to reproduce error

(As provided in #4144)

1. Go to https://designsystem.digital.gov/components/file-input/
2. Upload any text file to the first file input component in the form.
3. Upload the same file to the second file input component in the form.
4. The second file input will display the name of the newly uploaded file but, but the loader spins forever.

## Additional information

Code to create unique ID based on upload time. Here we devide by 1000 and use mathfloor to get rid of the milliseconds.
```
const createUniqueID = (name) => `${name}-${Math.floor(Date.now().toString() / 1000)}`;
```

Partnered with the existing makeSafeForID function:
```
const imageId = createUniqueID(makeSafeForID(fileName));
```

Example Output:
![image](https://user-images.githubusercontent.com/25211650/132065859-e211c1c8-503d-4f31-a5fb-64a2135f0c6e.png)


## Screenshot

![image](https://user-images.githubusercontent.com/25211650/132065591-94d42c98-481b-4c9f-b795-3409b5d2f0d5.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
