### PR TITLE
USWDS - update uswds npm package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![CircleCI Build Status](https://img.shields.io/circleci/build/gh/uswds/uswds/develop?style=for-the-badge&logo=circleci)](https://circleci.com/gh/uswds/uswds/tree/develop) ![Snyk vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/uswds?style=for-the-badge) [![npm Version](https://img.shields.io/npm/v/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![npm Downloads](https://img.shields.io/npm/dt/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![GitHub issues](https://img.shields.io/github/issues/uswds/uswds?style=for-the-badge&logo=github)](https://github.com/uswds/uswds/issues) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=for-the-badge)](https://github.com/prettier/prettier)
 
-:mega: **USWDS 3.0 is now live** Get the latest from USWDS by installing the [@uswds/uswds](https://www.npmjs.com/package/@uswds/uswds) package. :mega:
+## :mega: **USWDS 3.0 is now live** :mega:
+
+Starting with version 3.0, the latest updates to USWDS are now published to the [@uswds/uswds](https://www.npmjs.com/package/@uswds/uswds) package.
+
+This unscoped `uswds` package will remain active for legacy use.
+
+---
 
 The [United States Web Design System](https://designsystem.digital.gov) includes a library of open source UI components and a visual style guide for U.S. federal government websites.
 
@@ -11,6 +17,7 @@ This repository is for the design system code itself. We maintain [another repos
 ## Contents
 
 - [United States Web Design System](#united-states-web-design-system)
+  - [:mega: **USWDS 3.0 is now live** :mega:](#mega-uswds-30-is-now-live-mega)
   - [Contents](#contents)
   - [Background](#background)
   - [Recent updates](#recent-updates)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CircleCI Build Status](https://img.shields.io/circleci/build/gh/uswds/uswds/develop?style=for-the-badge&logo=circleci)](https://circleci.com/gh/uswds/uswds/tree/develop) ![Snyk vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/uswds?style=for-the-badge) [![npm Version](https://img.shields.io/npm/v/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![npm Downloads](https://img.shields.io/npm/dt/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![GitHub issues](https://img.shields.io/github/issues/uswds/uswds?style=for-the-badge&logo=github)](https://github.com/uswds/uswds/issues) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=for-the-badge)](https://github.com/prettier/prettier)
 
+:mega: **USWDS 3.0 is now live** Get the latest from USWDS by installing the [@uswds/uswds](https://www.npmjs.com/package/@uswds/uswds) package. :mega:
+
 The [United States Web Design System](https://designsystem.digital.gov) includes a library of open source UI components and a visual style guide for U.S. federal government websites.
 
 This repository is for the design system code itself. We maintain [another repository for the documentation and website](https://github.com/uswds/uswds-site). To see the design system and its documentation on the web, visit [https://designsystem.digital.gov](https://designsystem.digital.gov).
@@ -14,7 +16,13 @@ This repository is for the design system code itself. We maintain [another repos
   - [Recent updates](#recent-updates)
   - [Getting started](#getting-started)
   - [Using the design system](#using-the-design-system)
-    - [Download and install without npm](#download-and-install-without-npm)
+    - [Download and install without `npm`](#download-and-install-without-npm)
+    - [Install using npm](#install-using-npm)
+      - [Using the USWDS package](#using-the-uswds-package)
+      - [Sass and theme settings](#sass-and-theme-settings)
+      - [Sass compilation requirements](#sass-compilation-requirements)
+      - [JavaScript](#javascript)
+    - [Use another framework or package manager](#use-another-framework-or-package-manager)
   - [CSS architecture](#css-architecture)
   - [JS customization](#js-customization)
   - [Customization, theming, and tokens](#customization-theming-and-tokens)


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

Update the README for the `uswds` npm package to point users to the new `@uswds/uswds` package.  

### Problem
Users should be able to quickly and easily find the most recent version of USWDS to install. Currently, when you search for "USWDS npm" in Google or "uswds" on the [npmjs.com](https://www.npmjs.com/search?q=uswds) website, you are directed first to the `uswds` package instead of the current `@uswds/uswds` package. Once on the [`uswds` package page](https://www.npmjs.com/package/uswds), there is nothing to indicate that USWDS 3.0 or @uswds/uswds exists. 

### Solution
**Mockup of npm page**
![image](https://user-images.githubusercontent.com/93996430/177420344-05dbd5a3-5ae4-4350-aa67-5644ae781659.png)

## Additional information

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
