### PR TITLE
USWDS - Datepicker: Fix regression causing issues for Safari.

### DIFF
--- a/src/js/components/date-picker.js
+++ b/src/js/components/date-picker.js
@@ -1128,7 +1128,12 @@ const renderCalendar = (el, _dateToDisplay) => {
 
   const tableBody = createTableBody(datesGrid);
   table.insertAdjacentElement("beforeend", tableBody);
-  newCalendar.insertAdjacentElement("beforeend", table);
+
+  // Container for Years, Months, and Days
+  const datePickerCalendarContainer =
+    newCalendar.querySelector(CALENDAR_DATE_PICKER);
+
+  datePickerCalendarContainer.insertAdjacentElement("beforeend", table);
 
   calendarEl.parentNode.replaceChild(newCalendar, calendarEl);
 
@@ -2191,7 +2196,7 @@ const datePickerEvents = {
       validateDateInput(this);
     },
     [DATE_PICKER](event) {
-      if (!event.relatedTarget || !this.contains(event.target)) {
+      if (!this.contains(event.relatedTarget)) {
         hideCalendar(this);
       }
     },

--- a/src/js/components/date-picker.js
+++ b/src/js/components/date-picker.js
@@ -2191,7 +2191,7 @@ const datePickerEvents = {
       validateDateInput(this);
     },
     [DATE_PICKER](event) {
-      if (!this.contains(event.relatedTarget)) {
+      if (!event.relatedTarget || !this.contains(event.target)) {
         hideCalendar(this);
       }
     },


### PR DESCRIPTION
## Description

**Fixed Date Picker selection in Safari.** Date selection now works as expected in Safari. Closes #4446.

## Additional information

Newly generated Calendar date table was being placed as a sibling of `usa-date-picker__calendar__date-picker`, instead of being a child element.

**Expected markup**
```html
<div tabindex="-1" class="usa-date-picker__calendar__date-picker">
  <div class="usa-date-picker__calendar__row"></div>
  <table class="usa-date-picker__calendar__table" role="presentation"></table>
</div>
```

**Actual**
```html
<div tabindex="-1" class="usa-date-picker__calendar__date-picker">
  <div class="usa-date-picker__calendar__row"></div>
</div>
<table class="usa-date-picker__calendar__table" role="presentation"></table>
```


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
