### PR TITLE
USWDS - Password: Replace link with button

### DIFF
--- a/packages/_usa-password/src/index.js
+++ b/packages/_usa-password/src/index.js
@@ -4,7 +4,7 @@ const toggleFormInput = require("../../uswds-core/src/js/utils/toggle-form-input
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 
-const LINK = `.${PREFIX}-show-password, .${PREFIX}-show-multipassword`;
+const LINK = `.${PREFIX}-show-password`;
 
 function toggle(event) {
   event.preventDefault();

--- a/packages/_usa-password/src/usa-password.twig
+++ b/packages/_usa-password/src/usa-password.twig
@@ -1,6 +1,6 @@
 <button title="{{ toggle.title }}"
   type="button"
-  class="usa-show-password usa-button usa-button--unstyled"
+  class="usa-show-password"
   aria-controls="{{ toggle.aria_controls }}"
   data-show-text="{{ toggle.text.show | default("Show password") }}"
   data-hide-text="{{ toggle.text.hide | default("Hide password") }}"

--- a/packages/_usa-password/src/usa-password.twig
+++ b/packages/_usa-password/src/usa-password.twig
@@ -1,12 +1,8 @@
-
-<p class="usa-form__note">
-  <a title="{{ toggle.title }}"
-    href="{{ placeholder_link }}"
-    class="usa-show-password"
+  <button title="{{ toggle.title }}"
+    class="usa-form__note usa-show-password usa-button usa-button--unstyled"
     aria-controls="{{ toggle.aria_controls }}"
     data-show-text="{{ toggle.text.show | default("Show password") }}"
     data-hide-text="{{ toggle.text.hide | default("Hide password") }}"
   >
     {{- toggle.text.show |default('Show password') -}}
-  </a>
-</p>
+  </button>

--- a/packages/_usa-password/src/usa-password.twig
+++ b/packages/_usa-password/src/usa-password.twig
@@ -1,4 +1,4 @@
-  <button title="{{ toggle.title }}"
+  <button type="button" title="{{ toggle.title }}"
     class="usa-form__note usa-show-password usa-button usa-button--unstyled"
     aria-controls="{{ toggle.aria_controls }}"
     data-show-text="{{ toggle.text.show | default("Show password") }}"

--- a/packages/usa-form/src/styles/_usa-form.scss
+++ b/packages/usa-form/src/styles/_usa-form.scss
@@ -71,9 +71,15 @@
   }
 }
 
+.usa-show-password,
+.usa-show-multipassword {
+  @include button-unstyled;
+  cursor: pointer;
+}
+
 .usa-form__note,
-.usa-button.usa-show-password,
-.usa-button.usa-show-multipassword {
+.usa-show-password,
+.usa-show-multipassword {
   @include typeset($theme-form-font-family, "2xs", 3);
   float: right;
   margin: units(0.5) 0 units(2);

--- a/packages/usa-form/src/styles/_usa-form.scss
+++ b/packages/usa-form/src/styles/_usa-form.scss
@@ -71,7 +71,8 @@
   }
 }
 
-.usa-form__note {
+.usa-form__note,
+.usa-form__note.usa-button--unstyled {
   @include typeset($theme-form-font-family, "2xs", 3);
   float: right;
   margin: units(0.5) 0 units(2);

--- a/packages/usa-form/src/styles/_usa-form.scss
+++ b/packages/usa-form/src/styles/_usa-form.scss
@@ -71,15 +71,13 @@
   }
 }
 
