### PR TITLE
Repaired collection demo 404s

### DIFF
--- a/src/components/collection/collection--fancy-date.njk
+++ b/src/components/collection/collection--fancy-date.njk
@@ -8,7 +8,7 @@
     </div>
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
+        <a class="usa-link" href="https://trumpadministration.archives.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
       </h3>
       <p class="usa-collection__description">Today, the Administration announces the winners of the Gears of Government President’s Award. This program recognizes the contributions of individuals and teams across the federal workforce who make a profound difference in the lives of the American people.</p>
     </div>

--- a/src/components/collection/collection--media.njk
+++ b/src/components/collection/collection--media.njk
@@ -1,9 +1,9 @@
 <ul class="usa-collection">
   <li class="usa-collection__item">
-    <img class="usa-collection__img" src="https://www.performance.gov/img/GoG/gears-govt-presidents.png" alt="Gears of Government Awards - President's Award">
+    <img class="usa-collection__img" src="https://trumpadministration.archives.performance.gov/img/GoG/GoG-logo.png" alt="Gears of Government Awards - President's Award">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
+        <a class="usa-link" href="https://trumpadministration.archives.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
       </h3>
       <p class="usa-collection__description">Today, the Administration announces the winners of the Gears of Government President’s Award. This program recognizes the contributions of individuals and teams across the federal workforce who make a profound difference in the lives of the American people.</p>
       <ul class="usa-collection__meta" aria-label="More information">

--- a/src/components/collection/collection.njk
+++ b/src/components/collection/collection.njk
@@ -2,7 +2,7 @@
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       <h3 class="usa-collection__heading">
-        <a class="usa-link" href="https://www.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
+        <a class="usa-link" href="https://trumpadministration.archives.performance.gov/presidents-winners-press-release/">Gears of Government President’s Award winners</a>
       </h3>
       <p class="usa-collection__description">Today, the Administration announces the winners of the Gears of Government President’s Award. This program recognizes the contributions of individuals and teams across the federal workforce who make a profound difference in the lives of the American people.</p>
       <ul class="usa-collection__meta" aria-label="More information">


### PR DESCRIPTION
Completes https://github.com/uswds/uswds-site/issues/1320

Replaced broken icon and press release link for "gears of government" section of the collection component demo.

Relinked each to the following locations:
Press release: https://trumpadministration.archives.performance.gov/presidents-winners-press-release/
Logo: https://trumpadministration.archives.performance.gov/img/GoG/GoG-logo.png