### PR TITLE
Add specs and update components to allow JS initialization on document.body and component element itself

### DIFF
--- a/spec/unit/accordion/accordion.spec.js
+++ b/spec/unit/accordion/accordion.spec.js
@@ -1,6 +1,6 @@
-const Accordion = require("../../../src/js/components/accordion");
 const assert = require("assert");
 const fs = require("fs");
+const Accordion = require("../../../src/js/components/accordion");
 
 const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
 
@@ -10,96 +10,104 @@ const CONTROLS = "aria-controls";
 const HIDDEN = "hidden";
 const MULTISELECTABLE = "aria-multiselectable";
 
-describe("accordion behavior", () => {
-  const { body } = document;
+const accordionSelector = () => document.querySelector('.usa-accordion');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "accordion", selector: accordionSelector }
+];
 
-  let root;
-  let button;
-  let buttons;
-  let content;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Accordion behavior when initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    Accordion.on();
+    let root;
+    let button;
+    let buttons;
+    let content;
 
-    root = body.querySelector(".usa-accordion");
-    buttons = root.querySelectorAll(".usa-accordion__button");
-    /* eslint-disable */
-    button = buttons[0];
-    /* eslint-enable */
-    content = document.getElementById(button.getAttribute(CONTROLS));
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      Accordion.on(containerSelector());
 
-  afterEach(() => {
-    body.innerHTML = "";
-    Accordion.off();
-  });
-
-  describe("DOM state", () => {
-    it('has an "aria-expanded" attribute', () => {
-      assert(button.getAttribute(EXPANDED));
+      root = accordionSelector();
+      buttons = root.querySelectorAll(".usa-accordion__button");
+      /* eslint-disable */
+      button = buttons[0];
+      /* eslint-enable */
+      content = document.getElementById(button.getAttribute(CONTROLS));
     });
 
-    it('has an "aria-controls" attribute', () => {
-      assert(button.getAttribute(CONTROLS));
+    afterEach(() => {
+      Accordion.off(containerSelector());
+      body.innerHTML = "";
     });
 
-    describe("accordion.show()", () => {
-      beforeEach(() => {
-        Accordion.hide(button);
-        Accordion.show(button);
+    describe("DOM state", () => {
+      it('has an "aria-expanded" attribute', () => {
+        assert(button.getAttribute(EXPANDED));
       });
 
-      it('toggles button aria-expanded="true"', () => {
+      it('has an "aria-controls" attribute', () => {
+        assert(button.getAttribute(CONTROLS));
+      });
+
+      describe("accordion.show()", () => {
+        beforeEach(() => {
+          Accordion.hide(button);
+          Accordion.show(button);
+        });
+
+        it('toggles button aria-expanded="true"', () => {
+          assert.strictEqual(button.getAttribute(EXPANDED), "true");
+        });
+
+        it('toggles content "hidden" off', () => {
+          assert(content.getAttribute(HIDDEN) !== true);
+        });
+      });
+
+      describe("accordion.hide()", () => {
+        beforeEach(() => {
+          Accordion.show(button);
+          Accordion.hide(button);
+        });
+
+        it('toggles button aria-expanded="false"', () => {
+          assert.strictEqual(button.getAttribute(EXPANDED), "false");
+        });
+
+        it('toggles content "hidden" on', () => {
+          assert(content.hasAttribute(HIDDEN));
+        });
+      });
+    });
+
+    describe("interaction", () => {
+      it("shows the second item when clicked", () => {
+        const second = buttons[1];
+        const target = document.getElementById(second.getAttribute(CONTROLS));
+        second.click();
+        // first button and section should be collapsed
+        assert.strictEqual(button.getAttribute(EXPANDED), "false");
+        assert(content.hasAttribute(HIDDEN));
+        // second should be expanded
+        assert.strictEqual(second.getAttribute(EXPANDED), "true");
+        assert(target.getAttribute(HIDDEN) !== true);
+      });
+
+      it('keeps multiple sections open with aria-multiselectable="true"', () => {
+        root.setAttribute(MULTISELECTABLE, true);
+
+        const second = buttons[1];
+        second.click();
+        button.click();
+
         assert.strictEqual(button.getAttribute(EXPANDED), "true");
-      });
-
-      it('toggles content "hidden" off', () => {
+        assert(content.getAttribute(HIDDEN) !== true);
+        // second should be expanded
+        assert.strictEqual(second.getAttribute(EXPANDED), "true");
         assert(content.getAttribute(HIDDEN) !== true);
       });
-    });
-
-    describe("accordion.hide()", () => {
-      beforeEach(() => {
-        Accordion.show(button);
-        Accordion.hide(button);
-      });
-
-      it('toggles button aria-expanded="false"', () => {
-        assert.strictEqual(button.getAttribute(EXPANDED), "false");
-      });
-
-      it('toggles content "hidden" on', () => {
-        assert(content.hasAttribute(HIDDEN));
-      });
-    });
-  });
-
-  describe("interaction", () => {
-    it("shows the second item when clicked", () => {
-      const second = buttons[1];
-      const target = document.getElementById(second.getAttribute(CONTROLS));
-      second.click();
-      // first button and section should be collapsed
-      assert.strictEqual(button.getAttribute(EXPANDED), "false");
-      assert(content.hasAttribute(HIDDEN));
-      // second should be expanded
-      assert.strictEqual(second.getAttribute(EXPANDED), "true");
-      assert(target.getAttribute(HIDDEN) !== true);
-    });
-
-    it('keeps multiple sections open with aria-multiselectable="true"', () => {
-      root.setAttribute(MULTISELECTABLE, true);
-
-      const second = buttons[1];
-      second.click();
-      button.click();
-
-      assert.strictEqual(button.getAttribute(EXPANDED), "true");
-      assert(content.getAttribute(HIDDEN) !== true);
-      // second should be expanded
-      assert.strictEqual(second.getAttribute(EXPANDED), "true");
-      assert(content.getAttribute(HIDDEN) !== true);
     });
   });
 });

--- a/spec/unit/banner/banner.spec.js
+++ b/spec/unit/banner/banner.spec.js
@@ -1,53 +1,60 @@
 const assert = require("assert");
+const fs = require("fs");
 const banner = require("../../../src/js/components/banner");
 const accordion = require("../../../src/js/components/accordion");
-const fs = require("fs");
 
 const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
 const EXPANDED = "aria-expanded";
 const EXPANDED_CLASS = "usa-banner__header--expanded";
 const HIDDEN = "hidden";
 
-describe("banner", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "banner", selector: () => document.querySelector('.usa-banner') }
+];
 
-  let header;
-  let button;
-  let content;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Banner initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    header = body.querySelector(".usa-banner__header");
-    button = body.querySelector(".usa-banner__button");
-    content = body.querySelector(".usa-banner__content");
-    banner.on();
-    accordion.on();
-  });
+    let header;
+    let button;
+    let content;
 
-  afterEach(() => {
-    body.innerHTML = "";
-    banner.off();
-    accordion.off();
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      header = body.querySelector(".usa-banner__header");
+      button = body.querySelector(".usa-banner__button");
+      content = body.querySelector(".usa-banner__content");
+      banner.on(containerSelector());
+      accordion.on(containerSelector());
+    });
 
-  it("initializes closed", () => {
-    assert.strictEqual(header.classList.contains(EXPANDED_CLASS), false);
-    assert.strictEqual(button.getAttribute(EXPANDED), "false");
-    assert(content.hasAttribute(HIDDEN));
-  });
+    afterEach(() => {
+      banner.off(containerSelector());
+      accordion.off(containerSelector());
+      body.innerHTML = "";
+    });
 
-  it("opens when you click the button", () => {
-    button.click();
-    assert.strictEqual(header.classList.contains(EXPANDED_CLASS), true);
-    assert.strictEqual(button.getAttribute(EXPANDED), "true");
-    assert(content.getAttribute(HIDDEN) !== true);
-  });
+    it("initializes closed", () => {
+      assert.strictEqual(header.classList.contains(EXPANDED_CLASS), false);
+      assert.strictEqual(button.getAttribute(EXPANDED), "false");
+      assert(content.hasAttribute(HIDDEN));
+    });
 
-  it("closes when you click the button again", () => {
-    button.click();
-    button.click();
-    assert.strictEqual(header.classList.contains(EXPANDED_CLASS), false);
-    assert.strictEqual(button.getAttribute(EXPANDED), "false");
-    assert(content.hasAttribute(HIDDEN));
+    it("opens when you click the button", () => {
+      button.click();
+      assert.strictEqual(header.classList.contains(EXPANDED_CLASS), true);
+      assert.strictEqual(button.getAttribute(EXPANDED), "true");
+      assert(content.getAttribute(HIDDEN) !== true);
+    });
+
+    it("closes when you click the button again", () => {
+      button.click();
+      button.click();
+      assert.strictEqual(header.classList.contains(EXPANDED_CLASS), false);
+      assert.strictEqual(button.getAttribute(EXPANDED), "false");
+      assert(content.hasAttribute(HIDDEN));
+    });
   });
 });

--- a/spec/unit/character-count/character-count.spec.js
+++ b/spec/unit/character-count/character-count.spec.js
@@ -19,81 +19,89 @@ EVENTS.input = (el) => {
   el.dispatchEvent(new KeyboardEvent("input", { bubbles: true }));
 };
 
-describe("character count component", () => {
-  const { body } = document;
+const characterCountSelector = () => document.querySelector('.usa-character-count');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "character count", selector: characterCountSelector }
+];
 
-  let root;
-  let input;
-  let message;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`character count component initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    CharacterCount.on();
+    let root;
+    let input;
+    let message;
 
-    root = body.querySelector(".usa-character-count");
-    input = root.querySelector(".usa-character-count__field");
-    message = root.querySelector(".usa-character-count__message");
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      CharacterCount.on(containerSelector());
 
-  afterEach(() => {
-    body.textContent = "";
-    CharacterCount.off(body);
-  });
+      root = characterCountSelector();
+      input = root.querySelector(".usa-character-count__field");
+      message = root.querySelector(".usa-character-count__message");
+    });
 
-  it("adds initial message for the character count component", () => {
-    assert.strictEqual(message.innerHTML, "20 characters allowed");
-  });
+    afterEach(() => {
+      CharacterCount.off(containerSelector());
+      body.textContent = "";
+    });
 
-  it("informs the user how many more characters they are allowed", () => {
-    input.value = "1";
+    it("adds initial message for the character count component", () => {
+      assert.strictEqual(message.innerHTML, "20 characters allowed");
+    });
 
-    EVENTS.input(input);
+    it("informs the user how many more characters they are allowed", () => {
+      input.value = "1";
 
-    assert.strictEqual(message.innerHTML, "19 characters left");
-  });
+      EVENTS.input(input);
 
-  it("informs the user they are allowed a single character", () => {
-    input.value = "1234567890123456789";
+      assert.strictEqual(message.innerHTML, "19 characters left");
+    });
 
-    EVENTS.input(input);
+    it("informs the user they are allowed a single character", () => {
+      input.value = "1234567890123456789";
 
-    assert.strictEqual(message.innerHTML, "1 character left");
-  });
+      EVENTS.input(input);
 
-  it("informs the user they are over the limit by a single character", () => {
-    input.value = "123456789012345678901";
+      assert.strictEqual(message.innerHTML, "1 character left");
+    });
 
-    EVENTS.input(input);
+    it("informs the user they are over the limit by a single character", () => {
+      input.value = "123456789012345678901";
 
-    assert.strictEqual(message.innerHTML, "1 character over limit");
-  });
+      EVENTS.input(input);
 
-  it("informs the user how many characters they will need to remove", () => {
-    input.value = "1234567890123456789012345";
+      assert.strictEqual(message.innerHTML, "1 character over limit");
+    });
 
-    EVENTS.input(input);
+    it("informs the user how many characters they will need to remove", () => {
+      input.value = "1234567890123456789012345";
 
-    assert.strictEqual(message.innerHTML, "5 characters over limit");
-  });
+      EVENTS.input(input);
 
-  it("should show the component and input as valid when the input is under the limit", () => {
-    input.value = "1";
+      assert.strictEqual(message.innerHTML, "5 characters over limit");
+    });
 
-    EVENTS.input(input);
+    it("should show the component and input as valid when the input is under the limit", () => {
+      input.value = "1";
 
-    assert.strictEqual(input.validationMessage, "");
-    assert.strictEqual(
-      message.classList.contains(MESSAGE_INVALID_CLASS),
-      false
-    );
-  });
+      EVENTS.input(input);
 
-  it("should show the component and input as invalid when the input is over the limit", () => {
-    input.value = "123456789012345678901";
+      assert.strictEqual(input.validationMessage, "");
+      assert.strictEqual(
+        message.classList.contains(MESSAGE_INVALID_CLASS),
+        false
+      );
+    });
 
-    EVENTS.input(input);
+    it("should show the component and input as invalid when the input is over the limit", () => {
+      input.value = "123456789012345678901";
 
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-    assert.strictEqual(message.classList.contains(MESSAGE_INVALID_CLASS), true);
+      EVENTS.input(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+      assert.strictEqual(message.classList.contains(MESSAGE_INVALID_CLASS), true);
+    });
   });
 });

--- a/spec/unit/character-count/invalid-template-no-message.spec.js
+++ b/spec/unit/character-count/invalid-template-no-message.spec.js
@@ -5,18 +5,25 @@ const CharacterCount = require('../../../src/js/components/character-count');
 
 const INVALID_TEMPLATE_NO_MESSAGE = fs.readFileSync(path.join(__dirname, '/invalid-template-no-message.template.html'));
 
-describe('character count component without message', () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "character count", selector: () => document.querySelector('.usa-character-count') }
+];
 
-  afterEach(() => {
-    body.textContent = '';
-    CharacterCount.off(body);
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`character count component without message initialized at ${name}`, () => {
+    const { body } = document;
 
-  it('should throw an error when a character count component is created with no message element', () => {
-    body.innerHTML = INVALID_TEMPLATE_NO_MESSAGE;
-    assert.throws(() => CharacterCount.on(), {
-      message: '.usa-character-count is missing inner .usa-character-count__message',
+    afterEach(() => {
+      CharacterCount.off(containerSelector());
+      body.textContent = '';
+    });
+
+    it('should throw an error when a character count component is created with no message element', () => {
+      body.innerHTML = INVALID_TEMPLATE_NO_MESSAGE;
+      assert.throws(() => CharacterCount.on(containerSelector()), {
+        message: '.usa-character-count is missing inner .usa-character-count__message',
+      });
     });
   });
 });

--- a/spec/unit/character-count/invalid-template-no-wrapper.spec.js
+++ b/spec/unit/character-count/invalid-template-no-wrapper.spec.js
@@ -5,18 +5,24 @@ const CharacterCount = require('../../../src/js/components/character-count');
 
 const INVALID_TEMPLATE_NO_WRAPPER = fs.readFileSync(path.join(__dirname, '/invalid-template-no-wrapper.template.html'));
 
-describe('character count input without wrapping element', () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "character count", selector: () => document.querySelector('.usa-character-count') }
+];
 
-  afterEach(() => {
-    body.textContent = '';
-    CharacterCount.off(body);
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`character count input without wrapping element initialized at ${name}`, () => {
+    const { body } = document;
 
-  it('should throw an error when a character count component is created with no wrapping class', () => {
-    body.innerHTML = INVALID_TEMPLATE_NO_WRAPPER;
-    assert.throws(() => CharacterCount.on(), {
-      message: '.usa-character-count__field is missing outer .usa-character-count',
+    afterEach(() => {
+      body.textContent = '';
+    });
+
+    it('should throw an error when a character count component is created with no wrapping class', () => {
+      body.innerHTML = INVALID_TEMPLATE_NO_WRAPPER;
+      assert.throws(() => CharacterCount.on(containerSelector()), {
+        message: '.usa-character-count__field is missing outer .usa-character-count',
+      });
     });
   });
 });

--- a/spec/unit/character-count/valid-template-multiple-validators.spec.js
+++ b/spec/unit/character-count/valid-template-multiple-validators.spec.js
@@ -17,73 +17,81 @@ EVENTS.input = (el) => {
   el.dispatchEvent(new KeyboardEvent("input", { bubbles: true }));
 };
 
-describe("character count component with multiple validators", () => {
-  const { body } = document;
+const characterCountSelector = () => document.querySelector('.usa-character-count');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "character count", selector: characterCountSelector }
+];
 
-  let root;
-  let input;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`character count component with multiple validators initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    CharacterCount.on();
+    let root;
+    let input;
 
-    root = body.querySelector(".usa-character-count");
-    input = root.querySelector(".usa-character-count__field");
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      CharacterCount.on(containerSelector());
 
-  afterEach(() => {
-    body.textContent = "";
-    CharacterCount.off(body);
-  });
+      root = characterCountSelector();
+      input = root.querySelector(".usa-character-count__field");
+    });
 
-  it("assert that input constraint validation adds a validation message", () => {
-    input.value = "abcd5";
+    afterEach(() => {
+      CharacterCount.off(containerSelector());
+      body.textContent = "";
+    });
 
-    EVENTS.input(input);
+    it("assert that input constraint validation adds a validation message", () => {
+      input.value = "abcd5";
 
-    assert.strictEqual(input.validationMessage, "Constraints not satisfied");
-  });
+      EVENTS.input(input);
 
-  it("assert that input constraint validation does not overwrite a custom message", () => {
-    input.setCustomValidity("There is an error");
-    input.value = "abcd5";
+      assert.strictEqual(input.validationMessage, "Constraints not satisfied");
+    });
 
-    EVENTS.input(input);
+    it("assert that input constraint validation does not overwrite a custom message", () => {
+      input.setCustomValidity("There is an error");
+      input.value = "abcd5";
 
-    assert.strictEqual(input.validationMessage, "There is an error");
-  });
+      EVENTS.input(input);
 
-  it("should not affect the validation message when a custom error message is already present", () => {
-    input.setCustomValidity("There is an error");
-    input.value = "abcdef";
+      assert.strictEqual(input.validationMessage, "There is an error");
+    });
 
-    EVENTS.input(input);
+    it("should not affect the validation message when a custom error message is already present", () => {
+      input.setCustomValidity("There is an error");
+      input.value = "abcdef";
 
-    assert.strictEqual(input.validationMessage, "There is an error");
-  });
+      EVENTS.input(input);
 
-  it("should not affect the validation message when the input is already invalid", () => {
-    input.value = "abcde5";
+      assert.strictEqual(input.validationMessage, "There is an error");
+    });
 
-    EVENTS.input(input);
+    it("should not affect the validation message when the input is already invalid", () => {
+      input.value = "abcde5";
 
-    assert.strictEqual(input.validationMessage, "Constraints not satisfied");
-  });
+      EVENTS.input(input);
 
-  it("should clear the validation message when input is only invalid by character count validation", () => {
-    input.value = "abcdef";
+      assert.strictEqual(input.validationMessage, "Constraints not satisfied");
+    });
 
-    EVENTS.input(input);
+    it("should clear the validation message when input is only invalid by character count validation", () => {
+      input.value = "abcdef";
 
-    assert.strictEqual(
-      input.validationMessage,
-      CharacterCount.VALIDATION_MESSAGE
-    );
+      EVENTS.input(input);
 
-    input.value = "abcde";
+      assert.strictEqual(
+        input.validationMessage,
+        CharacterCount.VALIDATION_MESSAGE
+      );
 
-    EVENTS.input(input);
+      input.value = "abcde";
 
-    assert.strictEqual(input.validationMessage, "");
+      EVENTS.input(input);
+
+      assert.strictEqual(input.validationMessage, "");
+    });
   });
 });

--- a/spec/unit/character-count/valid-template-no-maxlength.spec.js
+++ b/spec/unit/character-count/valid-template-no-maxlength.spec.js
@@ -16,37 +16,44 @@ const EVENTS = {};
 EVENTS.input = (el) => {
   el.dispatchEvent(new KeyboardEvent("input", { bubbles: true }));
 };
+const characterCountSelector = () => document.querySelector('.usa-character-count');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "character count", selector: characterCountSelector }
+];
 
-describe("character count component without maxlength", () => {
-  const { body } = document;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`character count component without maxlength initialized at ${name}`, () => {
+    const { body } = document;
 
-  let root;
-  let input;
-  let message;
+    let root;
+    let input;
+    let message;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    CharacterCount.on();
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      CharacterCount.on(containerSelector());
 
-    root = body.querySelector(".usa-character-count");
-    input = root.querySelector(".usa-character-count__field");
-    message = root.querySelector(".usa-character-count__message");
-  });
+      root = characterCountSelector();
+      input = root.querySelector(".usa-character-count__field");
+      message = root.querySelector(".usa-character-count__message");
+    });
 
-  afterEach(() => {
-    body.textContent = "";
-    CharacterCount.off(body);
-  });
+    afterEach(() => {
+      CharacterCount.off(containerSelector());
+      body.textContent = "";
+    });
 
-  it("should not update an initial message for the character count component", () => {
-    assert.strictEqual(message.innerHTML, "");
-  });
+    it("should not update an initial message for the character count component", () => {
+      assert.strictEqual(message.innerHTML, "");
+    });
 
