### PR TITLE
USWDS - Pagination: Added stylings for Windows High Contrast mode

### DIFF
--- a/src/stylesheets/components/_pagination.scss
+++ b/src/stylesheets/components/_pagination.scss
@@ -124,6 +124,10 @@ $pagination-hover-token: nth($pagination-link-tokens, 2);
   &:active {
     color: color($pagination-hover-token);
     border-color: color($pagination-hover-token);
+
+    @media (forced-colors: active) {
+      border: 2px solid buttonText;
+    }
   }
 }
 
@@ -137,12 +141,21 @@ $pagination-hover-token: nth($pagination-link-tokens, 2);
   border-color: transparent;
   color: color($text-color);
 
+  @media (forced-colors: active) {
+    outline: 2px solid buttonText;
+    color: buttonText;
+  }
+
   &:hover,
   &:focus,
   &:active {
     background-color: color($pagination-current-color);
     color: color($text-color);
     text-decoration: none;
+
+    @media (forced-colors: active) {
+      color: buttontext;
+    }
   }
 }
 


### PR DESCRIPTION
## Preview

[Pagination →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/cm-hc-pagination/components/detail/pagination--default.html)

## Description

Resolves #4517 Pagination issues

Adds `forced-color` stylings for support in Windows High Contrast mode.

Before, the current page did not have depictive stylings so users could not easily see which page they are on, versus what is next or previous. This is mostly a problem in the unbounded variant where there are 4 page numbers grouped together.

## Additional information

Default:

![image](https://user-images.githubusercontent.com/25211650/154349579-75163f76-9d03-47ae-98b4-4768d3281565.png)

Unbounded:

![image](https://user-images.githubusercontent.com/25211650/154352226-7873af98-b064-4fdb-91c7-c64fc7a3cf46.png)



Current w/ high contrast:

![image](https://user-images.githubusercontent.com/25211650/154350426-75b7ad0d-4c11-4d4e-8809-965f158d0f93.png)
![image](https://user-images.githubusercontent.com/25211650/154352938-2197d8a9-7bd5-4deb-a1e1-b842dca2ebb4.png)


Fix w/ high contrast:

![image](https://user-images.githubusercontent.com/25211650/154350648-1380b223-614a-49d1-bac2-9540c8573c03.png)
![image](https://user-images.githubusercontent.com/25211650/154352978-312ea81f-2f78-4813-a99e-27c6e682e16f.png)




Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
