### PR TITLE
Time Picker: Preserve initial input value in Time Picker component

### DIFF
--- a/spec/unit/time-picker/time-picker.spec.js
+++ b/spec/unit/time-picker/time-picker.spec.js
@@ -62,6 +62,16 @@ describe("time picker component", () => {
       "transfers required attribute to combo box"
     );
     assert.strictEqual(
+      select.value,
+      "13:00",
+      "transfers value attribute to combo box"
+    );
+    assert.strictEqual(
+      input.value,
+      "1:00pm",
+      "transfers value attribute to combo box"
+    );
+    assert.strictEqual(
       select.getAttribute("name"),
       "appointment-time",
       "should not transfer name attribute to combo box"
@@ -71,9 +81,6 @@ describe("time picker component", () => {
       null,
       "should not transfer name attribute to combo box"
     );
-
-    assert.strictEqual(select.value, "", "the select value should be empty");
-    assert.strictEqual(input.value, "", "the input should be empty");
   });
 
   it("should focus the first item found in the list from the query when pressing down from the input", () => {

--- a/spec/unit/time-picker/time-picker.template.html
+++ b/spec/unit/time-picker/time-picker.template.html
@@ -9,7 +9,7 @@
       id="appointment-time"
       name="appointment-time"
       type="text"
-      value="1:00pm"
+      data-default-value="1:00pm"
       required
     />
   </div>

--- a/spec/unit/time-picker/time-picker.template.html
+++ b/spec/unit/time-picker/time-picker.template.html
@@ -9,6 +9,7 @@
       id="appointment-time"
       name="appointment-time"
       type="text"
+      value="13:00"
       required
     />
   </div>

--- a/spec/unit/time-picker/time-picker.template.html
+++ b/spec/unit/time-picker/time-picker.template.html
@@ -9,7 +9,7 @@
       id="appointment-time"
       name="appointment-time"
       type="text"
-      value="13:00"
+      value="1:00pm"
       required
     />
   </div>

--- a/spec/unit/time-picker/time-picker.template.html
+++ b/spec/unit/time-picker/time-picker.template.html
@@ -9,7 +9,7 @@
       id="appointment-time"
       name="appointment-time"
       type="text"
-      data-default-value="1:00pm"
+      value="1:00pm"
       required
     />
   </div>

--- a/src/components/time-picker/time-picker.config.yml
+++ b/src/components/time-picker/time-picker.config.yml
@@ -1,1 +1,11 @@
 preview: "@uswds-form"
+
+variants:
+  - name: default
+    label: Default
+
+  - name: default-value
+    label: Default Value
+    context:
+      timePicker:
+        defaultValue: "13:00"

--- a/src/components/time-picker/time-picker.config.yml
+++ b/src/components/time-picker/time-picker.config.yml
@@ -8,4 +8,4 @@ variants:
     label: Default Value
     context:
       timePicker:
-        defaultValue: "13:00"
+        defaultValue: "1:00pm"

--- a/src/components/time-picker/time-picker.njk
+++ b/src/components/time-picker/time-picker.njk
@@ -2,6 +2,13 @@
   <label class="usa-label" id="appointment-time-label" for="appointment-time">Appointment time</label>
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
   <div class="usa-time-picker">
-    <input class="usa-input" id="appointment-time" name="appointment-time" type="text" aria-describedby="appointment-time-label appointment-time-hint">
+    <input
+      class="usa-input"
+      id="appointment-time"
+      name="appointment-time"
+      type="text"
+      aria-describedby="appointment-time-label appointment-time-hint"
+      {% if timePicker.defaultValue %}value="{{ timePicker.defaultValue }}"{% endif %}
+    >
   </div>
 </div>

--- a/src/components/time-picker/time-picker.njk
+++ b/src/components/time-picker/time-picker.njk
@@ -8,7 +8,7 @@
       name="appointment-time"
       type="text"
       aria-describedby="appointment-time-label appointment-time-hint"
-      {% if timePicker.defaultValue %}value="{{ timePicker.defaultValue }}"{% endif %}
+      {% if timePicker.defaultValue %}data-default-value="{{ timePicker.defaultValue }}"{% endif %}
     >
   </div>
 </div>

--- a/src/components/time-picker/time-picker.njk
+++ b/src/components/time-picker/time-picker.njk
@@ -8,7 +8,7 @@
       name="appointment-time"
       type="text"
       aria-describedby="appointment-time-label appointment-time-hint"
-      {% if timePicker.defaultValue %}data-default-value="{{ timePicker.defaultValue }}"{% endif %}
+      {% if timePicker.defaultValue %}value="{{ timePicker.defaultValue }}"{% endif %}
     >
   </div>
 </div>

--- a/src/js/components/time-picker.js
+++ b/src/js/components/time-picker.js
@@ -104,7 +104,7 @@ const transformTimePicker = (el) => {
     const option = document.createElement("option");
     option.value = `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`;
     option.text = `${hour12}:${padZeros(minute, 2)}${ampm}`;
-    if (option.text === initialInputEl.value) {
+    if (option.text === initialInputEl.dataset.defaultValue) {
       defaultValue = option.value;
     }
     selectEl.appendChild(option);

--- a/src/js/components/time-picker.js
+++ b/src/js/components/time-picker.js
@@ -104,7 +104,7 @@ const transformTimePicker = (el) => {
     const option = document.createElement("option");
     option.value = `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`;
     option.text = `${hour12}:${padZeros(minute, 2)}${ampm}`;
-    if (option.text === initialInputEl.dataset.defaultValue) {
+    if (option.text === initialInputEl.value) {
       defaultValue = option.value;
     }
     selectEl.appendChild(option);

--- a/src/js/components/time-picker.js
+++ b/src/js/components/time-picker.js
@@ -113,6 +113,7 @@ const transformTimePicker = (el) => {
     timePickerEl.dataset[key] = FILTER_DATASET[key];
   });
   timePickerEl.dataset.disableFiltering = "true";
+  timePickerEl.dataset.defaultValue = initialInputEl.value;
 
   timePickerEl.appendChild(selectEl);
   initialInputEl.style.display = "none";

--- a/src/js/components/time-picker.js
+++ b/src/js/components/time-picker.js
@@ -97,12 +97,16 @@ const transformTimePicker = (el) => {
     Math.max(MIN_STEP, timePickerEl.dataset.step || DEFAULT_STEP)
   );
 
+  let defaultValue;
   for (let time = minTime; time <= maxTime; time += step) {
     const { minute, hour24, hour12, ampm } = getTimeContext(time);
 
     const option = document.createElement("option");
     option.value = `${padZeros(hour24, 2)}:${padZeros(minute, 2)}`;
     option.text = `${hour12}:${padZeros(minute, 2)}${ampm}`;
+    if (option.text === initialInputEl.value) {
+      defaultValue = option.value;
+    }
     selectEl.appendChild(option);
   }
 
@@ -113,7 +117,7 @@ const transformTimePicker = (el) => {
     timePickerEl.dataset[key] = FILTER_DATASET[key];
   });
   timePickerEl.dataset.disableFiltering = "true";
-  timePickerEl.dataset.defaultValue = initialInputEl.value;
+  timePickerEl.dataset.defaultValue = defaultValue;
 
   timePickerEl.appendChild(selectEl);
   initialInputEl.style.display = "none";


### PR DESCRIPTION
Partially addresses #4331

## Description

This pull request resolves an issue where if an enhanced Time Picker input has a value, the value is discarded during initialization, thereby preventing a developer from including an initial value for a time picker element.

## Additional information

Note that the Fractal component variant was based on a [similar Date Picker default value variant](https://github.com/uswds/uswds/blob/d9d4b91233aa8e650a32107fd58cde47278589ac/src/components/date-picker/date-picker.config.yml#L15-L19), but in that case the default value is expected to be assigned using a [`data-default-value` attribute](https://github.com/uswds/uswds/blob/d9d4b91233aa8e650a32107fd58cde47278589ac/src/components/date-picker/date-picker.njk#L6). ~Here, I chose instead to let the native `value` attribute be used since it is likely to be more intuitively understood as a way to control the input value, though I am open to revising this to `data-default-value` for consistency's sake.~ **Edit:** Per feedback, changed to `data-default-value` in [731748f](https://github.com/uswds/uswds/pull/4488/commits/731748f2c5ae05338fddbb46b1e04893f7c20f3c).

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