-  it("should not inform the user of remaining characters when typing", () => {
-    input.value = "1";
+    it("should not inform the user of remaining characters when typing", () => {
+      input.value = "1";
 
-    EVENTS.input(input);
+      EVENTS.input(input);
 
-    assert.strictEqual(message.innerHTML, "");
+      assert.strictEqual(message.innerHTML, "");
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-change-event.spec.js
+++ b/spec/unit/combo-box/combo-box-change-event.spec.js
@@ -9,199 +9,208 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-change-event.template.html")
 );
 
-describe("combo box component change event dispatch", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
 
-  let root;
-  let input;
-  let inputChangeSpy;
-  let select;
-  let selectChangeSpy;
-  let list;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component change event dispatch", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    select = root.querySelector(".usa-combo-box__select");
-    list = root.querySelector(".usa-combo-box__list");
-    inputChangeSpy = sinon.stub();
-    selectChangeSpy = sinon.stub();
+      let root;
+      let input;
+      let inputChangeSpy;
+      let select;
+      let selectChangeSpy;
+      let list;
 
-    select.addEventListener("change", selectChangeSpy);
-    input.addEventListener("change", inputChangeSpy);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+        select = root.querySelector(".usa-combo-box__select");
+        list = root.querySelector(".usa-combo-box__list");
+        inputChangeSpy = sinon.stub();
+        selectChangeSpy = sinon.stub();
 
-  afterEach(() => {
-    input.removeEventListener("change", inputChangeSpy);
-    select.removeEventListener("change", selectChangeSpy);
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+        select.addEventListener("change", selectChangeSpy);
+        input.addEventListener("change", inputChangeSpy);
+      });
 
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.ok(select, "select element exists");
-    assert.ok(list, "adds an list element");
-  });
+      afterEach(() => {
+        input.removeEventListener("change", inputChangeSpy);
+        select.removeEventListener("change", selectChangeSpy);
+        ComboBox.off(root);
+        body.textContent = "";
+      });
 
-  it("should emit change events when selecting an item from the option list when clicking a list option", () => {
-    input.value = "";
+      it("enhances a select element into a combo box component", () => {
+        assert.ok(input, "adds an input element");
+        assert.ok(select, "select element exists");
+        assert.ok(list, "adds an list element");
+      });
 
-    EVENTS.click(input);
-    EVENTS.click(list.children[0]);
+      it("should emit change events when selecting an item from the option list when clicking a list option", () => {
+        input.value = "";
 
-    assert.strictEqual(
-      select.value,
-      "apple",
-      "should set that item to being the select option"
-    );
-    assert.strictEqual(
-      input.value,
-      "Apple",
-      "should set that item to being the input value"
-    );
+        EVENTS.click(input);
+        EVENTS.click(list.children[0]);
 
-    assert.ok(
-      selectChangeSpy.called,
-      "should have dispatched a change event from the select"
-    );
-    assert.ok(
-      inputChangeSpy.called,
-      "should have dispatched a change event from the input"
-    );
-  });
+        assert.strictEqual(
+          select.value,
+          "apple",
+          "should set that item to being the select option"
+        );
+        assert.strictEqual(
+          input.value,
+          "Apple",
+          "should set that item to being the input value"
+        );
 
-  it("should emit change events when resetting input values when an incomplete item is submitted through enter", () => {
-    select.value = "apple";
-    input.value = "a";
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
+        assert.ok(
+          selectChangeSpy.called,
+          "should have dispatched a change event from the select"
+        );
+        assert.ok(
+          inputChangeSpy.called,
+          "should have dispatched a change event from the input"
+        );
+      });
 
-    EVENTS.keydownEnter(input);
+      it("should emit change events when resetting input values when an incomplete item is submitted through enter", () => {
+        select.value = "apple";
+        input.value = "a";
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
 
-    assert.strictEqual(select.value, "apple");
-    assert.strictEqual(
-      input.value,
-      "Apple",
-      "should reset the value on the input"
-    );
-    assert.ok(
-      selectChangeSpy.notCalled,
-      "should not have dispatched a change event"
-    );
-    assert.ok(inputChangeSpy.called, "should have dispatched a change event");
-  });
+        EVENTS.keydownEnter(input);
 
-  it("should emit change events when closing the list but not the clear the input value when escape is performed while the list is open", () => {
-    select.value = "apple";
-    input.value = "a";
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(select.value, "apple");
+        assert.strictEqual(
+          input.value,
+          "Apple",
+          "should reset the value on the input"
+        );
+        assert.ok(
+          selectChangeSpy.notCalled,
+          "should not have dispatched a change event"
+        );
+        assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+      });
 
-    EVENTS.keydownEscape(input);
+      it("should emit change events when closing the list but not the clear the input value when escape is performed while the list is open", () => {
+        select.value = "apple";
+        input.value = "a";
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
 
-    assert.strictEqual(
-      select.value,
-      "apple",
-      "should not change the value of the select"
-    );
-    assert.strictEqual(
-      input.value,
-      "Apple",
-      "should reset the value in the input"
-    );
-    assert.ok(
-      selectChangeSpy.notCalled,
-      "should not have dispatched a change event"
-    );
-    assert.ok(inputChangeSpy.called, "should have dispatched a change event");
-  });
+        EVENTS.keydownEscape(input);
 
-  it("should emit change events when setting the input value when a complete selection is submitted by pressing enter", () => {
-    select.value = "apple";
-    input.value = "fig";
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          select.value,
+          "apple",
+          "should not change the value of the select"
+        );
+        assert.strictEqual(
+          input.value,
+          "Apple",
+          "should reset the value in the input"
+        );
+        assert.ok(
+          selectChangeSpy.notCalled,
+          "should not have dispatched a change event"
+        );
+        assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+      });
 
-    EVENTS.keydownEnter(input);
+      it("should emit change events when setting the input value when a complete selection is submitted by pressing enter", () => {
+        select.value = "apple";
+        input.value = "fig";
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
 
-    assert.strictEqual(
-      select.value,
-      "fig",
-      "should set that item to being the select option"
-    );
-    assert.strictEqual(
-      input.value,
-      "Fig",
-      "should set that item to being the input value"
-    );
-    assert.ok(selectChangeSpy.called, "should have dispatched a change event");
-    assert.ok(inputChangeSpy.called, "should have dispatched a change event");
-  });
+        EVENTS.keydownEnter(input);
 
-  it("should emit change events when selecting the focused list item in the list when pressing enter on a focused item", () => {
-    select.value = "grapefruit";
-    input.value = "emo";
+        assert.strictEqual(
+          select.value,
+          "fig",
+          "should set that item to being the select option"
+        );
+        assert.strictEqual(
+          input.value,
+          "Fig",
+          "should set that item to being the input value"
+        );
+        assert.ok(selectChangeSpy.called, "should have dispatched a change event");
+        assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+      });
 
-    EVENTS.input(input);
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Lemon",
-      "should focus the first item in the list"
-    );
-    EVENTS.keydownEnter(focusedOption);
+      it("should emit change events when selecting the focused list item in the list when pressing enter on a focused item", () => {
+        select.value = "grapefruit";
+        input.value = "emo";
 
-    assert.strictEqual(
-      select.value,
-      "lemon",
-      "select the first item in the list"
-    );
-    assert.strictEqual(
-      input.value,
-      "Lemon",
-      "should set the value in the input"
-    );
-    assert.ok(selectChangeSpy.called, "should have dispatched a change event");
-    assert.ok(inputChangeSpy.called, "should have dispatched a change event");
-  });
+        EVENTS.input(input);
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Lemon",
+          "should focus the first item in the list"
+        );
+        EVENTS.keydownEnter(focusedOption);
 
-  it("should emit change events when pressing escape from a focused item", () => {
-    select.value = "grapefruit";
-    input.value = "dew";
+        assert.strictEqual(
+          select.value,
+          "lemon",
+          "select the first item in the list"
+        );
+        assert.strictEqual(
+          input.value,
+          "Lemon",
+          "should set the value in the input"
+        );
+        assert.ok(selectChangeSpy.called, "should have dispatched a change event");
+        assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+      });
 
-    EVENTS.input(input);
-    assert.ok(
-      !list.hidden && list.children.length,
-      "should display the option list with options"
-    );
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Honeydew melon",
-      "should focus the first item in the list"
-    );
-    EVENTS.keydownEscape(focusedOption);
+      it("should emit change events when pressing escape from a focused item", () => {
+        select.value = "grapefruit";
+        input.value = "dew";
 
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(
-      select.value,
-      "grapefruit",
-      "should not change the value of the select"
-    );
-    assert.strictEqual(
-      input.value,
-      "Grapefruit",
-      "should reset the value in the input"
-    );
-    assert.ok(
-      selectChangeSpy.notCalled,
-      "should not have dispatched a change event"
-    );
-    assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+        EVENTS.input(input);
+        assert.ok(
+          !list.hidden && list.children.length,
+          "should display the option list with options"
+        );
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Honeydew melon",
+          "should focus the first item in the list"
+        );
+        EVENTS.keydownEscape(focusedOption);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(
+          select.value,
+          "grapefruit",
+          "should not change the value of the select"
+        );
+        assert.strictEqual(
+          input.value,
+          "Grapefruit",
+          "should reset the value in the input"
+        );
+        assert.ok(
+          selectChangeSpy.notCalled,
+          "should not have dispatched a change event"
+        );
+        assert.ok(inputChangeSpy.called, "should have dispatched a change event");
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-default-value.spec.js
+++ b/spec/unit/combo-box/combo-box-default-value.spec.js
@@ -7,37 +7,46 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-default-value.template.html")
 );
 
-describe("combo box component with default value attribute", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
 
-  let root;
-  let input;
-  let select;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component with default value attribute", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    select = root.querySelector(".usa-combo-box__select");
-  });
+      let root;
+      let input;
+      let select;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+        select = root.querySelector(".usa-combo-box__select");
+      });
 
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.strictEqual(
-      input.value,
-      "Blackberry",
-      "updates the default value of the input"
-    );
-    assert.strictEqual(
-      select.value,
-      "blackberry",
-      "updates the default value of the select"
-    );
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
+
+      it("enhances a select element into a combo box component", () => {
+        assert.ok(input, "adds an input element");
+        assert.strictEqual(
+          input.value,
+          "Blackberry",
+          "updates the default value of the input"
+        );
+        assert.strictEqual(
+          select.value,
+          "blackberry",
+          "updates the default value of the select"
+        );
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-disable-filtering.spec.js
+++ b/spec/unit/combo-box/combo-box-disable-filtering.spec.js
@@ -8,46 +8,55 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-disable-filtering.template.html")
 );
 
-describe("combo box component with disable filtering attribute", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
 
-  let root;
-  let input;
-  let list;
-  let select;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component with disable filtering attribute", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    list = root.querySelector(".usa-combo-box__list");
-    select = root.querySelector(".usa-combo-box__select");
-  });
+      let root;
+      let input;
+      let list;
+      let select;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+        list = root.querySelector(".usa-combo-box__list");
+        select = root.querySelector(".usa-combo-box__select");
+      });
 
-  it("should display the full list and focus the first found item", () => {
-    input.value = "oo";
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
 
-    EVENTS.input(input);
+      it("should display the full list and focus the first found item", () => {
+        input.value = "oo";
 
-    const focusedOption = list.querySelector(
-      ".usa-combo-box__list-option--focused"
-    );
-    assert.ok(!list.hidden, "should show the option list");
-    assert.strictEqual(
-      list.children.length,
-      select.options.length - 1,
-      "should have all of the initial select items in the list except placeholder empty items"
-    );
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blood orange",
-      "should be the first found item"
-    );
+        EVENTS.input(input);
+
+        const focusedOption = list.querySelector(
+          ".usa-combo-box__list-option--focused"
+        );
+        assert.ok(!list.hidden, "should show the option list");
+        assert.strictEqual(
+          list.children.length,
+          select.options.length - 1,
+          "should have all of the initial select items in the list except placeholder empty items"
+        );
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blood orange",
+          "should be the first found item"
+        );
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-disabled.spec.js
+++ b/spec/unit/combo-box/combo-box-disabled.spec.js
@@ -8,60 +8,72 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-disabled.template.html")
 );
 
-describe("combo box component - disabled enhancement", () => {
-  const { body } = document;
+const comboBoxSelector = () => document.querySelector(".usa-combo-box");
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: comboBoxSelector }
+];
 
-  let root;
-  let input;
-  let select;
-  let toggle;
-  let list;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component - disabled enhancement", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    select = root.querySelector(".usa-combo-box__select");
-    toggle = root.querySelector(".usa-combo-box__toggle-list");
-    list = root.querySelector(".usa-combo-box__list");
-  });
+      let root;
+      let comboBox;
+      let input;
+      let select;
+      let toggle;
+      let list;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        comboBox = comboBoxSelector();
+        input = root.querySelector(".usa-combo-box__input");
+        select = root.querySelector(".usa-combo-box__select");
+        toggle = root.querySelector(".usa-combo-box__toggle-list");
+        list = root.querySelector(".usa-combo-box__list");
+      });
 
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.strictEqual(
-      input.disabled,
-      true,
-      "transfers disabled attribute to combo box"
-    );
-    assert.strictEqual(
-      select.disabled,
-      false,
-      "removes disabled attribute from select"
-    );
-  });
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
 
-  it("should not show the list when clicking the disabled input", () => {
-    EVENTS.click(input);
+      it("enhances a select element into a combo box component", () => {
+        assert.ok(input, "adds an input element");
+        assert.strictEqual(
+          input.disabled,
+          true,
+          "transfers disabled attribute to combo box"
+        );
+        assert.strictEqual(
+          select.disabled,
+          false,
+          "removes disabled attribute from select"
+        );
+      });
 
-    assert.ok(list.hidden, "should not display the option list");
-  });
+      it("should not show the list when clicking the disabled input", () => {
+        EVENTS.click(input);
 
-  it("should not show the list when clicking the disabled button", () => {
-    EVENTS.click(toggle);
+        assert.ok(list.hidden, "should not display the option list");
+      });
 
-    assert.ok(list.hidden, "should not display the option list");
-  });
+      it("should not show the list when clicking the disabled button", () => {
+        EVENTS.click(toggle);
 
-  it("should show the list when clicking the input once the component has been enabled", () => {
-    ComboBox.enable(root);
-    EVENTS.click(input);
+        assert.ok(list.hidden, "should not display the option list");
+      });
 
-    assert.ok(!list.hidden, "should display the option list");
+      it("should show the list when clicking the input once the component has been enabled", () => {
+        ComboBox.enable(comboBox);
+        EVENTS.click(input);
+
+        assert.ok(!list.hidden, "should display the option list");
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-filter.spec.js
+++ b/spec/unit/combo-box/combo-box-filter.spec.js
@@ -8,36 +8,45 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-filter.template.html")
 );
 
-describe("combo box component with filter attribute", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
 
-  let root;
-  let input;
-  let list;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component with filter attribute", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    list = root.querySelector(".usa-combo-box__list");
-  });
+      let root;
+      let input;
+      let list;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+        list = root.querySelector(".usa-combo-box__list");
+      });
 
-  it("should display and filter the option list after a character is typed", () => {
-    input.value = "st";
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
 
-    EVENTS.input(input);
+      it("should display and filter the option list after a character is typed", () => {
+        input.value = "st";
 
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      2,
-      "should filter the item by the string starting with the option"
-    );
+        EVENTS.input(input);
+
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          2,
+          "should filter the item by the string starting with the option"
+        );
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-placeholder.spec.js
+++ b/spec/unit/combo-box/combo-box-placeholder.spec.js
@@ -7,30 +7,39 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-placeholder.template.html")
 );
 
-describe("combo box component with placeholder attribute", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
 
-  let root;
-  let input;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component with placeholder attribute", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-  });
+      let root;
+      let input;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+      });
 
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.strictEqual(
-      input.placeholder,
-      "Select one...",
-      "transfers placeholder attribute from combo box"
-    );
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
+
+      it("enhances a select element into a combo box component", () => {
+        assert.ok(input, "adds an input element");
+        assert.strictEqual(
+          input.placeholder,
+          "Select one...",
+          "transfers placeholder attribute from combo box"
+        );
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box-subsequent-selection.spec.js
+++ b/spec/unit/combo-box/combo-box-subsequent-selection.spec.js
@@ -8,128 +8,141 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box-subsequent-selection.template.html")
 );
 
-describe("combo box component - subsequent selection", () => {
-  const { body } = document;
+const comboBoxSelector = () => document.querySelector(".usa-combo-box");
 
-  let root;
-  let input;
-  let select;
-  let list;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: comboBoxSelector }
+];
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    select = root.querySelector(".usa-combo-box__select");
-    list = root.querySelector(".usa-combo-box__list");
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component - subsequent selection", () => {
+      const { body } = document;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
+      let root;
+      let comboBox;
+      let input;
+      let select;
+      let list;
 
-  it("should display the full list and focus the selected item when the input is pristine (after fresh selection)", () => {
-    assert.ok(
-      root.classList.contains("usa-combo-box--pristine"),
-      "pristine class added after selection"
-    );
-    EVENTS.click(input);
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        comboBox = comboBoxSelector();
+        input = root.querySelector(".usa-combo-box__input");
+        select = root.querySelector(".usa-combo-box__select");
+        list = root.querySelector(".usa-combo-box__list");
+      });
 
-    assert.ok(!list.hidden, "should show the option list");
-    assert.strictEqual(
-      list.children.length,
-      select.options.length - 1,
-      "should have all of the initial select items in the list except placeholder empty items"
-    );
-    const highlightedOption = list.querySelector(
-      ".usa-combo-box__list-option--focused"
-    );
-    assert.ok(
-      highlightedOption.classList.contains(
-        "usa-combo-box__list-option--focused"
-      ),
-      "should style the focused item in the list"
-    );
-    assert.strictEqual(
-      highlightedOption.textContent,
-      "Blackberry",
-      "should be the previously selected item"
-    );
-  });
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
 
-  it("should display the filtered list when the input is dirty (characters inputted)", () => {
-    EVENTS.click(input);
-    assert.strictEqual(
-      list.children.length,
-      select.options.length - 1,
-      "should have all of the initial select items in the list except placeholder empty items"
-    );
+      it("should display the full list and focus the selected item when the input is pristine (after fresh selection)", () => {
+        assert.ok(
+          comboBox.classList.contains("usa-combo-box--pristine"),
+          "pristine class added after selection"
+        );
+        EVENTS.click(input);
 
-    input.value = "COBOL";
-    EVENTS.input(input);
+        assert.ok(!list.hidden, "should show the option list");
+        assert.strictEqual(
+          list.children.length,
+          select.options.length - 1,
+          "should have all of the initial select items in the list except placeholder empty items"
+        );
+        const highlightedOption = list.querySelector(
+          ".usa-combo-box__list-option--focused"
+        );
+        assert.ok(
+          highlightedOption.classList.contains(
+            "usa-combo-box__list-option--focused"
+          ),
+          "should style the focused item in the list"
+        );
+        assert.strictEqual(
+          highlightedOption.textContent,
+          "Blackberry",
+          "should be the previously selected item"
+        );
+      });
 
-    assert.ok(
-      !root.classList.contains("usa-combo-box--pristine"),
-      "pristine class is removed after input"
-    );
-    assert.strictEqual(
-      list.children.length,
-      1,
-      "should only show the filtered items"
-    );
-  });
+      it("should display the filtered list when the input is dirty (characters inputted)", () => {
+        EVENTS.click(input);
+        assert.strictEqual(
+          list.children.length,
+          select.options.length - 1,
+          "should have all of the initial select items in the list except placeholder empty items"
+        );
 
-  it("should show a clear button when the input has a selected value present", () => {
-    assert.ok(
-      root.classList.contains("usa-combo-box--pristine"),
-      "pristine class added after selection"
-    );
-    assert.ok(
-      root.querySelector(".usa-combo-box__clear-input"),
-      "clear input button is present"
-    );
-  });
+        input.value = "COBOL";
+        EVENTS.input(input);
 
-  it("should clear the input when the clear button is clicked", () => {
-    assert.strictEqual(select.value, "blackberry");
-    assert.strictEqual(input.value, "Blackberry");
+        assert.ok(
+          !comboBox.classList.contains("usa-combo-box--pristine"),
+          "pristine class is removed after input"
+        );
+        assert.strictEqual(
+          list.children.length,
+          1,
+          "should only show the filtered items"
+        );
+      });
 
-    EVENTS.click(root.querySelector(".usa-combo-box__clear-input"));
+      it("should show a clear button when the input has a selected value present", () => {
+        assert.ok(
+          comboBox.classList.contains("usa-combo-box--pristine"),
+          "pristine class added after selection"
+        );
+        assert.ok(
+          comboBox.querySelector(".usa-combo-box__clear-input"),
+          "clear input button is present"
+        );
+      });
 
-    assert.strictEqual(
-      select.value,
-      "",
-      "should clear the value on the select"
-    );
-    assert.strictEqual(input.value, "", "should clear the value on the input");
-    assert.strictEqual(document.activeElement, input, "should focus the input");
-  });
+      it("should clear the input when the clear button is clicked", () => {
+        assert.strictEqual(select.value, "blackberry");
+        assert.strictEqual(input.value, "Blackberry");
 
-  it("should update the filter and begin filtering once a pristine input value is changed", () => {
-    input.value = "go";
-    EVENTS.click(input);
-    EVENTS.keydownEnter(input);
-    assert.strictEqual(
-      input.value,
-      "Blackberry",
-      "should set that item to the input value"
-    );
-    EVENTS.click(input);
-    assert.strictEqual(
-      list.children.length,
-      select.options.length - 1,
-      "should have all of the initial select items in the list except placeholder empty items"
-    );
+        EVENTS.click(comboBox.querySelector(".usa-combo-box__clear-input"));
 
-    input.value = "Fig";
-    EVENTS.input(input);
+        assert.strictEqual(
+          select.value,
+          "",
+          "should clear the value on the select"
+        );
+        assert.strictEqual(input.value, "", "should clear the value on the input");
+        assert.strictEqual(document.activeElement, input, "should focus the input");
+      });
 
-    assert.strictEqual(
-      list.children.length,
-      1,
-      "should only show the filtered items"
-    );
+      it("should update the filter and begin filtering once a pristine input value is changed", () => {
+        input.value = "go";
+        EVENTS.click(input);
+        EVENTS.keydownEnter(input);
+        assert.strictEqual(
+          input.value,
+          "Blackberry",
+          "should set that item to the input value"
+        );
+        EVENTS.click(input);
+        assert.strictEqual(
+          list.children.length,
+          select.options.length - 1,
+          "should have all of the initial select items in the list except placeholder empty items"
+        );
+
+        input.value = "Fig";
+        EVENTS.input(input);
+
+        assert.strictEqual(
+          list.children.length,
+          1,
+          "should only show the filtered items"
+        );
+      });
+    });
   });
 });

--- a/spec/unit/combo-box/combo-box.spec.js
+++ b/spec/unit/combo-box/combo-box.spec.js
@@ -8,507 +8,516 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/combo-box.template.html")
 );
 
