### PR TITLE
Remove Lodash downstream dependencies (USWDS 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
-  "name": "uswds",
-  "version": "3.0.0-beta.3",
+  "name": "@uswds/uswds",
+  "version": "3.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "uswds",
-      "version": "3.0.0-beta.3",
+      "name": "@uswds/uswds",
+      "version": "3.0.0-beta.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
-        "src/stylesheets/core"
+        "packages/uswds-core"
       ],
       "dependencies": {
         "classlist-polyfill": "^1.0.3",
         "domready": "^1.0.8",
         "express": "^4.17.2",
-        "lodash.debounce": "^4.0.7",
-        "lodash.merge": "^4.6.2",
         "object-assign": "^4.1.1",
         "receptor": "^1.0.0",
         "resolve-id-refs": "^0.1.0"
@@ -80,6 +78,7 @@
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1",
         "lit-scss-loader": "^1.1.0",
+        "lodash.merge": "^4.6.2",
         "merge-stream": "^2.0.0",
         "mocha": "^6.2.0",
         "mq-polyfill": "^1.1.8",
@@ -9525,7 +9524,7 @@
       }
     },
     "node_modules/@uswds/core": {
-      "resolved": "src/stylesheets/core",
+      "resolved": "packages/uswds-core",
       "link": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -23759,7 +23758,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -23788,7 +23788,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -37111,9 +37112,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/uswds-core": {
+      "name": "@uswds/core",
+      "version": "0.0.1-alpha.0",
+      "license": "ISC",
+      "devDependencies": {
+        "sass-true": "^6.0.1"
+      }
+    },
     "src/stylesheets/core": {
       "name": "@uswds/core",
       "version": "0.0.1-alpha.0",
+      "extraneous": true,
       "license": "ISC",
       "devDependencies": {
         "sass-true": "^6.0.1"
@@ -44236,7 +44246,7 @@
       }
     },
     "@uswds/core": {
-      "version": "file:src/stylesheets/core",
+      "version": "file:packages/uswds-core",
       "requires": {
         "sass-true": "^6.0.1"
       }
@@ -55668,7 +55678,8 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -55697,7 +55708,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,6 @@
     "classlist-polyfill": "^1.0.3",
     "domready": "^1.0.8",
     "express": "^4.17.2",
-    "lodash.debounce": "^4.0.7",
-    "lodash.merge": "^4.6.2",
     "object-assign": "^4.1.1",
     "receptor": "^1.0.0",
     "resolve-id-refs": "^0.1.0"
@@ -159,6 +157,7 @@
     "lit-element": "^2.5.1",
     "lit-html": "^1.4.1",
     "lit-scss-loader": "^1.1.0",
+    "lodash.merge": "^4.6.2",
     "merge-stream": "^2.0.0",
     "mocha": "^6.2.0",
     "mq-polyfill": "^1.1.8",


### PR DESCRIPTION
## Description

This pull request removes an unused dependency, and moves another to `devDependencies`.

## Additional information

As a consumer of the USWDS package, I expect that the package includes only dependencies required to run / build USWDS, so that my install times are quick, and so that my dependency tree is small in order to reduce risk related to package security advisories.

- `lodash.debounce` is unused as of #4116, and is absent in the `develop` branch (merge conflict?)
- `lodash.merge` is only [used in `webpack.twig.config.js`](https://github.com/uswds/uswds/blob/library--develop/webpack.twig.config.js#L4) and shouldn't be a dependency installed in downstream projects

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
