### PR TITLE
[Docs] - [CONTRIBUTING]: Fix broken "Browser Support" link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ For JavaScript contributions, we will review the code coverage percentage and ch
 High code coverage numbers are generally good, and we would prefer that our coverage increases over time. We will not categorically reject contributions that reduce code coverage, but we may ask contributors to refactor their code, add new unit tests, or modify existing tests to avoid significant reductions in coverage.
 
 ## Browser support
-See [browser support](https://designsystem.digital.gov/getting-started/developers/#browser-support) in the “Getting started: Developers” guidelines.
+See [browser support](https://designsystem.digital.gov/documentation/developers/#browser-support) in the “Developer Documentation”.
 
 ## Our use of branches
 


### PR DESCRIPTION
## Description

Current link [here](https://designsystem.digital.gov/documentation/code-guidelines/#browser-support) in documentation goes to a 404 page