-describe("combo box component", () => {
-  const { body } = document;
-
-  let root;
-  let input;
-  let select;
-  let list;
-  let toggle;
-
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    toggle = root.querySelector(".usa-combo-box__toggle-list");
-    select = root.querySelector(".usa-combo-box__select");
-    list = root.querySelector(".usa-combo-box__list");
-  });
-
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-  });
-
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.ok(
-      select.classList.contains("usa-sr-only"),
-      "hides the select element from view"
-    );
-    assert.ok(list, "adds an list element");
-    assert.ok(list.hidden, "the list is hidden");
-    assert.strictEqual(
-      select.getAttribute("id"),
-      "",
-      "transfers id attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("id"),
-      "fruit",
-      "transfers id attribute to combo box"
-    );
-    assert.strictEqual(
-      select.getAttribute("required"),
-      null,
-      "transfers required attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("required"),
-      "",
-      "transfers required attribute to combo box"
-    );
-    assert.strictEqual(
-      select.getAttribute("name"),
-      "fruit",
-      "should not transfer name attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("name"),
-      null,
-      "should not transfer name attribute to combo box"
-    );
-    assert.strictEqual(
-      list.getAttribute("role"),
-      "listbox",
-      "the list should have a role of `listbox`"
-    );
-    assert.ok(
-      select.getAttribute("aria-hidden"),
-      "the select should be hidden from screen readers"
-    );
-    assert.strictEqual(
-      select.getAttribute("tabindex"),
-      "-1",
-      "the select should be hidden from keyboard navigation"
-    );
-    assert.ok(
-      select.classList.contains("usa-combo-box__select"),
-      "add the class for the select element"
-    );
-    assert.strictEqual(select.value, "", "the select value should be empty");
-    assert.strictEqual(input.value, "", "the input should be empty");
-  });
-
-  it("should show the list by clicking the input", () => {
-    EVENTS.click(input);
-
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      select.options.length - 1,
-      "should have all of the initial select items in the list except placeholder empty items"
-    );
-  });
-
-  it("should show the list by clicking the toggle button", () => {
-    EVENTS.click(toggle);
-
-    assert.ok(!list.hidden, "should display the option list");
-  });
-
-  it("should show the list by clicking when clicking the input twice", () => {
-    input.value = "";
-
-    EVENTS.click(input);
-    EVENTS.click(input);
-
-    assert.ok(!list.hidden, "should keep the option list displayed");
-  });
-
-  it("should toggle the list and close by clicking when clicking the toggle button twice", () => {
-    EVENTS.click(toggle);
-    EVENTS.click(toggle);
-
-    assert.ok(list.hidden, "should hide the option list");
-  });
-
-  it("should set up the list items for accessibility", () => {
-    let i = 0;
-    const len = list.children.length;
-    EVENTS.click(input);
-
-    assert.strictEqual(
-      list.children[i].getAttribute("aria-selected"),
-      "false",
-      `item ${i} should not be shown as selected`
-    );
-    assert.strictEqual(
-      list.children[i].getAttribute("tabindex"),
-      "0",
-      `item ${i} should be available with tab from keyboard navigation`
-    );
-    assert.strictEqual(
-      list.children[i].getAttribute("role"),
-      "option",
-      `item ${i} should have a role of 'option'`
-    );
-
-    for (i = 1; i < len; i += 1) {
-      assert.strictEqual(
-        list.children[i].getAttribute("aria-selected"),
-        "false",
-        `item ${i} should not be shown as selected`
-      );
-      assert.strictEqual(
-        list.children[i].getAttribute("tabindex"),
-        "-1",
-        `item ${i} should be hidden from keyboard navigation`
-      );
-      assert.strictEqual(
-        list.children[i].getAttribute("role"),
-        "option",
-        `item ${i} should have a role of 'option'`
-      );
-    }
-  });
-
-  it("should close the list by clicking away", () => {
-    EVENTS.click(input);
-    EVENTS.focusout(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-  });
-
-  it("should select an item from the option list when clicking a list option", () => {
-    input.value = "";
-
-    EVENTS.click(input);
-    EVENTS.click(list.children[0]);
-
-    assert.strictEqual(
-      select.value,
-      "apple",
-      "should set that item to the select option"
-    );
-    assert.strictEqual(
-      input.value,
-      "Apple",
-      "should set that item to the input value"
-    );
-    assert.ok(list.hidden, "should hide the option list");
-  });
-
-  it("should display and filter the option list after a character is typed", () => {
-    input.value = "a";
-
-    EVENTS.input(input);
-
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      44,
-      "should filter the item by the string being present in the option"
-    );
-  });
-
-  it("should reset input values when an incomplete item is remaining on blur", () => {
-    select.value = "apricot";
-    input.value = "a";
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-
-    EVENTS.focusout(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(select.value, "apricot");
-    assert.strictEqual(input.value, "Apricot");
-  });
-
-  it("should reset input values when an incomplete item is submitted through enter", () => {
-    select.value = "cantaloupe";
-    input.value = "a";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    const { preventDefaultSpy } = EVENTS.keydownEnter(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(select.value, "cantaloupe");
-    assert.strictEqual(
-      input.value,
-      "Cantaloupe",
-      "should reset the value on the input"
-    );
-    assert.ok(
-      preventDefaultSpy.called,
-      "should not have allowed enter to perform default action"
-    );
-  });
-
-  it("should not allow enter to perform default action when the list is hidden", () => {
-    assert.ok(list.hidden, "the list is hidden");
-    const { preventDefaultSpy } = EVENTS.keydownEnter(input);
-
-    assert.ok(
-      preventDefaultSpy.called,
-      "should not allow event to perform default action"
-    );
-  });
-
-  it("should close the list and reset input value when escape is performed while the list is open", () => {
-    select.value = "cherry";
-    input.value = "a";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    EVENTS.keydownEscape(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(
-      select.value,
-      "cherry",
-      "should not change the value of the select"
-    );
-    assert.strictEqual(
-      input.value,
-      "Cherry",
-      "should reset the value in the input"
-    );
-  });
-
-  it("should reset the input value when a complete selection is left on blur from the input element", () => {
-    select.value = "coconut";
-    input.value = "date";
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-
-    EVENTS.focusout(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(select.value, "coconut");
-    assert.strictEqual(input.value, "Coconut");
-  });
-
-  it("should set the input value when a complete selection is submitted by pressing enter", () => {
-    select.value = "cranberry";
-    input.value = "grape";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    EVENTS.keydownEnter(input);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(
-      select.value,
-      "grape",
-      "should set that item to the select option"
-    );
-    assert.strictEqual(
-      input.value,
-      "Grape",
-      "should set that item to the input value"
-    );
-  });
-
-  it("should show the no results item when a nonexistent option is typed", () => {
-    input.value = "Bibbidi-Bobbidi-Boo";
-
-    EVENTS.input(input);
-
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      1,
-      "should show no results list item"
-    );
-    assert.strictEqual(
-      list.children[0].textContent,
-      "No results found",
-      "should show the no results list item"
-    );
-  });
-
-  it("should show the list when pressing down from an empty input", () => {
-    assert.ok(list.hidden, "the option list is hidden");
-
-    EVENTS.keydownArrowDown(input);
-    assert.ok(!list.hidden, "should display the option list");
-  });
-
-  it("should focus the first item in the list when pressing down from the input", () => {
-    input.value = "grape";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      2,
-      "should filter the item by the string being present in the option"
-    );
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-
-    assert.ok(
-      focusedOption.classList.contains("usa-combo-box__list-option--focused"),
-      "should style the focused item in the list"
-    );
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Grape",
-      "should focus the first item in the list"
-    );
-  });
-
-  it("should select the focused list item in the list when pressing enter on a focused item", () => {
-    select.value = "pineapple";
-    input.value = "berry";
-    EVENTS.input(input);
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blackberry",
-      "should focus the first item in the list"
-    );
-
-    EVENTS.keydownEnter(focusedOption);
-
-    assert.strictEqual(
-      select.value,
-      "blackberry",
-      "select the first item in the list"
-    );
-    assert.strictEqual(
-      input.value,
-      "Blackberry",
-      "should set the value in the input"
-    );
-  });
-
-  it("should select the focused list item in the list when pressing tab on a focused item", () => {
-    select.value = "cantaloupe";
-    input.value = "berry";
-    EVENTS.input(input);
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blackberry",
-      "should focus the first item in the list"
-    );
-
-    EVENTS.keydownTab(focusedOption);
-
-    assert.strictEqual(
-      select.value,
-      "blackberry",
-      "select the first item in the list"
-    );
-    assert.strictEqual(
-      input.value,
-      "Blackberry",
-      "should set the value in the input"
-    );
-  });
-
-  it("should not select the focused list item in the list when blurring component from a focused item", () => {
-    input.value = "la";
-    EVENTS.input(input);
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blackberry",
-      "should focus the first item in the list"
-    );
-
-    EVENTS.focusout(focusedOption);
-
-    assert.strictEqual(select.value, "");
-    assert.strictEqual(input.value, "", "should reset the value in the input");
-  });
-
-  it("should focus the last item in the list when pressing down many times from the input", () => {
-    input.value = "la";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      2,
-      "should filter the item by the string being present in the option"
-    );
-    EVENTS.keydownArrowDown(input);
-    EVENTS.keydownArrowDown(document.activeElement);
-    EVENTS.keydownArrowDown(document.activeElement);
-    const focusedOption = document.activeElement;
-
-    assert.ok(
-      focusedOption.classList.contains("usa-combo-box__list-option--focused"),
-      "should style the focused item in the list"
-    );
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Plantain",
-      "should focus the last item in the list"
-    );
-  });
-
-  it("should not select the focused item in the list when pressing escape from the focused item", () => {
-    select.value = "pineapple";
-    input.value = "la";
-
-    EVENTS.input(input);
-    assert.ok(
-      !list.hidden && list.children.length,
-      "should display the option list with options"
-    );
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blackberry",
-      "should focus the first item in the list"
-    );
-    EVENTS.keydownEscape(focusedOption);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(
-      select.value,
-      "pineapple",
-      "should not change the value of the select"
-    );
-    assert.strictEqual(
-      input.value,
-      "Pineapple",
-      "should reset the value in the input"
-    );
-  });
-
-  it("should focus the input and hide the list when pressing up from the first item in the list", () => {
-    input.value = "la";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    assert.strictEqual(
-      list.children.length,
-      2,
-      "should filter the item by the string being present in the option"
-    );
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "Blackberry",
-      "should focus the first item in the list"
-    );
-    EVENTS.keydownArrowUp(focusedOption);
-
-    assert.ok(list.hidden, "should hide the option list");
-    assert.strictEqual(document.activeElement, input, "should focus the input");
-  });
-
-  it("should not allow for innerHTML of child elements ", () => {
-    input.value = "apricot";
-
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
-    Array.from(list.children).forEach((listItem) => {
-      Array.from(listItem.childNodes).forEach((childNode) => {
-        assert.strictEqual(childNode.nodeType, Node.TEXT_NODE);
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: () => document.querySelector(".usa-combo-box") }
+];
+
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component", () => {
+      const { body } = document;
+
+      let root;
+      let input;
+      let select;
+      let list;
+      let toggle;
+
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        input = root.querySelector(".usa-combo-box__input");
+        toggle = root.querySelector(".usa-combo-box__toggle-list");
+        select = root.querySelector(".usa-combo-box__select");
+        list = root.querySelector(".usa-combo-box__list");
+      });
+
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
+
+      it("enhances a select element into a combo box component", () => {
+        assert.ok(input, "adds an input element");
+        assert.ok(
+          select.classList.contains("usa-sr-only"),
+          "hides the select element from view"
+        );
+        assert.ok(list, "adds an list element");
+        assert.ok(list.hidden, "the list is hidden");
+        assert.strictEqual(
+          select.getAttribute("id"),
+          "",
+          "transfers id attribute to combo box"
+        );
+        assert.strictEqual(
+          input.getAttribute("id"),
+          "fruit",
+          "transfers id attribute to combo box"
+        );
+        assert.strictEqual(
+          select.getAttribute("required"),
+          null,
+          "transfers required attribute to combo box"
+        );
+        assert.strictEqual(
+          input.getAttribute("required"),
+          "",
+          "transfers required attribute to combo box"
+        );
+        assert.strictEqual(
+          select.getAttribute("name"),
+          "fruit",
+          "should not transfer name attribute to combo box"
+        );
+        assert.strictEqual(
+          input.getAttribute("name"),
+          null,
+          "should not transfer name attribute to combo box"
+        );
+        assert.strictEqual(
+          list.getAttribute("role"),
+          "listbox",
+          "the list should have a role of `listbox`"
+        );
+        assert.ok(
+          select.getAttribute("aria-hidden"),
+          "the select should be hidden from screen readers"
+        );
+        assert.strictEqual(
+          select.getAttribute("tabindex"),
+          "-1",
+          "the select should be hidden from keyboard navigation"
+        );
+        assert.ok(
+          select.classList.contains("usa-combo-box__select"),
+          "add the class for the select element"
+        );
+        assert.strictEqual(select.value, "", "the select value should be empty");
+        assert.strictEqual(input.value, "", "the input should be empty");
+      });
+
+      it("should show the list by clicking the input", () => {
+        EVENTS.click(input);
+
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          select.options.length - 1,
+          "should have all of the initial select items in the list except placeholder empty items"
+        );
+      });
+
+      it("should show the list by clicking the toggle button", () => {
+        EVENTS.click(toggle);
+
+        assert.ok(!list.hidden, "should display the option list");
+      });
+
+      it("should show the list by clicking when clicking the input twice", () => {
+        input.value = "";
+
+        EVENTS.click(input);
+        EVENTS.click(input);
+
+        assert.ok(!list.hidden, "should keep the option list displayed");
+      });
+
+      it("should toggle the list and close by clicking when clicking the toggle button twice", () => {
+        EVENTS.click(toggle);
+        EVENTS.click(toggle);
+
+        assert.ok(list.hidden, "should hide the option list");
+      });
+
+      it("should set up the list items for accessibility", () => {
+        let i = 0;
+        const len = list.children.length;
+        EVENTS.click(input);
+
+        assert.strictEqual(
+          list.children[i].getAttribute("aria-selected"),
+          "false",
+          `item ${i} should not be shown as selected`
+        );
+        assert.strictEqual(
+          list.children[i].getAttribute("tabindex"),
+          "0",
+          `item ${i} should be available with tab from keyboard navigation`
+        );
+        assert.strictEqual(
+          list.children[i].getAttribute("role"),
+          "option",
+          `item ${i} should have a role of 'option'`
+        );
+
+        for (i = 1; i < len; i += 1) {
+          assert.strictEqual(
+            list.children[i].getAttribute("aria-selected"),
+            "false",
+            `item ${i} should not be shown as selected`
+          );
+          assert.strictEqual(
+            list.children[i].getAttribute("tabindex"),
+            "-1",
+            `item ${i} should be hidden from keyboard navigation`
+          );
+          assert.strictEqual(
+            list.children[i].getAttribute("role"),
+            "option",
+            `item ${i} should have a role of 'option'`
+          );
+        }
+      });
+
+      it("should close the list by clicking away", () => {
+        EVENTS.click(input);
+        EVENTS.focusout(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+      });
+
+      it("should select an item from the option list when clicking a list option", () => {
+        input.value = "";
+
+        EVENTS.click(input);
+        EVENTS.click(list.children[0]);
+
+        assert.strictEqual(
+          select.value,
+          "apple",
+          "should set that item to the select option"
+        );
+        assert.strictEqual(
+          input.value,
+          "Apple",
+          "should set that item to the input value"
+        );
+        assert.ok(list.hidden, "should hide the option list");
+      });
+
+      it("should display and filter the option list after a character is typed", () => {
+        input.value = "a";
+
+        EVENTS.input(input);
+
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          44,
+          "should filter the item by the string being present in the option"
+        );
+      });
+
+      it("should reset input values when an incomplete item is remaining on blur", () => {
+        select.value = "apricot";
+        input.value = "a";
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+
+        EVENTS.focusout(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(select.value, "apricot");
+        assert.strictEqual(input.value, "Apricot");
+      });
+
+      it("should reset input values when an incomplete item is submitted through enter", () => {
+        select.value = "cantaloupe";
+        input.value = "a";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        const { preventDefaultSpy } = EVENTS.keydownEnter(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(select.value, "cantaloupe");
+        assert.strictEqual(
+          input.value,
+          "Cantaloupe",
+          "should reset the value on the input"
+        );
+        assert.ok(
+          preventDefaultSpy.called,
+          "should not have allowed enter to perform default action"
+        );
+      });
+
+      it("should not allow enter to perform default action when the list is hidden", () => {
+        assert.ok(list.hidden, "the list is hidden");
+        const { preventDefaultSpy } = EVENTS.keydownEnter(input);
+
+        assert.ok(
+          preventDefaultSpy.called,
+          "should not allow event to perform default action"
+        );
+      });
+
+      it("should close the list and reset input value when escape is performed while the list is open", () => {
+        select.value = "cherry";
+        input.value = "a";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        EVENTS.keydownEscape(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(
+          select.value,
+          "cherry",
+          "should not change the value of the select"
+        );
+        assert.strictEqual(
+          input.value,
+          "Cherry",
+          "should reset the value in the input"
+        );
+      });
+
+      it("should reset the input value when a complete selection is left on blur from the input element", () => {
+        select.value = "coconut";
+        input.value = "date";
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+
+        EVENTS.focusout(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(select.value, "coconut");
+        assert.strictEqual(input.value, "Coconut");
+      });
+
+      it("should set the input value when a complete selection is submitted by pressing enter", () => {
+        select.value = "cranberry";
+        input.value = "grape";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        EVENTS.keydownEnter(input);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(
+          select.value,
+          "grape",
+          "should set that item to the select option"
+        );
+        assert.strictEqual(
+          input.value,
+          "Grape",
+          "should set that item to the input value"
+        );
+      });
+
+      it("should show the no results item when a nonexistent option is typed", () => {
+        input.value = "Bibbidi-Bobbidi-Boo";
+
+        EVENTS.input(input);
+
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          1,
+          "should show no results list item"
+        );
+        assert.strictEqual(
+          list.children[0].textContent,
+          "No results found",
+          "should show the no results list item"
+        );
+      });
+
+      it("should show the list when pressing down from an empty input", () => {
+        assert.ok(list.hidden, "the option list is hidden");
+
+        EVENTS.keydownArrowDown(input);
+        assert.ok(!list.hidden, "should display the option list");
+      });
+
+      it("should focus the first item in the list when pressing down from the input", () => {
+        input.value = "grape";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          2,
+          "should filter the item by the string being present in the option"
+        );
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+
+        assert.ok(
+          focusedOption.classList.contains("usa-combo-box__list-option--focused"),
+          "should style the focused item in the list"
+        );
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Grape",
+          "should focus the first item in the list"
+        );
+      });
+
+      it("should select the focused list item in the list when pressing enter on a focused item", () => {
+        select.value = "pineapple";
+        input.value = "berry";
+        EVENTS.input(input);
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blackberry",
+          "should focus the first item in the list"
+        );
+
+        EVENTS.keydownEnter(focusedOption);
+
+        assert.strictEqual(
+          select.value,
+          "blackberry",
+          "select the first item in the list"
+        );
+        assert.strictEqual(
+          input.value,
+          "Blackberry",
+          "should set the value in the input"
+        );
+      });
+
+      it("should select the focused list item in the list when pressing tab on a focused item", () => {
+        select.value = "cantaloupe";
+        input.value = "berry";
+        EVENTS.input(input);
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blackberry",
+          "should focus the first item in the list"
+        );
+
+        EVENTS.keydownTab(focusedOption);
+
+        assert.strictEqual(
+          select.value,
+          "blackberry",
+          "select the first item in the list"
+        );
+        assert.strictEqual(
+          input.value,
+          "Blackberry",
+          "should set the value in the input"
+        );
+      });
+
+      it("should not select the focused list item in the list when blurring component from a focused item", () => {
+        input.value = "la";
+        EVENTS.input(input);
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blackberry",
+          "should focus the first item in the list"
+        );
+
+        EVENTS.focusout(focusedOption);
+
+        assert.strictEqual(select.value, "");
+        assert.strictEqual(input.value, "", "should reset the value in the input");
+      });
+
+      it("should focus the last item in the list when pressing down many times from the input", () => {
+        input.value = "la";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          2,
+          "should filter the item by the string being present in the option"
+        );
+        EVENTS.keydownArrowDown(input);
+        EVENTS.keydownArrowDown(document.activeElement);
+        EVENTS.keydownArrowDown(document.activeElement);
+        const focusedOption = document.activeElement;
+
+        assert.ok(
+          focusedOption.classList.contains("usa-combo-box__list-option--focused"),
+          "should style the focused item in the list"
+        );
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Plantain",
+          "should focus the last item in the list"
+        );
+      });
+
+      it("should not select the focused item in the list when pressing escape from the focused item", () => {
+        select.value = "pineapple";
+        input.value = "la";
+
+        EVENTS.input(input);
+        assert.ok(
+          !list.hidden && list.children.length,
+          "should display the option list with options"
+        );
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blackberry",
+          "should focus the first item in the list"
+        );
+        EVENTS.keydownEscape(focusedOption);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(
+          select.value,
+          "pineapple",
+          "should not change the value of the select"
+        );
+        assert.strictEqual(
+          input.value,
+          "Pineapple",
+          "should reset the value in the input"
+        );
+      });
+
+      it("should focus the input and hide the list when pressing up from the first item in the list", () => {
+        input.value = "la";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        assert.strictEqual(
+          list.children.length,
+          2,
+          "should filter the item by the string being present in the option"
+        );
+        EVENTS.keydownArrowDown(input);
+        const focusedOption = document.activeElement;
+        assert.strictEqual(
+          focusedOption.textContent,
+          "Blackberry",
+          "should focus the first item in the list"
+        );
+        EVENTS.keydownArrowUp(focusedOption);
+
+        assert.ok(list.hidden, "should hide the option list");
+        assert.strictEqual(document.activeElement, input, "should focus the input");
+      });
+
+      it("should not allow for innerHTML of child elements ", () => {
+        input.value = "apricot";
+
+        EVENTS.input(input);
+        assert.ok(!list.hidden, "should display the option list");
+        Array.from(list.children).forEach((listItem) => {
+          Array.from(listItem.childNodes).forEach((childNode) => {
+            assert.strictEqual(childNode.nodeType, Node.TEXT_NODE);
+          });
+        });
       });
     });
   });

--- a/spec/unit/date-picker/date-picker-default-date.spec.js
+++ b/spec/unit/date-picker/date-picker-default-date.spec.js
@@ -8,67 +8,75 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker-default-date.template.html")
 );
 
-describe("date picker component with default date", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component with default date initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    let root;
+    let input;
+    let button;
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${query ? ` ${query}` : ""}`
+      );
 
-  afterEach(() => {
-    window.onerror = null;
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should display the input date when an input date is present", () => {
-    input.value = "06/20/2020";
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      window.onerror = null;
+      body.textContent = "";
+    });
 
-    EVENTS.click(button);
+    it("should display the input date when an input date is present", () => {
+      input.value = "06/20/2020";
 
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "focuses correct date"
-    );
-  });
+      EVENTS.click(button);
 
-  it("should display the default date when the input date is empty", () => {
-    input.value = "";
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "focuses correct date"
+      );
+    });
 
-    EVENTS.click(button);
+    it("should display the default date when the input date is empty", () => {
+      input.value = "";
 
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
+      EVENTS.click(button);
 
-  it("should display the default date when the input date is invalid", () => {
-    input.value = "";
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
 
-    EVENTS.click(button);
+    it("should display the default date when the input date is invalid", () => {
+      input.value = "";
 
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-default-value.spec.js
+++ b/spec/unit/date-picker/date-picker-default-value.spec.js
@@ -8,43 +8,51 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker-default-value.template.html")
 );
 
-describe("date picker component with default date", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component with default date initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    let root;
+    let input;
+    let button;
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${ query ? ` ${query}` : ""}`
+      );
 
-  afterEach(() => {
-    window.onerror = null;
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should set the input date of the calendar", () => {
-    assert.strictEqual(input.value, "05/22/2020", "updates the calendar value");
-  });
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      window.onerror = null;
+      body.textContent = "";
+    });
 
