### PR TITLE
Use access public on publish, as with beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Publish to NPM
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish
+            npm publish --access public
   deploy-alpha:
     <<: *container
     steps:


### PR DESCRIPTION
Adds an `--access public` flag on the publish, just to be sure we're setting public access on an org-scoped package