### PR TITLE
Move global outputted CSS from `uswds-required` to `uswds-global` folder

### DIFF
--- a/src/stylesheets/core/placeholders/_forms.scss
+++ b/src/stylesheets/core/placeholders/_forms.scss
@@ -27,7 +27,3 @@ $input-select-margin-right: 1.5;
   }
 }
 
-// Don't show dotted underline with "required" asterisk because it can cause legibility issues ad appear as an ellipsis...
-abbr[title="required"] {
-  text-decoration: none;
-}

--- a/src/stylesheets/global/_forms.scss
+++ b/src/stylesheets/global/_forms.scss
@@ -1,0 +1,4 @@
+// Don't show dotted underline with "required" asterisk because it can cause legibility issues ad appear as an ellipsis...
+abbr[title="required"] {
+  text-decoration: none;
+}

--- a/src/stylesheets/packages/_uswds-global.scss
+++ b/src/stylesheets/packages/_uswds-global.scss
@@ -1,6 +1,7 @@
 // Global
 // -------------------------------------
 @import "../lib/normalize";
+@import "../global/forms";
 @import "../global/font-face";
 @import "../global/focus";
 @import "../global/sizing";


### PR DESCRIPTION
# Description 

In v2, importing `_uswds-required.scss` didn't cause any CSS to output. It just defined mixins/functions. In v3, a single `abbr[title="required"]` statement is outputted.

From what I can figure out, `uswds-required` should be idepotent, and `uswds-global` should be what outputs global CSS (though let me know if that understanding is incorrect).

## Additional information

This commit reverts that change and goes back to the v2 behavior.

I believe this issue was introduced in commit https://github.com/uswds/uswds/commit/df175b5916fb5cca5cb380f918fd5e1b1a85018e.

Comparing the generated CSS file before and after this PR gives the following `diff`. Although it does move the location of this CSS statement, it has a different specificity to most other CSS selectors in the file so it's unlikely to cause any issues.
```
30,33d29
< abbr[title=required]{
<   text-decoration:none;
< }
<
633a630,633
> }
>
> abbr[title=required]{
>   text-decoration:none;
```

We are exploring using [CSS Modules](https://github.com/css-modules/css-modules) to style our [Next.js](https://nextjs.org/) React application. Our hope is to be able to pull in the `uswds-required` file to set up all the mixins/functions, and then use those mixins/functions from our CSS Modules file. However, CSS Modules require *all* generated CSS to be wrapped in class/ID selectors. Having `uswds-required` output a single `attr[title="required"]` causes this to break, and the CSS Modules to not compile.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] (N/A) Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] (N/A) Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
