### PR TITLE
USWDS - Megamenu: Recalculate width of outer-megamenu elements

### DIFF
--- a/packages/usa-header/src/styles/_usa-megamenu.scss
+++ b/packages/usa-header/src/styles/_usa-megamenu.scss
@@ -1,23 +1,27 @@
 @use "sass:math";
-
+@use "sass:meta";
 @use "uswds-core" as *;
 
-@mixin outer-megamenu {
+@mixin outer-megamenu($header-max-width: $theme-header-max-width, $type) {
   @include u-pin("y");
   background-color: color("primary-darker");
   content: "";
   display: block;
   position: absolute;
-}
 
-@mixin outer-megamenu--standard {
-  @include outer-megamenu;
-  width: calc(50vw - units($theme-header-max-width) / 2 + units($theme-site-margins-width));
-}
+  // retrieve the unit value of $theme-header-max-width, depending on type of value added
+  $mw: smart-quote($header-max-width);
+  @if meta.type-of($header-max-width) == "string" {
+    $mw: units($header-max-width);
+  }
 
-@mixin outer-megamenu--extended {
-  @include outer-megamenu;
-  width: calc(50vw - units($theme-header-max-width) / 2);
+  // subtract half the value of the viewport width from half the value of the submenu width
+  // standard needs the additional $theme-site-margins-width to accommodate different paddings/structure on #basic-mega-nav-section-two
+  @if $type == "standard" {
+    width: calc(50vw - $mw / 2 + units($theme-site-margins-width));
+  } @else if $type == "extended" {
+    width: calc(50vw - $mw / 2);
+  }
 }
 
 .usa-megamenu {
@@ -45,31 +49,29 @@
 
   &::before {
     @include at-media($theme-header-min-width) {
-      @include outer-megamenu--standard;
+      @include outer-megamenu($type: "standard");
       right: 100%;
     }
   }
 
   &::after {
     @include at-media($theme-header-min-width) {
-      @include outer-megamenu--standard;
+      @include outer-megamenu($type: "standard");
       left: 100%;
     }
   }
-
-
 }
 
 .usa-header--extended .usa-megamenu.usa-nav__submenu {
   &::before {
     @include at-media($theme-header-min-width) {
-      @include outer-megamenu--extended;
+      @include outer-megamenu($type: "extended");
     }
   }
 
   &::after {
     @include at-media($theme-header-min-width) {
-      @include outer-megamenu--extended;
+      @include outer-megamenu($type: "extended");
     }
   }
 }


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Closes https://github.com/uswds/uswds/issues/4234

### Preview links: 
- [Megamenu component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-megamenu-viewport/?path=/story/components-header--megamenu)
- [Megamenu extended component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-megamenu-viewport/?path=/story/components-header--extended-megamenu)

### Problem
The `.usa-megamenu.usa-nav__submenu::after` and `.usa-megamenu.usa-nav__submenu::before` pseudo elements that surround the navigation on our megamenu extend beyond the viewport. This can cause problems when trying to capture screenshots, as well as other potential unknown issues. 

### Solution
Currently, these pseudo elements are set to a width of 100%, which is wider than they need to be and causes the elements to extend beyond the viewport. 

Recalculating the width using relevant theme settings values allows the pseudo elements to line up with the edge of the viewport.

### Testing
Because our header closes on click, I found the best method for testing this is to open desired story and **not** hit refresh to initialize the component. 

1. Open the header component `megamenu` and `extended megamenu` variants in Storybook 
1. Open web inspector and inspect `.usa-megamenu.usa-nav__submenu::after` and `.usa-megamenu.usa-nav__submenu::before` elements. 
1. Check if the elements extend beyond the viewport.

![image](https://user-images.githubusercontent.com/93996430/171662553-af8ee641-df50-4cf6-8927-40968d7df278.png)


## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
