### PR TITLE
USWDS - Input: Fix dropdown padding for error & success variants. Resolves #4192

### DIFF
--- a/packages/usa-input/src/styles/_usa-input.scss
+++ b/packages/usa-input/src/styles/_usa-input.scss
@@ -7,8 +7,10 @@
 
 .usa-input--error {
   @include u-border($theme-input-state-border-width, "error-dark");
+  padding: calc(#{units(1.5)} - #{units($theme-input-state-border-width)});
 }
 
 .usa-input--success {
   @include u-border($theme-input-state-border-width, "success");
+  padding: calc(#{units(1.5)} - #{units($theme-input-state-border-width)});
 }

--- a/packages/usa-input/src/styles/_usa-input.scss
+++ b/packages/usa-input/src/styles/_usa-input.scss
@@ -7,10 +7,12 @@
 
 .usa-input--error {
   @include u-border($theme-input-state-border-width, "error-dark");
-  padding: calc(#{units(1.5)} - #{units($theme-input-state-border-width)});
+  padding-top: calc(#{units(1)} - #{units($theme-input-state-border-width)});
+  padding-bottom: calc(#{units(1)} - #{units($theme-input-state-border-width)});
 }
 
 .usa-input--success {
   @include u-border($theme-input-state-border-width, "success");
-  padding: calc(#{units(1.5)} - #{units($theme-input-state-border-width)});
+  padding-top: calc(#{units(1)} - #{units($theme-input-state-border-width)});
+  padding-bottom: calc(#{units(1)} - #{units($theme-input-state-border-width)});
 }


### PR DESCRIPTION
## Description

Resolves #4192. When displaying error messages on dropdown menus, the bottom of the text would be cut off. We resolved this by subtracting the added border width from the default padding.

Continued from #4219 

## Additional information

Before:
<img width="458" alt="image" src="https://user-images.githubusercontent.com/25211650/169904361-10728253-9a76-49c2-a02e-c649cf44b0d8.png">

After:
<img width="458" alt="image" src="https://user-images.githubusercontent.com/25211650/169904506-fa19e2c5-0780-4680-ad9b-fbef28a9b419.png">


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
