### PR TITLE
Banner: Update banner copy and spec (#4419)

### DIFF
--- a/spec/unit/banner/template.html
+++ b/spec/unit/banner/template.html
@@ -6,7 +6,7 @@
                     <img class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="U.S. flag">
                 </div>
                 <div class="grid-col-fill tablet:grid-col-auto">
-                    <p class="usa-banner__header-text">An official website of the United States government</p>
+                    <p class="usa-banner__header-text">This is a United States government website</p>
                     <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
                 </div>
                 <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">

--- a/src/components/banner/banner.config.yml
+++ b/src/components/banner/banner.config.yml
@@ -3,7 +3,7 @@ status: ready
 
 context:
   banner:
-    text: "An official website of the United States government"
+    text: "This is a United States government website"
     action: "Here’s how you know"
     aria_label: "Official government website"
   domain:


### PR DESCRIPTION
## Description

 Updates the banner text to the more accessible text suggested in #4419

## Additional information
 - [The identifier component](https://designsystem.digital.gov/components/identifier/) is unchanged in this PR. The more flexible structure of that component makes the suggested text somewhat inappropriate, as the article preceding the `<Parent agency>` depends on the parent agency content, eg, `This is a United States Government website` vs `This is an Environmental Protection Agency website`.
 - One possible alternative is simply dropping the leading `An` from the original copy, ie, `Official website of the United States Government`. This would allow the same copy to exist for both `Banner` and `Identifier`.
