### PR TITLE
Mobile nav: make background content inert.

### DIFF
--- a/spec/unit/navigation/navigation.spec.js
+++ b/spec/unit/navigation/navigation.spec.js
@@ -30,6 +30,7 @@ describe("navigation toggle", () => {
   const { body } = document;
 
   let sandbox;
+  let header;
   let nav;
   let navControl;
   let overlay;
@@ -44,6 +45,7 @@ describe("navigation toggle", () => {
     body.innerHTML = TEMPLATE;
     accordion.on();
     navigation.on();
+    header = body.querySelector(".usa-header");
     nav = body.querySelector(".usa-nav");
     navControl = body.querySelector(".usa-nav__link");
     overlay = body.querySelector(".usa-overlay");
@@ -107,6 +109,15 @@ describe("navigation toggle", () => {
     closeButton.click();
     assert.strictEqual(document.activeElement, menuButton);
   });
+
+  it("makes all other page content invisible to screen readers", () => {
+    menuButton.click();
+
+    const activeContent = document.querySelectorAll("body > :not([aria-hidden])");
+
+    assert.strictEqual(activeContent.length, 1);
+    assert.strictEqual(activeContent[0], header);
+  })
 
   it("collapses nav if needed on window resize", () => {
     menuButton.click();

--- a/spec/unit/navigation/template.html
+++ b/spec/unit/navigation/template.html
@@ -72,3 +72,6 @@
     </nav>
   </div>
 </header>
+
+<!-- Tests: "makes all other page content invisible to screen readers" -->
+<div id="other-content"></div>

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -93,6 +93,8 @@ const toggleNav = (active) => {
       ? INITIAL_PADDING
       : TEMPORARY_PADDING;
 
+  toggleNonNavItems(safeActive);
+
   if (safeActive && closeButton) {
     // The mobile nav was just activated. Focus on the close button, which is
     // just before all the nav elements in the tab order.
@@ -110,8 +112,6 @@ const toggleNav = (active) => {
     menuButton.focus();
   }
 
-  toggleNonNavItems(safeActive);
-
   return safeActive;
 };
 
@@ -128,7 +128,7 @@ const resize = () => {
 
 const onMenuClose = () => {
   navigation.toggleNav.call(navigation, false);
-  menuButton.focus();
+  // menuButton.focus();
 };
 
 const hideActiveNavDropdown = () => {
@@ -198,13 +198,6 @@ navigation = behavior(
       [NAV_PRIMARY]: keymap({ Escape: handleEscape }),
     },
     focusout: {
-      [NAV](event) {
-        // Close entire navigation if focus leaves,
-        // for example focusing on address bar on mobile.
-        if (!event.relatedTarget) {
-          navigation.toggleNav.call(navigation, false);
-        }
-      },
       [NAV_PRIMARY](event) {
         const nav = event.target.closest(NAV_PRIMARY);
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -27,6 +27,7 @@ const VISIBLE_CLASS = "is-visible";
 let navigation;
 let navActive;
 
+const menuButton = document.querySelector(OPENERS);
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 const SCROLLBAR_WIDTH = ScrollBarWidth();
 const INITIAL_PADDING = window
@@ -50,7 +51,6 @@ const toggleNav = (active) => {
   navigation.focusTrap.update(safeActive);
 
   const closeButton = body.querySelector(CLOSE_BUTTON);
-  const menuButton = body.querySelector(OPENERS);
 
   body.style.paddingRight =
     body.style.paddingRight === TEMPORARY_PADDING
@@ -88,7 +88,10 @@ const resize = () => {
   }
 };
 
-const onMenuClose = () => navigation.toggleNav.call(navigation, false);
+const onMenuClose = () => {
+  navigation.toggleNav.call(navigation, false);
+  menuButton.focus();
+};
 
 const hideActiveNavDropdown = () => {
   if (!navActive) {
@@ -157,6 +160,13 @@ navigation = behavior(
       [NAV_PRIMARY]: keymap({ Escape: handleEscape }),
     },
     focusout: {
+      [NAV](event) {
+        // Close entire navigation if focus leaves,
+        // for example focusing on address bar on mobile.
+        if (!event.relatedTarget) {
+          navigation.toggleNav.call(navigation, false);
+        }
+      },
       [NAV_PRIMARY](event) {
         const nav = event.target.closest(NAV_PRIMARY);
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -48,7 +48,6 @@ const hideNonNavItems = () => {
   nonNavElements.forEach((nonNavElement) => {
     nonNavElement.setAttribute("aria-hidden", true);
     nonNavElement.setAttribute(NON_NAV_HIDDEN_ATTRIBUTE, "");
-    nonNavElement.setAttribute("tabindex", "-1");
   });
 };
 
@@ -63,7 +62,6 @@ const showNonNavItems = () => {
   nonNavElements.forEach((nonNavElement) => {
     nonNavElement.removeAttribute("aria-hidden");
     nonNavElement.removeAttribute(NON_NAV_HIDDEN_ATTRIBUTE);
-    nonNavElement.removeAttribute("tabindex");
   });
 };
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -48,6 +48,7 @@ const hideNonNavItems = () => {
   nonNavElements.forEach((nonNavElement) => {
     nonNavElement.setAttribute("aria-hidden", true);
     nonNavElement.setAttribute(NON_NAV_HIDDEN_ATTRIBUTE, "");
+    nonNavElement.setAttribute("tabindex", "-1");
   });
 };
 
@@ -62,6 +63,7 @@ const showNonNavItems = () => {
   nonNavElements.forEach((nonNavElement) => {
     nonNavElement.removeAttribute("aria-hidden");
     nonNavElement.removeAttribute(NON_NAV_HIDDEN_ATTRIBUTE);
+    nonNavElement.removeAttribute("tabindex");
   });
 };
 

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -10,6 +10,7 @@ const { CLICK } = require("../events");
 const { prefix: PREFIX } = require("../config");
 
 const BODY = "body";
+const HEADER = `.${PREFIX}-header`;
 const NAV = `.${PREFIX}-nav`;
 const NAV_PRIMARY = `.${PREFIX}-nav__primary`;
 const NAV_PRIMARY_ITEM = `.${PREFIX}-nav__primary-item`;
@@ -21,7 +22,7 @@ const CLOSE_BUTTON = `.${PREFIX}-nav__close`;
 const OVERLAY = `.${PREFIX}-overlay`;
 const CLOSERS = `${CLOSE_BUTTON}, .${PREFIX}-overlay`;
 const TOGGLES = [NAV, OVERLAY].join(", ");
-const NON_NAV_ELEMENTS = `body > *:not(.usa-header):not([aria-hidden])`;
+const NON_NAV_ELEMENTS = `body > *:not(${HEADER}):not([aria-hidden])`;
 const NON_NAV_HIDDEN = `[${NON_NAV_HIDDEN_ATTRIBUTE}]`;
 
 const ACTIVE_CLASS = "usa-js-mobile-nav--active";
@@ -48,7 +49,7 @@ const hideNonNavItems = () => {
     nonNavElement.setAttribute("aria-hidden", true);
     nonNavElement.setAttribute(NON_NAV_HIDDEN_ATTRIBUTE, "");
   });
-}
+};
 
 const showNonNavItems = () => {
   nonNavElements = document.querySelectorAll(NON_NAV_HIDDEN);
@@ -62,7 +63,7 @@ const showNonNavItems = () => {
     nonNavElement.removeAttribute("aria-hidden");
     nonNavElement.removeAttribute(NON_NAV_HIDDEN_ATTRIBUTE);
   });
-}
+};
 
 // Toggle all non-header elements #3527.
 const toggleNonNavItems = (active) => {
@@ -71,7 +72,7 @@ const toggleNonNavItems = (active) => {
   } else {
     showNonNavItems();
   }
-}
+};
 
 const toggleNav = (active) => {
   const { body } = document;

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -31,7 +31,6 @@ let navigation;
 let navActive;
 let nonNavElements;
 
-const menuButton = document.querySelector(OPENERS);
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 const SCROLLBAR_WIDTH = ScrollBarWidth();
 const INITIAL_PADDING = window
@@ -87,6 +86,7 @@ const toggleNav = (active) => {
   navigation.focusTrap.update(safeActive);
 
   const closeButton = body.querySelector(CLOSE_BUTTON);
+  const menuButton = document.querySelector(OPENERS);
 
   body.style.paddingRight =
     body.style.paddingRight === TEMPORARY_PADDING
@@ -126,10 +126,7 @@ const resize = () => {
   }
 };
 
-const onMenuClose = () => {
-  navigation.toggleNav.call(navigation, false);
-  // menuButton.focus();
-};
+const onMenuClose = () => navigation.toggleNav.call(navigation, false);
 
 const hideActiveNavDropdown = () => {
   if (!navActive) {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -15,17 +15,21 @@ const NAV_PRIMARY = `.${PREFIX}-nav__primary`;
 const NAV_PRIMARY_ITEM = `.${PREFIX}-nav__primary-item`;
 const NAV_CONTROL = `button.${PREFIX}-nav__link`;
 const NAV_LINKS = `${NAV} a`;
+const NON_NAV_HIDDEN_ATTRIBUTE = `data-nav-hidden`;
 const OPENERS = `.${PREFIX}-menu-btn`;
 const CLOSE_BUTTON = `.${PREFIX}-nav__close`;
 const OVERLAY = `.${PREFIX}-overlay`;
 const CLOSERS = `${CLOSE_BUTTON}, .${PREFIX}-overlay`;
 const TOGGLES = [NAV, OVERLAY].join(", ");
+const NON_NAV_ELEMENTS = `body > *:not(.usa-header):not([aria-hidden])`;
+const NON_NAV_HIDDEN = `[${NON_NAV_HIDDEN_ATTRIBUTE}]`;
 
 const ACTIVE_CLASS = "usa-js-mobile-nav--active";
 const VISIBLE_CLASS = "is-visible";
 
 let navigation;
 let navActive;
+let nonNavElements;
 
 const menuButton = document.querySelector(OPENERS);
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
@@ -37,6 +41,38 @@ const TEMPORARY_PADDING = `${
   parseInt(INITIAL_PADDING.replace(/px/, ""), 10) +
   parseInt(SCROLLBAR_WIDTH.replace(/px/, ""), 10)
 }px`;
+
+const hideNonNavItems = () => {
+  nonNavElements = document.querySelectorAll(NON_NAV_ELEMENTS);
+
+  nonNavElements.forEach((nonNavElement) => {
+    nonNavElement.setAttribute("aria-hidden", true);
+    nonNavElement.setAttribute(NON_NAV_HIDDEN_ATTRIBUTE, "");
+  });
+}
+
+const showNonNavItems = () => {
+  nonNavElements = document.querySelectorAll(NON_NAV_HIDDEN);
+
+  if (!nonNavElements) {
+    return;
+  }
+
+  // Remove aria-hidden from non-header elements
+  nonNavElements.forEach((nonNavElement) => {
+    nonNavElement.removeAttribute("aria-hidden");
+    nonNavElement.removeAttribute(NON_NAV_HIDDEN_ATTRIBUTE);
+  });
+}
+
+// Toggle all non-header elements #3527.
+const toggleNonNavItems = (active) => {
+  if (active) {
+    hideNonNavItems();
+  } else {
+    showNonNavItems();
+  }
+}
 
 const toggleNav = (active) => {
   const { body } = document;
@@ -58,8 +94,8 @@ const toggleNav = (active) => {
       : TEMPORARY_PADDING;
 
   if (safeActive && closeButton) {
-    // The mobile nav was just activated, so focus on the close button,
-    // which is just before all the nav elements in the tab order.
+    // The mobile nav was just activated. Focus on the close button, which is
+    // just before all the nav elements in the tab order.
     closeButton.focus();
   } else if (
     !safeActive &&
@@ -73,6 +109,8 @@ const toggleNav = (active) => {
     // if they triggered the mobile nav by mistake).
     menuButton.focus();
   }
+
+  toggleNonNavItems(safeActive);
 
   return safeActive;
 };


### PR DESCRIPTION
## Description

**Mobile navigation now makes background content inert.** When the mobile navigation is active, all other non-nav content is hidden. This prevents accidentally leaving the focus of the active mobile menu. Closes #3527.

## Additional information

- Uses the same technique as USA Modal by adding `aria-hidden` to background elements
- Adds a unit test to test that non-header content is hidden to screenreaders in [`navigation.spec.js:113`](https://github.com/uswds/uswds/pull/4411/files#diff-51bf3f9de7a2b5a598c1649c91bb3a606170d64591d455e1d356d70d034d8a88R113)

### How to test
1. Go to [Kitchen sink example](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-a11y-mobile-nav-dialog/components/preview/kitchen-sink.html)
2. Resize to get mobile menu
3. Inspect content and ensure there aren't any `aria-hidden` or `data-nav-hidden` attributes
4. Toggle the menu
5. Verify `.usa-header` siblings get `aria-hidden` and `data-nav-hidden` when active and disappear when menu is closed (via <kbd>ESC</kbd>, clicking close button, or clicking overlay).

**⚠️Note**
This work hides non-related header content from voiceover rotor. Now you can only jump to header items when the mobile navigation is active.

 This does **not** resolve the <kbd>CMD+L</kbd> focus issue mentioned in the original report. Which happens on USA Modal active too. Checking for `focusOut` on the header results in other issues (like not being able to inspect the navigation). Doesn't seem worth the tradeoff.

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