-  it("should display the selected date when the calendar is opened", () => {
-    EVENTS.click(button);
+    it("should set the input date of the calendar", () => {
+      assert.strictEqual(input.value, "05/22/2020", "updates the calendar value");
+    });
 
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
+    it("should display the selected date when the calendar is opened", () => {
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-disabled.spec.js
+++ b/spec/unit/date-picker/date-picker-disabled.spec.js
@@ -8,39 +8,47 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker-disabled.template.html")
 );
 
-describe("date picker component - disabled initialization", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let button;
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component initialized at ${name} - disabled initialization`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    let root;
+    let button;
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${ query ? ` ${query}` : ""}`
+      );
 
-  afterEach(() => {
-    window.onerror = null;
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should not display the calendar when the button is clicked as it is disabled", () => {
-    EVENTS.click(button);
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      window.onerror = null;
+      body.textContent = "";
+    });
 
-    assert.strictEqual(getCalendarEl().hidden, true, "the calendar is hidden");
-  });
+    it("should not display the calendar when the button is clicked as it is disabled", () => {
+      EVENTS.click(button);
 
-  it("should display the calendar when the button is clicked once the component is enabled", () => {
-    DatePicker.enable(root);
-    EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, true, "the calendar is hidden");
+    });
 
-    assert.strictEqual(getCalendarEl().hidden, false, "the calendar is shown");
+    it("should display the calendar when the button is clicked once the component is enabled", () => {
+      DatePicker.enable(root);
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "the calendar is shown");
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-focus-trap.spec.js
+++ b/spec/unit/date-picker/date-picker-focus-trap.spec.js
@@ -8,62 +8,70 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker.template.html")
 );
 
-describe("date picker component focus trap", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let button;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component focus trap initialized at ${name}`, () => {
+    const { body } = document;
 
-  //  const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
+    let root;
+    let button;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    //  const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should move focus to the first item when pressing tab form last item", () => {
-    EVENTS.click(button);
-    assert.ok(
-      document.activeElement.classList.contains(
-        "usa-date-picker__calendar__date--focused"
-      ),
-      "focuses correct item"
-    );
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-    EVENTS.keydownTab();
+    it("should move focus to the first item when pressing tab form last item", () => {
+      EVENTS.click(button);
+      assert.ok(
+        document.activeElement.classList.contains(
+          "usa-date-picker__calendar__date--focused"
+        ),
+        "focuses correct item"
+      );
 
-    assert.ok(
-      document.activeElement.classList.contains(
-        "usa-date-picker__calendar__previous-year"
-      ),
-      "focuses correct item"
-    );
-  });
+      EVENTS.keydownTab();
 
-  it("should move focus to the last item when pressing shift+tab form first item", () => {
-    EVENTS.click(button);
-    EVENTS.keydownTab();
-    assert.ok(
-      document.activeElement.classList.contains(
-        "usa-date-picker__calendar__previous-year"
-      ),
-      "focuses correct item"
-    );
+      assert.ok(
+        document.activeElement.classList.contains(
+          "usa-date-picker__calendar__previous-year"
+        ),
+        "focuses correct item"
+      );
+    });
 
-    EVENTS.keydownShiftTab();
+    it("should move focus to the last item when pressing shift+tab form first item", () => {
+      EVENTS.click(button);
+      EVENTS.keydownTab();
+      assert.ok(
+        document.activeElement.classList.contains(
+          "usa-date-picker__calendar__previous-year"
+        ),
+        "focuses correct item"
+      );
 
-    assert.ok(
-      document.activeElement.classList.contains(
-        "usa-date-picker__calendar__date--focused"
-      ),
-      "focuses correct item"
-    );
+      EVENTS.keydownShiftTab();
+
+      assert.ok(
+        document.activeElement.classList.contains(
+          "usa-date-picker__calendar__date--focused"
+        ),
+        "focuses correct item"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-min-date-max-date.spec.js
+++ b/spec/unit/date-picker/date-picker-min-date-max-date.spec.js
@@ -10,798 +10,806 @@ const TEMPLATE = fs.readFileSync(
 
 const VALIDATION_MESSAGE = "Please enter a valid date";
 
-describe("date picker component with min date and max date", () => {
-  const { body } = document;
-
-  let root;
-  let input;
-  let button;
-  let error;
-  let expectedError;
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
-
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-    expectedError = "";
-    window.onerror = (message) => {
-      error = message;
-      return error === expectedError;
-    };
-  });
-
-  afterEach(() => {
-    window.onerror = null;
-    body.textContent = "";
-    DatePicker.off(body);
-  });
-
-  it("should allow navigation back a year to a month that is partially disabled due to a minimum date being set", () => {
-    input.value = "05/15/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should disable back buttons when displaying the minimum month", () => {
-    input.value = "05/30/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__previous-month").disabled,
-      true,
-      "the previous month button is disabled"
-    );
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__previous-year").disabled,
-      true,
-      "the previous year button is disabled"
-    );
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-30",
-      "focuses correct date"
-    );
-  });
-
-  it("should disable forward buttons when displaying the maximum month", () => {
-    input.value = "06/01/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__next-month").disabled,
-      true,
-      "the next month button is disabled"
-    );
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__next-year").disabled,
-      true,
-      "the next year button is disabled"
-    );
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-01",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow navigation back a year to a month that is less than a year from the minimum date being set and cap at that minimum date", () => {
-    input.value = "04/15/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow navigation back a month to a month that is partially disabled due to a minimum date being set", () => {
-    input.value = "06/15/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should not allow navigation back a month to a month that is fully disabled due to a minimum date being set", () => {
-    input.value = "05/30/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__previous-year").disabled,
-      true,
-      "the button is disabled"
-    );
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-30",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow navigation forward a year to a month that is partially disabled due to a maximum date being set", () => {
-    input.value = "06/25/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow navigation forward a year to a month that is less than a year from the maximum date and cap at that maximum date", () => {
-    input.value = "07/25/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow navigation forward a month to a month that is partially disabled due to a maximum date being set", () => {
-    input.value = "05/25/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should not allow navigation forward a month to a month that is fully disabled due to a maximum date being set", () => {
-    input.value = "06/17/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-17",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow selection of a month in the month selection screen that is partially disabled due to a minimum date being set", () => {
-    input.value = "12/01/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__month[data-label="May"]'
-      )
-    );
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__date-picker"),
-      "the date picker is shown"
-    );
-  });
-
-  it("should not allow selection of a month in the month selection screen that is fully disabled due to a minimum date being set", () => {
-    input.value = "10/31/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__month[data-label="January"]')
-    );
-
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-  });
-
-  it("should allow selection of a month in the month selection screen that is partially disabled due to a maximum date being set", () => {
-    input.value = "01/30/2021";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__month[data-label="June"]'
-      )
-    );
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__date-picker"),
-      "the date picker is shown"
-    );
-  });
-
-  it("should not allow selection of a month in the month selection screen that is fully disabled due to a maximum date being set", () => {
-    input.value = "02/29/2021";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__month[data-label="December"]')
-    );
-
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__month-picker"),
-      "the month picker is shown"
-    );
-  });
-
-  it("should allow selection of a year in the year selection screen that is partially disabled due to a minimum date being set", () => {
-    input.value = "04/01/2021";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__year[data-value="2020"]')
-    );
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__date-picker"),
-      "the date picker is shown"
-    );
-  });
-
-  it("should allow selection of a year in the year selection screen that is partially disabled due to a maximum date being set", () => {
-    input.value = "12/01/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__year[data-value="2021"]')
-    );
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__date-picker"),
-      "the date picker is shown"
-    );
-  });
-
-  it("should not allow selection of a year in the year selection screen that is fully disabled due to a minimum date being set", () => {
-    input.value = "07/04/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__year[data-value="2018"]')
-    );
-
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-  });
-
-  it("should not allow selection of a year  in the year selection screen that is fully disabled due to a maximum date being set", () => {
-    input.value = "12/01/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-
-    EVENTS.click(
-      getCalendarEl('.usa-date-picker__calendar__year[data-value="2023"]')
-    );
-
-    assert.ok(
-      getCalendarEl(".usa-date-picker__calendar__year-picker"),
-      "the year picker is shown"
-    );
-  });
-
-  it("should allow selection of a date that is the minimum date", () => {
-    input.value = "05/25/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="22"]'
-      )
-    );
-
-    assert.strictEqual(
-      input.value,
-      "05/22/2020",
-      "The value has been filled in"
-    );
-  });
-
-  it("should allow selection of a date that is the maximum date", () => {
-    input.value = "06/15/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="20"]'
-      )
-    );
-
-    assert.strictEqual(
-      input.value,
-      "06/20/2020",
-      "The value has been filled in"
-    );
-  });
-
-  it("should not allow selection of a date that is before the minimum date", () => {
-    input.value = "05/25/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="15"]'
-      )
-    );
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-  });
-
-  it("should not allow selection of a date that is after the maximum date", () => {
-    input.value = "06/15/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="25"]'
-      )
-    );
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-  });
-
-  it("should allow keyboard navigation to move back one day to a date that is the minimum date", () => {
-    input.value = "05/23/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowLeft();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one week to a date that is the minimum date", () => {
-    input.value = "05/29/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one month to a date that is the minimum date", () => {
-    input.value = "06/22/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one year to a date that is the minimum date", () => {
-    input.value = "05/22/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should not allow keyboard navigation to move back one day to a date that is before the minimum date", () => {
-    input.value = "05/22/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowLeft();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move to the start of the week to a date that is before the minimum date but cap at minimum date", () => {
-    input.value = "05/23/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownHome();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one week to a date that is before the minimum date but cap at minimum date", () => {
-    input.value = "05/28/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one month to a date that is before the minimum date but cap at minimum date", () => {
-    input.value = "06/21/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move back one year to a date that is before the minimum date but cap at minimum date", () => {
-    input.value = "05/21/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageUp();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one day to a date that is the maximum date", () => {
-    input.value = "06/19/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowRight();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one week to a date that is the maximum date", () => {
-    input.value = "06/13/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one month to a date that is the maximum date", () => {
-    input.value = "05/20/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one year to a date that is the maximum date", () => {
-    input.value = "06/20/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should not allow keyboard navigation to move forward one day to a date that is after the maximum date", () => {
-    input.value = "06/20/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowRight();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move to the end of the week to a date that is after the maximum date but cap at maximum date", () => {
-    root.dataset.maxDate = "2021-06-21";
-    input.value = "06/20/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownEnd();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-21",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one week to a date that is after the maximum date but cap at maximum date", () => {
-    input.value = "06/14/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one month to a date that is after the maximum date but cap at maximum date", () => {
-    input.value = "05/21/2021";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should allow keyboard navigation to move forward one year to a date that is after the maximum date but cap at maximum date", () => {
-    input.value = "06/21/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageDown();
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should show a date that is after the maximum date as invalid", () => {
-    input.value = "06/30/2021";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-  });
-
-  it("should show a date that is the maximum date as valid", () => {
-    input.value = "06/20/2021";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, "");
-  });
-
-  it("should show a date that is before the minimum date as invalid", () => {
-    input.value = "05/01/2020";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-  });
-
-  it("should show a date that is the minimum date as valid", () => {
-    input.value = "05/22/2020";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, "");
-  });
-
-  it("should throw when minDate is larger than maxDate", () => {
-    root.dataset.minDate = "2020-07-04";
-    root.dataset.maxDate = "2020-06-20";
-    expectedError = "Minimum date cannot be after maximum date";
-
-    EVENTS.click(button);
-
-    assert.strictEqual(error, expectedError, "caught the error");
-  });
-
-  it("should open the calendar on the min date when the input date is before the min date", () => {
-    input.value = "04/15/2020";
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-05-22",
-      "focuses correct date"
-    );
-  });
-
-  it("should open the calendar on the max date when the input date is after the max date", () => {
-    input.value = "04/15/2023";
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2021-06-20",
-      "focuses correct date"
-    );
-  });
-
-  it("should open the calendar on the max date when the input is empty and the current date is after the max date", () => {
-    root.dataset.minDate = "2020-01-01";
-    root.dataset.maxDate = "2020-02-14";
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-02-14",
-      "focuses correct date"
-    );
-  });
-
-  it("should update the calendar to the max date when the input is changed and the input date is after the max date", () => {
-    root.dataset.minDate = "2020-01-01";
-    root.dataset.maxDate = "2020-02-14";
-    input.value = "01/20/2020";
-    EVENTS.click(button);
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-01-20",
-      "focuses correct date"
-    );
-
-    input.value = "6/20/2020";
-    EVENTS.input(input);
-
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-02-14",
-      "focuses correct date"
-    );
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
+
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component with min date and max date initialized at ${name}`, () => {
+    const { body } = document;
+
+    let root;
+    let input;
+    let button;
+    let error;
+    let expectedError;
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${ query ? ` ${query}` : ""}`
+      );
+
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+      expectedError = "";
+      window.onerror = (message) => {
+        error = message;
+        return error === expectedError;
+      };
+    });
+
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      window.onerror = null;
+      body.textContent = "";
+    });
+
+    it("should allow navigation back a year to a month that is partially disabled due to a minimum date being set", () => {
+      input.value = "05/15/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should disable back buttons when displaying the minimum month", () => {
+      input.value = "05/30/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__previous-month").disabled,
+        true,
+        "the previous month button is disabled"
+      );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__previous-year").disabled,
+        true,
+        "the previous year button is disabled"
+      );
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-30",
+        "focuses correct date"
+      );
+    });
+
+    it("should disable forward buttons when displaying the maximum month", () => {
+      input.value = "06/01/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__next-month").disabled,
+        true,
+        "the next month button is disabled"
+      );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__next-year").disabled,
+        true,
+        "the next year button is disabled"
+      );
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-01",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow navigation back a year to a month that is less than a year from the minimum date being set and cap at that minimum date", () => {
+      input.value = "04/15/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow navigation back a month to a month that is partially disabled due to a minimum date being set", () => {
+      input.value = "06/15/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should not allow navigation back a month to a month that is fully disabled due to a minimum date being set", () => {
+      input.value = "05/30/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__previous-year").disabled,
+        true,
+        "the button is disabled"
+      );
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__previous-month"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-30",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow navigation forward a year to a month that is partially disabled due to a maximum date being set", () => {
+      input.value = "06/25/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow navigation forward a year to a month that is less than a year from the maximum date and cap at that maximum date", () => {
+      input.value = "07/25/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-year"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow navigation forward a month to a month that is partially disabled due to a maximum date being set", () => {
+      input.value = "05/25/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should not allow navigation forward a month to a month that is fully disabled due to a maximum date being set", () => {
+      input.value = "06/17/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__next-month"));
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-17",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow selection of a month in the month selection screen that is partially disabled due to a minimum date being set", () => {
+      input.value = "12/01/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__month[data-label="May"]'
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__date-picker"),
+        "the date picker is shown"
+      );
+    });
+
+    it("should not allow selection of a month in the month selection screen that is fully disabled due to a minimum date being set", () => {
+      input.value = "10/31/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__month[data-label="January"]')
+      );
+
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+    });
+
+    it("should allow selection of a month in the month selection screen that is partially disabled due to a maximum date being set", () => {
+      input.value = "01/30/2021";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__month[data-label="June"]'
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__date-picker"),
+        "the date picker is shown"
+      );
+    });
+
+    it("should not allow selection of a month in the month selection screen that is fully disabled due to a maximum date being set", () => {
+      input.value = "02/29/2021";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__month[data-label="December"]')
+      );
+
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__month-picker"),
+        "the month picker is shown"
+      );
+    });
+
+    it("should allow selection of a year in the year selection screen that is partially disabled due to a minimum date being set", () => {
+      input.value = "04/01/2021";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__year[data-value="2020"]')
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__date-picker"),
+        "the date picker is shown"
+      );
+    });
+
+    it("should allow selection of a year in the year selection screen that is partially disabled due to a maximum date being set", () => {
+      input.value = "12/01/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__year[data-value="2021"]')
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__date-picker"),
+        "the date picker is shown"
+      );
+    });
+
+    it("should not allow selection of a year in the year selection screen that is fully disabled due to a minimum date being set", () => {
+      input.value = "07/04/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__year[data-value="2018"]')
+      );
+
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+    });
+
+    it("should not allow selection of a year  in the year selection screen that is fully disabled due to a maximum date being set", () => {
+      input.value = "12/01/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+
+      EVENTS.click(
+        getCalendarEl('.usa-date-picker__calendar__year[data-value="2023"]')
+      );
+
+      assert.ok(
+        getCalendarEl(".usa-date-picker__calendar__year-picker"),
+        "the year picker is shown"
+      );
+    });
+
+    it("should allow selection of a date that is the minimum date", () => {
+      input.value = "05/25/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="22"]'
+        )
+      );
+
+      assert.strictEqual(
+        input.value,
+        "05/22/2020",
+        "The value has been filled in"
+      );
+    });
+
+    it("should allow selection of a date that is the maximum date", () => {
+      input.value = "06/15/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="20"]'
+        )
+      );
+
+      assert.strictEqual(
+        input.value,
+        "06/20/2020",
+        "The value has been filled in"
+      );
+    });
+
+    it("should not allow selection of a date that is before the minimum date", () => {
+      input.value = "05/25/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="15"]'
+        )
+      );
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+    });
+
+    it("should not allow selection of a date that is after the maximum date", () => {
+      input.value = "06/15/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="25"]'
+        )
+      );
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+    });
+
+    it("should allow keyboard navigation to move back one day to a date that is the minimum date", () => {
+      input.value = "05/23/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowLeft();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one week to a date that is the minimum date", () => {
+      input.value = "05/29/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one month to a date that is the minimum date", () => {
+      input.value = "06/22/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one year to a date that is the minimum date", () => {
+      input.value = "05/22/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should not allow keyboard navigation to move back one day to a date that is before the minimum date", () => {
+      input.value = "05/22/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowLeft();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move to the start of the week to a date that is before the minimum date but cap at minimum date", () => {
+      input.value = "05/23/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownHome();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one week to a date that is before the minimum date but cap at minimum date", () => {
+      input.value = "05/28/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one month to a date that is before the minimum date but cap at minimum date", () => {
+      input.value = "06/21/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move back one year to a date that is before the minimum date but cap at minimum date", () => {
+      input.value = "05/21/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageUp();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one day to a date that is the maximum date", () => {
+      input.value = "06/19/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowRight();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one week to a date that is the maximum date", () => {
+      input.value = "06/13/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one month to a date that is the maximum date", () => {
+      input.value = "05/20/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one year to a date that is the maximum date", () => {
+      input.value = "06/20/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should not allow keyboard navigation to move forward one day to a date that is after the maximum date", () => {
+      input.value = "06/20/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowRight();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move to the end of the week to a date that is after the maximum date but cap at maximum date", () => {
+      root.dataset.maxDate = "2021-06-21";
+      input.value = "06/20/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownEnd();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-21",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one week to a date that is after the maximum date but cap at maximum date", () => {
+      input.value = "06/14/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one month to a date that is after the maximum date but cap at maximum date", () => {
+      input.value = "05/21/2021";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should allow keyboard navigation to move forward one year to a date that is after the maximum date but cap at maximum date", () => {
+      input.value = "06/21/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageDown();
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should show a date that is after the maximum date as invalid", () => {
+      input.value = "06/30/2021";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+    });
+
+    it("should show a date that is the maximum date as valid", () => {
+      input.value = "06/20/2021";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, "");
+    });
+
+    it("should show a date that is before the minimum date as invalid", () => {
+      input.value = "05/01/2020";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+    });
+
+    it("should show a date that is the minimum date as valid", () => {
+      input.value = "05/22/2020";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, "");
+    });
+
+    it("should throw when minDate is larger than maxDate", () => {
+      root.dataset.minDate = "2020-07-04";
+      root.dataset.maxDate = "2020-06-20";
+      expectedError = "Minimum date cannot be after maximum date";
+
+      EVENTS.click(button);
+
+      assert.strictEqual(error, expectedError, "caught the error");
+    });
+
+    it("should open the calendar on the min date when the input date is before the min date", () => {
+      input.value = "04/15/2020";
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-05-22",
+        "focuses correct date"
+      );
+    });
+
+    it("should open the calendar on the max date when the input date is after the max date", () => {
+      input.value = "04/15/2023";
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2021-06-20",
+        "focuses correct date"
+      );
+    });
+
+    it("should open the calendar on the max date when the input is empty and the current date is after the max date", () => {
+      root.dataset.minDate = "2020-01-01";
+      root.dataset.maxDate = "2020-02-14";
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-02-14",
+        "focuses correct date"
+      );
+    });
+
+    it("should update the calendar to the max date when the input is changed and the input date is after the max date", () => {
+      root.dataset.minDate = "2020-01-01";
+      root.dataset.maxDate = "2020-02-14";
+      input.value = "01/20/2020";
+      EVENTS.click(button);
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-01-20",
+        "focuses correct date"
+      );
+
+      input.value = "6/20/2020";
+      EVENTS.input(input);
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-02-14",
+        "focuses correct date"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-month-selection.spec.js
+++ b/spec/unit/date-picker/date-picker-month-selection.spec.js
@@ -8,145 +8,153 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker.template.html")
 );
 
-describe("date picker component month selection", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component month selection initialized at ${name}`, () => {
+    const { body } = document;
 
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+    let root;
+    let input;
+    let button;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${ query ? ` ${query}` : ""}`
+      );
 
-  beforeEach("Open month selection view", () => {
-    input.value = "6/20/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach("Open month selection view", () => {
+      input.value = "6/20/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__month-selection"));
+    });
 
-  it("should show month of June as focused", () => {
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "June",
-      "focuses correct month"
-    );
-  });
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-  it("should show month of June as selected", () => {
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--selected").dataset
-        .label,
-      "June",
-      "selects correct month"
-    );
-  });
+    it("should show month of June as focused", () => {
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "June",
+        "focuses correct month"
+      );
+    });
 
-  it("should navigate back three months when pressing up", () => {
-    EVENTS.keydownArrowUp();
+    it("should show month of June as selected", () => {
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--selected").dataset
+          .label,
+        "June",
+        "selects correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "March",
-      "focuses correct month"
-    );
-  });
+    it("should navigate back three months when pressing up", () => {
+      EVENTS.keydownArrowUp();
 
-  it("should navigate ahead three months when pressing down", () => {
-    EVENTS.keydownArrowDown();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "March",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "September",
-      "focuses correct month"
-    );
-  });
+    it("should navigate ahead three months when pressing down", () => {
+      EVENTS.keydownArrowDown();
 
-  it("should navigate back one month when pressing left", () => {
-    EVENTS.keydownArrowLeft();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "September",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "May",
-      "focuses correct month"
-    );
-  });
+    it("should navigate back one month when pressing left", () => {
+      EVENTS.keydownArrowLeft();
 
-  it("should navigate ahead one month when pressing right", () => {
-    EVENTS.keydownArrowRight();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "May",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "July",
-      "focuses correct month"
-    );
-  });
+    it("should navigate ahead one month when pressing right", () => {
+      EVENTS.keydownArrowRight();
 
-  it("should navigate to the beginning of the month row when pressing home", () => {
-    EVENTS.keydownHome();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "July",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "April",
-      "focuses correct month"
-    );
-  });
+    it("should navigate to the beginning of the month row when pressing home", () => {
+      EVENTS.keydownHome();
 
-  it("should navigate to the end of the month row when pressing end", () => {
-    EVENTS.keydownEnd();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "April",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "June",
-      "focuses correct month"
-    );
-  });
+    it("should navigate to the end of the month row when pressing end", () => {
+      EVENTS.keydownEnd();
 
-  it("should navigate to January when pressing page up", () => {
-    EVENTS.keydownPageUp();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "June",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "January",
-      "focuses correct month"
-    );
-  });
+    it("should navigate to January when pressing page up", () => {
+      EVENTS.keydownPageUp();
 
-  it("should navigate to December when pressing page down", () => {
-    EVENTS.keydownPageDown();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "January",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "December",
-      "focuses correct month"
-    );
-  });
+    it("should navigate to December when pressing page down", () => {
+      EVENTS.keydownPageDown();
 
-  it("should update the focus when moving over a non-selected valid month", () => {
-    EVENTS.mouseover(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__month[data-label="October"]'
-      )
-    );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "December",
+        "focuses correct month"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
-      "October",
-      "focuses correct month"
-    );
+    it("should update the focus when moving over a non-selected valid month", () => {
+      EVENTS.mouseover(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__month[data-label="October"]'
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__month--focused").dataset.label,
+        "October",
+        "focuses correct month"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-mousemove.spec.js
+++ b/spec/unit/date-picker/date-picker-mousemove.spec.js
@@ -8,103 +8,111 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker.template.html")
 );
 
-describe("date picker component mouse move selection", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component mouse move selection initialized at ${name}`, () => {
+    const { body } = document;
 
-  const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
+    let root;
+    let input;
+    let button;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should ignore mouse move events over disabled days", () => {
-    root.dataset.minDate = "2020-06-01";
-    root.dataset.maxDate = "2020-06-24";
-    input.value = "6/20/2020";
-    EVENTS.click(button);
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "focuses correct date"
-    );
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-    EVENTS.mouseover(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="26"]'
-      )
-    );
+    it("should ignore mouse move events over disabled days", () => {
+      root.dataset.minDate = "2020-06-01";
+      root.dataset.maxDate = "2020-06-24";
+      input.value = "6/20/2020";
+      EVENTS.click(button);
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "focuses correct date"
+      );
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "does not focus disabled day"
-    );
-  });
+      EVENTS.mouseover(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="26"]'
+        )
+      );
 
-  it("should update the focus when moving over a non-selected valid day", () => {
-    root.dataset.minDate = "2020-06-01";
-    root.dataset.maxDate = "2020-06-24";
-    input.value = "6/20/2020";
-    EVENTS.click(button);
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "focuses correct date"
-    );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "does not focus disabled day"
+      );
+    });
 
-    EVENTS.mouseover(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="19"]'
-      )
-    );
+    it("should update the focus when moving over a non-selected valid day", () => {
+      root.dataset.minDate = "2020-06-01";
+      root.dataset.maxDate = "2020-06-24";
+      input.value = "6/20/2020";
+      EVENTS.click(button);
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "focuses correct date"
+      );
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-19",
-      "focuses correct date"
-    );
-  });
+      EVENTS.mouseover(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="19"]'
+        )
+      );
 
-  it("should ignore mouse event on the same day", () => {
-    root.dataset.minDate = "2020-06-01";
-    root.dataset.maxDate = "2020-06-24";
-    input.value = "6/20/2020";
-    EVENTS.click(button);
-    getCalendarEl().dataset.wouldDisappearOnRerender = "true";
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "focuses correct date"
-    );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-19",
+        "focuses correct date"
+      );
+    });
 
-    EVENTS.mouseover(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="20"]'
-      )
-    );
+    it("should ignore mouse event on the same day", () => {
+      root.dataset.minDate = "2020-06-01";
+      root.dataset.maxDate = "2020-06-24";
+      input.value = "6/20/2020";
+      EVENTS.click(button);
+      getCalendarEl().dataset.wouldDisappearOnRerender = "true";
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "focuses correct date"
+      );
 
-    assert.strictEqual(
-      getCalendarEl().dataset.wouldDisappearOnRerender,
-      "true",
-      "calendar did not rerender"
-    );
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
-      "2020-06-20",
-      "focuses correct date"
-    );
+      EVENTS.mouseover(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="20"]'
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl().dataset.wouldDisappearOnRerender,
+        "true",
+        "calendar did not rerender"
+      );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--focused").dataset.value,
+        "2020-06-20",
+        "focuses correct date"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-range-date.spec.js
+++ b/spec/unit/date-picker/date-picker-range-date.spec.js
@@ -8,145 +8,153 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker-range-date.template.html")
 );
 
-describe("date picker component with range date", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component with range date initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    let root;
+    let input;
+    let button;
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${  query ? ` ${query}` : ""}`
+      );
 
-  afterEach(() => {
-    window.onerror = null;
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  it("should display the range date when showing the month of the range date", () => {
-    input.value = "05/21/2020";
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      window.onerror = null;
+      body.textContent = "";
+    });
 
-    EVENTS.click(button);
+    it("should display the range date when showing the month of the range date", () => {
+      input.value = "05/21/2020";
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--range-date").dataset
-        .value,
-      "2020-05-22",
-      "shows the correct date as the range date"
-    );
-  });
+      EVENTS.click(button);
 
-  it("should not display the range date when showing the a month different from the range date month", () => {
-    input.value = "06/21/2020";
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--range-date").dataset
+          .value,
+        "2020-05-22",
+        "shows the correct date as the range date"
+      );
+    });
 
-    EVENTS.click(button);
+    it("should not display the range date when showing the a month different from the range date month", () => {
+      input.value = "06/21/2020";
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__date--range-date"),
-      null,
-      "the range date is not present"
-    );
-  });
+      EVENTS.click(button);
 
-  it("should display the days between the calendar date and the range date as within range when the calendar date is above the range date", () => {
-    input.value = "05/25/2020";
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__date--range-date"),
+        null,
+        "the range date is not present"
+      );
+    });
 
-    EVENTS.click(button);
+    it("should display the days between the calendar date and the range date as within range when the calendar date is above the range date", () => {
+      input.value = "05/25/2020";
 
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="22"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "should not show the range date as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="23"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      true,
-      "shows date within range as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="24"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      true,
-      "shows date within range as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="25"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "should not show the current calendar date as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="26"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "does not show dates outside of the range as within range"
-    );
-  });
+      EVENTS.click(button);
 
-  it("should display the days between the calendar date and the range date as within range when the calendar date is below the range date", () => {
-    input.value = "05/18/2020";
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="22"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "should not show the range date as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="23"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        true,
+        "shows date within range as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="24"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        true,
+        "shows date within range as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="25"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "should not show the current calendar date as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="26"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "does not show dates outside of the range as within range"
+      );
+    });
 
-    EVENTS.click(button);
+    it("should display the days between the calendar date and the range date as within range when the calendar date is below the range date", () => {
+      input.value = "05/18/2020";
 
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="22"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "should not show the range date as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="21"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      true,
-      "shows date within range as within range"
-    );
+      EVENTS.click(button);
 
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="20"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      true,
-      "shows date within range as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="19"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      true,
-      "shows date within range as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="18"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "should not show the current calendar date as within range"
-    );
-    assert.strictEqual(
-      getCalendarEl(
-        '.usa-date-picker__calendar__date[data-day="17"]'
-      ).classList.contains("usa-date-picker__calendar__date--within-range"),
-      false,
-      "does not show dates outside of the range as within range"
-    );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="22"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "should not show the range date as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="21"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        true,
+        "shows date within range as within range"
+      );
+
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="20"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        true,
+        "shows date within range as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="19"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        true,
+        "shows date within range as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="18"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "should not show the current calendar date as within range"
+      );
+      assert.strictEqual(
+        getCalendarEl(
+          '.usa-date-picker__calendar__date[data-day="17"]'
+        ).classList.contains("usa-date-picker__calendar__date--within-range"),
+        false,
+        "does not show dates outside of the range as within range"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker-year-selection.spec.js
+++ b/spec/unit/date-picker/date-picker-year-selection.spec.js
@@ -8,144 +8,152 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker.template.html")
 );
 
-describe("date picker component year selection", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  let root;
-  let input;
-  let button;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component year selection initialized at ${name}`, () => {
+    const { body } = document;
 
-  const getCalendarEl = (query) =>
-    root.querySelector(
-      ".usa-date-picker__calendar" + (query ? ` ${query}` : "")
-    );
+    let root;
+    let input;
+    let button;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-  });
+    const getCalendarEl = (query) =>
+      root.querySelector(
+        `.usa-date-picker__calendar${  query ? ` ${query}` : ""}`
+      );
 
