### PR TITLE
USWDS - Add package exports for fonts and img src directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     },
     "./src/js/components": "./src/js/components/index.js",
     "./src/js/components/*": "./src/js/components/*.js",
+    "./src/fonts/*": "./src/fonts/*",
+    "./src/img/*": "./src/img/*",
     "./js/*": "./dist/js/*",
     "./css/*": "./dist/css/*",
     "./scss/*": "./dist/scss/*",


### PR DESCRIPTION
## USWDS - Add package exports for fonts and img src directories

## Description

After upgrading our project that uses USWDS to react-scripts v5.0.0 which uses Webpack 5. The following errors surfaced when trying to build our app

`
ModuleNotFoundError: Module not found: Error: Package path ./src/fonts/roboto-mono/roboto-mono-v5-latin-300.woff2 is not exported from package /Users/pearl/Projects/mymove/node_modules/uswds (see exports field in /Users/pearl/Projects/mymove/node_modules/uswds/package.json)
`

and

`
ModuleNotFoundError: Module not found: Error: Package path ./src/img/correct8.svg is not exported from package /Users/pearl/Projects/mymove/node_modules/uswds (see exports field in /Users/pearl/Projects/mymove/node_modules/uswds/package.json)
`

The changes in this PR resolves both issues