### PR TITLE
USWDS - Core: Repair color contrast issues for color-grade 45

### DIFF
--- a/packages/uswds-core/src/styles/functions/color/get-color-token-from-bg.scss
+++ b/packages/uswds-core/src/styles/functions/color/get-color-token-from-bg.scss
@@ -29,6 +29,12 @@
   }
   $target-magic-number: map.get($system-wcag-magic-numbers, $wcag-target);
   $bg-grade: calculate-grade($bg-color);
+  // When $bg-color = 45, serve alternate tokens with color grades of 0 and 100
+  // This provides sufficient contrast to pass WCAG AA standards
+  @if $bg-grade == 45 and $wcag-target == "AA" {
+    $preferred-text-token: "white";
+    $fallback-text-token: "black";
+  }
   $our-color-tokens: ($preferred-text-token, $fallback-text-token);
   $accessible-text-token: false;
   $accessible-text-grade: false;

--- a/packages/uswds-core/src/styles/variables/luminance-grade-ranges.scss
+++ b/packages/uswds-core/src/styles/variables/luminance-grade-ranges.scss
@@ -30,7 +30,7 @@ $system-color-grades: (
     "max": 0.183,
   ),
   40: (
-    "min": 0.25,
+    "min": 0.225,
     "max": 0.3,
   ),
   30: (

--- a/packages/uswds-core/src/test/tests.scss
+++ b/packages/uswds-core/src/test/tests.scss
@@ -417,6 +417,16 @@ $this-function: "get-color-token-from-bg()";
     $expect: $theme-text-reverse-color;
     @include assert-equal($test, $expect);
   }
