### PR TITLE
USWDS: Radio Button & Checkbox - Windows High Contrast Support

### DIFF
--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -55,6 +55,10 @@
       background: color($input-bg-color);
       box-shadow: 0 0 0 units($theme-input-select-border-width)
         adjust-color(color($input-text-color), $alpha: $input-border-alpha);
+      @media (forced-colors: active) {
+        outline: 2px solid transparent;
+        outline-offset: units(2px);
+      }
     }
   }
   .usa-checkbox__input,
@@ -64,11 +68,17 @@
         background-color: color($input-active-color);
         box-shadow: 0 0 0 units($theme-input-select-border-width)
           color($input-active-color);
+        @media (forced-colors: active) {
+          background-color: ButtonText;
+        }
       }
     }
     &:disabled {
       @include format-label {
         color: $color-input-disabled;
+        @media (forced-colors: active) {
+          color: GrayText;
+        }
       }
       @include format-input {
         background-color: color($input-bg-color);
@@ -90,6 +100,9 @@
             $alpha: -0.9
           );
           border-color: color($input-active-color);
+          @media (forced-colors: active) {
+            background-color: CanvasText;
+          }
         }
       }
       &:disabled:checked {

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -117,7 +117,7 @@
     &:checked,
     &:checked:disabled {
       @include format-input {
-        @include add-background-svg("$input-checkmark");
+        @include add-background-svg($input-checkmark);
       }
 
       @media (forced-colors: active) {

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -98,7 +98,7 @@
           );
           border-color: color($input-active-color);
           @media (forced-colors: active) {
-            background-color: CanvasText;
+            border: ButtonText solid units("05");
           }
         }
       }
@@ -114,7 +114,13 @@
     &:checked,
     &:checked:disabled {
       @include format-input {
-        @include add-background-svg($input-checkmark);
+        @include add-background-svg("$input-checkmark");
+      }
+
+      @media (forced-colors: active) {
+        @include format-input {
+          @include add-background-svg("correct8-alt");
+        }
       }
     }
     &:checked:disabled {
@@ -220,6 +226,14 @@
         background-color: color("white");
         content: "\2714";
         text-align: center;
+      }
+
+      @media (forced-colors: active) {
+        background-color: ButtonText;
+
+        &--tile {
+          background-color: ButtonText;
+        }
       }
     }
   }

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -68,9 +68,6 @@
         background-color: color($input-active-color);
         box-shadow: 0 0 0 units($theme-input-select-border-width)
           color($input-active-color);
-        @media (forced-colors: active) {
-          background-color: ButtonText;
-        }
       }
     }
     &:disabled {
@@ -133,6 +130,9 @@
             color($input-active-color),
           inset 0 0 0 units($theme-input-select-border-width)
             color($input-bg-color);
+        @media (forced-colors: active) {
+          background-color: ButtonText;
+        }
       }
     }
     &:checked:disabled {

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -58,7 +58,7 @@
 
       @media (forced-colors: active) {
         outline: 2px solid transparent;
-        outline-offset: units(2px);
+        outline-offset: 2px;
       }
     }
   }

--- a/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
+++ b/src/stylesheets/elements/form-controls/_checkbox-and-radio.scss
@@ -55,6 +55,7 @@
       background: color($input-bg-color);
       box-shadow: 0 0 0 units($theme-input-select-border-width)
         adjust-color(color($input-text-color), $alpha: $input-border-alpha);
+
       @media (forced-colors: active) {
         outline: 2px solid transparent;
         outline-offset: units(2px);
@@ -73,6 +74,7 @@
     &:disabled {
       @include format-label {
         color: $color-input-disabled;
+
         @media (forced-colors: active) {
           color: GrayText;
         }
@@ -97,6 +99,7 @@
             $alpha: -0.9
           );
           border-color: color($input-active-color);
+
           @media (forced-colors: active) {
             border: ButtonText solid units("05");
           }
@@ -136,6 +139,7 @@
             color($input-active-color),
           inset 0 0 0 units($theme-input-select-border-width)
             color($input-bg-color);
+
         @media (forced-colors: active) {
           background-color: ButtonText;
         }


### PR DESCRIPTION
## Previews

[Radio Button →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/cm-radio-high-contrast/components/detail/radio-buttons--default.html)

[Checkbox →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/cm-radio-high-contrast/components/detail/checkbox--default.html)

## Description

Resolves #4469  checkbox & radio button issues

Currently, the radio button and checkbox components are missing important visual queues for users implementing Windows High Contrast mode including the buttons/boxes themselves, when a selection has been made, and a visual queue of disabled form options.

This PR adds `forced-colors: active` settings to ensure visibility for all users.

Because most of the stylings are shared between Radio + Checkbox, it was easiest to fix together.

## Additional information

### Radio Buttons

**Currently:**

Default

![image](https://user-images.githubusercontent.com/25211650/153276569-dc69554d-6ad2-49c8-bd34-e1e7eee62252.png)

Tile

![image](https://user-images.githubusercontent.com/25211650/153276968-9e76c44a-393c-4003-a3a5-bbfebd045603.png)

**After Fix:**

_// Note: Bolder border around Radio button / checkbox indicates focus_

Default:

![image](https://user-images.githubusercontent.com/25211650/153277508-be258731-7e99-4bfb-b95c-e5b98a1e3b85.png)

Tile:

![image](https://user-images.githubusercontent.com/25211650/153673621-bb2031bb-7b80-4b3a-b079-befdb7d34f5b.png)

### Checkbox

**Currently**

Default:

![image](https://user-images.githubusercontent.com/25211650/153277962-b47c6391-919b-4e47-b54f-a75e24c8bc47.png)

Tile:

![image](https://user-images.githubusercontent.com/25211650/153278101-19caf43e-8982-45b4-94e7-24f5ebd57b8b.png)

**After Fix**

Default:

![image](https://user-images.githubusercontent.com/25211650/153672482-352ff94d-b0e5-41ca-925b-4db5207360ae.png)


Tile:

![image](https://user-images.githubusercontent.com/25211650/153672514-4ece7215-5dd3-47d6-ae07-7a27f57de5cf.png)

The checkmark will not show in both cases due to the limitations of forced-colors mode being able to determine light or dark themes, to switch between the light and dark versions of the checkmark.

Our thinking was that the dark high contrast themes are more frequently used than the light themes, so the broader user base will get the most similar checkboxes, stylistically speaking, while the light users still maintain a functional componen

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
