### PR TITLE
USWDS - Combobox: add aria-controls for 508 compliance

### DIFF
--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -210,6 +210,7 @@ const enhanceComboBox = (_comboBoxEl) => {
   const input = document.createElement("input");
   input.setAttribute("id", selectId);
   input.setAttribute("aria-owns", listId);
+  input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-describedby", assistiveHintID);
   input.setAttribute("aria-expanded", "false");

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -209,6 +209,7 @@ const enhanceComboBox = (_comboBoxEl) => {
   // sanitize doesn't like functions in template literals
   const input = document.createElement("input");
   input.setAttribute("id", selectId);
+  input.setAttribute("aria-owns", listId);
   input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-describedby", assistiveHintID);

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -209,7 +209,7 @@ const enhanceComboBox = (_comboBoxEl) => {
   // sanitize doesn't like functions in template literals
   const input = document.createElement("input");
   input.setAttribute("id", selectId);
-  input.setAttribute("aria-owns", listId);
+  input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-describedby", assistiveHintID);
   input.setAttribute("aria-expanded", "false");

--- a/src/js/components/combo-box.js
+++ b/src/js/components/combo-box.js
@@ -210,7 +210,6 @@ const enhanceComboBox = (_comboBoxEl) => {
   const input = document.createElement("input");
   input.setAttribute("id", selectId);
   input.setAttribute("aria-owns", listId);
-  input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-describedby", assistiveHintID);
   input.setAttribute("aria-expanded", "false");


### PR DESCRIPTION
Update the combobox input aria attributes to include aria-controls. 

Addresses issue [#1359 for uswds-site](https://github.com/uswds/uswds-site/issues/1359)

This addition aligns with the [Aria 1.1 combobox recommendations](https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html)
