### PR TITLE
Specify a public package at publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           name: Publish to NPM with `alpha` tag
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --tag alpha
+            npm publish --access public --tag alpha
   deploy-beta:
     <<: *container
     steps:
@@ -79,7 +79,7 @@ jobs:
           name: Publish to NPM with `beta` tag
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --tag beta
+            npm publish --access public --tag beta
 workflows:
   version: 2
   circle-uswds:


### PR DESCRIPTION
Since we're publishing to an org scope, we need to explicitly specify a public package.