### PR TITLE
Tests: Update "Behavior" spec to test expected behavior

### DIFF
--- a/spec/unit/utils/behavior.spec.js
+++ b/spec/unit/utils/behavior.spec.js
@@ -1,82 +1,58 @@
-/* eslint-disable */
-// TODO: many of these dont test anything, use spies to ensure the methods are being called
+const sinon = require("sinon");
 const assert = require("assert");
-const Behavior = require("../../../src/js/utils/behavior");
+const behavior = require("../../../src/js/utils/behavior");
 
 describe("behavior", () => {
   it("returns an object", () => {
-    const behavior = Behavior({});
-    assert(behavior && typeof behavior === "object");
+    const component = behavior({});
+    assert(component && typeof component === "object");
   });
 
   it("has on() and off() methods", () => {
-    const behavior = Behavior({});
-    assert.strictEqual(typeof behavior.on, "function");
-    assert.strictEqual(typeof behavior.off, "function");
+    const component = behavior({});
+    assert.strictEqual(typeof component.on, "function");
+    assert.strictEqual(typeof component.off, "function");
   });
 
   describe("behavior.on()", () => {
     it("calls init()", () => {
-      const behavior = Behavior({
-        init() {
-          done();
-        },
-      });
-      behavior.on();
+      const init = sinon.spy();
+      behavior({}, { init }).on();
+      assert(init.calledOnce);
     });
 
     it("passes document.body if no target is provided", () => {
-      const behavior = Behavior({
-        init(target) {
-          assert.strictEqual(target, document.body);
-          done();
-        },
-      });
-      behavior.on();
+      const init = sinon.spy();
+      behavior({}, { init }).on();
+      assert(init.calledWithExactly(document.body));
     });
 
     it("passes the right element if a target is provided", () => {
+      const init = sinon.spy();
       const el = document.createElement("div");
-      const behavior = Behavior({
-        init(target) {
-          assert.strictEqual(target, el);
-          done();
-        },
-      });
-      behavior.on(el);
+      behavior({}, { init }).on(el);
+      assert(init.calledWithExactly(el));
     });
   });
 
   describe("behavior.off()", () => {
     it("calls teardown()", () => {
-      const behavior = Behavior({
-        teardown() {
-          done();
-        },
-      });
-      behavior.off();
+      const teardown = sinon.spy();
+      behavior({}, { teardown }).off();
+      assert(teardown.calledOnce);
     });
 
     it("passes document.body if no target is provided", () => {
-      const behavior = Behavior({
-        teardown(target) {
-          assert.strictEqual(target, document.body);
-          done();
-        },
-      });
-      behavior.off();
+      const teardown = sinon.spy();
+      behavior({}, { teardown }).off();
+      assert(teardown.calledWithExactly(document.body));
     });
 
     it("passes the right element if a target is provided", () => {
+      const teardown = sinon.spy();
       const el = document.createElement("div");
-      const behavior = Behavior({
-        teardown(target) {
-          assert.strictEqual(target, el);
-          done();
-        },
-      });
-      behavior.off(el);
+      behavior({}, { teardown }).off(el);
+      assert(teardown.calledWithExactly(el));
     });
   });
 });
-/** eslint-enable */


### PR DESCRIPTION
## Description

This pull request updates `behavior.spec.js` so as to actually test the expected behavior, using Sinon spies as a synchronous alternative to Mocha `done` callbacks.

## Additional information

The `behavior.spec.js` file is not currently testing anything meaningful, because it is passing `init` callbacks with an incorrect function signature (`behavior({ init })` vs. `behavior(events, { init })`). This is also remarked in a comment at the top of the file, accompanied by disabling all ESLint rules for the file to prevent flagging `done()` calls which reference a `done` variable that does not exist.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
