### PR TITLE
3.0 beta: export artifacts for use by Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
       "default": "./dist/js/uswds.min.js"
     },
     "./src/js/components": "./src/js/components/index.js",
-    "./src/js/components/*": "./src/js/components/*.js"
+    "./src/js/components/*": "./src/js/components/*.js",
+    "./src/fonts/*": "./src/fonts/*",
+    "./src/img/*": "./src/img/*",
+    "./js/*": "./dist/js/*",
+    "./css/*": "./dist/css/*",
+    "./scss/*": "./dist/scss/*",
+    "./img/*": "./dist/img/*",
+    "./fonts/*": "./dist/fonts/*"
   },
   "types": "./index.d.ts",
   "main": "dist/js/uswds.min.js",


### PR DESCRIPTION
## Description

PRs #4468 and #4461 add exports to package.json so Webpack 5 can access font/img/etc assets. These changes are missing in the 3.0 betas

## Remaining issue

The structure of the `./src` directory changed from v2 to v3, which is causing the `./src/js/components` exports in the package.json file to not point at anything. This issue still needs to be resolved, but will require a little discussion in a ticket. EDIT ticket has been created #4507