### PR TITLE
[Dropdown]: Ensure select chevron is visible in forced colors mode.

### DIFF
--- a/src/stylesheets/elements/form-controls/_dropdown.scss
+++ b/src/stylesheets/elements/form-controls/_dropdown.scss
@@ -22,4 +22,11 @@
     color: transparent;
     text-shadow: 0 0 0 color("black");
   }
+  
+   // Necessary to show chevron in forced colors mode in modern browsers. 
+   @media (forced-colors: active) {
+    appearance: listbox; // Default <select> appearance value for modern browsers.
+    background-image: none;
+    padding-right: 0;
+  }
 }

--- a/src/stylesheets/elements/form-controls/_dropdown.scss
+++ b/src/stylesheets/elements/form-controls/_dropdown.scss
@@ -23,9 +23,9 @@
     text-shadow: 0 0 0 color("black");
   }
   
-   // Necessary to show chevron in forced colors mode in modern browsers. 
-   @media (forced-colors: active) {
-    appearance: listbox; // Default <select> appearance value for modern browsers.
+  // Necessary to show chevron in forced colors mode in modern browsers
+  @media (forced-colors: active) {
+    appearance: listbox; // Default <select> appearance value for modern browsers
     background-image: none;
     padding-right: 0;
   }

--- a/src/stylesheets/elements/form-controls/_dropdown.scss
+++ b/src/stylesheets/elements/form-controls/_dropdown.scss
@@ -22,7 +22,7 @@
     color: transparent;
     text-shadow: 0 0 0 color("black");
   }
-  
+
   // Necessary to show chevron in forced colors mode in modern browsers
   @media (forced-colors: active) {
     appearance: listbox; // Default <select> appearance value for modern browsers


### PR DESCRIPTION
## Ensure select chevron is visible in forced colors mode

Resolves #4454. This PR ensures that a chevron is visible when users are in forced colors mode no matter the theme they select. 

## Additional information

For more information on styling for forced colors see: https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
