### PR TITLE
USWDS Footer - bug fix: reveal hidden content at 480px window width

### DIFF
--- a/src/js/components/footer.js
+++ b/src/js/components/footer.js
@@ -48,7 +48,7 @@ module.exports = behavior(
     init() {
       toggleHidden(window.innerWidth < HIDE_MAX_WIDTH);
       this.mediaQueryList = window.matchMedia(
-        `(max-width: ${HIDE_MAX_WIDTH}px)`
+        `(max-width: ${HIDE_MAX_WIDTH - 1}px)`
       );
       this.mediaQueryList.addListener(resize);
     },

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -313,7 +313,7 @@
 
       @include at-media("mobile-lg") {
         cursor: auto;
-        
+
         &::before {
           content: none;
         }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -312,6 +312,8 @@
       }
 
       @include at-media("mobile-lg") {
+        cursor: auto;
+        
         &::before {
           content: none;
         }


### PR DESCRIPTION
## Description

From [jkjustjoshing](https://github.com/jkjustjoshing) in issue https://github.com/uswds/uswds/issues/4524
> The CSS to switch between the collapsed and expanded view of the "big footer" uses the media query `(min-width: 30em)` but the Javascript uses the media query `(max-width: 30em)`. This causes an edge case at exactly 30em (480px) viewport width.

## Resolution
To get expected behavior at 30em(480px), we must allow min-width rules to dominate and reset the max-width value to be 1px less than the breakpoint.

Also fixed the cursor behavior on the headers when the content is not collapsed (and the headers are no longer actionable)

Closes https://github.com/uswds/uswds/issues/4524