### PR TITLE
USWDS: Banner - WHC fix

### DIFF
--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -141,6 +141,12 @@ $banner-icon-close: (
     middle,
     $theme-banner-background-color
   );
+
+  &::after {
+    @media (forced-colors: active) {
+      background-color: buttonText;
+    }
+  }
   @include set-link-from-bg(
     $theme-banner-background-color,
     $theme-banner-link-color,

--- a/src/stylesheets/components/_banner.scss
+++ b/src/stylesheets/components/_banner.scss
@@ -238,6 +238,12 @@ $banner-icon-close: (
     margin-left: units(1);
     position: relative;
 
+    @media (forced-colors: active) {
+      &:after,
+      &:hover::after {
+        background-color: buttonText;
+      }
+    }
     &:after {
       position: absolute;
     }
@@ -277,6 +283,12 @@ $banner-icon-close: (
         @include u-pin("y");
         @include u-pin("right");
       }
+
+      @media (forced-colors: active) {
+        &::after {
+          background-color: buttonText;
+        }
+      }
     }
 
     @include at-media("tablet") {
@@ -290,6 +302,13 @@ $banner-icon-close: (
       height: auto;
       padding: units(0);
       position: relative;
+
+      @media (forced-colors: active) {
+        &:after,
+        &:hover::after {
+          background-color: buttonText;
+        }
+      }
 
       &:after {
         position: absolute;


### PR DESCRIPTION
## Description

Resolves #4517 banner issues

Icons would disappear in high contrast mode, causing users to lose critical information that the banner could be expanded.

Because the icons were already placed using `place-icon()`, the fix was simply adding `@media (forced-colors:active)` stylings.

## Additional information

Currently:

_Desktop_
![image](https://user-images.githubusercontent.com/25211650/155390586-77209c81-4664-4bad-8967-959128c72838.png)


_Mobile_
![image](https://user-images.githubusercontent.com/25211650/155390192-c45fd025-5cfd-48d1-9354-4e6a3592b8ff.png)

After Fix:

_Desktop_
![image](https://user-images.githubusercontent.com/25211650/155390451-e40588ae-e2b2-48ce-95cb-b569ffa87d4c.png)

_Mobile_
![image](https://user-images.githubusercontent.com/25211650/155390508-a06df1bb-a17e-4181-b699-065cb853bc8f.png)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
