### PR TITLE
USCIS: Export other artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "default": "./dist/js/uswds.min.js"
     },
     "./src/js/components": "./src/js/components/index.js",
-    "./src/js/components/*": "./src/js/components/*.js"
+    "./src/js/components/*": "./src/js/components/*.js",
     "./js/*": "./dist/js/*",
     "./css/*": "./dist/css/*",
     "./scss/*": "./dist/scss/*",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     },
     "./src/js/components": "./src/js/components/index.js",
     "./src/js/components/*": "./src/js/components/*.js"
+    "./js/*": "./dist/js/*",
+    "./css/*": "./dist/css/*",
+    "./scss/*": "./dist/scss/*",
+    "./img/*": "./dist/img*",
+    "./fonts/*": "./dist/fonts"
   },
   "types": "./index.d.ts",
   "main": "dist/js/uswds.min.js",


### PR DESCRIPTION
Webpack 5 enforces correct export rules and thus prevents importing things like uswds.css.

<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Upgrading to webpack 5 in our project caused our import of the css to break. The proposed change allows us to continue using this project without a fork/hack/or holding back a webpack upgrade.

## Additional information

I don't have the webpack change on hand, but if I run across it again i'll update this ticket.

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
