### PR TITLE
USWDS - Accordion: Windows High Contrast Mode

### DIFF
--- a/src/stylesheets/components/_accordions.scss
+++ b/src/stylesheets/components/_accordions.scss
@@ -3,6 +3,34 @@
 $accordion-border: units($theme-accordion-border-width) solid
   color($theme-accordion-border-color);
 
+// Maps for Icons
+
+$icon-object: (
+  "color": currentColor,
+  "svg-height": 24,
+  "svg-width": 24,
+  "height": units(3),
+);
+
+$add-icon: map-merge(
+  $icon-object,
+  (
+    "name": "add",
+  )
+);
+
+$remove-icon: map-merge(
+  $icon-object,
+  (
+    "name": "remove",
+  )
+);
+
+$after: "after";
+$icon-margin: "auto";
+$vertical-align: "auto";
+$contrast-bg: default;
+
 // Accordion Styles
 
 @mixin accordion-list-styles {
@@ -16,7 +44,13 @@ $accordion-border: units($theme-accordion-border-width) solid
 // scss-lint:disable PropertyCount
 @mixin accordion-button-styles {
   @include button-unstyled;
-  @include add-background-svg("usa-icons/remove");
+  @include place-icon(
+    $remove-icon,
+    $after,
+    $icon-margin,
+    $vertical-align,
+    $contrast-bg
+  );
 
   background-color: color("base-lightest");
   background-position: right units(2.5) center;
@@ -39,8 +73,17 @@ $accordion-border: units($theme-accordion-border-width) solid
 // scss-lint:enable PropertyCount
 
 @mixin accordion-button-unopened-styles {
-  @include add-background-svg("usa-icons/add");
-  background-size: units(3);
+  @include place-icon(
+    $add-icon,
+    $after,
+    $icon-margin,
+    $vertical-align,
+    $contrast-bg
+  );
+  &::after {
+    height: 100%;
+    background-color: ButtonText;
+  }
 }
 
 @mixin accordion-nested-list {
@@ -109,6 +152,23 @@ $accordion-border: units($theme-accordion-border-width) solid
 
 .usa-accordion__button {
   @include accordion-button-styles;
+
+  // Anchor for add/remove icons
+  position: relative;
+
+  &::after {
+    right: 0;
+    top: 0;
+    height: 100%;
+    content: "";
+    position: absolute;
+    margin: 0 units(2.5) 0 0;
+    background-color: ButtonText;
+  }
+
+  @media (forced-colors: active) {
+    outline: 2px solid transparent;
+  }
 }
 
 .usa-accordion__button[aria-expanded="false"] {


### PR DESCRIPTION
## Description

Resolves #4517 accordion issues

Replaced the `add-background-svg` functions with `place-icon` in order to ensure visibility in Windows High Contrast mode. 

## Additional information

Currently:

![image](https://user-images.githubusercontent.com/25211650/153949053-92b5812d-531b-4da7-9bc4-226ae4db3913.png)

After fix:

![image](https://user-images.githubusercontent.com/25211650/153949119-5daba60c-6bd2-4c03-97f9-37a7e323b90e.png)

Works with light or dark themes

![image](https://user-images.githubusercontent.com/25211650/153949214-3dd1af68-9214-4b93-8ab3-a726081462fb.png)

### Default view

This solution maintains appearance outside of WHC as well.

![image](https://user-images.githubusercontent.com/25211650/153949847-ece066ca-6394-4b50-a62c-22d1ab45836c.png)

_Current build on left // Fix build on the right_




Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
