### PR TITLE
Forms: Add required field guidance to Sign In form.

### DIFF
--- a/src/components/templates/sign-in-form.njk
+++ b/src/components/templates/sign-in-form.njk
@@ -1,9 +1,13 @@
 <form class="usa-form">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-legend--large">{{ form.legend }}</legend>
+    <p>
+      Required fields are marked with an asterisk (<abbr title="required" class="usa-hint usa-hint--required">*</abbr>).
+    </p>
     {# Email #}
     <label class="usa-label" for="{{ form.email.input.id }}">
       {{ form.email.label }}
+      <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <input
       class="usa-input"
@@ -18,6 +22,7 @@
     {# Password #}
     <label class="usa-label" for="{{ form.password.input.id }}">
       {{ form.password.label }}
+      <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <input
       class="usa-input"


### PR DESCRIPTION
## Description

**Sign in form includes updated required field guidance.** The sign in form template has required field instructions at the top of the form and required fields marked with an asterisk.

Related to https://github.com/uswds/uswds-site/issues/1354.

## Additional information

  Original guidance was provided in [issue #3691 -  Form controls: labeling required fields](https://github.com/uswds/uswds/issues/3691#issuecomment-710312597).

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
