### PR TITLE
File upload: Confirm file upload to screenreaders.

### DIFF
--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -129,7 +129,7 @@ const buildFileInput = (fileInputEl) => {
   instructions.classList.add(INSTRUCTIONS_CLASS);
   instructions.setAttribute("aria-hidden", "true");
   dropTarget.classList.add(TARGET_CLASS);
- 
+
   // Adds child elements to the DOM
   fileInputEl.parentNode.insertBefore(dropTarget, fileInputEl);
   fileInputEl.parentNode.insertBefore(fileInputParent, dropTarget);
@@ -201,8 +201,6 @@ const removeOldPreviews = (dropTarget, instructions) => {
     }
     Array.prototype.forEach.call(filePreviews, removeImages);
   }
-
-  
 };
 
 /**
@@ -216,20 +214,30 @@ const removeOldPreviews = (dropTarget, instructions) => {
 const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const fileNames = e.target.files;
   const filePreviewsHeading = document.createElement("div");
-  let   fileStore = [];
 
   // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
-
-  //set aria-label to assume no file selected
+  // Then set aria-label to reflect empty fileList
   fileInputEl.setAttribute("aria-label", "No files selected");
-  //enocurage screenreader to read out aria-label on state change
+  // And enocurage screenreader to read out aria on any state change
   fileInputEl.setAttribute("aria-live", "polite");
-  
+
   // Iterates through files list and creates previews
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
+    let   fileStore = [];
+
+    //help screenreaders read out the selected content
+    //Push selected file names into the array
+    fileStore.push(' ' + fileName);
+
+    //read out the file name array with the the appropriate aria-label, options based on file count
+    if (i === 0) {
+      fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileName);
+    } else if (i >= 1) {
+      fileInputEl.setAttribute("aria-label", "You have selected " + fileNames.length + " files:" + fileStore);
+    } 
 
     // Starts with a loading image while preview is created
     reader.onloadstart = function createLoadingImage() {
@@ -241,24 +249,12 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
           <img id="${imageId}" src="${SPACER_GIF}" alt="" class="${GENERIC_PREVIEW_CLASS_NAME} ${LOADING_CLASS}"/>${fileName}
         <div>`
       );
-
-      //help screenreaders read out the selected content
-      //Build array with the selected file names
-      fileStore.push(' ' + fileName);
-
-      //add the appropriate aria-label based on item count
-      if (i === 0) {
-        fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileName);
-      } else if (i >= 1) {
-        fileInputEl.setAttribute("aria-label", "You have selected " + fileNames.length + " files:" + fileStore);
-      } 
     };
 
     // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
       const imageId = createUniqueID(makeSafeForID(fileName));
       const previewImage = document.getElementById(imageId);
-
       if (fileName.indexOf(".pdf") > 0) {
         previewImage.setAttribute(
           "onerror",
@@ -300,8 +296,6 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
     if (fileNames[i]) {
       reader.readAsDataURL(fileNames[i]);
     }
-    
-    
 
     // Adds heading above file previews, pluralizes if there are multiple
     if (i === 0) {
@@ -311,7 +305,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
       dropTarget.insertBefore(filePreviewsHeading, instructions);
       filePreviewsHeading.innerHTML = Sanitizer.escapeHTML`${
         i + 1
-      } files selected <span class="usa-file-input__choose" >Change files</span>`;
+      } files selected <span class="usa-file-input__choose">Change files</span>`;
     }
 
     // Hides null state content and sets preview heading class

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -219,17 +219,18 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
   // Encourage screenreader to read out aria change immediately following upload status change
   fileInputEl.setAttribute("aria-live", "polite");
-  // Then set aria-label to assume empty fileList.
-  // This is helpful in case is able to clear selection by cancelling 
+  // Then set aria-label to assume empty fileList. This is helpful in case user is able to clear selection by cancelling task
   fileInputEl.setAttribute("aria-label", "No file selected");
   // Then get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
 
-  // Iterates through files list and creates previews; creates name 
+  // Iterates through files list and:
+  // 1. Adds selected file list names to aria-label
+  // 2. Creates previews
+  
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
-
     //accessibility - help screenreaders read out names the selected files
     //Push updated file names into the store array
     fileStore.push(' ' + fileName);

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -201,6 +201,8 @@ const removeOldPreviews = (dropTarget, instructions) => {
     }
     Array.prototype.forEach.call(filePreviews, removeImages);
   }
+
+  
 };
 
 /**
@@ -214,9 +216,11 @@ const removeOldPreviews = (dropTarget, instructions) => {
 const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const fileNames = e.target.files;
   const filePreviewsHeading = document.createElement("div");
+  let   fileStore = [];
 
   // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
+  
 
   // Iterates through files list and creates previews
   for (let i = 0; i < fileNames.length; i += 1) {
@@ -233,12 +237,21 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
           <img id="${imageId}" src="${SPACER_GIF}" alt="" class="${GENERIC_PREVIEW_CLASS_NAME} ${LOADING_CLASS}"/>${fileName}
         <div>`
       );
+
+      fileStore.push(' ' + fileName);
+
+      if (i === 0) {
+        fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileStore);
+      } else if (i >= 1) {
+        fileInputEl.setAttribute("aria-label", "You have selected the files:" + fileStore);
+      } 
     };
 
     // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
       const imageId = createUniqueID(makeSafeForID(fileName));
       const previewImage = document.getElementById(imageId);
+
       if (fileName.indexOf(".pdf") > 0) {
         previewImage.setAttribute(
           "onerror",
@@ -279,8 +292,9 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
     if (fileNames[i]) {
       reader.readAsDataURL(fileNames[i]);
-      fileInputEl.setAttribute("aria-label", "You have selected the file " + fileName);
     }
+    
+    
 
     // Adds heading above file previews, pluralizes if there are multiple
     if (i === 0) {
@@ -290,7 +304,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
       dropTarget.insertBefore(filePreviewsHeading, instructions);
       filePreviewsHeading.innerHTML = Sanitizer.escapeHTML`${
         i + 1
-      } files selected <span class="usa-file-input__choose">Change files</span>`;
+      } files selected <span class="usa-file-input__choose" >Change files</span>`;
     }
 
     // Hides null state content and sets preview heading class

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -129,7 +129,7 @@ const buildFileInput = (fileInputEl) => {
   instructions.classList.add(INSTRUCTIONS_CLASS);
   instructions.setAttribute("aria-hidden", "true");
   dropTarget.classList.add(TARGET_CLASS);
-
+ 
   // Adds child elements to the DOM
   fileInputEl.parentNode.insertBefore(dropTarget, fileInputEl);
   fileInputEl.parentNode.insertBefore(fileInputParent, dropTarget);
@@ -279,6 +279,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
     if (fileNames[i]) {
       reader.readAsDataURL(fileNames[i]);
+      fileInputEl.setAttribute("aria-label", "You have selected the file " + fileName);
     }
 
     // Adds heading above file previews, pluralizes if there are multiple

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -221,19 +221,19 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const filePreviewsHeading = document.createElement("div");
   const fileStore = [];
 
-  // Then get rid of existing previews
+  // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
 
-  // Iterates through files list and:
-  // 1. Adds selected file list names to aria-label
-  // 2. Creates previews
+  // Then, iterate through files list and:
+  // 1. Add selected file list names to aria-label
+  // 2. Create previews
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
-    // Help screenreaders read out names of the selected files
+
     // Push updated file names into the store array
     fileStore.push(fileName);
-
+    
     // read out the store array via aria-label, wording options vary based on file count
     if (i === 0) {
       fileInputEl.setAttribute("aria-label", `You have selected the file: ${fileName}`);

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -217,14 +217,14 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const filePreviewsHeading = document.createElement("div");
   let   fileStore = [];
 
-  // And enocurage screenreader to read out aria on any state change
+  // Enocurage screenreader to read out aria on any state change
   fileInputEl.setAttribute("aria-live", "polite");
-
-  // First, get rid of existing previews
-  removeOldPreviews(dropTarget, instructions);
- 
   // Then set aria-label to reflect empty fileList
   fileInputEl.setAttribute("aria-label", "");
+  // Then get rid of existing previews
+  removeOldPreviews(dropTarget, instructions);
+ 
+
 
   // Iterates through files list and creates previews
   for (let i = 0; i < fileNames.length; i += 1) {

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -217,27 +217,26 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const filePreviewsHeading = document.createElement("div");
   let   fileStore = [];
 
-  // Enocurage screenreader to read out aria on any state change
+  // Encourage screenreader to read out aria change immediately following upload status change
   fileInputEl.setAttribute("aria-live", "polite");
-  // Then set aria-label to reflect empty fileList
-  fileInputEl.setAttribute("aria-label", "");
+  // Then set aria-label to assume empty fileList.
+  // This is helpful in case is able to clear selection by cancelling 
+  fileInputEl.setAttribute("aria-label", "No file selected");
   // Then get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
- 
 
-
-  // Iterates through files list and creates previews
+  // Iterates through files list and creates previews; creates name 
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
 
-    //help screenreaders read out the selected content
-    //Push selected file names into the array
+    //accessibility - help screenreaders read out names the selected files
+    //Push updated file names into the store array
     fileStore.push(' ' + fileName);
 
-    //read out the file name array with the the appropriate aria-label, options based on file count
+    //read out the store array via aria-label, wording options vary based on file count
     if (i === 0) {
-      fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileName);
+      fileInputEl.setAttribute("aria-label", "You have selected the file: " + fileName);
     } else if (i >= 1) {
       fileInputEl.setAttribute("aria-label", "You have selected " + fileNames.length + " files:" + fileStore);
     } 

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -220,8 +220,12 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
 
   // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
-  
 
+  //set aria-label to assume no file selected
+  fileInputEl.setAttribute("aria-label", "No files selected");
+  //enocurage screenreader to read out aria-label on state change
+  fileInputEl.setAttribute("aria-live", "polite");
+  
   // Iterates through files list and creates previews
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
@@ -238,12 +242,15 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
         <div>`
       );
 
+      //help screenreaders read out the selected content
+      //Build array with the selected file names
       fileStore.push(' ' + fileName);
 
+      //add the appropriate aria-label based on item count
       if (i === 0) {
-        fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileStore);
+        fileInputEl.setAttribute("aria-label", "You have selected the file:" + fileName);
       } else if (i >= 1) {
-        fileInputEl.setAttribute("aria-label", "You have selected the files:" + fileStore);
+        fileInputEl.setAttribute("aria-label", "You have selected " + fileNames.length + " files:" + fileStore);
       } 
     };
 

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -211,22 +211,25 @@ const removeOldPreviews = (dropTarget, instructions) => {
  * @param {HTMLElement} instructions - text to inform users to drag or select files
  * @param {HTMLElement} dropTarget - target area div that encases the input
  */
