### PR TITLE
USWDS - Core: Repair normalize.css precedence 

### DIFF
--- a/packages/usa-prose/src/styles/_usa-prose.scss
+++ b/packages/usa-prose/src/styles/_usa-prose.scss
@@ -1,12 +1,45 @@
 @use "uswds-core" as *;
+@use "../../../uswds-core/src/styles/placeholders/typography" as *;
 
 .usa-prose {
   @include typeset($theme-prose-font-family);
 
   & > {
-    @include usa-paragraph-style;
-    @include usa-headings-styles;
-    @include usa-list-styles;
-    @include usa-table-styles;
+    p {
+      @extend %usa-prose-p;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      @extend %usa-prose-heading;
+    }
+
+    h1 {
+      @include h1;
+    }
+
+    h2 {
+      @include h2;
+    }
+
+    h3 {
+      @include h3;
+    }
+
+    h4 {
+      @include h4;
+    }
+
+    h5 {
+      @include h5;
+    }
+
+    h6 {
+      @include h6;
+    }
   }
 }

--- a/packages/usa-prose/src/styles/_usa-prose.scss
+++ b/packages/usa-prose/src/styles/_usa-prose.scss
@@ -41,5 +41,8 @@
     h6 {
       @include h6;
     }
+
+    @include usa-list-styles;
+    @include usa-table-styles;
   }
 }

--- a/packages/uswds-core/src/styles/mixins/typography/usa-content-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/typography/usa-content-styles.scss
@@ -7,7 +7,7 @@
 
 @mixin usa-paragraph-style {
   p {
-    @extend %usa-prose-p;
+    @include typeset-p;
   }
 }
 
@@ -24,7 +24,7 @@
   h4,
   h5,
   h6 {
-    @extend %usa-prose-heading;
+    @include typeset-heading;
   }
 
   h1 {


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Closes: https://github.com/uswds/uswds/issues/4698

### Problem details:
Styles from `normalize.css` are taking precedence over some USWDS global typography styles when either the `$theme-global-content-styles` and/or `$theme-global-paragraph-styles` setting is set to `true`. Because `normalize.css` is reset CSS, it should not take precedence over any USWDS styles. 

#### How this is happening
In limited cases, some root global styles are compiling at the top of the CSS file, above the normalize reset CSS. This appears to happen under the following conditions:
1. The related style rule is defined using a Sass placeholder
1. The placeholder is declared in one file and `@extended` in another
    1. Example:  [usa-content-styles.scss](https://github.com/uswds/uswds/blob/develop/packages/uswds-core/src/styles/mixins/typography/usa-content-styles.scss#L10)

Here, the main risk is to root global styles (in this case, the heading and paragraph elements) that do not have the specificity to take precedence over normalize CSS.

#### Compilation order
![image](https://user-images.githubusercontent.com/93996430/169160960-94eefd7b-1219-4a8a-a59f-c1b2d7ace75a.png)

To solve this and retain normalize.css as our reset, we must reorder how the CSS compiles root global styles so that reset CSS does not take precedence over USWDS styles. 

### Proposed solution:

Sass mixins compile differently than placeholders, and replacing the affected placeholders with mixins reorders the root CSS below normalize.

However, using mixins throughout has a pitfall we discovered previously: Using the typeset mixins [with `* + &` inside ](https://github.com/uswds/uswds/blob/develop/packages/uswds-core/src/styles/mixins/typography/typeset.scss#L42-L58) caused confusion in the compilation. Please reference the [notes](https://github.com/uswds/uswds/pull/4576#issuecomment-1065577521) in PR 4576 for more details. 

Placeholders do not struggle with `* + &` in the same way, so I have limited the placeholder implementation of `%usa-prose-p` and `%usa-prose-headline` to be only inside `usa-prose.scss`. This code will compile above normalize in the CSS, but it has the specificity to take precendence. 

#### Specificity wins
Now only elements with parent selectors live above normalize:

![image](https://user-images.githubusercontent.com/93996430/169390848-8678330c-12a5-4e0e-9123-429487b6290f.png)

### To reproduce issue:
1. Create test USWDS project
1. Set `$theme-global-content-styles: true`
1. Open sample html
    ```html 
    <h1>Headline</h1>
    <p>The heading and button have different margins between v2 and v3 of USWDS, due to the import order of _normalize.scss (I think?). </p>
    <button class="usa-button">Button</button>
    ```
1. Notice the vertical margin issues (outlined in https://github.com/uswds/uswds/issues/4698)
![image](https://user-images.githubusercontent.com/93996430/169401447-4ea2f48c-9fe3-4d09-865f-c064bca5548a.png)

### Things to check:

#### Confirm vertical margins 
![image](https://user-images.githubusercontent.com/93996430/169403109-a7c27815-6723-4b51-a31e-5929e00c744f.png)
- Headlines should have `margin-bottom: 0`
- `<p>`, `<button>` should have `margin-top: 1em`

#### Confirm successul `usa-prose` compilation
A successful test will show:
```
.usa-prose > * + p{
  margin-top:1em;
}
.usa-prose > p + *{
  margin-top:1em;
}

.usa-prose > h1,
.usa-prose > h2,
.usa-prose > h3,
.usa-prose > h4,
.usa-prose > h5,
.usa-prose > h6{
  margin-bottom:0;
  margin-top:0;
  clear:both;
}
.usa-prose > * + h1,
.usa-prose > * + h2,
.usa-prose > * + h3,
.usa-prose > * + h4,
.usa-prose > * + h5,
.usa-prose > * + h6{
  margin-top:1.5em;
}
.usa-prose > h1 + *,
.usa-prose > h2 + *,
.usa-prose > h3 + *,
.usa-prose > h4 + *,
.usa-prose > h5 + *,
.usa-prose > h6 + *{
  margin-top:1em;
}
```
## Future solution
In the future, we should look to replace normalize, as it does not appear to be an actively maintained code base. 

## Additional information
Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
