### PR TITLE
USWDS - Icons: Repair redundant outline icons

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -22,7 +22,7 @@ module.exports = {
   // Copy material icons to /dist/img/material-icons
   copyIcons() {
     dutil.logMessage("copyIcons", "Copying Material icons to dist/img/material-icons");
-    return src(["node_modules/@material-design-icons/svg/outlined/*"])
+    return src(["node_modules/@material-design-icons/svg/filled/*"])
       .pipe(dest("dist/img/material-icons"));
   },
 

--- a/tasks/svg-sprite.js
+++ b/tasks/svg-sprite.js
@@ -38,7 +38,7 @@ function cleanIcons() {
 function collectIcons() {
   dutil.logMessage("collectIcons", "Collecting default icon set in dist/img/usa-icons");
   return src([
-    `node_modules/@material-design-icons/svg/outlined/{${iconConfig.material}}.svg`,
+    `node_modules/@material-design-icons/svg/filled/{${iconConfig.material}}.svg`,
     `packages/usa-icon/src/img/material-icons-deprecated/{${iconConfig.materialDeprecated}}.svg`,
     `packages/usa-icon/src/img/uswds-icons/{${iconConfig.uswds}}.svg`,
   ])


### PR DESCRIPTION
## Summary
Repaired the icons that were displaying in outline form by default. Now, all icons should again display as filled by default.

## Related issue
Closes https://github.com/uswds/uswds/issues/4827

## Preview link
Preview link:[ Icon Storybook demo](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-icon-outline/?path=/story/design-tokens-icons--icons)

## Problem
Some icons were mistakenly being displayed in outline form when they should have been displayed as filled. This was happening because the Material icons were being pulled from the `/@material-design-icons/svg/outline` directory when they should have been retrieved from the `/@material-design-icons/svg/filled` directory. Updating this path resolved the issue.

This problem should affects the icons pulled from Material. The issue was confirmed on these example icons: mail, info, lightbulb

### Before
![image](https://user-images.githubusercontent.com/93996430/180088985-e5b18e7c-0073-4851-90dd-99f69d191c0e.png)

### After
![image](https://user-images.githubusercontent.com/93996430/180088887-cf961bd7-0aa0-428f-906d-2b4f907fee47.png)

## Testing and review
To test:
- Check that icons shown on [our site](https://designsystem.digital.gov/components/icon/) match [updated Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-icon-outline/?path=/story/design-tokens-icons--icons)
    - Some example icons to check : mail, info, lightbulb
---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
