### PR TITLE
Improve utility settings

### DIFF
--- a/packages/usa-identifier/src/styles/_usa-identifier.scss
+++ b/packages/usa-identifier/src/styles/_usa-identifier.scss
@@ -142,7 +142,8 @@ $identifier-links-gap: 4 !default;
   }
 }
 
-.usa-identifier__required-link {
+.usa-identifier__required-link,
+.usa-identifier__required-link.usa-link {
   @include identifier-secondary-link;
   display: inline-block;
 }

--- a/packages/uswds-core/src/styles/_deprecated.scss
+++ b/packages/uswds-core/src/styles/_deprecated.scss
@@ -17,28 +17,5 @@
     major version.
 */
 
-@use "./mixins" as *;
-@use "./settings" as *;
-
-// Deprecated in 2.0.2
-$theme-title-font-size: $theme-display-font-size !default;
-
-// Deprecated in 2.2.0
-$theme-navigation-width: $theme-header-min-width !default;
-$theme-megamenu-logo-text-width: $theme-header-logo-text-width !default;
-
-// Deprecated in 2.11.2
-$theme-site-max-width: $theme-grid-container-max-width !default;
-
-@mixin title {
-  @include display;
-}
-
-@mixin typeset-title {
-  @include typeset-display;
-}
-
-// Deprecated in 2.12.0
-$theme-input-tile-background-color-selected: "primary-lighter" !default;
-$theme-input-tile-border-color: "base-lighter" !default;
-$theme-input-tile-border-color-selected: "primary-lighter" !default;
+// Deprecated in 3.0.0
+$output-all-utilities: true;

--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -13,11 +13,14 @@
 
 /* prettier-ignore */
 $uswds-notifications:
-    "\A"
-  + "\A --------------------------------------------------------------------"
-  + "\A \2709  USWDS Notifications"
-  + "\A --------------------------------------------------------------------"
-  + "\A No notifications";
+  "\A"
++ "\A --------------------------------------------------------------------"
++ "\A \2709  USWDS Notifications"
++ "\A --------------------------------------------------------------------"
++ "\A 3.0.0"
++ "\A We deprecated the $output-all-utilities setting."
++ "\A Control utility output with $output-all-utilities."
++ "\A See designsystem.digital.com/documentation/settings for more.";
 
 /* prettier-ignore */
 $uswds-notification-disable-message:
@@ -26,8 +29,7 @@ $uswds-notification-disable-message:
 + "\A These are notifications from the USWDS team, not necessarily a"
 + "\A problem with your code."
 + "\A"
-+ "\A Disable notifications using `$theme-show-notifications: false`"
-+ "\A in your general settings file."
++ "\A Disable notifications using `$theme-show-notifications: false`."
 + "\A --------------------------------------------------------------------\A";
 
 @if $theme-show-notifications {

--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -19,7 +19,7 @@ $uswds-notifications:
 + "\A --------------------------------------------------------------------"
 + "\A 3.0.0"
 + "\A We deprecated the $output-all-utilities setting."
-+ "\A Control utility output with $output-all-utilities."
++ "\A Control utility output with $output-these-utilities."
 + "\A See designsystem.digital.com/documentation/settings for more.";
 
 /* prettier-ignore */

--- a/packages/uswds-core/src/styles/mixins/_utility-builder.scss
+++ b/packages/uswds-core/src/styles/mixins/_utility-builder.scss
@@ -3,6 +3,7 @@
 @use "sass:map";
 @use "sass:meta";
 @use "sass:string";
+@use "sass:list";
 
 @use "../settings" as *;
 @use "../properties" as *;
@@ -169,192 +170,194 @@ through all possible variants
 @mixin these-utilities($utilities, $media-key: false) {
   // loop through the $utilities
   @each $utility-name, $utility in $utilities {
-    // Only do this if the the utility is meant to output
+    // Check to see if the utility is in the output uselist
+    @if ($output-these-utilities == "default") or list.index($output-these-utilities, $utility-name) {
+      // Only do this if the the utility is meant to output
+      @if not($media-key) or
+        ($media-key and map-deep-get($utility, settings, responsive))
+      {
+        @if map-deep-get($utility, settings, output) {
+          // set intital variants
+          // $property-default is a single value for all these utilities
 
-    @if not($media-key) or
-      ($media-key and map-deep-get($utility, settings, responsive))
-    {
-      @if map-deep-get($utility, settings, output) or $output-all-utilities {
-        // set intital variants
-        // $property-default is a single value for all these utilities
+          $base-props: null;
+          $modifier: null;
+          $selector: null;
+          $property-default: map.get($utility, property);
+          $property: null;
+          $value: null;
+          $our-modifiers: ();
+          $b: null;
+          $v: null;
+          $mv: null;
+          $val-props: ();
+          $no-value: false;
 
-        $base-props: null;
-        $modifier: null;
-        $selector: null;
-        $property-default: map.get($utility, property);
-        $property: null;
-        $value: null;
-        $our-modifiers: ();
-        $b: null;
-        $v: null;
-        $mv: null;
-        $val-props: ();
-        $no-value: false;
+          $b: map.get($utility, base);
 
-        $b: map.get($utility, base);
+          // Each utility rule takes a value, so let's start here
+          // and begin building.
 
-        // Each utility rule takes a value, so let's start here
-        // and begin building.
+          // -------- For each value in utility.values ----------
 
-        // -------- For each value in utility.values ----------
+          @each $val-key, $val-value in map.get($utility, values) {
+            // If $val-value == null, or if $val-value is a map and
+            // the content key or the dependency key has a null value
+            // set $val-value to `false`...
 
-        @each $val-key, $val-value in map.get($utility, values) {
-          // If $val-value == null, or if $val-value is a map and
-          // the content key or the dependency key has a null value
-          // set $val-value to `false`...
-
-          @if meta.type-of($val-value) == "map" {
-            @if not map.get($val-value, content) {
-              $val-value: false;
-            } @else if
-              map.has-key($val-value, dependency) and not
-              map.get($val-value, dependency)
-            {
-              $val-value: false;
-            }
-          }
-
-          // ...so we can skip building this rule altogether.
-          // So, if $val-value is _not_ false...
-
-          @if $val-value {
-            // Set the value of our rule.
-            // If its a map, use val-value.content.
-
-            $val-slug: if(
-              meta.type-of($val-value) == "map",
-              map.get($val-value, "slug"),
-              $val-key
-            );
-
-            $value: if(
-              meta.type-of($val-value) == "map",
-              map.get($val-value, "content"),
-              $val-value
-            );
-
-            @if $val-slug == "" or smart-quote($val-slug) == "noValue" {
-              $no-value: true;
-            }
-
-            // Add any appended values...
-
-            @if map.get($utility, valueAppend) {
-              $value: $value + map.get($utility, valueAppend);
-            }
-
-            // ...or prepended values.
-
-            @if map.get($utility, valuePrepend) {
-              $value: map.get($utility, valuePrepend) + $value;
-            }
-
-            // And we'll set the $v as $val-slug for use in
-            // constructing the selector (.$b-$m-$v).
-
-            $v: $val-slug;
-
-            // -------- Start of Modifiers ----------
-
-            // Now we'll check for modifiers and loop through them
-            // to get the props we need to build our rule.
-
-            // Modifiers are held in a MAP,
-            // where each individual modifer has the keypair
-            // [slug]:[value]
-
-            // So, check for modifiers.
-
-            @if map.get($utility, modifiers) {
-              // If there are modifiers, capture them as $our-modifiers.
-
-              $our-modifiers: map.get($utility, modifiers);
-            } @else {
-              // If there aren't, build a dummy so we can keep
-              // all our build in the same loop.
-
-              $our-modifiers: (
-                "slug": null,
-              );
-            }
-
-            // OK! C'mon, let's loop!
-            // https://www.youtube.com/watch?v=X9i2i07wPUw
-
-            // -------- For each modifier in $our-modifiers ----------
-
-            @each $mod-key, $mod-val in $our-modifiers {
-              $property: if(
-                $mod-val == null or $mod-val == "",
-                $property-default,
-                multi-cat($property-default, $mod-val)
-              );
-
-              // Now we go through to set the $selector.
-
-              // If mod-props.slug is noModifier...
-
-              @if $mod-key ==
-                "" or
-                $mod-key ==
-                slug or
-                smart-quote($mod-key) ==
-                "noModifier"
+            @if meta.type-of($val-value) == "map" {
+              @if not map.get($val-value, content) {
+                $val-value: false;
+              } @else if
+                map.has-key($val-value, dependency) and not
+                map.get($val-value, dependency)
               {
-                // First, we can test to see if the base $b is null
-
-                @if not $b {
-                  // If it _is_ null, the rule's selector is $v.
-
-                  $selector: $v;
-
-                  // if the value is noValue ('')
-                } @else if $no-value {
-                  // selector is the base only
-
-                  $selector: $b;
-                } @else {
-                  // otherwise, selctor is joined with a hyphen.
-
-                  $selector: $b + "-" + $v;
-
-                  // Nice! We just took care of the non-modifier cases!
-                }
+                $val-value: false;
               }
+            }
 
-              // If there _is_ a modifier...
+            // ...so we can skip building this rule altogether.
+            // So, if $val-value is _not_ false...
 
-              @else {
-                $mv: if($no-value, $mod-key, $mod-key + "-" + $v);
+            @if $val-value {
+              // Set the value of our rule.
+              // If its a map, use val-value.content.
 
-                // Once we have $mv, test for $b
-                // and build the selector as before.
-
-                $selector: if($b == null, $mv, $b + "-" + $mv);
-              }
-
-              // finished setting modifier vars
-
-              // Hey. Did we just finish $selector?
-              // And do we also have $property and $value?
-              // We do?!?!?! We do!
-
-              // FINALLY, 'BUILD THE RULE, MAX!'
-              // https://www.youtube.com/watch?v=R3Igz5SfBCE
-
-              @include render-utility(
-                $utility,
-                $selector,
-                $property,
-                $value,
-                $val-value,
-                $media-key
+              $val-slug: if(
+                meta.type-of($val-value) == "map",
+                map.get($val-value, "slug"),
+                $val-key
               );
-            } // end the modifier loop
-          } // end the null value conditional
-        } // end the value loop
-      } // end the output conditional
-    }
+
+              $value: if(
+                meta.type-of($val-value) == "map",
+                map.get($val-value, "content"),
+                $val-value
+              );
+
+              @if $val-slug == "" or smart-quote($val-slug) == "noValue" {
+                $no-value: true;
+              }
+
+              // Add any appended values...
+
+              @if map.get($utility, valueAppend) {
+                $value: $value + map.get($utility, valueAppend);
+              }
+
+              // ...or prepended values.
+
+              @if map.get($utility, valuePrepend) {
+                $value: map.get($utility, valuePrepend) + $value;
+              }
+
+              // And we'll set the $v as $val-slug for use in
+              // constructing the selector (.$b-$m-$v).
+
+              $v: $val-slug;
+
+              // -------- Start of Modifiers ----------
+
+              // Now we'll check for modifiers and loop through them
+              // to get the props we need to build our rule.
+
+              // Modifiers are held in a MAP,
+              // where each individual modifer has the keypair
+              // [slug]:[value]
+
+              // So, check for modifiers.
+
+              @if map.get($utility, modifiers) {
+                // If there are modifiers, capture them as $our-modifiers.
+
+                $our-modifiers: map.get($utility, modifiers);
+              } @else {
+                // If there aren't, build a dummy so we can keep
+                // all our build in the same loop.
+
+                $our-modifiers: (
+                  "slug": null,
+                );
+              }
+
+              // OK! C'mon, let's loop!
+              // https://www.youtube.com/watch?v=X9i2i07wPUw
+
+              // -------- For each modifier in $our-modifiers ----------
+
+              @each $mod-key, $mod-val in $our-modifiers {
+                $property: if(
+                  $mod-val == null or $mod-val == "",
+                  $property-default,
+                  multi-cat($property-default, $mod-val)
+                );
+
+                // Now we go through to set the $selector.
+
+                // If mod-props.slug is noModifier...
+
+                @if $mod-key ==
+                  "" or
+                  $mod-key ==
+                  slug or
+                  smart-quote($mod-key) ==
+                  "noModifier"
+                {
+                  // First, we can test to see if the base $b is null
+
+                  @if not $b {
+                    // If it _is_ null, the rule's selector is $v.
+
+                    $selector: $v;
+
+                    // if the value is noValue ('')
+                  } @else if $no-value {
+                    // selector is the base only
+
+                    $selector: $b;
+                  } @else {
+                    // otherwise, selctor is joined with a hyphen.
+
+                    $selector: $b + "-" + $v;
+
+                    // Nice! We just took care of the non-modifier cases!
+                  }
+                }
+
+                // If there _is_ a modifier...
+
+                @else {
+                  $mv: if($no-value, $mod-key, $mod-key + "-" + $v);
+
+                  // Once we have $mv, test for $b
+                  // and build the selector as before.
+
+                  $selector: if($b == null, $mv, $b + "-" + $mv);
+                }
+
+                // finished setting modifier vars
+
+                // Hey. Did we just finish $selector?
+                // And do we also have $property and $value?
+                // We do?!?!?! We do!
+
+                // FINALLY, 'BUILD THE RULE, MAX!'
+                // https://www.youtube.com/watch?v=R3Igz5SfBCE
+
+                @include render-utility(
+                  $utility,
+                  $selector,
+                  $property,
+                  $value,
+                  $val-value,
+                  $media-key
+                );
+              } // end the modifier loop
+            } // end the null value conditional
+          } // end the value loop
+        } // end the output conditional
+      }
+    } // end the uselist conditional
   } // end the utility loop
   // (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧
 }

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -18,7 +18,6 @@ https://designsystem.digital.gov/utilities
 */
 
 $utilities-use-important: false !default;
-$output-all-utilities: false !default;
 $output-these-utilities: default !default;
 
 /*

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -18,7 +18,8 @@ https://designsystem.digital.gov/utilities
 */
 
 $utilities-use-important: false !default;
-$output-all-utilities: true !default;
+$output-all-utilities: false !default;
+$output-these-utilities: default !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/theme/_uswds-theme-utilities.scss
+++ b/packages/uswds-core/src/theme/_uswds-theme-utilities.scss
@@ -18,7 +18,7 @@ https://designsystem.digital.gov/utilities
 */
 
 $utilities-use-important: false;
-$output-these-utilities: default !default;
+$output-these-utilities: default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/theme/_uswds-theme-utilities.scss
+++ b/packages/uswds-core/src/theme/_uswds-theme-utilities.scss
@@ -18,7 +18,7 @@ https://designsystem.digital.gov/utilities
 */
 
 $utilities-use-important: false;
-$output-all-utilities: true;
+$output-these-utilities: default !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-utilities/src/styles/rules/add-list-reset.scss
+++ b/packages/uswds-utilities/src/styles/rules/add-list-reset.scss
@@ -19,7 +19,7 @@ example:
 @use "uswds-core/src/styles/settings" as *;
 
 $add-list-reset: (
-  list-reset: (
+  add-list-reset: (
     base: "add-list",
     modifiers: null,
     values: (

--- a/packages/uswds-utilities/src/styles/utility-fonts.scss
+++ b/packages/uswds-utilities/src/styles/utility-fonts.scss
@@ -6,6 +6,7 @@ utilities to reference.
 */
 
 @use "sass:map";
+@use "sass:list";
 @use "uswds-core" as *;
 
 $if-important: "";
@@ -14,7 +15,9 @@ $if-important: "";
   $if-important: " !important";
 }
 
-@if (map-get($font-settings, "output") == true) or $output-all-utilities {
+// Generate font rules if the `font` utility is on the uselist 
+// and its output is set to true
+@if (($output-these-utilities == "default" or list.index($output-these-utilities, "font")) and map.get($font-settings, "output") == true) {
   @each $face, $stack in $project-font-stacks {
     @if $stack {
       [class*="#{ns('utility')}font-#{$face}-"] {

--- a/packages/uswds-utilities/src/styles/utility-fonts.scss
+++ b/packages/uswds-utilities/src/styles/utility-fonts.scss
@@ -5,6 +5,7 @@ utilities to reference.
 ----------------------------------------
 */
 
+@use "sass:map";
 @use "uswds-core" as *;
 
 $if-important: "";
@@ -13,10 +14,12 @@ $if-important: "";
   $if-important: " !important";
 }
 
-@each $face, $stack in $project-font-stacks {
-  @if $stack {
-    [class*="#{ns('utility')}font-#{$face}-"] {
-      font-family: #{$stack}#{$if-important};
+@if (map-get($font-settings, "output") == true) or $output-all-utilities {
+  @each $face, $stack in $project-font-stacks {
+    @if $stack {
+      [class*="#{ns('utility')}font-#{$face}-"] {
+        font-family: #{$stack}#{$if-important};
+      }
     }
-  }
+  }  
 }


### PR DESCRIPTION
Removes `$output-all-utilities` setting and replaces it with `$output-these-utilities`. `$output-all-utilities` is an unusual setting — it overrides any utility-specific settings to output all utilities. `$output-these-utilities` allows users to to create a uselist of all utility modules they want to include in the project. 

Previously, to disable any utility, a developer would have to change the value of its settings object. Since all utilities are output by default, disabling the status of multiple utility modules requires adding multiple settings objects, a dreary and tedious affair that looks something like this:

```
  $display-settings: (
    output: false,
  ),
  $flex-settings: (
    output: false
  ),
  $flex-direction-settings: (
    output: false
  ),
  $flex-wrap-settings: (
    output: false
  ),
  $float-settings: (
    output: false
  ),
  $font-settings: (
    output: false,
  ),

... ad infinitum
```

With `$output-these-utilities`, the default is `default` — which means "all utilities". To include only specific utilities, devs can pass a uselist of all the desired utilities:

```
  $output-these-utilities: (
    "add-list-reset",
    "align-items",
    "align-self",
    "border",
    "border-style",
    "border-width",
    "color",
    "display",
    "font",
    "font-weight",
    "order",
    "text-decoration"
    ),
```

## Also

- A couple other minor changes outlined in the notes
