### PR TITLE
[usa-header] Close accordion on sidenav close

### DIFF
--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -197,7 +197,7 @@ navigation = behavior(
     },
     focusout: {
       [NAV_PRIMARY](event) {
-        const nav = event.target.closest(NAV_PRIMARY);
+        const nav = event.target.closest(NAV);
 
         if (!nav.contains(event.relatedTarget)) {
           hideActiveNavDropdown();


### PR DESCRIPTION
## Description

When tabbing through the mobile side nav and opening an accordion, it seems like the accordion should either close when you tab to the next top-level item, or the side nav is closed.
The current implementation closes the accordion when you tab to an item not in the `<ul>` of links, which is a weird in-between option. You can see this on designsystem.digital.gov by doing the following:
* Open mobile side nav
* Tab to "Templates" and open the accordion
* Tab to the "About" top level item - note that the accordion stays open
* Tab once more to the "Read website standards" link, which is outside the `<ul>` of the menu - the accordion closes.

This PR keeps the accordion open until the side nav is fully closed.

I didn't add a test for this change, since I'm not sure if the team is interested in the change or will just close it. If the team is interested in merging this I can write a few tests for it.