### PR TITLE
Beta: Repair typography vertical margins

### DIFF
--- a/src/stylesheets/core/mixins/typography/usa-content-styles.scss
+++ b/src/stylesheets/core/mixins/typography/usa-content-styles.scss
@@ -3,10 +3,11 @@
 @use "./usa-prose" as *;
 @use "./usa-list" as *;
 @use "./usa-table-styles" as *;
+@use "../../placeholders/typography" as *;
 
 @mixin usa-paragraph-style {
   p {
-    @include usa-prose-p;
+    @extend %usa-prose-p;
   }
 }
 
@@ -23,7 +24,7 @@
   h4,
   h5,
   h6 {
-    @include usa-prose-heading;
+    @extend %usa-prose-heading;
   }
 
   h1 {

--- a/src/stylesheets/core/mixins/typography/usa-prose.scss
+++ b/src/stylesheets/core/mixins/typography/usa-prose.scss
@@ -5,18 +5,6 @@
 @use "./headings" as *;
 @use "./typeset" as *;
 
-@mixin usa-prose-p {
-  line-height: line-height($theme-body-font-family, $theme-body-line-height);
-  margin-bottom: 0;
-  margin-top: 0;
-  max-width: measure($theme-text-measure);
-}
-
-@mixin usa-prose-heading {
-  @include u-margin-y(0);
-  clear: both;
-}
-
 @mixin usa-prose-link {
   color: color($theme-link-color);
   text-decoration: underline;

--- a/src/stylesheets/core/placeholders/_index.scss
+++ b/src/stylesheets/core/placeholders/_index.scss
@@ -1,3 +1,4 @@
 @forward "forms";
 @forward "list";
 @forward "table";
+@forward "typography";

--- a/src/stylesheets/core/placeholders/_typography.scss
+++ b/src/stylesheets/core/placeholders/_typography.scss
@@ -1,0 +1,9 @@
+@use "../mixins/typography/typeset.scss" as *;
+
+%usa-prose-p {
+  @include typeset-p;
+}
+
+%usa-prose-heading {
+  @include typeset-heading;
+}


### PR DESCRIPTION
### Description:
Repair typography vertical margin settings errors found in https://github.com/uswds/uswds/issues/4574

### Solution notes:
Discovered that pulling in the typeset-p/typeset-heading (or usa-prose-p/usa-prose-heading) styles as a mixin instead of a placeholder compiles as `*+.usa-prose>h2` instead of `.usa-prose>*+h2`, which results in incorrect visual display. 

Closes https://github.com/uswds/uswds/issues/4574