+
 const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const fileNames = e.target.files;
   const filePreviewsHeading = document.createElement("div");
+  let   fileStore = [];
+
+  // And enocurage screenreader to read out aria on any state change
+  fileInputEl.setAttribute("aria-live", "polite");
 
   // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
+ 
   // Then set aria-label to reflect empty fileList
-  fileInputEl.setAttribute("aria-label", "No files selected");
-  // And enocurage screenreader to read out aria on any state change
-  fileInputEl.setAttribute("aria-live", "polite");
+  fileInputEl.setAttribute("aria-label", "");
 
   // Iterates through files list and creates previews
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
-    let   fileStore = [];
 
     //help screenreaders read out the selected content
     //Push selected file names into the array

--- a/src/js/components/file-input.js
+++ b/src/js/components/file-input.js
@@ -129,6 +129,8 @@ const buildFileInput = (fileInputEl) => {
   instructions.classList.add(INSTRUCTIONS_CLASS);
   instructions.setAttribute("aria-hidden", "true");
   dropTarget.classList.add(TARGET_CLASS);
+  // Encourage screenreader to read out aria changes immediately following upload status change
+  fileInputEl.setAttribute("aria-live", "polite");
 
   // Adds child elements to the DOM
   fileInputEl.parentNode.insertBefore(dropTarget, fileInputEl);
@@ -143,11 +145,13 @@ const buildFileInput = (fileInputEl) => {
     disable(fileInputEl);
   }
 
-  // Sets instruction test based on whether or not multiple files are accepted
+  // Sets instruction test and aria-label based on whether or not multiple files are accepted
   if (acceptsMultiple) {
     instructions.innerHTML = Sanitizer.escapeHTML`<span class="${DRAG_TEXT_CLASS}">Drag files here or </span><span class="${CHOOSE_CLASS}">choose from folder</span>`;
+    fileInputEl.setAttribute("aria-label", "No files selected");
   } else {
     instructions.innerHTML = Sanitizer.escapeHTML`<span class="${DRAG_TEXT_CLASS}">Drag file here or </span><span class="${CHOOSE_CLASS}">choose from folder</span>`;
+    fileInputEl.setAttribute("aria-label", "No file selected");
   }
 
   // IE11 and Edge do not support drop files on file inputs, so we've removed text that indicates that
@@ -215,31 +219,26 @@ const removeOldPreviews = (dropTarget, instructions) => {
 const handleChange = (e, fileInputEl, instructions, dropTarget) => {
   const fileNames = e.target.files;
   const filePreviewsHeading = document.createElement("div");
-  let   fileStore = [];
+  const fileStore = [];
 
-  // Encourage screenreader to read out aria change immediately following upload status change
-  fileInputEl.setAttribute("aria-live", "polite");
-  // Then set aria-label to assume empty fileList. This is helpful in case user is able to clear selection by cancelling task
-  fileInputEl.setAttribute("aria-label", "No file selected");
   // Then get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
 
   // Iterates through files list and:
   // 1. Adds selected file list names to aria-label
   // 2. Creates previews
-  
   for (let i = 0; i < fileNames.length; i += 1) {
     const reader = new FileReader();
     const fileName = fileNames[i].name;
-    //accessibility - help screenreaders read out names the selected files
-    //Push updated file names into the store array
-    fileStore.push(' ' + fileName);
+    // Help screenreaders read out names of the selected files
+    // Push updated file names into the store array
+    fileStore.push(fileName);
 
-    //read out the store array via aria-label, wording options vary based on file count
+    // read out the store array via aria-label, wording options vary based on file count
     if (i === 0) {
-      fileInputEl.setAttribute("aria-label", "You have selected the file: " + fileName);
+      fileInputEl.setAttribute("aria-label", `You have selected the file: ${fileName}`);
     } else if (i >= 1) {
-      fileInputEl.setAttribute("aria-label", "You have selected " + fileNames.length + " files:" + fileStore);
+      fileInputEl.setAttribute("aria-label", `You have selected ${fileNames.length} files: ${fileStore.join(", ")}`);
     } 
 
     // Starts with a loading image while preview is created


### PR DESCRIPTION
## Description
[Preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-file-upload-confirmation/components/detail/file-input.html)

**File upload confirms files to screenreaders.**  Closes #4232. Now file input will tell screenreaders how many files were uploaded and their names on upload.

## Additional information

Based off of Amy's work in #4406. By default the file input will say `No file(s) uploaded`. And on file upload it will change to `You have selected {{ NUMBER_OF_FILES }} files: {{ FILES_LISTED }}`. When a user clears files, it'll go back to the default message.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
