### PR TITLE
Add build step to federalist

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prepare": "npx gulp",
     "preversion": "npm test",
     "release": "gulp release",
-    "federalist": "npm run build:storybook",
+    "federalist": "npm run build && npm run build:storybook",
     "start": "npm run start:storybook",
     "test": "snyk test && npm run lint && gulp typecheck && gulp lintSass && gulp test",
     "test:ci": "npm run lint && gulp test && gulp lintSass && npm run test:a11y",


### PR DESCRIPTION
## Description

Add missing icons to Storybook. Closes #4785.

## Additional information
Component library depends on `dist/` directory in order to pull assets for static build we deploy to Federalist. Icons were missing because when storybook built in federalist the `dist` directory didn't exist.

To fix this issue, I've added the build step to federalist script (`npm run federalist`). Now it builds assets before bundling the component library.

## How to test
1. Verify icons show locally
1. Verify icons show up in [Federalist](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/jm-sprite-fix/?path=/story/design-tokens-icons--icons)


Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