-  beforeEach("Open year selection view", () => {
-    input.value = "6/20/2020";
-    EVENTS.click(button);
-    EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+    });
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach("Open year selection view", () => {
+      input.value = "6/20/2020";
+      EVENTS.click(button);
+      EVENTS.click(getCalendarEl(".usa-date-picker__calendar__year-selection"));
+    });
 
-  it("should show year of 2020 as focused", () => {
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2020",
-      "focuses correct year"
-    );
-  });
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-  it("should show year of 2020 as selected", () => {
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--selected").dataset.value,
-      "2020",
-      "selects correct year"
-    );
-  });
+    it("should show year of 2020 as focused", () => {
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2020",
+        "focuses correct year"
+      );
+    });
 
-  it("should navigate back three years when pressing up", () => {
-    EVENTS.keydownArrowUp();
+    it("should show year of 2020 as selected", () => {
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--selected").dataset.value,
+        "2020",
+        "selects correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2017",
-      "focuses correct year"
-    );
-  });
+    it("should navigate back three years when pressing up", () => {
+      EVENTS.keydownArrowUp();
 
-  it("should navigate ahead three years when pressing down", () => {
-    EVENTS.keydownArrowDown();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2017",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2023",
-      "focuses correct year"
-    );
-  });
+    it("should navigate ahead three years when pressing down", () => {
+      EVENTS.keydownArrowDown();
 
-  it("should navigate back one year when pressing left", () => {
-    EVENTS.keydownArrowLeft();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2023",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2019",
-      "focuses correct year"
-    );
-  });
+    it("should navigate back one year when pressing left", () => {
+      EVENTS.keydownArrowLeft();
 
-  it("should navigate ahead one year when pressing right", () => {
-    EVENTS.keydownArrowRight();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2019",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2021",
-      "focuses correct year"
-    );
-  });
+    it("should navigate ahead one year when pressing right", () => {
+      EVENTS.keydownArrowRight();
 
-  it("should navigate to the beginning of the year row when pressing home", () => {
-    EVENTS.keydownHome();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2021",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2019",
-      "focuses correct year"
-    );
-  });
+    it("should navigate to the beginning of the year row when pressing home", () => {
+      EVENTS.keydownHome();
 
-  it("should navigate to the end of the year row when pressing end", () => {
-    EVENTS.keydownEnd();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2019",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2021",
-      "focuses correct year"
-    );
-  });
+    it("should navigate to the end of the year row when pressing end", () => {
+      EVENTS.keydownEnd();
 
-  it("should navigate back 12 years when pressing page up", () => {
-    EVENTS.keydownPageUp();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2021",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2008",
-      "focuses correct year"
-    );
-  });
+    it("should navigate back 12 years when pressing page up", () => {
+      EVENTS.keydownPageUp();
 
-  it("should navigate forward 12 years when pressing page down", () => {
-    EVENTS.keydownPageDown();
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2008",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2032",
-      "focuses correct year"
-    );
-  });
+    it("should navigate forward 12 years when pressing page down", () => {
+      EVENTS.keydownPageDown();
 
-  it("should update the focus when moving over a non-selected valid year", () => {
-    EVENTS.mouseover(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__year[data-value="2022"]'
-      )
-    );
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2032",
+        "focuses correct year"
+      );
+    });
 
-    assert.strictEqual(
-      getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
-      "2022",
-      "focuses correct year"
-    );
+    it("should update the focus when moving over a non-selected valid year", () => {
+      EVENTS.mouseover(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__year[data-value="2022"]'
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl(".usa-date-picker__calendar__year--focused").dataset.value,
+        "2022",
+        "focuses correct year"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/date-picker.spec.js
+++ b/spec/unit/date-picker/date-picker.spec.js
@@ -1,9 +1,9 @@
 const fs = require("fs");
 const path = require("path");
 const assert = require("assert");
+const sinon = require("sinon");
 const DatePicker = require("../../../src/js/components/date-picker");
 const EVENTS = require("./events");
-const sinon = require("sinon");
 
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-picker.template.html")
@@ -11,941 +11,949 @@ const TEMPLATE = fs.readFileSync(
 
 const VALIDATION_MESSAGE = "Please enter a valid date";
 
-describe("date picker component", () => {
-  const { body } = document;
-
-  let root;
-  let input;
-  let button;
-  let inputChangeSpy;
-
-  const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
-
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    root = body.querySelector(".usa-date-picker");
-    input = root.querySelector(".usa-date-picker__external-input");
-    button = root.querySelector(".usa-date-picker__button");
-    inputChangeSpy = sinon.stub();
-    input.addEventListener("change", inputChangeSpy);
-  });
-
-  afterEach(() => {
-    input.removeEventListener("change", inputChangeSpy);
-    body.textContent = "";
-    DatePicker.off(body);
-  });
-
-  it("should enhance the date input with a date picker button", () => {
-    assert.ok(input, "has an input element");
-    assert.ok(button, "has a button element");
-  });
-
-  // mouse interactions
-  it("should display a calendar for the current date when the date picker button is clicked", () => {
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.ok(
-      getCalendarEl().contains(document.activeElement),
-      "The focus is within the component"
-    );
-  });
-
-  it("should hide the calendar when the date picker button is clicked and the calendar is already open", () => {
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
-  });
-
-  it("should close the calendar you click outside of an active calendar", () => {
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.focusout();
-
-    assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
-  });
-
-  it("should close the calendar you press escape from the input", () => {
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownEscape(input);
-
-    assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
-  });
-
-  it("should display a calendar for the inputted date when the date picker button is clicked with a date entered", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should allow for the selection of a date within the calendar", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="10"]'
-      )
-    );
-
-    assert.strictEqual(
-      input.value,
-      "01/10/2020",
-      "The value has been filled in"
-    );
-    assert.strictEqual(
-      input,
-      document.activeElement,
-      "The focus is on the input"
-    );
-    assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
-    assert.ok(
-      inputChangeSpy.called,
-      "should have dispatched a change event from the input"
-    );
-  });
-
-  it("should allow for navigation to the preceding month by clicking the left single arrow button within the calendar", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__previous-month"
-      )
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "December",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should allow for navigation to the succeeding month by clicking the right single arrow button within the calendar", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__next-month")
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should allow for navigation to the preceding year by clicking the left double arrow button within the calendar", () => {
-    input.value = "1/1/2016";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__previous-year")
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2015",
-      "shows correct year"
-    );
-  });
-
-  it("should allow for navigation to the succeeding year by clicking the right double arrow button within the calendar", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__next-year")
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2021",
-      "shows correct year"
-    );
-  });
-
-  it("should display a month selection screen by clicking the month display within the calendar", () => {
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      )
-    );
-
-    const focusedMonth = document.activeElement;
-
-    assert.strictEqual(
-      focusedMonth.classList.contains(
-        "usa-date-picker__calendar__month--focused"
-      ),
-      true,
-      "calendar month is focused"
-    );
-    assert.ok(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__month-picker"),
-      "calendar is showing the month picker"
-    );
-  });
-
-  it("should allow for the selection of a month within month selection screen", () => {
-    input.value = "2/1/2020";
-    EVENTS.click(button);
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      )
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__month")
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-  });
-
-  it("should display a year selection screen by clicking the year display within the calendar", () => {
-    EVENTS.click(button);
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      )
-    );
-
-    const focusedYear = document.activeElement;
-    assert.ok(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__year-picker"),
-      "calendar is showing the year picker"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__year")
-        .textContent,
-      "2016",
-      "shows correct first year of chunk"
-    );
-    assert.strictEqual(
-      focusedYear.classList.contains(
-        "usa-date-picker__calendar__year--focused"
-      ),
-      true,
-      "calendar year is focused"
-    );
-  });
-
-  it("should allow for navigation to the preceding dozen years by clicking the left single arrow button within the year selection screen", () => {
-    EVENTS.click(button);
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      )
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__previous-year-chunk"
-      )
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__year")
-        .textContent,
-      "2004",
-      "shows correct first year of chunk"
-    );
-  });
-
-  it("should allow for navigation to the succeeding dozen year by clicking the right single arrow button within the year selection screen", () => {
-    EVENTS.click(button);
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      )
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__next-year-chunk"
-      )
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__year")
-        .textContent,
-      "2028",
-      "shows correct first year of chunk"
-    );
-  });
-
-  it("should allow for the selection of a year within year selection screen", () => {
-    input.value = "2/1/2020";
-    EVENTS.click(button);
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      )
-    );
-
-    EVENTS.click(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__year")
-    );
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2016",
-      "shows correct year"
-    );
-  });
-
-  // keyboard interactions
-
-  it("should close the calendar when escape is pressed within the calendar", () => {
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownEscape();
-
-    assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
-  });
-
-  it("should move focus to the same day of week of the previous week when up is pressed from the currently focused day", () => {
-    input.value = "1/10/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowUp();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "3",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day of week of the next week when down is pressed from the currently focused day", () => {
-    input.value = "1/10/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "17",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the previous day when left is pressed from the currently focused day", () => {
-    input.value = "1/10/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowLeft();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "9",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the next day when right is pressed from the currently focused day", () => {
-    input.value = "1/10/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownArrowRight();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "11",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the first day (e.g. Sunday) of the current week when home is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownHome();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "29",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "December",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the last day (e.g. Saturday) of the current week when end is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownEnd();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "4",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day of the previous month when page up is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageUp();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "December",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the last day of the previous month when page up is pressed from the the last day of a longer month", () => {
-    input.value = "12/31/2019";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageUp();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "30",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "November",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day of the next month when page down is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the last day of the next month when page down is pressed from the the last day of a longer month", () => {
-    input.value = "1/31/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "29",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day of the month January when page down is pressed from the currently focused day in December", () => {
-    input.value = "12/31/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownPageDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "31",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2021",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day/month of the previous year when shift + page up is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageUp();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to February 28th of the previous year when shift + page up is pressed from a focused February 29th date of a leap year", () => {
-    input.value = "2/29/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageUp();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "28",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2019",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to the same day/month of the next year when shift + page down is pressed from the currently focused day", () => {
-    input.value = "1/1/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "1",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "January",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2021",
-      "shows correct year"
-    );
-  });
-
-  it("should move focus to February 28th of the next year when shift + page down is pressed from a focused February 29th date of a leap year", () => {
-    input.value = "2/29/2020";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.keydownShiftPageDown();
-
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "28",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2021",
-      "shows correct year"
-    );
-  });
-
-  it("should accept a parse-able date with a two digit year and display the calendar of that year in the current century", () => {
-    input.value = "2/29/20";
-    EVENTS.click(button);
-
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    assert.strictEqual(
-      getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
-        .textContent,
-      "29",
-      "focuses correct date"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__month-selection"
-      ).textContent,
-      "February",
-      "shows correct month"
-    );
-    assert.strictEqual(
-      getCalendarEl().querySelector(
-        ".usa-date-picker__calendar__year-selection"
-      ).textContent,
-      "2020",
-      "shows correct year"
-    );
-  });
-
-  it("should show an improper date as invalid as the user leaves the input", () => {
-    input.value = "abcdefg... That means the convo is done";
-    EVENTS.focusout(input);
-
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-  });
-
-  it("should validate input on the static validate function being emitted", () => {
-    input.value = "ab/cd/efg";
-    DatePicker.validateDateInput(input);
-
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-  });
-
-  it("should update the calendar when a valid date is entered in the input while the date picker is open", () => {
-    input.value = "6/1/2020";
-    EVENTS.click(button);
-    const firstFocus = getCalendarEl().querySelector(
-      ".usa-date-picker__calendar__date--focused"
-    );
-
-    input.value = "6/20/2020";
-    EVENTS.input(input);
-
-    const secondFocus = getCalendarEl().querySelector(
-      ".usa-date-picker__calendar__date--focused"
-    );
-
-    assert.strictEqual(firstFocus !== secondFocus, true);
-  });
-
-  it("should validate the input when a date is selected", () => {
-    input.value = "2/31/2019";
-    EVENTS.focusout(input);
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-
-    EVENTS.click(
-      getCalendarEl().querySelector(
-        '.usa-date-picker__calendar__date[data-day="10"]'
-      )
-    );
-
-    assert.strictEqual(input.validationMessage, "");
-  });
-
-  it("should show an improper date as invalid if the user presses enter from the input", () => {
-    input.value = "2/31/2019";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
-  });
-
-  it("should show an empty input as valid", () => {
-    input.value = "";
-
-    EVENTS.keydownEnter(input);
-
-    assert.strictEqual(input.validationMessage, "");
-  });
-
-  it("should prevent action from button when event didn't originate from date", () => {
-    input.value = "2/31/2019";
-    EVENTS.click(button);
-    assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
-    const { preventDefaultSpy } = EVENTS.keyupEnter();
-    assert.ok(
-      preventDefaultSpy.called,
-      "should not have allowed enter to perform default action"
-    );
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
+
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date picker component initialized at ${name}`, () => {
+    const { body } = document;
+
+    let root;
+    let input;
+    let button;
+    let inputChangeSpy;
+
+    const getCalendarEl = () => root.querySelector(".usa-date-picker__calendar");
+
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      root = datePickerSelector();
+      input = root.querySelector(".usa-date-picker__external-input");
+      button = root.querySelector(".usa-date-picker__button");
+      inputChangeSpy = sinon.stub();
+      input.addEventListener("change", inputChangeSpy);
+    });
+
+    afterEach(() => {
+      input.removeEventListener("change", inputChangeSpy);
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
+
+    it("should enhance the date input with a date picker button", () => {
+      assert.ok(input, "has an input element");
+      assert.ok(button, "has a button element");
+    });
+
+    // mouse interactions
+    it("should display a calendar for the current date when the date picker button is clicked", () => {
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.ok(
+        getCalendarEl().contains(document.activeElement),
+        "The focus is within the component"
+      );
+    });
+
+    it("should hide the calendar when the date picker button is clicked and the calendar is already open", () => {
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
+    });
+
+    it("should close the calendar you click outside of an active calendar", () => {
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.focusout();
+
+      assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
+    });
+
+    it("should close the calendar you press escape from the input", () => {
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownEscape(input);
+
+      assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
+    });
+
+    it("should display a calendar for the inputted date when the date picker button is clicked with a date entered", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should allow for the selection of a date within the calendar", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="10"]'
+        )
+      );
+
+      assert.strictEqual(
+        input.value,
+        "01/10/2020",
+        "The value has been filled in"
+      );
+      assert.strictEqual(
+        input,
+        document.activeElement,
+        "The focus is on the input"
+      );
+      assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
+      assert.ok(
+        inputChangeSpy.called,
+        "should have dispatched a change event from the input"
+      );
+    });
+
+    it("should allow for navigation to the preceding month by clicking the left single arrow button within the calendar", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__previous-month"
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "December",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should allow for navigation to the succeeding month by clicking the right single arrow button within the calendar", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__next-month")
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should allow for navigation to the preceding year by clicking the left double arrow button within the calendar", () => {
+      input.value = "1/1/2016";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__previous-year")
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2015",
+        "shows correct year"
+      );
+    });
+
+    it("should allow for navigation to the succeeding year by clicking the right double arrow button within the calendar", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__next-year")
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2021",
+        "shows correct year"
+      );
+    });
+
+    it("should display a month selection screen by clicking the month display within the calendar", () => {
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        )
+      );
+
+      const focusedMonth = document.activeElement;
+
+      assert.strictEqual(
+        focusedMonth.classList.contains(
+          "usa-date-picker__calendar__month--focused"
+        ),
+        true,
+        "calendar month is focused"
+      );
+      assert.ok(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__month-picker"),
+        "calendar is showing the month picker"
+      );
+    });
+
+    it("should allow for the selection of a month within month selection screen", () => {
+      input.value = "2/1/2020";
+      EVENTS.click(button);
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        )
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__month")
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+    });
+
+    it("should display a year selection screen by clicking the year display within the calendar", () => {
+      EVENTS.click(button);
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        )
+      );
+
+      const focusedYear = document.activeElement;
+      assert.ok(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__year-picker"),
+        "calendar is showing the year picker"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__year")
+          .textContent,
+        "2016",
+        "shows correct first year of chunk"
+      );
+      assert.strictEqual(
+        focusedYear.classList.contains(
+          "usa-date-picker__calendar__year--focused"
+        ),
+        true,
+        "calendar year is focused"
+      );
+    });
+
+    it("should allow for navigation to the preceding dozen years by clicking the left single arrow button within the year selection screen", () => {
+      EVENTS.click(button);
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        )
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__previous-year-chunk"
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__year")
+          .textContent,
+        "2004",
+        "shows correct first year of chunk"
+      );
+    });
+
+    it("should allow for navigation to the succeeding dozen year by clicking the right single arrow button within the year selection screen", () => {
+      EVENTS.click(button);
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        )
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__next-year-chunk"
+        )
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__year")
+          .textContent,
+        "2028",
+        "shows correct first year of chunk"
+      );
+    });
+
+    it("should allow for the selection of a year within year selection screen", () => {
+      input.value = "2/1/2020";
+      EVENTS.click(button);
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        )
+      );
+
+      EVENTS.click(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__year")
+      );
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2016",
+        "shows correct year"
+      );
+    });
+
+    // keyboard interactions
+
+    it("should close the calendar when escape is pressed within the calendar", () => {
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownEscape();
+
+      assert.strictEqual(getCalendarEl().hidden, true, "The calendar is hidden");
+    });
+
+    it("should move focus to the same day of week of the previous week when up is pressed from the currently focused day", () => {
+      input.value = "1/10/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowUp();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "3",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day of week of the next week when down is pressed from the currently focused day", () => {
+      input.value = "1/10/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "17",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the previous day when left is pressed from the currently focused day", () => {
+      input.value = "1/10/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowLeft();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "9",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the next day when right is pressed from the currently focused day", () => {
+      input.value = "1/10/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownArrowRight();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "11",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the first day (e.g. Sunday) of the current week when home is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownHome();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "29",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "December",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the last day (e.g. Saturday) of the current week when end is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownEnd();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "4",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day of the previous month when page up is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageUp();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "December",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the last day of the previous month when page up is pressed from the the last day of a longer month", () => {
+      input.value = "12/31/2019";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageUp();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "30",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "November",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day of the next month when page down is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the last day of the next month when page down is pressed from the the last day of a longer month", () => {
+      input.value = "1/31/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "29",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day of the month January when page down is pressed from the currently focused day in December", () => {
+      input.value = "12/31/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownPageDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "31",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2021",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day/month of the previous year when shift + page up is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageUp();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to February 28th of the previous year when shift + page up is pressed from a focused February 29th date of a leap year", () => {
+      input.value = "2/29/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageUp();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "28",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2019",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to the same day/month of the next year when shift + page down is pressed from the currently focused day", () => {
+      input.value = "1/1/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "1",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "January",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2021",
+        "shows correct year"
+      );
+    });
+
+    it("should move focus to February 28th of the next year when shift + page down is pressed from a focused February 29th date of a leap year", () => {
+      input.value = "2/29/2020";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.keydownShiftPageDown();
+
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "28",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2021",
+        "shows correct year"
+      );
+    });
+
+    it("should accept a parse-able date with a two digit year and display the calendar of that year in the current century", () => {
+      input.value = "2/29/20";
+      EVENTS.click(button);
+
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      assert.strictEqual(
+        getCalendarEl().querySelector(".usa-date-picker__calendar__date--focused")
+          .textContent,
+        "29",
+        "focuses correct date"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__month-selection"
+        ).textContent,
+        "February",
+        "shows correct month"
+      );
+      assert.strictEqual(
+        getCalendarEl().querySelector(
+          ".usa-date-picker__calendar__year-selection"
+        ).textContent,
+        "2020",
+        "shows correct year"
+      );
+    });
+
+    it("should show an improper date as invalid as the user leaves the input", () => {
+      input.value = "abcdefg... That means the convo is done";
+      EVENTS.focusout(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+    });
+
+    it("should validate input on the static validate function being emitted", () => {
+      input.value = "ab/cd/efg";
+      DatePicker.validateDateInput(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+    });
+
+    it("should update the calendar when a valid date is entered in the input while the date picker is open", () => {
+      input.value = "6/1/2020";
+      EVENTS.click(button);
+      const firstFocus = getCalendarEl().querySelector(
+        ".usa-date-picker__calendar__date--focused"
+      );
+
+      input.value = "6/20/2020";
+      EVENTS.input(input);
+
+      const secondFocus = getCalendarEl().querySelector(
+        ".usa-date-picker__calendar__date--focused"
+      );
+
+      assert.strictEqual(firstFocus !== secondFocus, true);
+    });
+
+    it("should validate the input when a date is selected", () => {
+      input.value = "2/31/2019";
+      EVENTS.focusout(input);
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+
+      EVENTS.click(
+        getCalendarEl().querySelector(
+          '.usa-date-picker__calendar__date[data-day="10"]'
+        )
+      );
+
+      assert.strictEqual(input.validationMessage, "");
+    });
+
+    it("should show an improper date as invalid if the user presses enter from the input", () => {
+      input.value = "2/31/2019";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, VALIDATION_MESSAGE);
+    });
+
+    it("should show an empty input as valid", () => {
+      input.value = "";
+
+      EVENTS.keydownEnter(input);
+
+      assert.strictEqual(input.validationMessage, "");
+    });
+
+    it("should prevent action from button when event didn't originate from date", () => {
+      input.value = "2/31/2019";
+      EVENTS.click(button);
+      assert.strictEqual(getCalendarEl().hidden, false, "The calendar is shown");
+      const { preventDefaultSpy } = EVENTS.keyupEnter();
+      assert.ok(
+        preventDefaultSpy.called,
+        "should not have allowed enter to perform default action"
+      );
+    });
   });
 });

--- a/spec/unit/date-picker/invalid-template-no-input.spec.js
+++ b/spec/unit/date-picker/invalid-template-no-input.spec.js
@@ -7,21 +7,29 @@ const INVALID_TEMPLATE_NO_INPUT = fs.readFileSync(
   path.join(__dirname, "/invalid-template-no-input.template.html")
 );
 
-describe("Date picker without input", () => {
-  const { body } = document;
+const datePickerSelector = () => document.querySelector('.usa-date-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date picker", selector: datePickerSelector }
+];
 
-  beforeEach(() => {
-    body.innerHTML = INVALID_TEMPLATE_NO_INPUT;
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Date picker without input initialized at ${name}`, () => {
+    const { body } = document;
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = INVALID_TEMPLATE_NO_INPUT;
+    });
 
-  it('should throw an error when date picker is activated without a wrapping "usa-date-picker"', () => {
-    assert.throws(() => DatePicker.on(), {
-      message: ".usa-date-picker is missing inner input"
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      body.textContent = "";
+    });
+
+    it('should throw an error when date picker is activated without a wrapping "usa-date-picker"', () => {
+      assert.throws(() => DatePicker.on(containerSelector()), {
+        message: ".usa-date-picker is missing inner input"
+      });
     });
   });
 });

--- a/spec/unit/date-range-picker/date-range-picker-min-date-max-date.spec.js
+++ b/spec/unit/date-range-picker/date-range-picker-min-date-max-date.spec.js
@@ -9,199 +9,207 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-range-picker-min-date-max-date.template.html")
 );
 
