### PR TITLE
3.1.0 release updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CircleCI Build Status](https://img.shields.io/circleci/build/gh/uswds/uswds/develop?style=for-the-badge&logo=circleci)](https://circleci.com/gh/uswds/uswds/tree/develop) ![Snyk vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/@uswds/uswds?style=for-the-badge) [![npm Version](https://img.shields.io/npm/v/@uswds/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![npm Downloads](https://img.shields.io/npm/dt/@uswds/uswds?style=for-the-badge)](https://www.npmjs.com/package/uswds) [![GitHub issues](https://img.shields.io/github/issues/uswds/uswds?style=for-the-badge&logo=github)](https://github.com/uswds/uswds/issues) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=for-the-badge)](https://github.com/prettier/prettier)
 
+:grinning_face_with_big_eyes:
+
 The [United States Web Design System](https://designsystem.digital.gov) includes a library of open source UI components and a visual style guide for U.S. federal government websites.
 
 This repository is for the design system code itself. We maintain [another repository for the documentation and website](https://github.com/uswds/uswds-site). To see the design system and its documentation on the web, visit [https://designsystem.digital.gov](https://designsystem.digital.gov).
@@ -195,7 +197,7 @@ The `@uswds/uswds` module is now installed as a dependency. You can use the comp
 ### Install the package directly from GitHub
 If you’re using a framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the steps outlined in this section.
 
-1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.0.2/uswds-uswds-3.0.2.tgz) directly from the latest USWDS release and uncompress that file.
+1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.1.0/uswds-uswds-3.1.0.tgz) directly from the latest USWDS release and uncompress that file.
 
 2. Copy these files and folders into a relevant place in your project's code base. Here is an example structure for how this might look:
 

--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -18,9 +18,26 @@ $uswds-notifications:
 + "\A \2709  USWDS Notifications"
 + "\A --------------------------------------------------------------------"
 + "\A 3.0.0"
-+ "\A We deprecated the $output-all-utilities setting."
-+ "\A Control utility output with $output-these-utilities."
-+ "\A See designsystem.digital.gov/documentation/settings for more.";
++ "\A - Settings: We deprecated the $output-all-utilities setting."
++ "\A   Control utility output with $output-these-utilities."
++ "\A   See designsystem.digital.gov/documentation/settings for more."
++ "\A "
++ "\A --------------------------------------------------------------------"
++ "\A 3.1.0"
++ "\A - Accessibility: We added `type='button'` to all buttons that"
++ "\A   do not submit a form. All your non-form project buttons will"
++ "\A   need `type='button'`."
++ "\A - Accessibility: We updated the markup in the usa-password package"
++ "\A   to use a <button> element instead of an anchor element."
++ "\A - Accessibility: Elements that get `aria-disabled` instead of"
++ "\A    `disabled` are now styled as disabled."
++ "\A - Compatibility: We're using some CSS selectors not supported"
++ "\A   by IE11."
++ "\A - Display: We removed the outline circle from social media icons."
++ "\A - Settings: We changed the default value of $theme-hero-image."
++ "\A   Teams that use the default image (hero.png) will need to get the"
++ "\A   new image (hero.jpg) from the distribution package."
++ "\A ";
 
 /* prettier-ignore */
 $uswds-notification-disable-message:


### PR DESCRIPTION
- Update references from `3.0.2` → `3.1.0`
- Add notifications for potential breaking changes

Please check the notifications and let me know if they look correct, clear, and complete. 

This should be the last merge to `develop` before the release.