### PR TITLE
USWDS - Select: Add quotes to multiselect size attribute

### DIFF
--- a/packages/usa-select/src/test/test-patterns/usa-select--multiple.twig
+++ b/packages/usa-select/src/test/test-patterns/usa-select--multiple.twig
@@ -1,6 +1,6 @@
 <form class="usa-form">
   <label class="usa-label" for="options">Dropdown label</label>
-  <select class="usa-select" name="options" id="options" multiple  size={{ size }} >
+  <select class="usa-select" name="options" id="options" multiple size="{{ size }}" >
     <option value>- Select -</option>
     <option value="value1">Option A</option>
     <option value="value2">Option B</option>


### PR DESCRIPTION
## Related issue
<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here: https://github.com/uswds/uswds/issues/new/choose.
-->

Closes #4861

## Preview link

Preview link: [Multiselect test page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-repair-select-size/?path=/story/components-form-inputs-select--multiple-test)

## Problem statement
The `size` attribute on `usa-select` was causing errors during `npm run build:html`. Adding quotes around the twig variable resolves this error.

## Testing and review
1. Run `npm run build:html` and check for errors
1. Open the [Multiselect test page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-repair-select-size/?path=/story/components-form-inputs-select--multiple-test) and change the size value in the control panel. Check that it behaves as expected. 

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:scss` to format code.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.