-describe("date range picker component with min date and max date", () => {
-  const { body } = document;
+const dateRangePickerSelector = () => document.querySelector('.usa-date-range-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date range picker", selector: dateRangePickerSelector }
+];
 
-  let root;
-  let rangeStart;
-  let rangeStartInputEl;
-  let rangeEnd;
-  let rangeEndInputEl;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date range picker component with min date and max date initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    DateRangePicker.on();
-    root = body.querySelector(".usa-date-range-picker");
-    rangeStart = root.querySelector(".usa-date-range-picker__range-start");
-    rangeEnd = root.querySelector(".usa-date-range-picker__range-end");
-    rangeStartInputEl = rangeStart.querySelector(
-      ".usa-date-picker__external-input"
-    );
-    rangeEndInputEl = rangeEnd.querySelector(
-      ".usa-date-picker__external-input"
-    );
-  });
+    let root;
+    let rangeStart;
+    let rangeStartInputEl;
+    let rangeEnd;
+    let rangeEndInputEl;
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-    DateRangePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      DateRangePicker.on(containerSelector());
+      root = dateRangePickerSelector();
+      rangeStart = root.querySelector(".usa-date-range-picker__range-start");
+      rangeEnd = root.querySelector(".usa-date-range-picker__range-end");
+      rangeStartInputEl = rangeStart.querySelector(
+        ".usa-date-picker__external-input"
+      );
+      rangeEndInputEl = rangeEnd.querySelector(
+        ".usa-date-picker__external-input"
+      );
+    });
 
-  it("should enhance the date picker and identify the start and end date pickers", () => {
-    assert.ok(rangeStart, "has a range start date picker element");
-    assert.strictEqual(
-      rangeStart.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      DateRangePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-    assert.ok(rangeEnd, "has a range end date picker element");
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-  });
+    it("should enhance the date picker and identify the start and end date pickers", () => {
+      assert.ok(rangeStart, "has a range start date picker element");
+      assert.strictEqual(
+        rangeStart.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
 
-  // event interactions
+      assert.ok(rangeEnd, "has a range end date picker element");
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+    });
 
-  it("should not update the range end date picker properties when the range start date picker has an empty value", () => {
-    rangeStartInputEl.value = "";
+    // event interactions
 
-    EVENTS.input(rangeStartInputEl);
+    it("should not update the range end date picker properties when the range start date picker has an empty value", () => {
+      rangeStartInputEl.value = "";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-    assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should update the range end date picker properties to have a min date and range date when the range start date picker has an updated valid value", () => {
-    rangeStartInputEl.value = "12/12/2020";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+      assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
+    });
 
-    EVENTS.input(rangeStartInputEl);
+    it("should update the range end date picker properties to have a min date and range date when the range start date picker has an updated valid value", () => {
+      rangeStartInputEl.value = "12/12/2020";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "2020-12-12",
-      "has updated min date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.rangeDate,
-      "2020-12-12",
-      "has updated range date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.defaultDate,
-      "2020-12-12",
-      "has updated default date to display"
-    );
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
-    rangeStartInputEl.value = "ab/dc/efg";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "2020-12-12",
+        "has updated min date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.rangeDate,
+        "2020-12-12",
+        "has updated range date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.defaultDate,
+        "2020-12-12",
+        "has updated default date to display"
+      );
+    });
 
-    EVENTS.input(rangeStartInputEl);
+    it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
+      rangeStartInputEl.value = "ab/dc/efg";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-    assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should not update the range end date picker properties when the range start date picker has an empty value", () => {
-    rangeEndInputEl.value = "";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+      assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should not update the range end date picker properties when the range start date picker has an empty value", () => {
+      rangeEndInputEl.value = "";
 
-    assert.strictEqual(
-      rangeStart.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-    assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "",
-      "has no default date"
-    );
-  });
+      EVENTS.input(rangeEndInputEl);
 
-  it("should update the range start date picker properties to have a max date and range date when the range end date picker has an updated valid value", () => {
-    rangeEndInputEl.value = "12/11/2020";
+      assert.strictEqual(
+        rangeStart.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+      assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "",
+        "has no default date"
+      );
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should update the range start date picker properties to have a max date and range date when the range end date picker has an updated valid value", () => {
+      rangeEndInputEl.value = "12/11/2020";
 
-    assert.strictEqual(
-      rangeStart.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.maxDate,
-      "2020-12-11",
-      "has updated min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.rangeDate,
-      "2020-12-11",
-      "has updated range date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "2020-12-11",
-      "has updated default date to display"
-    );
-  });
+      EVENTS.input(rangeEndInputEl);
 
-  it("should not update the range end date picker properties when the range start date picker has an updated invalid value", () => {
-    rangeEndInputEl.value = "35/35/3535";
+      assert.strictEqual(
+        rangeStart.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.maxDate,
+        "2020-12-11",
+        "has updated min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.rangeDate,
+        "2020-12-11",
+        "has updated range date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "2020-12-11",
+        "has updated default date to display"
+      );
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should not update the range end date picker properties when the range start date picker has an updated invalid value", () => {
+      rangeEndInputEl.value = "35/35/3535";
 
-    assert.strictEqual(
-      rangeStart.dataset.minDate,
-      "2020-05-22",
-      "has the default min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.maxDate,
-      "2021-06-20",
-      "has the default max date"
-    );
-    assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "",
-      "has no default date"
-    );
+      EVENTS.input(rangeEndInputEl);
+
+      assert.strictEqual(
+        rangeStart.dataset.minDate,
+        "2020-05-22",
+        "has the default min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.maxDate,
+        "2021-06-20",
+        "has the default max date"
+      );
+      assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "",
+        "has no default date"
+      );
+    });
   });
 });

--- a/spec/unit/date-range-picker/date-range-picker.spec.js
+++ b/spec/unit/date-range-picker/date-range-picker.spec.js
@@ -9,140 +9,148 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/date-range-picker.template.html")
 );
 
-describe("date range picker component", () => {
-  const { body } = document;
+const dateRangePickerSelector = () => document.querySelector('.usa-date-range-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date range picker", selector: dateRangePickerSelector }
+];
 
-  let root;
-  let rangeStart;
-  let rangeStartInputEl;
-  let rangeEnd;
-  let rangeEndInputEl;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`date range picker component initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    DatePicker.on();
-    DateRangePicker.on();
-    root = body.querySelector(".usa-date-range-picker");
-    rangeStart = root.querySelector(".usa-date-range-picker__range-start");
-    rangeEnd = root.querySelector(".usa-date-range-picker__range-end");
-    rangeStartInputEl = rangeStart.querySelector(
-      ".usa-date-picker__external-input"
-    );
-    rangeEndInputEl = rangeEnd.querySelector(
-      ".usa-date-picker__external-input"
-    );
-  });
+    let root;
+    let rangeStart;
+    let rangeStartInputEl;
+    let rangeEnd;
+    let rangeEndInputEl;
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-    DateRangePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      DatePicker.on(containerSelector());
+      DateRangePicker.on(containerSelector());
+      root = dateRangePickerSelector();
+      rangeStart = root.querySelector(".usa-date-range-picker__range-start");
+      rangeEnd = root.querySelector(".usa-date-range-picker__range-end");
+      rangeStartInputEl = rangeStart.querySelector(
+        ".usa-date-picker__external-input"
+      );
+      rangeEndInputEl = rangeEnd.querySelector(
+        ".usa-date-picker__external-input"
+      );
+    });
 
-  it("should enhance the date picker and identify the start and end date pickers", () => {
-    assert.ok(rangeStart, "has a range start date picker element");
-    assert.ok(rangeEnd, "has a range end date picker element");
-  });
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      DateRangePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-  // event interactions
+    it("should enhance the date picker and identify the start and end date pickers", () => {
+      assert.ok(rangeStart, "has a range start date picker element");
+      assert.ok(rangeEnd, "has a range end date picker element");
+    });
 
-  it("should reset the range end date picker properties when the range start date picker has an empty value", () => {
-    rangeStartInputEl.value = "";
+    // event interactions
 
-    EVENTS.input(rangeStartInputEl);
+    it("should reset the range end date picker properties when the range start date picker has an empty value", () => {
+      rangeStartInputEl.value = "";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "0000-01-01",
-      "has the default min date"
-    );
-    assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should update the range end date picker properties to have a min date and range date when the range start date picker has an updated valid value", () => {
-    rangeStartInputEl.value = "12/12/2020";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "0000-01-01",
+        "has the default min date"
+      );
+      assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
+    });
 
-    EVENTS.input(rangeStartInputEl);
+    it("should update the range end date picker properties to have a min date and range date when the range start date picker has an updated valid value", () => {
+      rangeStartInputEl.value = "12/12/2020";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "2020-12-12",
-      "has updated min date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.rangeDate,
-      "2020-12-12",
-      "has updated range date"
-    );
-    assert.strictEqual(
-      rangeEnd.dataset.defaultDate,
-      "2020-12-12",
-      "has updated default date"
-    );
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
-    rangeStartInputEl.value = "ab/dc/efg";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "2020-12-12",
+        "has updated min date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.rangeDate,
+        "2020-12-12",
+        "has updated range date"
+      );
+      assert.strictEqual(
+        rangeEnd.dataset.defaultDate,
+        "2020-12-12",
+        "has updated default date"
+      );
+    });
 
-    EVENTS.input(rangeStartInputEl);
+    it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
+      rangeStartInputEl.value = "ab/dc/efg";
 
-    assert.strictEqual(
-      rangeEnd.dataset.minDate,
-      "0000-01-01",
-      "has the default min date"
-    );
-    assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
-  });
+      EVENTS.input(rangeStartInputEl);
 
-  it("should reset the range start date picker properties when the range end date picker has an empty value", () => {
-    rangeEndInputEl.value = "";
+      assert.strictEqual(
+        rangeEnd.dataset.minDate,
+        "0000-01-01",
+        "has the default min date"
+      );
+      assert.strictEqual(rangeEnd.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(rangeEnd.dataset.defaultDate, "", "has no default date");
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should reset the range start date picker properties when the range end date picker has an empty value", () => {
+      rangeEndInputEl.value = "";
 
-    assert.strictEqual(rangeStart.dataset.maxDate, "", "has no max date");
-    assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "",
-      "has no default date"
-    );
-  });
+      EVENTS.input(rangeEndInputEl);
 
-  it("should update the range start date picker properties to have a max date and range date when the range end date picker has an updated valid value", () => {
-    rangeEndInputEl.value = "12/11/2020";
+      assert.strictEqual(rangeStart.dataset.maxDate, "", "has no max date");
+      assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "",
+        "has no default date"
+      );
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should update the range start date picker properties to have a max date and range date when the range end date picker has an updated valid value", () => {
+      rangeEndInputEl.value = "12/11/2020";
 
-    assert.strictEqual(
-      rangeStart.dataset.maxDate,
-      "2020-12-11",
-      "has updated min date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.rangeDate,
-      "2020-12-11",
-      "has updated range date"
-    );
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "2020-12-11",
-      "has updated default date"
-    );
-  });
+      EVENTS.input(rangeEndInputEl);
 
-  it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
-    rangeEndInputEl.value = "35/35/3535";
+      assert.strictEqual(
+        rangeStart.dataset.maxDate,
+        "2020-12-11",
+        "has updated min date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.rangeDate,
+        "2020-12-11",
+        "has updated range date"
+      );
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "2020-12-11",
+        "has updated default date"
+      );
+    });
 
-    EVENTS.input(rangeEndInputEl);
+    it("should reset the range end date picker properties when the range start date picker has an updated invalid value", () => {
+      rangeEndInputEl.value = "35/35/3535";
 
-    assert.strictEqual(rangeStart.dataset.maxDate, "", "has no max date");
-    assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
-    assert.strictEqual(
-      rangeStart.dataset.defaultDate,
-      "",
-      "has no default date"
-    );
+      EVENTS.input(rangeEndInputEl);
+
+      assert.strictEqual(rangeStart.dataset.maxDate, "", "has no max date");
+      assert.strictEqual(rangeStart.dataset.rangeDate, "", "has no range date");
+      assert.strictEqual(
+        rangeStart.dataset.defaultDate,
+        "",
+        "has no default date"
+      );
+    });
   });
 });

--- a/spec/unit/date-range-picker/invalid-template-one-input.spec.js
+++ b/spec/unit/date-range-picker/invalid-template-one-input.spec.js
@@ -8,24 +8,32 @@ const INVALID_TEMPLATE_ONE_INPUT = fs.readFileSync(
   path.join(__dirname, "/invalid-template-one-input.template.html")
 );
 
-describe("Date range picker without second date picker", () => {
-  const { body } = document;
+const dateRangePickerSelector = () => document.querySelector('.usa-date-range-picker');
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "date range picker", selector: dateRangePickerSelector }
+];
 
-  beforeEach(() => {
-    body.innerHTML = INVALID_TEMPLATE_ONE_INPUT;
-    DatePicker.on();
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Date range picker without second date picker initialized at ${name}`, () => {
+    const { body } = document;
 
-  afterEach(() => {
-    body.textContent = "";
-    DatePicker.off(body);
-    DateRangePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = INVALID_TEMPLATE_ONE_INPUT;
+      DatePicker.on(containerSelector());
+    });
 
-  it('should throw an error when a date range picker without two "usa-date-picker" elements', () => {
-    assert.throws(() => DateRangePicker.on(), {
-      message:
-        ".usa-date-range-picker is missing second '.usa-date-picker' element"
+    afterEach(() => {
+      DatePicker.off(containerSelector());
+      DateRangePicker.off(containerSelector());
+      body.textContent = "";
+    });
+
+    it('should throw an error when a date range picker without two "usa-date-picker" elements', () => {
+      assert.throws(() => DateRangePicker.on(containerSelector()), {
+        message:
+          ".usa-date-range-picker is missing second '.usa-date-picker' element"
+      });
     });
   });
 });

--- a/spec/unit/file-input/file-input-accepts.spec.js
+++ b/spec/unit/file-input/file-input-accepts.spec.js
@@ -49,69 +49,82 @@ function makeFileList(...files) {
   return ret;
 }
 
-describe("file input component should respond to file type on change", () => {
-  const { body } = document;
-  const INVALID_FILE_CLASS = "has-invalid-file";
-  const size = 1024 * 1024 * 2;
-  const mock = new MockFile();
-  const file = mock.create("pic.jpg", size, "image/jpeg");
-  const fileList = makeFileList(file);
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "file input", selector: () => document.querySelector('.usa-file-input') }
+];
 
-  let dropZone;
-  let instructions;
-  let inputEl;
-  let dragText;
-  let box;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`File input initialized at ${name}`, () => {
+    describe("file input component should respond to file type on change", () => {
+      const { body } = document;
+      const INVALID_FILE_CLASS = "has-invalid-file";
+      const size = 1024 * 1024 * 2;
+      const mock = new MockFile();
+      const file = mock.create("pic.jpg", size, "image/jpeg");
+      const fileList = makeFileList(file);
 
-  before(() => {
-    body.innerHTML = TEMPLATE;
-    fileInput.on();
-    dropZone = body.querySelector(".usa-file-input__target");
-    instructions = body.querySelector(".usa-file-input__instructions");
-    inputEl = document.getElementById("file-input-specific");
-    box = body.querySelector(".usa-file-input__box");
-    dragText = body.querySelector(".usa-file-input__drag-text");
-    fileInput.on(body);
-  });
+      let dropZone;
+      let instructions;
+      let inputEl;
+      let dragText;
+      let box;
 
-  it("instructions are created", () => {
-    assert.strictEqual(
-      instructions.getAttribute("class"),
-      "usa-file-input__instructions"
-    );
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        fileInput.on(containerSelector());
+        dropZone = body.querySelector(".usa-file-input__target");
+        instructions = body.querySelector(".usa-file-input__instructions");
+        inputEl = document.getElementById("file-input-specific");
+        box = body.querySelector(".usa-file-input__box");
+        dragText = body.querySelector(".usa-file-input__drag-text");
+      });
 
-  it("target ui is created", () => {
-    assert.strictEqual(
-      dropZone.getAttribute("class"),
-      "usa-file-input__target"
-    );
-  });
+      afterEach(() => {
+        fileInput.off(containerSelector());
+        body.innerHTML = "";
+      });
 
-  it("input gets new class", () => {
-    assert.strictEqual(inputEl.getAttribute("class"), "usa-file-input__input");
-  });
+      it("instructions are created", () => {
+        assert.strictEqual(
+          instructions.getAttribute("class"),
+          "usa-file-input__instructions"
+        );
+      });
 
-  it("box is created", () => {
-    assert.strictEqual(box.getAttribute("class"), "usa-file-input__box");
-  });
+      it("target ui is created", () => {
+        assert.strictEqual(
+          dropZone.getAttribute("class"),
+          "usa-file-input__target"
+        );
+      });
 
-  it('pluralizes "files" if there is a "multiple" attribute', () => {
-    assert.strictEqual(dragText.innerHTML, "Drag files here or ");
-  });
+      it("input gets new class", () => {
+        assert.strictEqual(inputEl.getAttribute("class"), "usa-file-input__input");
+      });
 
-  it("mock file should be defined with specific values", () => {
-    assert(file);
-    assert.strictEqual(file.name, "pic.jpg");
-    assert.strictEqual(file.size, size);
-    assert.strictEqual(file.type, "image/jpeg");
-  });
+      it("box is created", () => {
+        assert.strictEqual(box.getAttribute("class"), "usa-file-input__box");
+      });
 
-  it("mock file should not be allowed", () => {
-    // add to our elements FileList
-    inputEl.files = fileList;
-    const e = new Event("change");
-    inputEl.dispatchEvent(e);
-    assert.strictEqual(dropZone.classList.contains(INVALID_FILE_CLASS), true);
+      it('pluralizes "files" if there is a "multiple" attribute', () => {
+        assert.strictEqual(dragText.innerHTML, "Drag files here or ");
+      });
+
+      it("mock file should be defined with specific values", () => {
+        assert(file);
+        assert.strictEqual(file.name, "pic.jpg");
+        assert.strictEqual(file.size, size);
+        assert.strictEqual(file.type, "image/jpeg");
+      });
+
+      it("mock file should not be allowed", () => {
+        // add to our elements FileList
+        inputEl.files = fileList;
+        const e = new Event("change");
+        inputEl.dispatchEvent(e);
+        assert.strictEqual(dropZone.classList.contains(INVALID_FILE_CLASS), true);
+      });
+    });
   });
 });

--- a/spec/unit/file-input/file-input-disabled.spec.js
+++ b/spec/unit/file-input/file-input-disabled.spec.js
@@ -1,35 +1,43 @@
 const assert = require("assert");
-const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
+const fileInput = require("../../../src/js/components/file-input");
 
 const RENDER = "../../../build/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--disabled.html")
 );
 
-describe("file input is disabled", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "file input", selector: () => document.querySelector('.usa-file-input') }
+];
 
-  let component;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`File input initialized at ${name}`, () => {
+    describe("file input is disabled", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    fileInput.on();
-    component = body.querySelector(".usa-file-input");
-    fileInput.on(body);
-  });
+      let component;
 
-  afterEach(() => {
-    body.innerHTML = "";
-    fileInput.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        fileInput.on(containerSelector());
+        component = body.querySelector(".usa-file-input");
+      });
 
-  it("has disabled styling", () => {
-    const expectedClass = "usa-file-input--disabled";
-    assert.strictEqual(
-      component.getAttribute("class").includes(expectedClass),
-      true
-    );
+      afterEach(() => {
+        fileInput.off(containerSelector());
+        body.innerHTML = "";
+      });
+
+      it("has disabled styling", () => {
+        const expectedClass = "usa-file-input--disabled";
+        assert.strictEqual(
+          component.getAttribute("class").includes(expectedClass),
+          true
+        );
+      });
+    });
   });
 });

--- a/spec/unit/file-input/file-input.spec.js
+++ b/spec/unit/file-input/file-input.spec.js
@@ -1,61 +1,69 @@
 const assert = require("assert");
-const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
+const fileInput = require("../../../src/js/components/file-input");
 
 const RENDER = "../../../build/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--multiple.html")
 );
 
-describe("file input component builds successfully", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "file input", selector: () => document.querySelector('.usa-file-input') }
+];
 
-  let dropZone;
-  let instructions;
-  let inputEl;
-  let dragText;
-  let box;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`File input initialized at ${name}`, () => {
+    describe("file input component builds successfully", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    fileInput.on();
-    dropZone = body.querySelector(".usa-file-input__target");
-    instructions = body.querySelector(".usa-file-input__instructions");
-    inputEl = body.querySelector(".usa-file-input__input");
-    box = body.querySelector(".usa-file-input__box");
-    dragText = body.querySelector(".usa-file-input__drag-text");
-    fileInput.on(body);
-  });
+      let dropZone;
+      let instructions;
+      let inputEl;
+      let dragText;
+      let box;
 
-  afterEach(() => {
-    body.innerHTML = "";
-    fileInput.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        fileInput.on(containerSelector());
+        dropZone = body.querySelector(".usa-file-input__target");
+        instructions = body.querySelector(".usa-file-input__instructions");
+        inputEl = body.querySelector(".usa-file-input__input");
+        box = body.querySelector(".usa-file-input__box");
+        dragText = body.querySelector(".usa-file-input__drag-text");
+      });
 
-  it("instructions are created", () => {
-    assert.strictEqual(
-      instructions.getAttribute("class"),
-      "usa-file-input__instructions"
-    );
-  });
+      afterEach(() => {
+        fileInput.off(containerSelector());
+        body.innerHTML = "";
+      });
 
-  it("target ui is created", () => {
-    assert.strictEqual(
-      dropZone.getAttribute("class"),
-      "usa-file-input__target"
-    );
-  });
+      it("instructions are created", () => {
+        assert.strictEqual(
+          instructions.getAttribute("class"),
+          "usa-file-input__instructions"
+        );
+      });
 
-  it("input gets new class", () => {
-    assert.strictEqual(inputEl.getAttribute("class"), "usa-file-input__input");
-  });
+      it("target ui is created", () => {
+        assert.strictEqual(
+          dropZone.getAttribute("class"),
+          "usa-file-input__target"
+        );
+      });
 
-  it("box is created", () => {
-    assert.strictEqual(box.getAttribute("class"), "usa-file-input__box");
-  });
+      it("input gets new class", () => {
+        assert.strictEqual(inputEl.getAttribute("class"), "usa-file-input__input");
+      });
 
-  it('pluralizes "files" if there is a "multiple" attribute', () => {
-    assert.strictEqual(dragText.innerHTML, "Drag files here or ");
+      it("box is created", () => {
+        assert.strictEqual(box.getAttribute("class"), "usa-file-input__box");
+      });
+
+      it('pluralizes "files" if there is a "multiple" attribute', () => {
+        assert.strictEqual(dragText.innerHTML, "Drag files here or ");
+      });
+    });
   });
 });

--- a/spec/unit/file-input/single-file-input.spec.js
+++ b/spec/unit/file-input/single-file-input.spec.js
@@ -1,31 +1,39 @@
 const assert = require("assert");
-const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
+const fileInput = require("../../../src/js/components/file-input");
 
 const RENDER = "../../../build/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--default.html")
 );
 
-describe("file input: single file input", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "file input", selector: () => document.querySelector('.usa-file-input') }
+];
 
-  let dragText;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`File input initialized at ${name}`, () => {
+    describe("file input: single file input", () => {
+      const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    fileInput.on();
-    dragText = body.querySelector(".usa-file-input__drag-text");
-    fileInput.on(body);
-  });
+      let dragText;
 
-  afterEach(() => {
-    body.innerHTML = "";
-    fileInput.off(body);
-  });
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        fileInput.on(containerSelector());
+        dragText = body.querySelector(".usa-file-input__drag-text");
+      });
 
-  it('uses singular "file" if there is not a "multiple" attribute', () => {
-    assert.strictEqual(dragText.innerHTML, "Drag file here or ");
+      afterEach(() => {
+        fileInput.off(containerSelector());
+        body.innerHTML = "";
+      });
+
+      it('uses singular "file" if there is not a "multiple" attribute', () => {
+        assert.strictEqual(dragText.innerHTML, "Drag file here or ");
+      });
+    });
   });
 });

--- a/spec/unit/footer/footer.spec.js
+++ b/spec/unit/footer/footer.spec.js
@@ -30,82 +30,89 @@ const assertHidden = (el, hidden) => {
   );
 };
 
-describe("big footer accordion", () => {
-  const { body } = document;
-  let buttons;
-  let lists;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "footer", selector: () => document.querySelector('.usa-footer') }
+];
 
