### PR TITLE
USWDS - Header: Increase navigation link target size

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -375,7 +375,6 @@ $expand-less-icon: map-merge(
     @include add-list-reset;
     background-color: color("primary-darker");
     width: units("card-lg");
-    padding: units(2);
     position: absolute;
     z-index: z-index(400);
   }
@@ -386,19 +385,18 @@ $expand-less-icon: map-merge(
 
   .usa-nav__submenu-item {
     @include at-media($theme-header-min-width) {
-      & + * {
-        margin-top: units(1.5);
-      }
-
       a {
         color: color("white");
         padding: 0;
         line-height: line-height($theme-navigation-font-family, 3);
+        display: block;
+        padding: units(1);
+        &:focus {
+          outline-offset: units("neg-05");
+        }
 
         &:hover {
-          background-color: transparent;
           color: color("white");
-          padding: 0;
           text-decoration: underline;
         }
       }


### PR DESCRIPTION
## Preview

[Header →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/cm-navigation-link-target-3.0/?path=/story/components-header--default)

## Description

Fixes #2836

Originally #4427

Modeled some of the suggestions in #2836 and #3033 which give subnav menu items a larger targeting area.

The desired effect was accomplished by setting the submenu item anchor tag to `display: block;` and moving the padding from the parent tag to the anchor itself.

## Additional information

Current Nav menus

![image](https://user-images.githubusercontent.com/25211650/146054427-5a5ef89e-8779-4163-a6f9-7c279f1a5d2f.png)
![image](https://user-images.githubusercontent.com/25211650/146054457-e022e0f7-de1c-49c7-a96a-59b33c1a1ccc.png)



Suggested on #2836 
![image](https://user-images.githubusercontent.com/25211650/146051741-9dc5891f-1e35-4cb6-902f-7b6e81eab400.png)

After this fix

<img width="896" alt="Screen Shot 2022-05-23 at 12 07 59 PM" src="https://user-images.githubusercontent.com/25211650/169861744-a430bdde-eea5-4fd2-b4bb-c0a340428218.png">
<img width="896" alt="Screen Shot 2022-05-23 at 12 08 15 PM" src="https://user-images.githubusercontent.com/25211650/169861748-a5c8b422-54a1-4727-8312-f456c902216c.png">




