### PR TITLE
Beta sass modules - fix module loop in function color()

### DIFF
--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -15,31 +15,30 @@ Derive a color from a color shortcode
 @use "../../tokens/color/shortcodes-color-system" as *;
 @use "../../tokens/color/assignments-theme-color" as *;
 
-
 @function color($value, $flags...) {
+  // Create lists of single items 
   $value: general.unpack($value);
 
+  // If theme color is found, prepare that value to be parsed by $system-color-shortcodes
   @if map.has-key($assignments-theme-color, $value) {
     $value: map.get($assignments-theme-color, $value);
-    @if $value == false {
-      @if list.index($flags, set-theme) {
-        @return $value;
-      }
-      @error 'error: set to false';
-    }
-    @if meta.type-of($value) == string {
-      $value: string.quote($value);
-    }
   }
 
-  // If it's a color, return that color
-  // Withhold warning if "no-warn" flag
+  // If theme or system color is found, return that value
+  @if map.has-key($system-color-shortcodes, $value) {
+    $quote: general.smart-quote($value);
+    $value: map.get($system-color-shortcodes, $value);
+    @return $value;
+  }
 
-  @if meta.type-of($value) == color {
-    @if list.index($flags, "override") or list.index($flags, "set-theme") {
+  // If color is NOT found in theme or system colors
+  // Check if there is an acceptable value that can be passed into the system with flags 
+  // Acceptable values: False and non-token css color values 
+  @if meta.type-of($value) == color or $value == false {
+    @if list.index($flags, 'override') or list.index($flags, 'set-theme') {
       // override + no-warn will skip warnings
-      @if list.index($flags, "no-warn") {
-        @return "no-warn"
+      @if list.index($flags, no-warn) {
+        @return $value;
       }
 
       @if $theme-show-compile-warnings {
@@ -50,47 +49,39 @@ Derive a color from a color shortcode
     }
   }
 
-  // False values may be passed through when setting theme colors
-  @if $value == false {
-    @if list.index($flags, set-theme) {
-      @return $value;
-    }
-  }
-
-  // Now, any value should be evaluated as a token
-
-  @if map.has-key($system-color-shortcodes, $value) {
-    $value: general.smart-quote($value);
-    $our-color: map.get($system-color-shortcodes, $value);
-    @if $our-color == false {
-      @error '`#{$value}` is a color that does not exist '
-        + 'or is set to false.';
-    }
-    @return $our-color;
-  }
-
+  // If no acceptable value found, return an error
   @error '`#{$value}` is not a valid USWDS color token. '
       + 'See designsystem.digital.gov/design-tokens/color '
       + 'for more information.';
 }
 
-@debug color("orange-80v");
+@debug color('orange-80v');
 // @return #352313;
-@debug color("primary-dark");
+@debug color('primary-dark');
 // @return #1a4480;
 @debug color($theme-color-accent-warm-dark);
 // @return #c05600;
-@debug color("info");
+@debug color('info');
 // @return #00bde3
+@debug color(orange, set-theme, no-warn);
+// @return orange 
+@debug color(#ff0, set-theme, no-warn);
+// @return #ff0 
+@debug color(rgba(0,0,0,1), set-theme, no-warn);
+// @return black
 @debug color(green, set-theme);
-// @return Warning: Override: `green` is not a USWDS color token.
+// @return green with Warning: Override: `green` is not a USWDS color token.
+@debug color(green, override);
+// @return green with Warning: Override: `green` is not a USWDS color token.
+@debug color('primary-lightest', set-theme);
+// @return false
+
+// these should result in errors
+// @debug color(green);
+// error: '"green" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
 //@debug color(#f00);
 // @return error: '"#f00" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
-// @debug color(orange);
-// error: '"orange" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
 // @debug color(hamburgers);
 // error: '"hamburgers" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
-// @debug color("primary-lightest");
+@debug color('primary-lightest');
 // @return error: set to false;
-// @debug color("primary-lightest", set-theme);
-// @return false

--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -10,8 +10,7 @@ Derive a color from a color shortcode
 @use "sass:meta";
 @use "sass:string";
 @use "../../functions/general";
-@use "../../settings/settings-color" as *;
-@use "../../settings/settings-general" as *;
+@use "../../settings" as *;
 @use "../../tokens/color/shortcodes-color-system" as *;
 @use "../../tokens/color/assignments-theme-color" as *;
 
@@ -31,9 +30,8 @@ Derive a color from a color shortcode
     @return $value;
   }
 
-  // If color is NOT found in theme or system colors
-  // Check if there is an acceptable value that can be passed into the system with flags 
-  // Acceptable values: False and non-token css color values 
+  // If not a theme or system color, check if there is an acceptable value that can be passed into the system via flags 
+  // Acceptable values: False, non-token css color values 
   @if meta.type-of($value) == color or $value == false {
     @if list.index($flags, 'override') or list.index($flags, 'set-theme') {
       // override + no-warn will skip warnings
@@ -50,9 +48,7 @@ Derive a color from a color shortcode
   }
 
   // If no acceptable value found, return an error
-  @error '`#{$value}` is not a valid USWDS color token. '
-      + 'See designsystem.digital.gov/design-tokens/color '
-      + 'for more information.';
+  @return general.error-not-token($value, "color");
 }
 
 @debug color('orange-80v');

--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -5,24 +5,30 @@ color()
 Derive a color from a color shortcode
 ----------------------------------------
 */
-
+@use "sass:list";
 @use "sass:map";
 @use "sass:meta";
 @use "sass:string";
-@use "../../settings";
 @use "../../functions/general";
+@use "../../settings/settings-color" as *;
 @use "../../tokens/color/shortcodes-color-system" as *;
-@use "../../tokens/color/shortcodes-color-project" as *;
+@use "../../tokens/color/assignments-theme-color" as *;
+
 
 @function color($value, $flags...) {
   $value: general.unpack($value);
 
+  @if map.has-key($assignments-theme-color, $value) {
+    $var: map.get($assignments-theme-color, $value);
+    $value: string.quote($var);
+  }
+
   // Non-token colors may be passed with specific flags
   @if meta.type-of($value) == color {
     // override or set-theme will allow any color
-    @if index($flags, override) or index($flags, set-theme) {
+    @if list.index($flags, override) or list.index($flags, set-theme) {
       // override + no-warn will skip warnings
-      @if index($flags, no-warn) {
+      @if list.index($flags, no-warn) {
         @return $value;
       }
 
@@ -36,7 +42,7 @@ Derive a color from a color shortcode
 
   // False values may be passed through when setting theme colors
   @if $value == false {
-    @if index($flags, set-theme) {
+    @if list.index($flags, set-theme) {
       @return $value;
     }
   }
@@ -54,8 +60,9 @@ Derive a color from a color shortcode
     @return $our-color;
   }
 
+  /*
   // If we're using the theme flag, $project-color-shortcodes has not yet been set
-  @if not index($flags, set-theme) {
+  @if not list.index($flags, set-theme) {
     @if map.has-key($project-color-shortcodes, $value) {
       $our-color: (map.get($project-color-shortcodes, $value));
       @if $our-color == false {
@@ -65,14 +72,19 @@ Derive a color from a color shortcode
       @return $our-color;
     }
   }
+  */
 
   @return general.error-not-token($value, "color");
 }
 
-// @debug color("orange-80v");
+@debug color("orange-80v");
 // @return #352313;
-// @debug color("primary-dark");
+@debug color("primary-dark");
 // @return #1a4480;
+@debug color($theme-color-accent-warm-dark);
+// @return #c05600;
+@debug color("info");
+// @return #00bde3
 // @debug color("primary-lightest");
 // @return error: set to false;
 // @debug color(#f00);

--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -90,7 +90,7 @@ Derive a color from a color shortcode
 // error: '"orange" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
 // @debug color(hamburgers);
 // error: '"hamburgers" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
-@debug color("primary-lightest");
+// @debug color("primary-lightest");
 // @return error: set to false;
-@debug color("primary-lightest", set-theme);
+// @debug color("primary-lightest", set-theme);
 // @return false

--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -48,7 +48,6 @@ Derive a color from a color shortcode
   }
 
   // Now, any value should be evaluated as a token
-
   $value: general.smart-quote($value);
 
   @if map.has-key($system-color-shortcodes, $value) {
@@ -59,20 +58,6 @@ Derive a color from a color shortcode
     }
     @return $our-color;
   }
-
-  /*
-  // If we're using the theme flag, $project-color-shortcodes has not yet been set
-  @if not list.index($flags, set-theme) {
-    @if map.has-key($project-color-shortcodes, $value) {
-      $our-color: (map.get($project-color-shortcodes, $value));
-      @if $our-color == false {
-        @error '`#{$value}` is a color that does not exist '
-          + 'or is set to false.';
-      }
-      @return $our-color;
-    }
-  }
-  */
 
   @return general.error-not-token($value, "color");
 }

--- a/src/stylesheets/core/functions/utilities/color.scss
+++ b/src/stylesheets/core/functions/utilities/color.scss
@@ -11,6 +11,7 @@ Derive a color from a color shortcode
 @use "sass:string";
 @use "../../functions/general";
 @use "../../settings/settings-color" as *;
+@use "../../settings/settings-general" as *;
 @use "../../tokens/color/shortcodes-color-system" as *;
 @use "../../tokens/color/assignments-theme-color" as *;
 
@@ -19,17 +20,26 @@ Derive a color from a color shortcode
   $value: general.unpack($value);
 
   @if map.has-key($assignments-theme-color, $value) {
-    $var: map.get($assignments-theme-color, $value);
-    $value: string.quote($var);
+    $value: map.get($assignments-theme-color, $value);
+    @if $value == false {
+      @if list.index($flags, set-theme) {
+        @return $value;
+      }
+      @error 'error: set to false';
+    }
+    @if meta.type-of($value) == string {
+      $value: string.quote($value);
+    }
   }
 
-  // Non-token colors may be passed with specific flags
+  // If it's a color, return that color
+  // Withhold warning if "no-warn" flag
+
   @if meta.type-of($value) == color {
-    // override or set-theme will allow any color
-    @if list.index($flags, override) or list.index($flags, set-theme) {
+    @if list.index($flags, "override") or list.index($flags, "set-theme") {
       // override + no-warn will skip warnings
-      @if list.index($flags, no-warn) {
-        @return $value;
+      @if list.index($flags, "no-warn") {
+        @return "no-warn"
       }
 
       @if $theme-show-compile-warnings {
@@ -48,9 +58,9 @@ Derive a color from a color shortcode
   }
 
   // Now, any value should be evaluated as a token
-  $value: general.smart-quote($value);
 
   @if map.has-key($system-color-shortcodes, $value) {
+    $value: general.smart-quote($value);
     $our-color: map.get($system-color-shortcodes, $value);
     @if $our-color == false {
       @error '`#{$value}` is a color that does not exist '
@@ -59,7 +69,9 @@ Derive a color from a color shortcode
     @return $our-color;
   }
 
-  @return general.error-not-token($value, "color");
+  @error '`#{$value}` is not a valid USWDS color token. '
+      + 'See designsystem.digital.gov/design-tokens/color '
+      + 'for more information.';
 }
 
 @debug color("orange-80v");
@@ -70,7 +82,15 @@ Derive a color from a color shortcode
 // @return #c05600;
 @debug color("info");
 // @return #00bde3
-// @debug color("primary-lightest");
+@debug color(green, set-theme);
+// @return Warning: Override: `green` is not a USWDS color token.
+//@debug color(#f00);
+// @return error: '"#f00" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
+// @debug color(orange);
+// error: '"orange" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
+// @debug color(hamburgers);
+// error: '"hamburgers" is not a valid USWDS color token. See designsystem.digital.gov/design-tokens/color for more information.'
+@debug color("primary-lightest");
 // @return error: set to false;
-// @debug color(#f00);
-// @return error: not a valid token;
+@debug color("primary-lightest", set-theme);
+// @return false

--- a/src/stylesheets/core/tokens/color/assignments-theme-color.scss
+++ b/src/stylesheets/core/tokens/color/assignments-theme-color.scss
@@ -62,4 +62,6 @@ $assignments-theme-color: (
   "disabled-light": settings.$theme-color-disabled-light,
   "disabled": settings.$theme-color-disabled,
   "disabled-dark": settings.$theme-color-disabled-dark,
+  "emergency": settings.$theme-color-emergency,
+  "emergency-dark": settings.$theme-color-emergency-dark,
 );

--- a/src/stylesheets/core/tokens/color/shortcodes-color-state.scss
+++ b/src/stylesheets/core/tokens/color/shortcodes-color-state.scss
@@ -38,4 +38,4 @@ $tokens-color-state: (
     color(settings.$theme-color-emergency-dark, set-theme, no-warn),
 );
 
-@debug $tokens-color-state;
+// @debug $tokens-color-state;


### PR DESCRIPTION
To prevent module looping, I rebuilt aspects of the function color() so that it points to assignments-theme-color instead of shortcodes-color-project (which is dependent on the color function). 

This is still unrefined and I don't fully understand the ramifications of the change on the system, but figured it could be a good conversation starter. 

Note: There is a chance the 'set-theme' and 'no-warn' flags were essential for the theme colors to be built correctly, and this scratches those right out. 

[Color function success criteria](https://github.com/uswds/uswds/pull/3258) 