### PR TITLE
USWDS - global: Fix normalize.css precedence

### DIFF
--- a/packages/uswds-global/_index.scss
+++ b/packages/uswds-global/_index.scss
@@ -1,5 +1,5 @@
+@forward "uswds-elements/lib/normalize";
 @forward "uswds-core";
 @forward "uswds-fonts";
-@forward "uswds-elements/lib/normalize";
 @forward "uswds-elements";
 @forward "uswds-helpers";

--- a/src/stylesheets/packages/_uswds-global.scss
+++ b/src/stylesheets/packages/_uswds-global.scss
@@ -1,6 +1,6 @@
 // Global
 // -------------------------------------
-@forward "uswds-core";
 @forward "uswds-elements/lib/normalize";
+@forward "uswds-core";
 @forward "uswds-elements";
 @forward "uswds-helpers";


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description
Closes https://github.com/uswds/uswds/issues/4698

### Problem:
When either the `$theme-global-content-styles` or `$theme-global-paragraph-styles` settings are set to true, styles from normalize.css take precedence over some USWDS global typography styles . Because normalize.css is reset CSS, it should not take precedence over any USWDS styles.

This issue is demonstrated with vertical margin issues between text elements (outlined in https://github.com/uswds/uswds/issues/4698)

![image](https://user-images.githubusercontent.com/93996430/170708071-a44463d9-3cb4-4b01-b07c-57292bb6e589.png)
    
### Solution: 
This precedence issue is happening because normalize CSS is not compiling at the top of the file:

![image](https://user-images.githubusercontent.com/93996430/170583628-68634580-57af-46d9-b344-31eabae88ec7.png)

Because normalize does not reside at the top of the compiled file, it can take precedence over any compiled USWDS styles that come before it. 

Moving the `@forward` references for `normalize` above `uswds-core` will reorder the compiled CSS, and bring normalize to the top of the file. 

### Testing:
1. Create test USWDS project
1. Set `$theme-global-content-styles`  to `true`
1. Compile CSS 
1. Create and open a file with this sample html:
    ```html
    <h1>Headline</h1>
    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et aliquet ligula. Donec nec varius turpis. Pellentesque vehicula egestas maximus. </p>
    <p>Nunc a quam vel felis sollicitudin euismod. Vivamus dolor ex, lobortis non elit vel, tempor viverra augue. Nulla facilisi. Ut scelerisque ante at nunc pretium, vitae pellentesque massa auctor. Morbi non accumsan nunc, et bibendum nisi. Ut dapibus euismod laoreet. Nunc eu tortor euismod dui porta pulvinar.</p>
    <button class="usa-button">Button</button>
    ```
1. Confirm that normalize appears at the top of `uswds.css`
1. Perform visual checks on the html file to confirm that USWDS global styles are taking precedence. Some sample styles to check:
    - Headlines should have `margin-top: 0` and `margin-bottom: 0`
    - `<button>` should have `margin-top: 1em`

![image](https://user-images.githubusercontent.com/93996430/170708524-b561bad8-4346-4974-b717-00cd7ce4dadd.png)

## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