+  @include it("Returns black from top threshold of color-grade 45") {
+    $test: get-color-token-from-bg(#598c7f);
+    $expect: "black";
+    @include assert-equal($test, $expect);
+  }
+  @include it("Returns black from bottom threshold of color-grade 45") {
+    $test: get-color-token-from-bg(#577c8e);
+    $expect: "black";
+    @include assert-equal($test, $expect);
+  }
   @include it("Returns the proper AA Large color.") {
     $test: get-color-token-from-bg("white", "gray-40", "gray-50", "AA-large");
     $expect: "gray-40";


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description
Closes https://github.com/uswds/uswds/issues/4146.

### Problem details:
Background colors with a color-grade of 45 will produce inaccurate results when fed into the`get-color-token-from-bg` mixin. Two distinct issues have been identified and are outlined below:

_Note: Color-grade 45 is a mid-range grade given to any color with a relative luminance (rLum)  value of [0.183 < rLum < 0.25](https://github.com/uswds/uswds/blob/develop/packages/uswds-core/src/styles/variables/luminance-grade-ranges.scss#L30-L33)._

- Issue 1: For some colors inside color-grade 45, our checks return a fail when manual checks return a passing grade.
    - A range of rLum values inside color-grade 45 would pass contrast tests against `ink` `#1b1b1b` (ie, have a contrast ratio >4.5:1) but our system returns a warning that neither `white` nor `ink` is accessible, and returns the preferred token (`white` by default)
        - Affected rLum range: 0.225 --->  0.25
            - Test color with 0.225 rLum: `#7a8677`
            - Test color with 0.25 rLum: `#629739`
- Issue 2: For other colors inside color-grade 45, no accessible contrast is possible with project defaults.
    - A range of rLum values inside color-grade 45 cannot pass contrast tests with with either `white` or `ink` (ie, have a contrast ratio <4.5:1 when tested against both colors)
        - Affected rLum ranges: 0.184 ---> 0.224
            - Test color with 0.184 rLum: `#577c8e`
            - Test color with 0.224 rLum: `#7e847d`

Testing revealed that rLum = 0.225 is the breakpoint that separates the two issues. You can see the errors shift in the following `@debug` results, which include sample colors with specific [rLUM values](https://contrastchecker.online/color-relative-luminance-calculator) as well as notes from manual contrast testing with the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/): 
```scss
@debug "#629739: rLum = 0.25, ink passes manual contrast check" calculate-grade(#629739); // returns 45
@debug get-color-token-from-bg(#629739); //returns ink

@debug "#619736: rLum = 0.249, ink passes manual contrast check" calculate-grade(#619736); // returns 45
@debug get-color-token-from-bg(#619736); //returns white and 'Warning: Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `#619736` background. Using `white`. Please check your source code and project settings.

// DHS green
@debug "#5E9732: rLum = 0.247, ink passes manual contrast check" calculate-grade(#5E9732); // returns 45
@debug get-color-token-from-bg(#5E9732); //returns white and 'Warning: Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `#5E9732` background. Using `white`. Please check your source code and project settings.'

@debug "#7a8677: rLum = 0.225, ink passes manual contrast check" calculate-grade(#7a8677); // returns 45
@debug get-color-token-from-bg(#7a8677); //returns white and  'Warning: Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `#7a8677` background. Using `white`. Please check your source code and project settings.

@debug "#598c7f: rLum = 0.224, white and ink fail manual contrast check; black passes manual contrast check" calculate-grade(#598c7f); // returns 45
@debug get-color-token-from-bg(#598c7f); //returns white and 'Warning: Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `#598c7f` background. Using `white`. Please check your source code and project settings.

@debug "#577c8e: rLum = 0.184, white and ink fail manual contrast check; black passes manual contrast check" calculate-grade(#577c8e); // returns 45
@debug get-color-token-from-bg(#577c8e); //returns white and 'Warning: Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `#577c8e` background. Using `white`. Please check your source code and project settings.

@debug "#587e75: rLum = 0.183 white passes manual contrast check" calculate-grade(#587e75); // returns 50
@debug get-color-token-from-bg(#587e75); //returns white
```

### Proposed solution: 
To solve, we must:
1. Include the rLum values that CAN pass contrast tests in the appropriate luminance range grade 
    - Action: rLum values of  0.25 > rLum > 0.225 should be included in grade 40 
1. Serve alternate token values with color-grades 0 and 100 (black and white) for color grades that CANNOT pass against system defaults
    - Action: Test `$bg-color` for color-grade 45 and serve positive results "black" and "white" contrast tokens
    
#### Results after implementing this solution:
_Note the shift in calculate-grade results. Some items that were color-grade 45 are now color-grade 40. Color-grade 45 now receives `black` for contrast token_
```scss
@debug "#629739: rLum = 0.25, ink passes manual contrast check" calculate-grade(#629739); // returns 40
@debug get-color-token-from-bg(#629739); //returns ink

@debug "#619736: rLum = 0.249, ink passes manual contrast check" calculate-grade(#619736); // returns 40
@debug get-color-token-from-bg(#619736); //returns ink

// DHS green
@debug "#5E9732: rLum = 0.247, ink passes manual contrast check" calculate-grade(#5E9732); // returns 40
@debug get-color-token-from-bg(#5E9732); //returns ink

@debug "#7a8677: rLum = 0.225, ink passes manual contrast check" calculate-grade(#7a8677); // returns 40
@debug get-color-token-from-bg(#7a8677); //returns ink

@debug "#598c7f: rLum = 0.224, white and ink fail manual contrast check; black passes manual contrast check" calculate-grade(#598c7f); // returns 45
@debug get-color-token-from-bg(#598c7f); //returns black

@debug "#577c8e: rLum = 0.184, white and ink fail manual contrast check; black passes manual contrast check" calculate-grade(#577c8e); // returns 45
@debug get-color-token-from-bg(#577c8e); //returns black

@debug "#587e75: rLum = 0.183 white passes manual contrast check" calculate-grade(#587e75); // returns 50
@debug get-color-token-from-bg(#587e75); //returns white
```

## Additional information
### To reproduce original issue:
1. Update value of `$theme-color-accent-cool:` to ` #5E9732 !default;`in `packages/uswds-core/src/styles/settings/_settings-color.scss`
1. Compile Sass
1. Receive the following warning:
    Warning: [Button] Neither the specified preferred color token (`white`) nor the fallback color token (`ink`) have AA contrast on a `accent-cool` background. Using `white`. Please check your source code and project settings.
1. Check contrast ratio for both [white](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=5E9732) and [ink](https://webaim.org/resources/contrastchecker/?fcolor=1B1B1B&bcolor=5E9732) against #5E9732 in WebAIM contrast checker tool. Ink receives a passing grade 4.87:1. (WCAG AA defines 4.5:1 as passing)





- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