-  before(() => {
-    matchMediaPolyfill(window);
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`big footer accordion initialized at ${name}`, () => {
+    const { body } = document;
+    let buttons;
+    let lists;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
+    before(() => {
+      matchMediaPolyfill(window);
+    });
 
-    lists = document.querySelectorAll(PRIMARY_CONTENT_SELECTOR);
-    buttons = document.querySelectorAll(BUTTON_SELECTOR);
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
 
-    window.innerWidth = 1024;
-    behavior.on(body);
-  });
+      lists = document.querySelectorAll(PRIMARY_CONTENT_SELECTOR);
+      buttons = document.querySelectorAll(BUTTON_SELECTOR);
 
-  afterEach(() => {
-    body.innerHTML = "";
-    behavior.off(body);
-  });
+      window.innerWidth = 1024;
+      behavior.on(containerSelector());
+    });
 
-  it("defines a max. width", () => {
-    assert(typeof behavior.HIDE_MAX_WIDTH === "number", "no value defined");
-  });
+    afterEach(() => {
+      behavior.off(containerSelector());
+      body.innerHTML = "";
+    });
 
-  it("collapses at small screens", () => {
-    resizeTo(400);
-    assertHidden(lists[0], true);
-  });
+    it("defines a max. width", () => {
+      assert(typeof behavior.HIDE_MAX_WIDTH === "number", "no value defined");
+    });
 
-  it("collapses then expands again on larger screens", () => {
-    resizeTo(400);
-    resizeTo(1024);
-    assertHidden(lists[0], false);
-  });
+    it("collapses at small screens", () => {
+      resizeTo(400);
+      assertHidden(lists[0], true);
+    });
 
-  it("opens panel when clicked", () => {
-    resizeTo(400);
-    buttons[0].click();
-    assertHidden(lists[0], false);
-  });
+    it("collapses then expands again on larger screens", () => {
+      resizeTo(400);
+      resizeTo(1024);
+      assertHidden(lists[0], false);
+    });
 
-  it("does not open panels when clicked on larger screens", () => {
-    buttons[0].click();
-    assertHidden(lists[0], false);
-  });
+    it("opens panel when clicked", () => {
+      resizeTo(400);
+      buttons[0].click();
+      assertHidden(lists[0], false);
+    });
 
-  it("closes panel on subsequent click", () => {
-    resizeTo(800);
-    resizeTo(400);
-    buttons[0].click();
-    assertHidden(lists[0], false);
-    buttons[0].click();
-    assertHidden(lists[0], true);
-  });
+    it("does not open panels when clicked on larger screens", () => {
+      buttons[0].click();
+      assertHidden(lists[0], false);
+    });
 
-  it("closes other panels on small screens", () => {
-    resizeTo(800);
-    resizeTo(400);
-    buttons[0].click();
-    assertHidden(lists[0], false);
-    assertHidden(lists[1], true);
-    assertHidden(lists[2], true);
-    buttons[1].click();
-    assertHidden(lists[0], true);
-    assertHidden(lists[1], false);
-    assertHidden(lists[2], true);
-  });
+    it("closes panel on subsequent click", () => {
+      resizeTo(800);
+      resizeTo(400);
+      buttons[0].click();
+      assertHidden(lists[0], false);
+      buttons[0].click();
+      assertHidden(lists[0], true);
+    });
 
-  it("does not close other panels on larger screens", () => {
-    buttons[0].click();
-    assertHidden(lists[0], false);
-    assertHidden(lists[1], false);
-    assertHidden(lists[2], false);
+    it("closes other panels on small screens", () => {
+      resizeTo(800);
+      resizeTo(400);
+      buttons[0].click();
+      assertHidden(lists[0], false);
+      assertHidden(lists[1], true);
+      assertHidden(lists[2], true);
+      buttons[1].click();
+      assertHidden(lists[0], true);
+      assertHidden(lists[1], false);
+      assertHidden(lists[2], true);
+    });
+
+    it("does not close other panels on larger screens", () => {
+      buttons[0].click();
+      assertHidden(lists[0], false);
+      assertHidden(lists[1], false);
+      assertHidden(lists[2], false);
+    });
   });
 });

--- a/spec/unit/input-prefix/input-prefix.spec.js
+++ b/spec/unit/input-prefix/input-prefix.spec.js
@@ -5,39 +5,47 @@ const behavior = require("../../../src/js/components/input-prefix-suffix");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "/template.html"));
 
-describe("input prefix", () => {
-  const { body } = document;
+const inputGroupSelector = () => document.querySelector(".usa-input-group");
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "input group", selector: inputGroupSelector }
+];
 
-  let input;
-  let container;
-  let prefix;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`input prefix initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    input = body.querySelector(".usa-input");
-    container = body.querySelector(".usa-input-group");
-    prefix = body.querySelector(".usa-input-prefix");
-    behavior.on(body);
-  });
+    let input;
+    let container;
+    let prefix;
 
-  afterEach(() => {
-    body.innerHTML = "";
-    behavior.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      input = body.querySelector(".usa-input");
+      container = inputGroupSelector();
+      prefix = body.querySelector(".usa-input-prefix");
+      behavior.on(containerSelector());
+    });
 
-  it('it should add "is-focused" class name to container when the prefix is clicked', () => {
-    prefix.click();
-    assert.strictEqual(container.classList.contains("is-focused"), true);
-  });
+    afterEach(() => {
+      behavior.off(containerSelector());
+      body.innerHTML = "";
+    });
 
-  it('it should add "is-focused" class name to container when input recieves focus()', () => {
-    input.focus();
-    assert.strictEqual(container.classList.contains("is-focused"), true);
-  });
+    it('it should add "is-focused" class name to container when the prefix is clicked', () => {
+      prefix.click();
+      assert.strictEqual(container.classList.contains("is-focused"), true);
+    });
 
-  it('it should remove "is-focused" class name from container on input blur() event', () => {
-    input.focus();
-    input.blur();
-    assert.strictEqual(container.classList.contains("is-focused"), false);
+    it('it should add "is-focused" class name to container when input recieves focus()', () => {
+      input.focus();
+      assert.strictEqual(container.classList.contains("is-focused"), true);
+    });
+
+    it('it should remove "is-focused" class name from container on input blur() event', () => {
+      input.focus();
+      input.blur();
+      assert.strictEqual(container.classList.contains("is-focused"), false);
+    });
   });
 });

--- a/spec/unit/modal/modal.spec.js
+++ b/spec/unit/modal/modal.spec.js
@@ -5,129 +5,140 @@ const path = require("path");
 const modal = require("../../../src/js/components/modal");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "template.html"));
+const modalWindowSelector = () => document.querySelector(".usa-modal");
+const bodySelector = () => document.body;
+const openButton1Selector = () => document.querySelector("#open-button1");
+const openButton2Selector = () => document.querySelector("#open-button2");
 
-describe("Modal window", () => {
-  const { body } = document;
+const tests = [
+  { name: "document.body", selector: bodySelector },
+  { name: "modal", selector: modalWindowSelector }
+];
 
-  let closeButton;
-  let modalWrapper;
-  let modalWindow;
-  let openButton1;
-  let openButton2;
-  let overlay;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Modal window initialized at ${name}`, () => {
+    const { body } = document;
 
-  const isVisible = (el) => el.classList.contains("is-visible");
+    let closeButton;
+    let modalWrapper;
+    let modalWindow;
+    let openButton1;
+    let openButton2;
+    let overlay;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    modal.on();
-    closeButton = body.querySelector("#close-button");
-    modalWrapper = body.querySelector(".usa-modal-wrapper");
-    modalWindow = body.querySelector(".usa-modal");
-    overlay = body.querySelector(".usa-modal-overlay");
-    openButton1 = body.querySelector("#open-button1");
-    openButton2 = body.querySelector("#open-button2");
-  });
+    const isVisible = (el) => el.classList.contains("is-visible");
 
