### PR TITLE
USWDS - Input: Remove top margin from error inputs. Resolves #4189

### DIFF
--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -12,7 +12,6 @@
 // Block input elements
 .usa-form-group--error {
   @include u-border-left(0.5, "error-dark");
-  margin-top: units(4);
   padding-left: units(2);
   position: relative;
 


### PR DESCRIPTION
## Description

Resolves #4189 

Removes defined top margin from `usa-form-group--error` so that it inherits `usa-form-group` top margin. This prevents the input from shifting vertically when the error state is initiated.

## Additional information

Before:

https://user-images.githubusercontent.com/1779930/117032141-3e65d180-accf-11eb-8266-184b57340a48.mov



After:


https://user-images.githubusercontent.com/25211650/171281383-70967daf-f876-4c90-9778-f637a5997664.mov


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
