### PR TITLE
USWDS: Date Picker - Update month-label width for mobile

### DIFF
--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -364,7 +364,7 @@ $navigate_far_next: map-merge(
 .usa-date-picker__calendar__month-picker {
   padding: 20px 5px;
 
-  @include at-media-max("card-lg") {
+  @include at-media-max("mobile") {
     padding-bottom: 12px;
     padding-top: 12px;
 

--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -363,6 +363,16 @@ $navigate_far_next: map-merge(
 // Date Picker - Month Selection View
 .usa-date-picker__calendar__month-picker {
   padding: 20px 5px;
+
+  @include at-media-max("card-lg") {
+    padding-bottom: 12px;
+    padding-top: 12px;
+
+    tr {
+      display: flex;
+      flex-direction: column;
+    }
+  }
 }
 
 .usa-date-picker__calendar__month {

--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -335,8 +335,15 @@ $navigate_far_next: map-merge(
 }
 
 .usa-date-picker__calendar__month-label {
-  flex: 4;
-  text-align: center;
+  @include at-media-max("mobile") {
+    min-width: 100%;
+    order: -1;
+  }
+
+  @include at-media("mobile") {
+    flex: 4;
+    text-align: center;
+  }
 }
 
 .usa-date-picker__calendar__year-selection,
@@ -346,6 +353,11 @@ $navigate_far_next: map-merge(
   height: 100%;
   padding: 8px 4px;
   width: auto;
+
+  @include at-media-max("mobile") {
+    padding-bottom: 0;
+    padding-top: 12px;
+  }
 }
 
 // Date Picker - Month Selection View


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description
Closes https://github.com/uswds/uswds/issues/4761

Preview link: [Date picker component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-date-picker-month/iframe.html?args=&id=components-form-inputs-date-picker--date-picker&viewMode=story)

### Problem:
The date picker component can experience visual breaks with long month names like `November` and `September` when the window width is <320px. This problem is exacerbated by putting the field group in an error state, which adds another rem or so of left padding.

In real-life usage, this means that the date picker needs to support a width of about 224-256px.

<img width="321" alt="Date picker display breaks at very narrow widths" src="https://user-images.githubusercontent.com/11464021/171675860-2d3f0672-269f-428a-8ac7-1f54d1b94ac9.png">

### Solution:
By setting the month label to be full width and ordering it so that it lives above the navigation buttons (rather than in-between) we no longer see these visual breaks in the calendar at mobile (<320px) widths. 

### Testing:
To test, 
1. Open the [date picker component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-date-picker-month/iframe.html?args=&id=components-form-inputs-date-picker--date-picker&viewMode=story) and use devTools to reset the dimensions of the window to 224px, 319px, and 320px. 
2. Check for line breaks in the month and year, especially with longer names like "September"

### Solution screenshots:
224px:
![image](https://user-images.githubusercontent.com/93996430/172207732-b0eaebe7-9622-485d-9611-50a5c80fd6ac.png)

319px:
![image](https://user-images.githubusercontent.com/93996430/172207951-ffaf910f-3785-466a-9f26-bc7f83879b22.png)

320px:
![image](https://user-images.githubusercontent.com/93996430/172207530-db66e859-b29d-4bab-bb8b-f4e349e3b047.png)

224px with error state:
![image](https://user-images.githubusercontent.com/93996430/172210344-3ad37265-e3aa-484d-a628-e7ab4aff825f.png)

320px with error state:
![image](https://user-images.githubusercontent.com/93996430/172210479-a17393dc-0469-4baf-aa82-cbac7c9a2e54.png)

## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
