### PR TITLE
USWDS - Add @frctl/mandelbrot to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@18f/identity-stylelint-config": "1.0.0",
         "@babel/preset-env": "7.15.8",
         "@frctl/fractal": "1.5.11",
+        "@frctl/mandelbrot": "1.10.1",
         "@frctl/nunjucks": "2.0.13",
         "@types/node": "16.11.6",
         "ansi-colors": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@18f/identity-stylelint-config": "1.0.0",
     "@babel/preset-env": "7.15.8",
     "@frctl/fractal": "1.5.11",
+    "@frctl/mandelbrot": "1.10.1",
     "@frctl/nunjucks": "2.0.13",
     "@types/node": "16.11.6",
     "ansi-colors": "4.1.1",


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Add explicit reference to @frctl/mandelbrot in devDependencies.

This missing dependency was discovered after getting an error during USWDS-site build using USWDS 2.13.3.

Tested with the following versions:
- NPM 8.1.0
- Node 16.13.0