### PR TITLE
Page template updates

### DIFF
--- a/packages/templates/usa-create-account/usa-create-account~lang-es.json
+++ b/packages/templates/usa-create-account/usa-create-account~lang-es.json
@@ -11,6 +11,7 @@
     "password": {
       "label": "Cree una contraseña",
       "toggle": {
+        "aria_controls": "password-create-account password-create-account-confirm",
         "text": {
           "show": "Muestre la contraseña",
           "hide": "Esconda la contraseña"

--- a/packages/templates/usa-sign-in/includes/_usa-sign-in-multiple-inner.twig
+++ b/packages/templates/usa-sign-in/includes/_usa-sign-in-multiple-inner.twig
@@ -19,7 +19,7 @@
               <p>
                 <a href="{{ placeholder_link }}"
                   class="usa-button usa-button--outline width-full">
-                  {{ item.label }}
+                  {{ item.label | e }}
                 </a>
               </p>
             {% endfor %}

--- a/packages/templates/usa-sign-in/usa-sign-in-form/usa-sign-in-form.twig
+++ b/packages/templates/usa-sign-in/usa-sign-in-form/usa-sign-in-form.twig
@@ -29,14 +29,7 @@
       required
     >
     {% include "@components/_usa-password/src/usa-password.twig" with {
-      "toggle": {
-        "title": "Toggle password",
-        "aria_controls": password_id,
-        "text": {
-          "show": "Show password",
-          "hide": "Hide password"
-        }
-      }
+      toggle: password.toggle
     } %}
     {# /Password #}
     <input class="usa-button" type="submit" value="{{ submit.label |default('Sign in') }}">

--- a/packages/templates/usa-sign-in/usa-sign-in.json
+++ b/packages/templates/usa-sign-in/usa-sign-in.json
@@ -15,6 +15,14 @@
     "label": "Password",
     "input": {
       "id": "password-sign-in"
+    },
+    "toggle": {
+      "title": "Toggle password",
+      "aria_controls": "password-sign-in",
+      "text": {
+        "show": "Show password",
+        "hide": "Hide password"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Description

Minor fixes to Create Account and Sign in templates for rendering in Site. Closes #4659.

## Previews
- [Create account Spanish →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-template-fixes/?path=/story/pages-create-account--create-account-page-spanish)
- [Sign in Spanish →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-template-fixes/?path=/story/pages-sign-in--sign-in-page-spanish)
- [Multiple sign in  Spanish →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-template-fixes/?path=/story/pages-sign-in--multiple-sign-in-page-spanish)

## Additional information

**Show Password works consistently in Spanish variants**
![image](https://user-images.githubusercontent.com/3385219/166265251-04642e63-1f8e-4d69-9768-38c6bcd14537.png)

![image](https://user-images.githubusercontent.com/3385219/166265396-619458e6-4fe6-4522-b20f-7e092688949d.png)

---

**Buttons in multiple sign in are no longer empty**
![image](https://user-images.githubusercontent.com/3385219/166265503-bc0da70a-cbd6-492d-83db-49a690ef3339.png)

![image](https://user-images.githubusercontent.com/3385219/166265542-fbe104ce-bf24-4c53-8dee-04d0a43c54f3.png)

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
