### PR TITLE
USWDS: Range Slider - Fixes high contrast visibility

### DIFF
--- a/src/stylesheets/elements/form-controls/_range-input.scss
+++ b/src/stylesheets/elements/form-controls/_range-input.scss
@@ -18,6 +18,7 @@
   border: none;
   box-shadow: 0 0 0 units($theme-input-select-border-width) color("base");
   cursor: pointer;
+
   @media (forced-colors: active) {
     outline: 2px solid transparent;
   }

--- a/src/stylesheets/elements/form-controls/_range-input.scss
+++ b/src/stylesheets/elements/form-controls/_range-input.scss
@@ -1,6 +1,9 @@
 @mixin range-focus {
   background-color: color("white");
   box-shadow: 0 0 0 units(2px) color($theme-focus-color);
+  // @media (forced-colors: active) {
+  //   outline: 2px solid transparent;
+  // }
 }
 
 @mixin range-track {
@@ -18,6 +21,9 @@
   border: none;
   box-shadow: 0 0 0 units($theme-input-select-border-width) color("base");
   cursor: pointer;
+  @media (forced-colors: active) {
+    outline: 2px solid transparent;
+  }
 }
 
 @mixin range-ms-fill {

--- a/src/stylesheets/elements/form-controls/_range-input.scss
+++ b/src/stylesheets/elements/form-controls/_range-input.scss
@@ -1,9 +1,6 @@
 @mixin range-focus {
   background-color: color("white");
   box-shadow: 0 0 0 units(2px) color($theme-focus-color);
-  // @media (forced-colors: active) {
-  //   outline: 2px solid transparent;
-  // }
 }
 
 @mixin range-track {


### PR DESCRIPTION
## Preview

[Range Slider →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/cm-hc-range-slider/components/detail/range-slider.html)

## Description

Resolves #4469 - Range Slider issue

This PR adds an outline to the range slider handle (or "thumb") when high contrast mode is detected

## Additional information

Currently:

![image](https://user-images.githubusercontent.com/25211650/153293313-74e3d365-5cec-43e4-a6c2-248a509cddee.png)

After Fix:

![image](https://user-images.githubusercontent.com/25211650/153293371-6263bafe-b739-4120-8f54-b01eb55c2ad0.png)



Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