-  afterEach(() => {
-    body.innerHTML = "";
-    body.className = "";
-    modal.off();
-  });
-
-  describe("Builds the modal HTML", () => {
-    it("creates new parent elements", () => {
-      assert.ok(modalWindow, "creates inner div");
-      assert.ok(overlay, "creates the overlay");
-      assert.ok(modalWrapper, "creates the outer div");
-    });
-
-    it('adds role="dialog" to modal parent', () => {
-      assert.strictEqual(modalWrapper.getAttribute("role"), "dialog");
-    });
-
-    it("moves aria-labelledby, aria-describedby, and id to the parent", () => {
-      assert.strictEqual(modalWindow.hasAttribute("aria-describedby"), false);
-      assert.strictEqual(modalWindow.hasAttribute("aria-labelledby"), false);
-      assert.strictEqual(modalWindow.hasAttribute("id"), false);
-      assert.strictEqual(modalWrapper.hasAttribute("aria-describedby"), true);
-      assert.strictEqual(modalWrapper.hasAttribute("aria-labelledby"), true);
-      assert.strictEqual(modalWrapper.getAttribute("id"), "modal");
-    });
-
-    it('sets tabindex="-1" to the modal window', () => {
-      assert.strictEqual(modalWindow.getAttribute("tabindex"), "-1");
-    });
-
-    it("moves the modal to the bottom of the DOM", () => {
-      assert.strictEqual(
-        body.lastElementChild.classList.contains("usa-modal-wrapper"),
-        true
-      );
-    });
-
-    it('adds role="button" to any <a> opener, but not <button>', () => {
-      assert.strictEqual(openButton1.getAttribute("role"), "button");
-      assert.strictEqual(openButton2.hasAttribute("role"), false);
-    });
-
-    it("adds aria-controls to each opener", () => {
-      assert.strictEqual(openButton1.getAttribute("aria-controls"), "modal");
-      assert.strictEqual(openButton2.getAttribute("aria-controls"), "modal");
-    });
-  });
-
-  describe("When opened", () => {
     beforeEach(() => {
-      openButton1.click();
+      body.innerHTML = TEMPLATE;
+      modal.on(containerSelector());
+      modalWindow = modalWindowSelector();
+      closeButton = body.querySelector("#close-button");
+      modalWrapper = body.querySelector(".usa-modal-wrapper");
+      overlay = body.querySelector(".usa-modal-overlay");
+      openButton1 = openButton1Selector();
+      openButton2 = openButton2Selector();
     });
 
-    it("makes the modal visible", () => {
-      assert.strictEqual(isVisible(modalWrapper), true);
+    afterEach(() => {
+      modal.off(containerSelector());
+      body.innerHTML = "";
+      body.className = "";
     });
 
-    it("focuses the modal window when opened", () => {
-      assert.strictEqual(document.activeElement, modalWindow);
+    describe("Builds the modal HTML", () => {
+      it("creates new parent elements", () => {
+        assert.ok(modalWindow, "creates inner div");
+        assert.ok(overlay, "creates the overlay");
+        assert.ok(modalWrapper, "creates the outer div");
+      });
+
+      it('adds role="dialog" to modal parent', () => {
+        assert.strictEqual(modalWrapper.getAttribute("role"), "dialog");
+      });
+
+      it("moves aria-labelledby, aria-describedby, and id to the parent", () => {
+        assert.strictEqual(modalWindow.hasAttribute("aria-describedby"), false);
+        assert.strictEqual(modalWindow.hasAttribute("aria-labelledby"), false);
+        assert.strictEqual(modalWindow.hasAttribute("id"), false);
+        assert.strictEqual(modalWrapper.hasAttribute("aria-describedby"), true);
+        assert.strictEqual(modalWrapper.hasAttribute("aria-labelledby"), true);
+        assert.strictEqual(modalWrapper.getAttribute("id"), "modal");
+      });
+
+      it('sets tabindex="-1" to the modal window', () => {
+        assert.strictEqual(modalWindow.getAttribute("tabindex"), "-1");
+      });
+
+      it("moves the modal to the bottom of the DOM", () => {
+        assert.strictEqual(
+          body.lastElementChild.classList.contains("usa-modal-wrapper"),
+          true
+        );
+      });
+
+      it('adds role="button" to any <a> opener, but not <button>', () => {
+        assert.strictEqual(openButton1.getAttribute("role"), "button");
+        assert.strictEqual(openButton2.hasAttribute("role"), false);
+      });
+
+      it("adds aria-controls to each opener", () => {
+        assert.strictEqual(openButton1.getAttribute("aria-controls"), "modal");
+        assert.strictEqual(openButton2.getAttribute("aria-controls"), "modal");
+      });
     });
 
-    it("makes all other page content invisible to screen readers", () => {
-      const activeContent = document.querySelectorAll(
-        "body > :not([aria-hidden])"
-      );
+    describe("When opened", () => {
+      beforeEach(() => {
+        openButton1.click();
+      });
 
-      assert.strictEqual(activeContent.length, 1);
-      assert.strictEqual(activeContent[0], modalWrapper);
-    });
-  });
+      it("makes the modal visible", () => {
+        assert.strictEqual(isVisible(modalWrapper), true);
+      });
 
-  describe("When closing", () => {
-    beforeEach(() => {
-      openButton2.click();
-    });
+      it("focuses the modal window when opened", () => {
+        assert.strictEqual(document.activeElement, modalWindow);
+      });
 
-    it("hides the modal when close button is clicked", () => {
-      closeButton.click();
-      assert.strictEqual(isVisible(modalWrapper), false);
-    });
+      it("makes all other page content invisible to screen readers", () => {
+        const activeContent = document.querySelectorAll(
+          "body > :not([aria-hidden])"
+        );
 
-    it("closes the modal when the overlay is clicked", () => {
-      overlay.click();
-      assert.strictEqual(isVisible(modalWrapper), false);
+        assert.strictEqual(activeContent.length, 1);
+        assert.strictEqual(activeContent[0], modalWrapper);
+      });
     });
 
-    it("sends focus to the element that opened it", () => {
-      closeButton.click();
-      assert.strictEqual(document.activeElement, openButton2);
-    });
+    describe("When closing", () => {
+      beforeEach(() => {
+        openButton2.click();
+      });
 
-    it("restores other page content screen reader visibility", () => {
-      closeButton.click();
-      const activeContent = document.querySelectorAll(
-        "body > :not([aria-hidden])"
-      );
-      const staysHidden = document.getElementById("stays-hidden");
-      assert.strictEqual(activeContent.length, 4);
-      assert.strictEqual(staysHidden.hasAttribute("aria-hidden"), true);
+      it("hides the modal when close button is clicked", () => {
+        closeButton.click();
+        assert.strictEqual(isVisible(modalWrapper), false);
+      });
+
+      it("closes the modal when the overlay is clicked", () => {
+        overlay.click();
+        assert.strictEqual(isVisible(modalWrapper), false);
+      });
+
+      it("sends focus to the element that opened it", () => {
+        closeButton.click();
+        assert.strictEqual(document.activeElement, openButton2);
+      });
+
+      it("restores other page content screen reader visibility", () => {
+        closeButton.click();
+        const activeContent = document.querySelectorAll(
+          "body > :not([aria-hidden])"
+        );
+        const staysHidden = document.getElementById("stays-hidden");
+        assert.strictEqual(activeContent.length, 4);
+        assert.strictEqual(staysHidden.hasAttribute("aria-hidden"), true);
+      });
     });
   });
 });

--- a/spec/unit/table/table.spec.js
+++ b/spec/unit/table/table.spec.js
@@ -1,6 +1,6 @@
-const Table = require("../../../src/js/components/table");
 const assert = require("assert");
 const fs = require("fs");
+const Table = require("../../../src/js/components/table");
 
 const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
 const STYLES = fs.readFileSync(`${__dirname}/../../../dist/css/uswds.min.css`);
@@ -9,136 +9,144 @@ const ASCENDING = "ascending";
 const DESCENDING = "descending";
 const sortButtonEl = ".usa-table__header__button";
 
-describe("Sortable Table", () => {
-  const { body } = document;
+const tableSelector = () => document.querySelector(".usa-table");
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "table", selector: tableSelector }
+];
 
-  document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`Sortable Table initialized at ${name}`, () => {
+    const { body } = document;
 
-  let root;
-  let tbody;
-  let sortableHeaders;
-  let unsortableHeader;
-  let alphabeticalSortButton;
-  let numericSortButton;
-  let dataSortValueSortButton;
-  let ariaLive;
+    document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
 
-  function getCellValuesByColumn(index) {
-    return Array.from(tbody.querySelectorAll("tr")).map((row) => {
-      return row.children[index].innerHTML;
-    });
-  }
+    let root;
+    let tbody;
+    let sortableHeaders;
+    let unsortableHeader;
+    let alphabeticalSortButton;
+    let numericSortButton;
+    let dataSortValueSortButton;
+    let ariaLive;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    Table.on();
+    function getCellValuesByColumn(index) {
+      return Array.from(tbody.querySelectorAll("tr")).map((row) => {
+        return row.children[index].innerHTML;
+      });
+    }
 
-    root = body.querySelector(".usa-table");
-    tbody = root.querySelector("tbody");
-    sortableHeaders = root.querySelectorAll("th[data-sortable]");
-    unsortableHeader = root.querySelector("th:not([data-sortable])");
-    alphabeticalSortButton = sortableHeaders[0].querySelector(sortButtonEl);
-    numericSortButton = sortableHeaders[1].querySelector(sortButtonEl);
-    dataSortValueSortButton = sortableHeaders[2].querySelector(sortButtonEl);
-    ariaLive = body.querySelector(
-      ".usa-table__announcement-region[aria-live='polite']"
-    );
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      Table.on(containerSelector());
 
-  afterEach(() => {
-    body.innerHTML = "";
-    Table.off();
-  });
-
-  it('is immediately followed by an "aria-live" region', () => {
-    assert.notEqual(ariaLive, null);
-    assert.strictEqual(root.nextElementSibling, ariaLive);
-  });
-
-  it("has at least one sortable column", () => {
-    assert.notEqual(sortableHeaders[0], null);
-  });
-
-  it("sorts rows by cell content alphabetically when clicked", () => {
-    alphabeticalSortButton.click();
-    assert.deepEqual(getCellValuesByColumn(0), ["A", "X", "Y", "Z"]);
-  });
-
-  it("sorts rows by cell content numerically when clicked", () => {
-    // what about negative values?
-    numericSortButton.click();
-    assert.deepEqual(getCellValuesByColumn(1), ["1", "2", "3", "4"]);
-  });
-
-  it("sorts rows by 'data-sort-value' attribute on cells when clicked", () => {
-    dataSortValueSortButton.click();
-    assert.deepEqual(getCellValuesByColumn(2), ["-1", "Zero", "25%", "2,000"]);
-  });
-
-  it("sorts rows descending if already sorted ascending when clicked", () => {
-    alphabeticalSortButton.click();
-    assert.deepEqual(getCellValuesByColumn(0), ["A", "X", "Y", "Z"]);
-    assert.strictEqual(sortableHeaders[0].getAttribute("aria-sort"), ASCENDING);
-    alphabeticalSortButton.click();
-    assert.deepEqual(getCellValuesByColumn(0), ["Z", "Y", "X", "A"]);
-    assert.strictEqual(
-      sortableHeaders[0].getAttribute("aria-sort"),
-      DESCENDING
-    );
-  });
-
-  it("announces sort direction when sort changes", () => {
-    alphabeticalSortButton.click();
-    assert.strictEqual(ariaLive.innerText.length > 0, true);
-  });
-
-  describe("Sortable column header", () => {
-    it("has an aria-label that describes the current sort direction", () => {
-      const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
-      const currentAriaLabel = sortableHeaders[0].getAttribute("aria-label");
-      assert.strictEqual(currentAriaLabel.includes(currentSortDirection), true);
+      root = tableSelector();
+      tbody = root.querySelector("tbody");
+      sortableHeaders = root.querySelectorAll("th[data-sortable]");
+      unsortableHeader = root.querySelector("th:not([data-sortable])");
+      alphabeticalSortButton = sortableHeaders[0].querySelector(sortButtonEl);
+      numericSortButton = sortableHeaders[1].querySelector(sortButtonEl);
+      dataSortValueSortButton = sortableHeaders[2].querySelector(sortButtonEl);
+      ariaLive = body.querySelector(
+        ".usa-table__announcement-region[aria-live='polite']"
+      );
     });
 
-    it("has sort button with a title that describes what the sort direction will be if clicked", () => {
-      const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
-      const futureSortDirection =
-        currentSortDirection === DESCENDING ? ASCENDING : DESCENDING;
-      const firstHeaderButton = sortableHeaders[0].querySelector(sortButtonEl);
+    afterEach(() => {
+      Table.off(containerSelector());
+      body.innerHTML = "";
+    });
+
+    it('is immediately followed by an "aria-live" region', () => {
+      assert.notEqual(ariaLive, null);
+      assert.strictEqual(root.nextElementSibling, ariaLive);
+    });
+
+    it("has at least one sortable column", () => {
+      assert.notEqual(sortableHeaders[0], null);
+    });
+
+    it("sorts rows by cell content alphabetically when clicked", () => {
+      alphabeticalSortButton.click();
+      assert.deepEqual(getCellValuesByColumn(0), ["A", "X", "Y", "Z"]);
+    });
+
+    it("sorts rows by cell content numerically when clicked", () => {
+      // what about negative values?
+      numericSortButton.click();
+      assert.deepEqual(getCellValuesByColumn(1), ["1", "2", "3", "4"]);
+    });
+
+    it("sorts rows by 'data-sort-value' attribute on cells when clicked", () => {
+      dataSortValueSortButton.click();
+      assert.deepEqual(getCellValuesByColumn(2), ["-1", "Zero", "25%", "2,000"]);
+    });
+
+    it("sorts rows descending if already sorted ascending when clicked", () => {
+      alphabeticalSortButton.click();
+      assert.deepEqual(getCellValuesByColumn(0), ["A", "X", "Y", "Z"]);
+      assert.strictEqual(sortableHeaders[0].getAttribute("aria-sort"), ASCENDING);
+      alphabeticalSortButton.click();
+      assert.deepEqual(getCellValuesByColumn(0), ["Z", "Y", "X", "A"]);
       assert.strictEqual(
-        firstHeaderButton.classList.contains("usa-table__header__button"),
-        true
-      );
-      assert.strictEqual(
-        firstHeaderButton.getAttribute("title").includes(futureSortDirection),
-        true
+        sortableHeaders[0].getAttribute("aria-sort"),
+        DESCENDING
       );
     });
 
-    it("has an SVG which displays the correct icon", () => {
-      const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
-      const futureSortDirection =
-        currentSortDirection === DESCENDING ? ASCENDING : DESCENDING;
-      const activeSVGNode = sortableHeaders[0].querySelector(
-        `.usa-icon > .${currentSortDirection}`
-      );
-      const inactiveSVGNode = sortableHeaders[0].querySelector(
-        `.usa-icon > .${futureSortDirection}`
-      );
-      const unsortedSVGNode = sortableHeaders[0].querySelector(
-        ".usa-icon > .unsorted"
-      );
-      assert.notEqual(getComputedStyle(activeSVGNode).fill, "transparent");
-      assert.strictEqual(getComputedStyle(inactiveSVGNode).fill, "transparent");
-      assert.strictEqual(getComputedStyle(unsortedSVGNode).fill, "transparent");
+    it("announces sort direction when sort changes", () => {
+      alphabeticalSortButton.click();
+      assert.strictEqual(ariaLive.innerText.length > 0, true);
     });
-  });
 
-  describe("Non-sortable column header", () => {
-    it("does not have a sort button", () => {
-      const unsortableHeaderButton = unsortableHeader.querySelector(
-        sortButtonEl
-      );
-      assert.strictEqual(unsortableHeaderButton, null);
+    describe("Sortable column header", () => {
+      it("has an aria-label that describes the current sort direction", () => {
+        const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
+        const currentAriaLabel = sortableHeaders[0].getAttribute("aria-label");
+        assert.strictEqual(currentAriaLabel.includes(currentSortDirection), true);
+      });
+
+      it("has sort button with a title that describes what the sort direction will be if clicked", () => {
+        const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
+        const futureSortDirection =
+          currentSortDirection === DESCENDING ? ASCENDING : DESCENDING;
+        const firstHeaderButton = sortableHeaders[0].querySelector(sortButtonEl);
+        assert.strictEqual(
+          firstHeaderButton.classList.contains("usa-table__header__button"),
+          true
+        );
+        assert.strictEqual(
+          firstHeaderButton.getAttribute("title").includes(futureSortDirection),
+          true
+        );
+      });
+
+      it("has an SVG which displays the correct icon", () => {
+        const currentSortDirection = sortableHeaders[0].getAttribute("aria-sort");
+        const futureSortDirection =
+          currentSortDirection === DESCENDING ? ASCENDING : DESCENDING;
+        const activeSVGNode = sortableHeaders[0].querySelector(
+          `.usa-icon > .${currentSortDirection}`
+        );
+        const inactiveSVGNode = sortableHeaders[0].querySelector(
+          `.usa-icon > .${futureSortDirection}`
+        );
+        const unsortedSVGNode = sortableHeaders[0].querySelector(
+          ".usa-icon > .unsorted"
+        );
+        assert.notEqual(getComputedStyle(activeSVGNode).fill, "transparent");
+        assert.strictEqual(getComputedStyle(inactiveSVGNode).fill, "transparent");
+        assert.strictEqual(getComputedStyle(unsortedSVGNode).fill, "transparent");
+      });
+    });
+
+    describe("Non-sortable column header", () => {
+      it("does not have a sort button", () => {
+        const unsortableHeaderButton = unsortableHeader.querySelector(
+          sortButtonEl
+        );
+        assert.strictEqual(unsortableHeaderButton, null);
+      });
     });
   });
 });

--- a/spec/unit/time-picker/time-picker.spec.js
+++ b/spec/unit/time-picker/time-picker.spec.js
@@ -9,100 +9,108 @@ const TEMPLATE = fs.readFileSync(
   path.join(__dirname, "/time-picker.template.html")
 );
 
-describe("time picker component", () => {
-  const { body } = document;
+const timePickerSelector = () => document.querySelector(".usa-time-picker");
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "time picker", selector: timePickerSelector }
+];
 
-  let root;
-  let input;
-  let select;
-  let list;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`time picker component initialized at ${name}`, () => {
+    const { body } = document;
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    TimePicker.on();
-    ComboBox.on();
-    root = body.querySelector(".usa-combo-box");
-    input = root.querySelector(".usa-combo-box__input");
-    select = root.querySelector(".usa-combo-box__select");
-    list = root.querySelector(".usa-combo-box__list");
-  });
+    let root;
+    let input;
+    let select;
+    let list;
 
-  afterEach(() => {
-    body.textContent = "";
-    ComboBox.off(body);
-    TimePicker.off(body);
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      TimePicker.on(containerSelector());
+      ComboBox.on(containerSelector());
+      root = body.querySelector(".usa-combo-box");
+      input = root.querySelector(".usa-combo-box__input");
+      select = root.querySelector(".usa-combo-box__select");
+      list = root.querySelector(".usa-combo-box__list");
+    });
 
-  it("enhances a select element into a combo box component", () => {
-    assert.ok(input, "adds an input element");
-    assert.ok(
-      select.classList.contains("usa-sr-only"),
-      "hides the select element from view"
-    );
-    assert.ok(list, "adds an list element");
-    assert.ok(list.hidden, "the list is hidden");
-    assert.strictEqual(
-      select.getAttribute("id"),
-      "",
-      "transfers id attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("id"),
-      "appointment-time",
-      "transfers id attribute to combo box"
-    );
-    assert.strictEqual(
-      select.getAttribute("required"),
-      null,
-      "transfers required attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("required"),
-      "",
-      "transfers required attribute to combo box"
-    );
-    assert.strictEqual(
-      select.getAttribute("name"),
-      "appointment-time",
-      "should not transfer name attribute to combo box"
-    );
-    assert.strictEqual(
-      input.getAttribute("name"),
-      null,
-      "should not transfer name attribute to combo box"
-    );
+    afterEach(() => {
+      ComboBox.off(containerSelector());
+      TimePicker.off(containerSelector());
+      body.textContent = "";
+    });
 
-    assert.strictEqual(select.value, "", "the select value should be empty");
-    assert.strictEqual(input.value, "", "the input should be empty");
-  });
+    it("enhances a select element into a combo box component", () => {
+      assert.ok(input, "adds an input element");
+      assert.ok(
+        select.classList.contains("usa-sr-only"),
+        "hides the select element from view"
+      );
+      assert.ok(list, "adds an list element");
+      assert.ok(list.hidden, "the list is hidden");
+      assert.strictEqual(
+        select.getAttribute("id"),
+        "",
+        "transfers id attribute to combo box"
+      );
+      assert.strictEqual(
+        input.getAttribute("id"),
+        "appointment-time",
+        "transfers id attribute to combo box"
+      );
+      assert.strictEqual(
+        select.getAttribute("required"),
+        null,
+        "transfers required attribute to combo box"
+      );
+      assert.strictEqual(
+        input.getAttribute("required"),
+        "",
+        "transfers required attribute to combo box"
+      );
+      assert.strictEqual(
+        select.getAttribute("name"),
+        "appointment-time",
+        "should not transfer name attribute to combo box"
+      );
+      assert.strictEqual(
+        input.getAttribute("name"),
+        null,
+        "should not transfer name attribute to combo box"
+      );
 
-  it("should focus the first item found in the list from the query when pressing down from the input", () => {
-    input.value = "4p";
+      assert.strictEqual(select.value, "", "the select value should be empty");
+      assert.strictEqual(input.value, "", "the input should be empty");
+    });
 
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
+    it("should focus the first item found in the list from the query when pressing down from the input", () => {
+      input.value = "4p";
 
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "4:00pm",
-      "should focus the last item in the list"
-    );
-  });
+      EVENTS.input(input);
+      assert.ok(!list.hidden, "should display the option list");
 
-  it("should focus the first complete hour found in the list from the query when pressing down from the input", () => {
-    input.value = "1p";
+      EVENTS.keydownArrowDown(input);
+      const focusedOption = document.activeElement;
+      assert.strictEqual(
+        focusedOption.textContent,
+        "4:00pm",
+        "should focus the last item in the list"
+      );
+    });
 
-    EVENTS.input(input);
-    assert.ok(!list.hidden, "should display the option list");
+    it("should focus the first complete hour found in the list from the query when pressing down from the input", () => {
+      input.value = "1p";
 
-    EVENTS.keydownArrowDown(input);
-    const focusedOption = document.activeElement;
-    assert.strictEqual(
-      focusedOption.textContent,
-      "1:00pm",
-      "should focus the last item in the list"
-    );
+      EVENTS.input(input);
+      assert.ok(!list.hidden, "should display the option list");
+
+      EVENTS.keydownArrowDown(input);
+      const focusedOption = document.activeElement;
+      assert.strictEqual(
+        focusedOption.textContent,
+        "1:00pm",
+        "should focus the last item in the list"
+      );
+    });
   });
 });

--- a/spec/unit/tooltip/tooltips.spec.js
+++ b/spec/unit/tooltip/tooltips.spec.js
@@ -1,49 +1,56 @@
 const assert = require("assert");
-const tooltip = require("../../../src/js/components/tooltip");
 const fs = require("fs");
 const path = require("path");
+const tooltip = require("../../../src/js/components/tooltip");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "/template.html"));
 
-describe("tooltips", () => {
-  const { body } = document;
-  let tooltipBody;
-  let tooltipTrigger;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "tooltip", selector: () => document.querySelector(".usa-tooltip") }
+];
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
-    tooltip.on();
-    tooltipBody = body.querySelector(".usa-tooltip__body");
-    tooltipTrigger = body.querySelector(".usa-tooltip__trigger");
-    tooltip.on(body);
-  });
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`tooltips initialized at ${name}`, () => {
+    const { body } = document;
+    let tooltipBody;
+    let tooltipTrigger;
 
-  afterEach(() => {
-    body.textContent = "";
-  });
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      tooltip.on(containerSelector());
+      tooltipBody = body.querySelector(".usa-tooltip__body");
+      tooltipTrigger = body.querySelector(".usa-tooltip__trigger");
+    });
 
-  it("trigger is created", () => {
-    assert.strictEqual(
-      tooltipTrigger.getAttribute("class"),
-      "usa-button usa-tooltip__trigger"
-    );
-  });
+    afterEach(() => {
+      tooltip.off(containerSelector());
+      body.textContent = "";
+    });
 
-  it("title attribute on trigger is cleared", () => {
-    assert.strictEqual(tooltipTrigger.getAttribute("title"), "");
-  });
+    it("trigger is created", () => {
+      assert.strictEqual(
+        tooltipTrigger.getAttribute("class"),
+        "usa-button usa-tooltip__trigger"
+      );
+    });
 
-  it("tooltip body is created", () => {
-    assert.strictEqual(tooltipBody.innerHTML, "This is a tooltip");
-  });
+    it("title attribute on trigger is cleared", () => {
+      assert.strictEqual(tooltipTrigger.getAttribute("title"), "");
+    });
 
-  it("tooltip is visible on focus", () => {
-    tooltipTrigger.focus();
-    assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
-  });
+    it("tooltip body is created", () => {
+      assert.strictEqual(tooltipBody.innerHTML, "This is a tooltip");
+    });
 
-  it("tooltip is hidden on blur", () => {
-    tooltipTrigger.blur();
-    assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    it("tooltip is visible on focus", () => {
+      tooltipTrigger.focus();
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
+    it("tooltip is hidden on blur", () => {
+      tooltipTrigger.blur();
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    });
   });
 });

--- a/spec/unit/validator/validator.spec.js
+++ b/spec/unit/validator/validator.spec.js
@@ -13,44 +13,51 @@ const keyup = (el) => {
   el.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
 };
 
-describe("validator component", () => {
-  const { body } = document;
-  let validated;
-  let validators;
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "input", selector: () => document.querySelector(INPUT_SELECTOR) }
+];
 
-  beforeEach(() => {
-    body.innerHTML = TEMPLATE;
+tests.forEach(({name, selector: containerSelector}) => {
+  describe(`validator component initialized at ${name}`, () => {
+    const { body } = document;
+    let validated;
+    let validators;
 
-    validated = document.querySelector(INPUT_SELECTOR);
-    validators = Array.from(document.querySelectorAll(VALIDATORS));
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
 
-    validator.on(body);
-  });
+      validated = document.querySelector(INPUT_SELECTOR);
+      validators = Array.from(document.querySelectorAll(VALIDATORS));
 
-  afterEach(() => {
-    body.textContent = "";
-    validator.off(body);
-  });
-
-  describe("validation state", () => {
-    it("adds ." + CHECKED_CLASS + " for all successful validations", () => {
-      validated.value = "GreatPassword1";
-      keyup(validated);
-      validators.forEach((checkbox) => {
-        assert.strictEqual(checkbox.classList.contains(CHECKED_CLASS), true);
-      });
+      validator.on(containerSelector());
     });
 
-    it("removes ." + CHECKED_CLASS + " for failed validations", () => {
-      validated.value = "GreatPassword";
-      keyup(validated);
-      validators.forEach((checkbox) => {
-        const checked = checkbox.classList.contains(CHECKED_CLASS);
-        if (checkbox.getAttribute("data-validator") === "numerical") {
-          assert.strictEqual(checked, false);
-        } else {
-          assert.strictEqual(checked, true);
-        }
+    afterEach(() => {
+      validator.off(containerSelector());
+      body.textContent = "";
+    });
+
+    describe("validation state", () => {
+      it("adds ." + CHECKED_CLASS + " for all successful validations", () => {
+        validated.value = "GreatPassword1";
+        keyup(validated);
+        validators.forEach((checkbox) => {
+          assert.strictEqual(checkbox.classList.contains(CHECKED_CLASS), true);
+        });
+      });
+
+      it("removes ." + CHECKED_CLASS + " for failed validations", () => {
+        validated.value = "GreatPassword";
+        keyup(validated);
+        validators.forEach((checkbox) => {
+          const checked = checkbox.classList.contains(CHECKED_CLASS);
+          if (checkbox.getAttribute("data-validator") === "numerical") {
+            assert.strictEqual(checked, false);
+          } else {
+            assert.strictEqual(checked, true);
+          }
+        });
       });
     });
   });

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -1,5 +1,5 @@
 const keymap = require("receptor/keymap");
-const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const behavior = require("../utils/behavior");
 const { prefix: PREFIX } = require("../config");
 const { CLICK } = require("../events");
@@ -783,7 +783,7 @@ const comboBox = behavior(
   },
   {
     init(root) {
-      select(COMBO_BOX, root).forEach((comboBoxEl) => {
+      selectOrMatches(COMBO_BOX, root).forEach((comboBoxEl) => {
         enhanceComboBox(comboBoxEl);
       });
     },

--- a/src/js/components/date-picker.js
+++ b/src/js/components/date-picker.js
@@ -1,6 +1,7 @@
 const keymap = require("receptor/keymap");
 const behavior = require("../utils/behavior");
 const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const { prefix: PREFIX } = require("../config");
 const { CLICK } = require("../events");
 const activeElement = require("../utils/active-element");
@@ -2146,7 +2147,7 @@ if (!isIosDevice()) {
 
 const datePicker = behavior(datePickerEvents, {
   init(root) {
-    select(DATE_PICKER, root).forEach((datePickerEl) => {
+    selectOrMatches(DATE_PICKER, root).forEach((datePickerEl) => {
       enhanceDatePicker(datePickerEl);
     });
   },

--- a/src/js/components/date-range-picker.js
+++ b/src/js/components/date-range-picker.js
@@ -1,5 +1,6 @@
 const behavior = require("../utils/behavior");
 const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const { prefix: PREFIX } = require("../config");
 const {
   getDatePickerContext,
@@ -165,7 +166,7 @@ const dateRangePicker = behavior(
   },
   {
     init(root) {
-      select(DATE_RANGE_PICKER, root).forEach((dateRangePickerEl) => {
+      selectOrMatches(DATE_RANGE_PICKER, root).forEach((dateRangePickerEl) => {
         enhanceDateRangePicker(dateRangePickerEl);
       });
     },

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -424,7 +424,7 @@ const fileInput = behavior(
       selectOrMatches(INPUT, root).forEach((fileInputEl) => {
         const fileInputTopElement = fileInputEl.parentElement.parentElement;
         fileInputTopElement.parentElement.replaceChild(fileInputEl, fileInputTopElement);
-        fileInputEl.className = DROPZONE_CLASS;
+        fileInputEl.setAttribute('class', DROPZONE_CLASS);
       });
     },
     getFileInputContext,

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -1,4 +1,3 @@
-const select = require("../utils/select");
 const selectOrMatches = require("../utils/select-or-matches");
 const behavior = require("../utils/behavior");
 const { prefix: PREFIX } = require("../config");

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -1,4 +1,5 @@
 const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const behavior = require("../utils/behavior");
 const { prefix: PREFIX } = require("../config");
 
@@ -386,7 +387,7 @@ const fileInput = behavior(
   {},
   {
     init(root) {
-      select(DROPZONE, root).forEach((fileInputEl) => {
+      selectOrMatches(DROPZONE, root).forEach((fileInputEl) => {
         const { instructions, dropTarget } = buildFileInput(fileInputEl);
 
         dropTarget.addEventListener(

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -420,6 +420,13 @@ const fileInput = behavior(
         );
       });
     },
+    teardown(root) {
+      selectOrMatches(INPUT, root).forEach((fileInputEl) => {
+        const fileInputTopElement = fileInputEl.parentElement.parentElement;
+        fileInputTopElement.parentElement.replaceChild(fileInputEl, fileInputTopElement);
+        fileInputEl.className = DROPZONE_CLASS;
+      });
+    },
     getFileInputContext,
     disable,
     enable,

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -1,9 +1,7 @@
-const behavior = require("../utils/behavior");
-const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const FocusTrap = require("../utils/focus-trap");
 const ScrollBarWidth = require("../utils/scrollbar-width");
 
-const { CLICK } = require("../events");
 const { prefix: PREFIX } = require("../config");
 
 const MODAL_CLASSNAME = `${PREFIX}-modal`;
@@ -177,16 +175,26 @@ function toggleModal(event) {
  *
  * @param {HTMLElement} baseComponent the modal html in the DOM
  */
-const setUpAttributes = (baseComponent) => {
+const setUpModal = (baseComponent) => {
   const modalContent = baseComponent;
   const modalWrapper = document.createElement("div");
   const overlayDiv = document.createElement("div");
   const modalID = baseComponent.getAttribute("id");
   const ariaLabelledBy = baseComponent.getAttribute("aria-labelledby");
   const ariaDescribedBy = baseComponent.getAttribute("aria-describedby");
-  const forceUserAction = baseComponent.hasAttribute(FORCE_ACTION_ATTRIBUTE)
-    ? baseComponent.hasAttribute(FORCE_ACTION_ATTRIBUTE)
-    : false;
+  const forceUserAction = baseComponent.hasAttribute(FORCE_ACTION_ATTRIBUTE);
+
+  // Create placeholder where modal is for cleanup
+  const originalLocationPlaceHolder = document.createElement("div");
+  originalLocationPlaceHolder.setAttribute(`data-placeholder-for`, modalID);
+  originalLocationPlaceHolder.style.display = "none";
+  originalLocationPlaceHolder.setAttribute('aria-hidden', 'true');
+  for (let attributeIndex = 0; attributeIndex < modalContent.attributes.length; attributeIndex += 1) {
+    const attribute = modalContent.attributes[attributeIndex];
+    originalLocationPlaceHolder.setAttribute(`data-original-${attribute.name}`, attribute.value);
+  }
+
+  modalContent.after(originalLocationPlaceHolder);
 
   // Rebuild the modal element
   modalContent.parentNode.insertBefore(modalWrapper, modalContent);
@@ -223,7 +231,7 @@ const setUpAttributes = (baseComponent) => {
 
   // Add aria-controls
   const modalClosers = modalWrapper.querySelectorAll(CLOSERS);
-  select(modalClosers).forEach((el) => {
+  modalClosers.forEach((el) => {
     el.setAttribute("aria-controls", modalID);
   });
 
@@ -233,27 +241,43 @@ const setUpAttributes = (baseComponent) => {
   document.body.appendChild(modalWrapper);
 };
 
-modal = behavior(
-  {
-    [CLICK]: {
-      [OPENERS]: toggleModal,
-      [CLOSERS]: toggleModal,
-    },
-  },
-  {
-    init(root) {
-      select(MODAL, root).forEach((modalWindow) => {
-        setUpAttributes(modalWindow);
-      });
+const cleanUpModal = (baseComponent) => {
+  const modalContent = baseComponent;
+  const modalWrapper = modalContent.parentElement.parentElement;
+  const modalID = modalWrapper.getAttribute("id");
 
-      select(OPENERS, root).forEach((item) => {
+  const originalLocationPlaceHolder = document.querySelector(`[data-placeholder-for="${modalID}"]`);
+  if(originalLocationPlaceHolder)
+  {
+    for (let attributeIndex = 0; attributeIndex < originalLocationPlaceHolder.attributes.length; attributeIndex += 1) {
+      const attribute = originalLocationPlaceHolder.attributes[attributeIndex];
+      if(attribute.name.startsWith('data-original-')) 
+      {
+        // data-original- is 14 long
+        modalContent.setAttribute(attribute.name.substr(14), attribute.value);
+      }
+    }
+  
+    originalLocationPlaceHolder.after(modalContent);
+    originalLocationPlaceHolder.parentElement.removeChild(originalLocationPlaceHolder);
+  }
+
+  modalWrapper.parentElement.removeChild(modalWrapper);
+};
+
+modal = {
+  init(root) {
+    selectOrMatches(MODAL, root).forEach((modalWindow) => {
+      const modalId = modalWindow.id;
+      setUpModal(modalWindow);
+
+      // this will query all openers and closers including the overlay 
+      document.querySelectorAll(`[aria-controls="${modalId}"]`).forEach((item) => {
         // Turn anchor links into buttons because of
         // VoiceOver on Safari
         if (item.nodeName === "A") {
           item.setAttribute("role", "button");
-          item.addEventListener("click", (e) => {
-            e.preventDefault();
-          });
+          item.addEventListener("click", (e) => e.preventDefault());
         }
 
         // Can uncomment when aria-haspopup="dialog" is supported
@@ -261,11 +285,28 @@ modal = behavior(
         // Most screen readers support aria-haspopup, but might announce
         // as opening a menu if "dialog" is not supported.
         // item.setAttribute("aria-haspopup", "dialog");
+
+        item.addEventListener("click", toggleModal);
       });
-    },
-    focusTrap: null,
-    toggleModal,
+    });
+  },
+  teardown(root) {
+    selectOrMatches(MODAL, root).forEach((modalWindow) => {
+      cleanUpModal(modalWindow);
+      const modalId = modalWindow.id;
+
+      document.querySelectorAll(`[aria-controls="${modalId}"]`)
+        .forEach((item) => item.removeEventListener("click", toggleModal));
+    });
+  },
+  focusTrap: null,
+  toggleModal,
+  on(root) {
+    this.init(root);
+  },
+  off(root) {
+    this.teardown(root);
   }
-);
+};
 
 module.exports = modal;

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -168,8 +168,8 @@ navigation = behavior(
   },
   {
     init(root) {
-      const trapContainer = root.querySelector(NAV);
-
+      const trapContainer = root.matches(NAV) ? root : root.querySelector(NAV);
+      
       if (trapContainer) {
         navigation.focusTrap = FocusTrap(trapContainer, {
           Escape: onMenuClose,

--- a/src/js/components/time-picker.js
+++ b/src/js/components/time-picker.js
@@ -1,5 +1,5 @@
 const behavior = require("../utils/behavior");
-const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const { prefix: PREFIX } = require("../config");
 const { COMBO_BOX_CLASS, enhanceComboBox } = require("./combo-box");
 
@@ -124,7 +124,7 @@ const timePicker = behavior(
   {},
   {
     init(root) {
-      select(TIME_PICKER, root).forEach((timePickerEl) => {
+      selectOrMatches(TIME_PICKER, root).forEach((timePickerEl) => {
         transformTimePicker(timePickerEl);
         enhanceComboBox(timePickerEl);
       });

--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -1,5 +1,5 @@
 // Tooltips
-const select = require("../utils/select");
+const selectOrMatches = require("../utils/select-or-matches");
 const behavior = require("../utils/behavior");
 const { prefix: PREFIX } = require("../config");
 const isElementInViewport = require("../utils/is-in-viewport");
@@ -359,7 +359,7 @@ const tooltip = behavior(
   {},
   {
     init(root) {
-      select(TOOLTIP, root).forEach((tooltipTrigger) => {
+      selectOrMatches(TOOLTIP, root).forEach((tooltipTrigger) => {
         const {
           tooltipBody,
           position,

--- a/src/js/utils/select-or-matches.js
+++ b/src/js/utils/select-or-matches.js
@@ -1,0 +1,30 @@
+const select = require("./select");
+/**
+ * @name isElement
+ * @desc returns whether or not the given argument is a DOM element.
+ * @param {any} value
+ * @return {boolean}
+ */
+const isElement = (value) =>
+  value && typeof value === "object" && value.nodeType === 1;
+
+/**
+ * @name selectOrMatches
+ * @desc selects elements from the DOM by class selector or ID selector.
+ * @param {string} selector - The selector to traverse the DOM with.
+ * @param {Document|HTMLElement?} context - The context to traverse the DOM
+ *   in. If not provided, it defaults to the document.
+ * @return {HTMLElement[]} - An array of DOM nodes or an empty array.
+ */
+module.exports = (selector, context) => {
+  const selection = select(selector, context);
+  if (typeof selector !== "string") {
+    return selection;
+  }
+
+  if (isElement(context) && context.matches(selector)) {
+    selection.push(context);
+  }
+
+  return selection;
+};


### PR DESCRIPTION
# Add specs and update components to allow JS initialization on `document.body` and component element

## Description

One of the challenges we faced trying to create React components was that we couldn't initialize USWDS components at the root element of the component, and had to use a wrapper element or `document.body`.
Initializing components at `document.body` results in weird issues because the initialization could have already happened before in which case you have a mix of initialized and uninitialized components.
For example, if an accordion is added and initialized it works fine, but if another is added the original does double toggles which results in the accordion not working anymore.

The modal component is the only component that required some extra work to setup and teardown cleanly.

In general, this will make the components more flexible and easy to use, especially in scenarios where components are rendered after initial page load + USWDS init regardless of whether it's with Angular, React, jQuery, vanilla JavaScript, etc.
Fixes:
- #4300
- #3753

Potentially fixes:
- #4055

This would help when creating Angular/React wrappers if USWDS plans to do so (#2890, #2884).

### Code changes
Generally, the approach I took was to update the spec files so they initialized components at `document.body` and also the root component element. This way I could verify that at least all existing tests were still passing for both `document.body` and root component elements.

To get the new tests to work, usually it just meant to not just query the subtree of the passed in element, but also check if the passed in element itself `matches`.

The only component that required more work was the modal, due to its specific behavior.
When a modal is initialized, the modal DOM is wrapped and moved to the document.body, so using the event behaviors, this just wouldn't work in all scenario's.
I fell back to using ```document.querySelectorAll(`[aria-controls="${modalId}"]`)``` to query all openers/closers to attach toggle behavior using event listeners.
I also added some extra logic to clean up on `.off` including moving the original modal DOM back to its original place.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] ~~Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/)~~.
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] ~~Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free~~.
- [x] ~~Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.~~

---

This contribution is made on behalf of @MetroStar.