### PR TITLE
Cm navigation link target

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -392,7 +392,6 @@ $expand-less-icon: map-merge(
         padding: units(1);
 
         &:hover {
-          background-color: color(primary);
           color: color("white");
           text-decoration: underline;
         }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -375,7 +375,6 @@ $expand-less-icon: map-merge(
     @include add-list-reset;
     background-color: color("primary-darker");
     width: units("card-lg");
-    padding: units(2);
     position: absolute;
     z-index: z-index(400);
   }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -386,19 +386,15 @@ $expand-less-icon: map-merge(
 
   .usa-nav__submenu-item {
     @include at-media($theme-header-min-width) {
-      & + * {
-        margin-top: units(1.5);
-      }
-
       a {
         color: color("white");
-        padding: 0;
         line-height: line-height($theme-navigation-font-family, 3);
+        display: block;
+        padding: units(2);
 
         &:hover {
-          background-color: transparent;
+          background-color: color(primary);
           color: color("white");
-          padding: 0;
           text-decoration: underline;
         }
       }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -389,7 +389,7 @@ $expand-less-icon: map-merge(
         color: color("white");
         line-height: line-height($theme-navigation-font-family, 3);
         display: block;
-        padding: units(2);
+        padding: units(1);
 
         &:hover {
           background-color: color(primary);

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -390,6 +390,9 @@ $expand-less-icon: map-merge(
         line-height: line-height($theme-navigation-font-family, 3);
         display: block;
         padding: units(1);
+        &:focus {
+          outline-offset: units("neg-05");
+        }
 
         &:hover {
           color: color("white");


### PR DESCRIPTION
## Preview

Header →

## Description

Fixes #2836

Originally #4427

Modeled some of the suggestions in #2836 and #3033 which give subnav menu items a larger targeting area.

The desired effect was accomplished by setting the submenu item anchor tag to `display: block;` and moving the padding from the parent tag to the anchor itself.

## Additional information

Current Nav menus

![image](https://user-images.githubusercontent.com/25211650/146054427-5a5ef89e-8779-4163-a6f9-7c279f1a5d2f.png)
![image](https://user-images.githubusercontent.com/25211650/146054457-e022e0f7-de1c-49c7-a96a-59b33c1a1ccc.png)



Suggested on #2836 
![image](https://user-images.githubusercontent.com/25211650/146051741-9dc5891f-1e35-4cb6-902f-7b6e81eab400.png)

After this fix

<img width="896" alt="Screen Shot 2022-05-23 at 12 07 59 PM" src="https://user-images.githubusercontent.com/25211650/169861744-a430bdde-eea5-4fd2-b4bb-c0a340428218.png">
<img width="896" alt="Screen Shot 2022-05-23 at 12 08 15 PM" src="https://user-images.githubusercontent.com/25211650/169861748-a5c8b422-54a1-4727-8312-f456c902216c.png">




