### PR TITLE
Change fractal output directory to standard Federalist setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 
 # ignore the Fractal build directory
 build/
+_site/
 
 # ignore gulp-generated vendor files
 src/stylesheets/lib

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 !dist/
 !src/
 
+_site/
 build/
 coverage/
 spec/

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-# when publishing on Federalist, build only the files in ./build
-# (where Fractal puts everything)
-source: build

--- a/fractal.config.js
+++ b/fractal.config.js
@@ -51,7 +51,7 @@ web.theme(
 
 web.set("static.path", "dist");
 web.set("static.mount", "dist");
-// output files to /build
-web.set("builder.dest", "build");
+// output files to /_site
+web.set("builder.dest", "_site");
 
 module.exports = fractal;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "version": "gulp build release",
     "watch": "NODE_ENV=development nswatch",
     "prettier:scss": "npx prettier --write ./src/stylesheets/**/*.scss",
-    "prettier:templates": "npx prettier --write './build/components/render/*.html'"
+    "prettier:templates": "npx prettier --write './_site/components/render/*.html'"
   },
   "watch": {
     "src/stylesheets/**/*.scss": "build:css",

--- a/spec/unit/file-input/file-input-disabled.spec.js
+++ b/spec/unit/file-input/file-input-disabled.spec.js
@@ -3,7 +3,7 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const RENDER = "../../../build/components/render/";
+const RENDER = "../../../_site/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--disabled.html")
 );

--- a/spec/unit/file-input/file-input.spec.js
+++ b/spec/unit/file-input/file-input.spec.js
@@ -3,7 +3,7 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const RENDER = "../../../build/components/render/";
+const RENDER = "../../../_site/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--multiple.html")
 );

--- a/spec/unit/file-input/single-file-input.spec.js
+++ b/spec/unit/file-input/single-file-input.spec.js
@@ -3,7 +3,7 @@ const fileInput = require("../../../src/js/components/file-input");
 const fs = require("fs");
 const path = require("path");
 
-const RENDER = "../../../build/components/render/";
+const RENDER = "../../../_site/components/render/";
 const TEMPLATE = fs.readFileSync(
   path.join(__dirname, RENDER, "file-input--default.html")
 );


### PR DESCRIPTION
## Description

**Updated Federalist setup**. This PR updates the Federalist process to use the latest and standard setup. This closes #4519.

## Additional information

Previously we depended on a `_config.yml` to point Federalist to the generated output to properly deploy. This causes 2 issues:

1. That's no longer necessary and will be deprecated in the future. 
2. Builds take longer than necessary, run out of memory, and are prone to crashing.

More info in [slack conversation](https://gsa-tts.slack.com/archives/C1NUUGTT5/p1644531085462329?thread_ts=1644524861.884029&cid=C1NUUGTT5). 

### Related issues
Related to issue #4520. 

**⚠️ Note:** Once both issues are closed we need to go into [Federalist](https://federalistapp.18f.gov/sites/377/settings) and update the **Site Engine** field from `Jekyll → Node`.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