-.usa-show-password,
-.usa-show-multipassword {
+.usa-show-password {
   @include button-unstyled;
   cursor: pointer;
 }
 
 .usa-form__note,
-.usa-show-password,
-.usa-show-multipassword {
+.usa-show-password {
   @include typeset($theme-form-font-family, "2xs", 3);
   float: right;
   margin: units(0.5) 0 units(2);

--- a/packages/uswds-core/src/js/utils/test/toggle-form-input.spec.js
+++ b/packages/uswds-core/src/js/utils/test/toggle-form-input.spec.js
@@ -5,7 +5,7 @@ const toggleFormInput = require("../toggle-form-input");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "/toggle.template.html"));
 
-const CONTROL_SELECTOR = ".usa-show-multipassword";
+const CONTROL_SELECTOR = ".usa-show-password";
 const PASSWORD_SELECTOR = "#password";
 const CONFIRM_SELECTOR = "#confirmPassword";
 const HIDE_TEXT = "Hide my typing";

--- a/packages/uswds-core/src/js/utils/test/toggle.template.html
+++ b/packages/uswds-core/src/js/utils/test/toggle.template.html
@@ -1,6 +1,6 @@
 <form>
   <input id="password" name="password" type="password">
   <input id="confirmPassword" name="confirmPassword" type="password">
-  <button type="button" class="usa-show-multipassword usa-button usa-button--unstyled" aria-controls="password confirmPassword"
+  <button type="button" class="usa-show-password usa-button usa-button--unstyled" aria-controls="password confirmPassword"
       data-hide-text="Hide my typing">Show my typing</button>
 </form>

--- a/packages/uswds-core/src/js/utils/test/toggle.template.html
+++ b/packages/uswds-core/src/js/utils/test/toggle.template.html
@@ -1,6 +1,6 @@
 <form>
   <input id="password" name="password" type="password">
   <input id="confirmPassword" name="confirmPassword" type="password">
-  <button class="usa-form__note usa-show-multipassword usa-button usa-button--unstyled" aria-controls="password confirmPassword"
+  <button type="button" class="usa-form__note usa-show-multipassword usa-button usa-button--unstyled" aria-controls="password confirmPassword"
       data-hide-text="Hide my typing">Show my typing</button>
 </form>

--- a/packages/uswds-core/src/js/utils/test/toggle.template.html
+++ b/packages/uswds-core/src/js/utils/test/toggle.template.html
@@ -1,8 +1,6 @@
 <form>
   <input id="password" name="password" type="password">
   <input id="confirmPassword" name="confirmPassword" type="password">
-  <p class="usa-form__note">
-    <a href="#" class="usa-show-multipassword" aria-controls="password confirmPassword"
-      data-hide-text="Hide my typing">Show my typing</a>
-  </p>
+  <button class="usa-form__note usa-show-multipassword usa-button usa-button--unstyled" aria-controls="password confirmPassword"
+      data-hide-text="Hide my typing">Show my typing</button>
 </form>


### PR DESCRIPTION
## Summary
**Updated markup in the `usa-password` package to use a `<button>` element instead of an anchor element.** This markup is more semantically appropriate for the related on-page user interaction. 

## Related issue

Closes https://github.com/uswds/uswds/issues/4592

## Preview link

Preview link: [Sign-in pattern template](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-password-button/?path=/story/pages-sign-in--sign-in-page)

## Problem statement
Interactive on-page actions should be controlled by `<button>` elements instead of `<a>` elements. However, our show/hide password functionality in our sign-in template us declared with an `<a>` tag, despite being related to an on-page action. 

## Solution
Replace the `<a>` element with a `<button>` in the sign-in template.

Note: This is not a breaking change. Using the old markup will still render a result that looks and behaves as expected. 

## Testing and review

To review:
1. Open the updated [sign-in template page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-password-button/?path=/story/pages-sign-in--sign-in-page)
2. Confirm that the button element has the appropriate markup
3. Confirm that the button appearance matches [current style](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/develop/?path=/story/pages-sign-in--sign-in-page)
4. Confirm that the show/hide functionality works as expected by typing anything in the password field and then click on the `Show password` and `Hide password` button. 
5. Confirm that prior markup still looks and behaves as expected by injecting the following via web inspector.
```
<p class="usa-form__note">
  <a title="Toggle password" href="" class="usa-show-password" aria-controls="password-sign-in" data-show-text="Show password" data-hide-text="Hide password">Show password</a>
</p>
```
---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
