### PR TITLE
USWDS - Install @types/eslint@8.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@storybook/builder-webpack5": "6.5.5",
         "@storybook/html": "6.5.5",
         "@storybook/manager-webpack5": "6.5.5",
+        "@types/eslint": "8.4.3",
         "@types/node": "16.11.19",
         "ansi-colors": "4.1.1",
         "autoprefixer": "10.4.1",
@@ -9132,9 +9133,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
-      "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.3.tgz",
+      "integrity": "sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -40846,9 +40847,9 @@
       "dev": true
     },
     "@types/eslint": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
-      "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.3.tgz",
+      "integrity": "sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@storybook/builder-webpack5": "6.5.5",
     "@storybook/html": "6.5.5",
     "@storybook/manager-webpack5": "6.5.5",
+    "@types/eslint": "8.4.3",
     "@types/node": "16.11.19",
     "ansi-colors": "4.1.1",
     "autoprefixer": "10.4.1",


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Closes: https://github.com/uswds/uswds/issues/4840

### Problem

`npm install` is failing because the @types/eslint@8.4.4 sub-dependency cannot be found. Others are also experiencing broken builds due to @types/eslint@8.4.4. Details can be found in this [open issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/61032).

Resource: [NPM @types/eslint page](https://www.npmjs.com/package/@types/eslint) 

This issue also causes `gulp buildUSWDSComponents` to fail in USWDS-Site

### Solution
Installing `@types/eslint@8.4.3` directly as a devDependency bypasses the call for the missing v8.4.4 and allows `npm install` to successfully complete.

This fix also allows `gulp buildUSWDSComponents` to run successfully on site.

## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
