### PR TITLE
Fix Sanitizer export for Webpack 🐛.

### DIFF
--- a/src/js/utils/sanitizer.js
+++ b/src/js/utils/sanitizer.js
@@ -13,16 +13,10 @@
  *  https://wiki.mozilla.org/User:Fbraun/Gaia/SafeinnerHTMLRoadmap
  *
  */
-(function (root, factory) {
-  'use strict';
-  if (typeof define === 'function' && define.amd) {
-    define(factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory();
-  } else {
-    root.Sanitizer = factory();
-  }
-}(this, function () {
+
+!(function (factory) {
+  module.exports = factory();
+})(function () {
   'use strict';
 
   var Sanitizer = {
@@ -99,4 +93,4 @@
 
   return Sanitizer;
 
-}));
+});


### PR DESCRIPTION
## Description

**Simplified Sanitizer script export.** The minified file of USWDS.js was not exporting properly. Now the export is simplified and works in both `uswds.js` and `uswds.min.js`. Closes #4455.

## Additional information
- This was **only** happening on the minified version of USWDS.js
- Similar to work done for SVG4Everybody polyfill in PR #4035. 

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
