### PR TITLE
USWDS - Align alert content with banner

### DIFF
--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -27,7 +27,9 @@ $alert-icons: (
   }
 
   &.usa-alert--no-icon {
-    @include alert-styles-no-icon;
+    .usa-alert__body {
+      @include alert-styles-no-icon;
+    }
   }
 }
 

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -12,12 +12,7 @@ $alert-icons: (
 );
 
 .usa-alert {
-  @include alert-styles-background;
-
-  .usa-alert__body {
-    @include alert-styles;
-    @include alert-styles-no-icon;
-  }
+  @include alert-styles;
 }
 
 @each $name, $icon in $alert-icons {
@@ -36,9 +31,7 @@ $alert-icons: (
   }
 
   &.usa-alert--no-icon {
-    .usa-alert__body {
-      @include alert-styles-no-icon;
-    }
+    @include alert-styles-no-icon;
   }
 }
 

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -12,10 +12,11 @@ $alert-icons: (
 );
 
 .usa-alert {
-  @include alert-status-styles-background("base");
+  @include alert-styles-background;
 
   .usa-alert__body {
     @include alert-styles;
+    @include alert-styles-no-icon;
   }
 }
 

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -17,10 +17,10 @@ $alert-icons: (
 
 @each $name, $icon in $alert-icons {
   .usa-alert--#{$name} {
-    @include alert-status-styles-background($name);
+    @include alert-status-wrapper-styles($name);
 
     .usa-alert__body {
-      @include alert-status-styles($name, $icon);
+      @include alert-status-body-styles($name, $icon);
     }
   }
 }

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -11,71 +11,23 @@ $alert-icons: (
   emergency: "error",
 );
 
-.usa-alert {
-  @include typeset($theme-alert-font-family);
-  @include border-box-sizing;
-  @include set-text-and-bg(
-    "base-lightest",
-    $theme-alert-text-color,
-    $theme-alert-text-reverse-color
-  );
-  @include u-padding-y($theme-alert-padding-y);
-  position: relative;
-
-  * + & {
-    margin-top: units(2);
-  }
-
-  border-left: units($theme-alert-bar-width) solid color("base-light");
-
-  > .usa-list,
-  .usa-alert__body > .usa-list {
-    padding-left: 0;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}
-
-.usa-alert__body {
-  @include u-padding-x($theme-alert-padding-x);
-}
-
 @each $name, $icon in $alert-icons {
   .usa-alert--#{$name} {
-    @include alert-status-styles($name, $icon);
+    @include alert-status-styles-background($name, $icon);
 
     .usa-alert__body {
-      padding-left: units($theme-alert-icon-size) +
-        (2 * $alert-icon-optical-padding);
+      @include alert-status-styles($name, $icon);
     }
   }
 }
 
-.usa-alert__heading {
-  @include typeset($theme-alert-font-family, "lg", 1);
-  margin-top: 0;
-  margin-bottom: units(1);
-}
-
-.usa-alert__text {
-  @include u-margin-y(0);
-
-  a {
-    @include typeset-link;
+.usa-alert {
+  &.usa-alert--slim {
+    @include alert-styles-slim;
   }
-}
 
-.usa-alert__text:only-child {
-  @include u-padding-y(0);
-}
-
-.usa-alert--slim {
-  @include u-padding-y(1);
-
-  .usa-alert__body {
-    padding-left: $alert-slim-icon-size + (2 * $alert-icon-optical-padding);
+  &.usa-alert--no-icon {
+    @include alert-styles-no-icon;
   }
 }
 
@@ -83,8 +35,4 @@ $alert-icons: (
   .usa-checklist {
     margin-top: units(2);
   }
-}
-
-.usa-alert--emergency {
-  border-left: none;
 }

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -25,14 +25,12 @@ $alert-icons: (
   }
 }
 
-.usa-alert {
-  &.usa-alert--slim {
-    @include alert-styles-slim;
-  }
+.usa-alert--slim {
+  @include alert-styles-slim;
+}
 
-  &.usa-alert--no-icon {
-    @include alert-styles-no-icon;
-  }
+.usa-alert--no-icon {
+  @include alert-styles-no-icon;
 }
 
 .usa-alert--validation {

--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -11,9 +11,17 @@ $alert-icons: (
   emergency: "error",
 );
 
+.usa-alert {
+  @include alert-status-styles-background("base");
+
+  .usa-alert__body {
+    @include alert-styles;
+  }
+}
+
 @each $name, $icon in $alert-icons {
   .usa-alert--#{$name} {
-    @include alert-status-styles-background($name, $icon);
+    @include alert-status-styles-background($name);
 
     .usa-alert__body {
       @include alert-status-styles($name, $icon);

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.json
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.json
@@ -1,42 +1,42 @@
 {
-    "alerts": [
-        {
-            "header": "Info alert",
-            "alertModifier": "usa-alert--info",
-            "siteModifier": "usa-site-alert--info",
-            "title": "Informative status",
-            "aria": "Site alert info"
-        },
-        {
-            "header": "Info alert - slim",
-            "alertModifier": "usa-alert--info usa-alert--slim",
-            "siteModifier": "usa-site-alert--info usa-site-alert--slim",
-            "aria": "Site alert info,"
-        },
-        {
-            "header": "Info alert - no icon",
-            "alertModifier": "usa-alert--info usa-alert--no-icon",
-            "siteModifier": "usa-site-alert--info usa-site-alert--no-icon",
-            "aria": "Site alert info,,"
-        },
-        {
-            "header": "Emergency alert",
-            "alertModifier": "usa-alert--emergency",
-            "siteModifier": "usa-site-alert--emergency",
-            "title": "Informative status",
-            "aria": "Emergency alert info"
-        },
-        {
-            "header": "Emergency alert - slim",
-            "alertModifier": "usa-alert--emergency usa-alert--slim",
-            "siteModifier": "usa-site-alert--emergency usa-site-alert--slim",
-            "aria": "Emergency alert info,"
-        },
-        {
-            "header": "Emergency alert - no icon",
-            "alertModifier": "usa-alert--emergency usa-alert--no-icon",
-            "siteModifier": "usa-site-alert--emergency usa-site-alert--no-icon",
-            "aria": "Emergency alert info,,"
-        }
-      ]
-  }
+  "alerts": [
+    {
+      "header": "Info alert",
+      "alertModifier": "usa-alert--info",
+      "siteModifier": "usa-site-alert--info",
+      "title": "Informative status",
+      "aria": "Site alert info"
+    },
+    {
+      "header": "Info alert - slim",
+      "alertModifier": "usa-alert--info usa-alert--slim",
+      "siteModifier": "usa-site-alert--info usa-site-alert--slim",
+      "aria": "Site alert info,"
+    },
+    {
+      "header": "Info alert - no icon",
+      "alertModifier": "usa-alert--info usa-alert--no-icon",
+      "siteModifier": "usa-site-alert--info usa-site-alert--no-icon",
+      "aria": "Site alert info,,"
+    },
+    {
+      "header": "Emergency alert",
+      "alertModifier": "usa-alert--emergency",
+      "siteModifier": "usa-site-alert--emergency",
+      "title": "Informative status",
+      "aria": "Emergency alert info"
+    },
+    {
+      "header": "Emergency alert - slim",
+      "alertModifier": "usa-alert--emergency usa-alert--slim",
+      "siteModifier": "usa-site-alert--emergency usa-site-alert--slim",
+      "aria": "Emergency alert info,"
+    },
+    {
+      "header": "Emergency alert - no icon",
+      "alertModifier": "usa-alert--emergency usa-alert--no-icon",
+      "siteModifier": "usa-site-alert--emergency usa-site-alert--no-icon",
+      "aria": "Emergency alert info,,"
+    }
+  ]
+}

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.json
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.json
@@ -1,0 +1,42 @@
+{
+    "alerts": [
+        {
+            "header": "Info alert",
+            "alertModifier": "usa-alert--info",
+            "siteModifier": "usa-site-alert--info",
+            "title": "Informative status",
+            "aria": "Site alert info"
+        },
+        {
+            "header": "Info alert - slim",
+            "alertModifier": "usa-alert--info usa-alert--slim",
+            "siteModifier": "usa-site-alert--info usa-site-alert--slim",
+            "aria": "Site alert info,"
+        },
+        {
+            "header": "Info alert - no icon",
+            "alertModifier": "usa-alert--info usa-alert--no-icon",
+            "siteModifier": "usa-site-alert--info usa-site-alert--no-icon",
+            "aria": "Site alert info,,"
+        },
+        {
+            "header": "Emergency alert",
+            "alertModifier": "usa-alert--emergency",
+            "siteModifier": "usa-site-alert--emergency",
+            "title": "Informative status",
+            "aria": "Emergency alert info"
+        },
+        {
+            "header": "Emergency alert - slim",
+            "alertModifier": "usa-alert--emergency usa-alert--slim",
+            "siteModifier": "usa-site-alert--emergency usa-site-alert--slim",
+            "aria": "Emergency alert info,"
+        },
+        {
+            "header": "Emergency alert - no icon",
+            "alertModifier": "usa-alert--emergency usa-alert--no-icon",
+            "siteModifier": "usa-site-alert--emergency usa-site-alert--no-icon",
+            "aria": "Emergency alert info,,"
+        }
+      ]
+  }

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -1,331 +1,81 @@
-<section class="usa-banner" aria-label="Official government website">
-  <div class="usa-accordion">
-    <header class="usa-banner__header">
-      <div class="usa-banner__inner">
-        <div class="grid-col-auto">
-          <img
-            class="usa-banner__header-flag"
-            src="https://designsystem.digital.gov/assets/img/us_flag_small.png"
-            alt="U.S. flag"
-          />
-        </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
-          <p class="usa-banner__header-text">
-            An official website of the United States government
-          </p>
-          <p class="usa-banner__header-action" aria-hidden="true">
-            Here’s how you know
-          </p>
-        </div>
-        <button
-          type="button"
-          class="usa-accordion__button usa-banner__button"
-          aria-expanded="false"
-          aria-controls="gov-banner-default-default"
-        >
-          <span class="usa-banner__button-text">Here’s how you know</span>
-        </button>
-      </div>
-    </header>
-    <div
-      class="usa-banner__content usa-accordion__content"
-      id="gov-banner-default-default"
-    >
-      <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img
-            class="usa-banner__icon usa-media-block__img"
-            src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"
-            role="img"
-            alt=""
-            aria-hidden="true"
-          />
-          <div class="usa-media-block__body">
-            <p>
-              <strong>Official websites use .gov</strong><br />A
-              <strong>.gov</strong> website belongs to an official government
-              organization in the United States.
-            </p>
-          </div>
-        </div>
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <img
-            class="usa-banner__icon usa-media-block__img"
-            src="https://designsystem.digital.gov/assets/img/icon-https.svg"
-            role="img"
-            alt=""
-            aria-hidden="true"
-          />
-          <div class="usa-media-block__body">
-            <p>
-              <strong>Secure .gov websites use HTTPS</strong><br />A
-              <strong>lock</strong> (
-              <span class="icon-lock"
-                ><svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="52"
-                  height="64"
-                  viewBox="0 0 52 64"
-                  class="usa-banner__lock-image"
-                  role="img"
-                  aria-labelledby="banner-lock-title-default banner-lock-description-default"
-                  focusable="false"
-                >
-                  <title id="banner-lock-title-default">Lock</title>
-                  <desc id="banner-lock-description-default">A locked padlock</desc>
-                  <path
-                    fill="#000000"
-                    fill-rule="evenodd"
-                    d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
-                  />
-                </svg> </span
-              >) or <strong>https://</strong> means you’ve safely connected to
-              the .gov website. Share sensitive information only on official,
-              secure websites.
-            </p>
-          </div>
-        </div>
+
+{% set banner = {
+    'banner': {
+      'id': 'gov-banner-default',
+      'text': 'An official website of the United States government',
+      'action': 'Here’s how you know',
+      'aria_label': 'Official government website'
+    },
+    'domain': {
+      'heading': 'Official websites use .gov',
+      'text': 'A <strong>.gov</strong> website belongs to an official government organization in the United States.'
+    },
+    'https': {
+      'heading': 'Secure .gov websites use HTTPS',
+      'pretext': 'A <strong>lock</strong>',
+      'posttext': 'or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.'
+    }
+} %}
+
+{% include "@components/usa-banner/src/usa-banner.twig" with banner %}
+
+{% for alert in alerts %}
+  <h3>{{ alert.header }}</h3>
+  <div class="usa-alert {{ alert.alertModifier }}">
+    <div class="usa-alert__body">
+      {% if alert.title %}<h4 class="usa-alert__heading">{{ alert.title }}</h4>{% endif %}
+      <p class="usa-alert__text">
+        Lorem ipsum dolor sit amet,
+        <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+        elit, sed do eiusmod.
+      </p>
+    </div>
+  </div>
+  <hr/>
+  <section
+    class="usa-site-alert {{ alert.siteModifier }}"
+    aria-label="{{ alert.aria }}"
+  >
+    <div class="usa-alert">
+      <div class="usa-alert__body">
+        {% if alert.title %}<h3 class="usa-alert__heading">{{ alert.title }}</h3>{% endif %}
+        <p class="usa-alert__text">
+          Additional context and followup information including
+          <a class="usa-link" href="javascript:void(0);">a link</a>.
+        </p>
       </div>
     </div>
-  </div>
-</section>
-
-<h3 class="site-preview-heading">Info alert</h3>
-<div class="usa-alert usa-alert--info" role="alert">
-  <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">Error status</h4>
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--info"
-  aria-label="Site alert info"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">Emergency alert message</h3>
-      <p class="usa-alert__text">
-        Additional context and followup information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-<h3 class="site-preview-heading">Slim alert - Info</h3>
-<div class="usa-alert usa-alert--info usa-alert--slim">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--info usa-site-alert--slim"
-  aria-label="Site alert info,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
+  </section>
+{% endfor %}
 
 
-<h3 class="site-preview-heading">Alert with no icon - Info</h3>
-<div class="usa-alert usa-alert--info usa-alert--no-icon">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--info usa-site-alert--no-icon"
-  aria-label="Site alert info,,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
+{% set footer = {
+  'footer': {
+    'return_to_top': 'Return to top',
+    'primary_section': {
+      'nav': {
+        'links': [
+          {'label': '<Primary link>'},
+          {'label': '<Primary link>'},
+          {'label': '<Primary link>'},
+          {'label': '<Primary link>'}
+        ]
+      }
+    },
+    'secondary_section': {
+      'agency_name': '<Name of Agency>',
+      'heading': '<Agency Contact Center>',
+      'phone': '<(800) 555-GOVT>',
+      'email': '<info@agency.gov>',
+      'social_nav': [
+        'Facebook',
+        'Twitter',
+        'YouTube',
+        'Instagram',
+        'RSS'
+      ]
+    }
+  }
+} %}
 
-<h3 class="site-preview-heading">Emergency alert</h3>
-<div class="usa-alert usa-alert--emergency" role="alert">
-  <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">Error status</h4>
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--emergency"
-  aria-label="Site alert emergency"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">Emergency alert message</h3>
-      <p class="usa-alert__text">
-        Additional context and followup information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-<h3 class="site-preview-heading">Slim alert - Emergency</h3>
-<div class="usa-alert usa-alert--emergency usa-alert--slim">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--emergency usa-site-alert--slim"
-  aria-label="Site alert emergency,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-
-<h3 class="site-preview-heading">Alert with no icon - Emergency</h3>
-<div class="usa-alert usa-alert--emergency usa-alert--no-icon">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-icon"
-  aria-label="Site alert emergency,,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-<h3 class="site-preview-heading">Default alert</h3>
-<div class="usa-alert" role="alert">
-  <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">Error status</h4>
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert"
-  aria-label="Site alert"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">Emergency alert message</h3>
-      <p class="usa-alert__text">
-        Additional context and followup information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-<h3 class="site-preview-heading">Slim alert - Default</h3>
-<div class="usa-alert usa-alert--slim usa-alert--no-icon">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--slim usa-site-alert--no-icon"
-  aria-label="Site alert,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
-
-
-<h3 class="site-preview-heading">Alert with no icon - Default</h3>
-<div class="usa-alert usa-alert--no-icon">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      Lorem ipsum dolor sit amet,
-      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-      elit, sed do eiusmod.
-    </p>
-  </div>
-</div>
-<hr/>
-<section
-  class="usa-site-alert usa-site-alert--no-icon"
-  aria-label="Site alert,,"
->
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <strong>Short alert message.</strong> Additional context and followup
-        information including
-        <a class="usa-link" href="javascript:void(0);">a link</a>.
-      </p>
-    </div>
-  </div>
-</section>
+{% include '@components/usa-footer/src/usa-footer.twig' with footer %}

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -289,7 +289,7 @@
 </div>
 <hr/>
 <section
-  class="usa-site-alert usa-site-alert--slim usa-alert--no-icon"
+  class="usa-site-alert usa-site-alert--slim usa-site-alert--no-icon"
   aria-label="Site alert,"
 >
   <div class="usa-alert">

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -1,0 +1,251 @@
+<section class="usa-banner" aria-label="Official government website">
+  <div class="usa-accordion">
+    <header class="usa-banner__header">
+      <div class="usa-banner__inner">
+        <div class="grid-col-auto">
+          <img
+            class="usa-banner__header-flag"
+            src="https://designsystem.digital.gov/assets/img/us_flag_small.png"
+            alt="U.S. flag"
+          />
+        </div>
+        <div class="grid-col-fill tablet:grid-col-auto">
+          <p class="usa-banner__header-text">
+            An official website of the United States government
+          </p>
+          <p class="usa-banner__header-action" aria-hidden="true">
+            Here’s how you know
+          </p>
+        </div>
+        <button
+          type="button"
+          class="usa-accordion__button usa-banner__button"
+          aria-expanded="false"
+          aria-controls="gov-banner-default-default"
+        >
+          <span class="usa-banner__button-text">Here’s how you know</span>
+        </button>
+      </div>
+    </header>
+    <div
+      class="usa-banner__content usa-accordion__content"
+      id="gov-banner-default-default"
+    >
+      <div class="grid-row grid-gap-lg">
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong><br />A
+              <strong>.gov</strong> website belongs to an official government
+              organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img
+            class="usa-banner__icon usa-media-block__img"
+            src="https://designsystem.digital.gov/assets/img/icon-https.svg"
+            role="img"
+            alt=""
+            aria-hidden="true"
+          />
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong><br />A
+              <strong>lock</strong> (
+              <span class="icon-lock"
+                ><svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="52"
+                  height="64"
+                  viewBox="0 0 52 64"
+                  class="usa-banner__lock-image"
+                  role="img"
+                  aria-labelledby="banner-lock-title-default banner-lock-description-default"
+                  focusable="false"
+                >
+                  <title id="banner-lock-title-default">Lock</title>
+                  <desc id="banner-lock-description-default">A locked padlock</desc>
+                  <path
+                    fill="#000000"
+                    fill-rule="evenodd"
+                    d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                  />
+                </svg> </span
+              >) or <strong>https://</strong> means you’ve safely connected to
+              the .gov website. Share sensitive information only on official,
+              secure websites.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<h3 class="site-preview-heading">Info alert</h3>
+<div class="usa-alert usa-alert--info" role="alert">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">Error status</h4>
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--info"
+  aria-label="Site alert info"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">Emergency alert message</h3>
+      <p class="usa-alert__text">
+        Additional context and followup information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<h3 class="site-preview-heading">Slim alert - Info</h3>
+<div class="usa-alert usa-alert--info usa-alert--slim">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--info usa-site-alert--slim"
+  aria-label="Site alert info,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+<h3 class="site-preview-heading">Alert with no icon - Info</h3>
+<div class="usa-alert usa-alert--info usa-alert--no-icon">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--info usa-site-alert--no-icon"
+  aria-label="Site alert info,,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<h3 class="site-preview-heading">Emergency alert</h3>
+<div class="usa-alert usa-alert--emergency" role="alert">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">Error status</h4>
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--emergency"
+  aria-label="Site alert emergency"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">Emergency alert message</h3>
+      <p class="usa-alert__text">
+        Additional context and followup information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<h3 class="site-preview-heading">Slim alert - Emergency</h3>
+<div class="usa-alert usa-alert--emergency usa-alert--slim">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--emergency usa-site-alert--slim"
+  aria-label="Site alert emergency,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+<h3 class="site-preview-heading">Alert with no icon - Emergency</h3>
+<div class="usa-alert usa-alert--emergency usa-alert--no-icon">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-icon"
+  aria-label="Site alert emergency,,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -249,3 +249,83 @@
     </div>
   </div>
 </section>
+
+<h3 class="site-preview-heading">Default alert</h3>
+<div class="usa-alert" role="alert">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">Error status</h4>
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert"
+  aria-label="Site alert"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">Emergency alert message</h3>
+      <p class="usa-alert__text">
+        Additional context and followup information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<h3 class="site-preview-heading">Slim alert - Default</h3>
+<div class="usa-alert usa-alert--slim usa-alert--no-icon">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--slim usa-alert--no-icon"
+  aria-label="Site alert,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+<h3 class="site-preview-heading">Alert with no icon - Default</h3>
+<div class="usa-alert usa-alert--no-icon">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Lorem ipsum dolor sit amet,
+      <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+      elit, sed do eiusmod.
+    </p>
+  </div>
+</div>
+<hr/>
+<section
+  class="usa-site-alert usa-site-alert--no-icon"
+  aria-label="Site alert,,"
+>
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <strong>Short alert message.</strong> Additional context and followup
+        information including
+        <a class="usa-link" href="javascript:void(0);">a link</a>.
+      </p>
+    </div>
+  </div>
+</section>

--- a/packages/usa-alert/src/usa-alert.stories.js
+++ b/packages/usa-alert/src/usa-alert.stories.js
@@ -1,5 +1,7 @@
 import Component from "./usa-alert.twig";
 import TestComponent from "./test/test-patterns/test-usa-alert-lists.twig";
+import ComparisonComponent from "./test/test-patterns/test-alert-comparison.twig";
+
 import {
   DefaultContent,
   EmergencyContent,
@@ -18,6 +20,7 @@ export default {
 
 const Template = (args) => Component(args);
 const TestTemplate = (args) => TestComponent(args);
+const ComparisonTemplate = (args) => ComparisonComponent(args);
 
 export const Default = Template.bind({});
 Default.args = DefaultContent;
@@ -47,3 +50,5 @@ export const Warning = Template.bind({});
 Warning.args = WarningContent;
 
 export const Test = TestTemplate.bind({});
+
+export const AlertComparison = ComparisonTemplate.bind({});

--- a/packages/usa-alert/src/usa-alert.stories.js
+++ b/packages/usa-alert/src/usa-alert.stories.js
@@ -1,6 +1,7 @@
 import Component from "./usa-alert.twig";
 import TestComponent from "./test/test-patterns/test-usa-alert-lists.twig";
 import ComparisonComponent from "./test/test-patterns/test-alert-comparison.twig";
+import ComparisonContent from "./test/test-patterns/test-alert-comparison.json";
 
 import {
   DefaultContent,
@@ -52,3 +53,4 @@ Warning.args = WarningContent;
 export const Test = TestTemplate.bind({});
 
 export const AlertComparison = ComparisonTemplate.bind({});
+AlertComparison.args = ComparisonContent;

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -23,12 +23,10 @@ $site-alert-icons: (
   }
 }
 
-.usa-site-alert {
-  &.usa-site-alert--slim {
-    @include alert-styles-slim;
-  }
+.usa-site-alert--slim .usa-alert {
+  @include alert-styles-slim;
+}
 
-  &.usa-site-alert--no-icon {
-    @include alert-styles-no-icon;
-  }
+.usa-site-alert--no-icon .usa-alert {
+  @include alert-styles-no-icon;
 }

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -15,10 +15,10 @@ $site-alert-icons: (
 
 @each $name, $icon in $site-alert-icons {
   .usa-site-alert--#{$name} .usa-alert {
-    @include alert-status-styles-background($name);
+    @include alert-status-wrapper-styles($name);
 
     .usa-alert__body {
-      @include alert-status-styles($name, $icon);
+      @include alert-status-body-styles($name, $icon);
     }
   }
 }

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -23,6 +23,8 @@ $site-alert-icons: (
   }
 
   &.usa-site-alert--no-icon {
-    @include alert-styles-no-icon;
+    .usa-alert__body {
+      @include alert-styles-no-icon;
+    }
   }
 }

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "uswds-core" as *;
 
 // Alert variables ---------- //
@@ -6,88 +7,22 @@ $site-alert-icons: (
   emergency: "error",
 );
 
-@mixin site-alert-margins {
-  &:before {
-    left: units($theme-site-margins-mobile-width);
-    @include at-media($theme-site-margins-breakpoint) {
-      left: units($theme-site-margins-width);
+@each $name, $icon in $site-alert-icons {
+  .usa-site-alert--#{$name} {
+    @include alert-status-styles-background($name, $icon);
+
+    .usa-alert__body {
+      @include alert-status-styles($name, $icon);
     }
   }
 }
 
 .usa-site-alert {
-  position: relative;
-  background-color: color("base-lightest");
-
-  .usa-alert {
-    @include u-margin-x("auto");
-    @include u-maxw($theme-site-alert-max-width);
-
-    // Don't show the left bar
-    border-left: none;
-
-    > .usa-list,
-    .usa-alert__body > .usa-list {
-      padding-left: 2ch;
-    }
+  &.usa-site-alert--slim {
+    @include alert-styles-slim;
   }
 
-  .usa-alert__body {
-    @include add-responsive-site-margins;
-  }
-}
-
-@each $name, $icon in $site-alert-icons {
-  .usa-site-alert--#{$name} {
-    $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-    @include set-text-and-bg($bgcolor);
-
-    .usa-alert {
-      @include alert-status-styles($name, $icon);
-      @include site-alert-margins;
-    }
-
-    .usa-alert__body {
-      padding-right: units($theme-site-margins-mobile-width);
-      padding-left: units($theme-site-margins-mobile-width) +
-        units($theme-alert-icon-size) +
-        units(1.5);
-
-      @include at-media($theme-site-margins-breakpoint) {
-        padding-right: units($theme-site-margins-width);
-        padding-left: units($theme-site-margins-width) +
-          units($theme-alert-icon-size) + units(1.5);
-      }
-    }
-  }
-}
-
-.usa-site-alert--no-icon {
-  .usa-alert {
-    &:before {
-      display: none;
-    }
-
-    .usa-alert__body {
-      padding-left: units($theme-site-margins-mobile-width);
-      @include at-media($theme-site-margins-breakpoint) {
-        padding-left: units($theme-site-margins-width);
-      }
-    }
-  }
-}
-
-.usa-site-alert--slim {
-  .usa-alert {
-    @include add-slim-alert-icon;
-    @include u-padding-y(1);
-  }
-  .usa-alert__body {
-    padding-left: units($theme-site-margins-mobile-width) +
-      $alert-slim-icon-size + units(1.5);
-    @include at-media($theme-site-margins-breakpoint) {
-      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size +
-        units(1.5);
-    }
+  &.usa-site-alert--no-icon {
+    @include alert-styles-no-icon;
   }
 }

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -8,10 +8,11 @@ $site-alert-icons: (
 );
 
 .usa-site-alert .usa-alert {
-  @include alert-status-styles-background("base");
+  @include alert-styles-background;
 
   .usa-alert__body {
     @include alert-styles;
+    @include alert-styles-no-icon;
   }
 }
 

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -7,12 +7,9 @@ $site-alert-icons: (
   emergency: "error",
 );
 
-.usa-site-alert .usa-alert {
-  @include alert-styles-background;
-
-  .usa-alert__body {
+.usa-site-alert {
+  .usa-alert {
     @include alert-styles;
-    @include alert-styles-no-icon;
   }
 }
 
@@ -32,8 +29,6 @@ $site-alert-icons: (
   }
 
   &.usa-site-alert--no-icon {
-    .usa-alert__body {
-      @include alert-styles-no-icon;
-    }
+    @include alert-styles-no-icon;
   }
 }

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -7,9 +7,17 @@ $site-alert-icons: (
   emergency: "error",
 );
 
+.usa-site-alert .usa-alert {
+  @include alert-status-styles-background("base");
+
+  .usa-alert__body {
+    @include alert-styles;
+  }
+}
+
 @each $name, $icon in $site-alert-icons {
-  .usa-site-alert--#{$name} {
-    @include alert-status-styles-background($name, $icon);
+  .usa-site-alert--#{$name} .usa-alert {
+    @include alert-status-styles-background($name);
 
     .usa-alert__body {
       @include alert-status-styles($name, $icon);

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -13,43 +13,6 @@
 
 // Common alert styles
 @mixin alert-styles {
-  @include border-box-sizing;
-  @include typeset($theme-alert-font-family);
-  @include u-margin-x("auto");
-  @include u-maxw($theme-site-alert-max-width);
-  @include u-padding-y($theme-alert-padding-y);
-  @include u-padding-x($theme-site-margins-mobile-width);
-
-  position: relative;
-
-  .usa-alert__text {
-    @include u-margin-y(0);
-
-    &:only-child {
-      @include u-padding-y(0);
-    }
-  }
-
-  .usa-alert__heading {
-    @include typeset($theme-alert-font-family, "lg", 1);
-    margin-top: 0;
-    margin-bottom: units(1);
-  }
-
-  > .usa-list {
-    padding-left: 0;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  .usa-list {
-    padding-left: 2ch;
-  }
-}
-
-@mixin alert-styles-background {
   $bgcolor: "base-lightest";
   $banner-text-color-token: get-color-token-from-bg(
     $bgcolor,
@@ -61,9 +24,51 @@
   background-color: color($bgcolor);
   border-left: units($theme-alert-bar-width) solid color("base-light");
   color: color($banner-text-color-token);
+
+  .usa-alert__body {
+    @include border-box-sizing;
+    @include typeset($theme-alert-font-family);
+    @include u-margin-x("auto");
+    @include u-maxw($theme-site-alert-max-width);
+    @include u-padding-y($theme-alert-padding-y);
+    @include u-padding-x($theme-site-margins-mobile-width);
+
+    padding-left: units($theme-site-margins-mobile-width);
+    @include at-media($theme-site-margins-breakpoint) {
+      padding-left: 2 * $alert-icon-optical-padding;
+    }
+    position: relative;
+
+    .usa-alert__text {
+      @include u-margin-y(0);
+
+      &:only-child {
+        @include u-padding-y(0);
+      }
+    }
+
+    .usa-alert__heading {
+      @include typeset($theme-alert-font-family, "lg", 1);
+      margin-top: 0;
+      margin-bottom: units(1);
+    }
+
+    > .usa-list {
+      padding-left: 0;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    .usa-list {
+      padding-left: 2ch;
+    }
+  }
 }
 
-// Set styles for alert wrapper/background
+
+// Set status styles for alert wrapper/background
 @mixin alert-status-styles-background($name) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(
@@ -74,10 +79,10 @@
   );
 
   background-color: color($bgcolor);
-  border-left: units($theme-alert-bar-width) solid color($name);
+  border-left-color: color($name);
 }
 
-// Set styles for alert content
+// Set status styles for alert content
 @mixin alert-status-styles($name, $icon) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(
@@ -131,13 +136,15 @@
 
 // Variant - no icon
 @mixin alert-styles-no-icon {
-  &:before {
-    display: none;
-  }
+  .usa-alert__body {
+    &:before {
+      display: none;
+    }
 
-  padding-left: units($theme-site-margins-mobile-width);
-  @include at-media($theme-site-margins-breakpoint) {
-    padding-left: 2 * $alert-icon-optical-padding;
+    padding-left: units($theme-site-margins-mobile-width);
+    @include at-media($theme-site-margins-breakpoint) {
+      padding-left: 2 * $alert-icon-optical-padding;
+    }
   }
 }
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -119,7 +119,7 @@
 
   padding-left: units($theme-site-margins-mobile-width);
   @include at-media($theme-site-margins-breakpoint) {
-    padding-left: units($theme-site-margins-width);
+    padding-left: 2 * $alert-icon-optical-padding;
   }
 }
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -11,15 +11,79 @@
 @use "../typography/typeset.scss" as *;
 @use "../helpers/set-link-from-bg" as *;
 
-@mixin add-slim-alert-icon {
-  &:before {
-    background-size: $alert-slim-icon-size;
-    height: $alert-slim-icon-size;
-    top: units(1);
-    width: $alert-slim-icon-size;
-    @supports (mask: url("")) {
-      mask-size: $alert-slim-icon-size;
+// Set styles for alert wrapper/background
+@mixin alert-status-styles-background($name, $icon) {
+  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (#{$name})"
+  );
+
+  background-color: color($bgcolor);
+  border-left: units($theme-alert-bar-width) solid color($name);
+  color: color($banner-text-color-token);
+}
+
+// Set styles for alert content
+@mixin alert-status-styles($name, $icon) {
+  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (#{$name})"
+  );
+  @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
+  @include border-box-sizing;
+  @include set-text-and-bg($bgcolor);
+  @include typeset($theme-alert-font-family);
+  @include u-margin-x("auto");
+  @include u-maxw($theme-site-alert-max-width);
+  @include u-padding-y($theme-alert-padding-y);
+  @include u-padding-x($theme-site-margins-mobile-width);
+
+  position: relative;
+  padding-left: units($theme-alert-icon-size) +
+  (2 * $alert-icon-optical-padding);
+  @include at-media($theme-site-margins-breakpoint) {
+    @include u-padding-x($theme-site-margins-width * 2);
+  }
+
+  .usa-alert__text {
+    @include u-margin-y(0);
+
+    &:only-child {
+      @include u-padding-y(0);
     }
+  }
+
+  .usa-alert__heading {
+    @include typeset($theme-alert-font-family, "lg", 1);
+    margin-top: 0;
+    margin-bottom: units(1);
+  }
+
+  .usa-link {
+    @include set-link-from-bg(
+      $bgcolor,
+      $theme-alert-link-reverse-color,
+      $theme-alert-link-color,
+      $context: "Alert (#{$name})"
+    );
+  }
+
+  > .usa-list {
+    padding-left: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .usa-list {
+    padding-left: 2ch;
   }
 }
 
@@ -32,8 +96,6 @@
     "height": $theme-alert-icon-size,
   );
 
-  $alert-icon-left: $theme-site-margins-width - $theme-alert-bar-width;
-
   &:before {
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
@@ -44,91 +106,12 @@
     position: absolute;
     top: units($theme-alert-padding-y * 0.75);
     @include at-media($theme-site-margins-breakpoint) {
-      left: units($alert-icon-left);
+      left: units($theme-site-margins-width - $theme-alert-bar-width);
     }
   }
 }
 
-@mixin alert-status-styles-background($name, $icon) {
-  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-  $banner-text-color-token: get-color-token-from-bg(
-    $bgcolor,
-    $theme-alert-text-reverse-color,
-    $theme-alert-text-color,
-    $context: "Alert (#{$name})"
-  );
-
-  background-color: color($bgcolor);
-  border-left: units($theme-alert-bar-width) solid color("base-light");
-  border-left-color: color($name);
-  color: color($banner-text-color-token);
-}
-
-@mixin alert-status-styles($name, $icon) {
-  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-  $banner-text-color-token: get-color-token-from-bg(
-    $bgcolor,
-    $theme-alert-text-reverse-color,
-    $theme-alert-text-color,
-    $context: "Alert (#{$name})"
-  );
-
-  position: relative;
-  @include border-box-sizing;
-  @include u-padding-y($theme-alert-padding-y);
-  @include u-padding-x($theme-site-margins-mobile-width);
-
-  padding-left: units($theme-alert-icon-size) +
-    (2 * $alert-icon-optical-padding);
-
-  @include at-media($theme-site-margins-breakpoint) {
-    @include u-padding-x($theme-site-margins-width * 2);
-  }
-
-  @include u-margin-x("auto");
-  @include u-maxw($theme-site-alert-max-width);
-
-  @include typeset($theme-alert-font-family);
-  @include set-text-and-bg($bgcolor);
-  @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
-
-  > .usa-list,
-  .usa-alert__body > .usa-list {
-    padding-left: 0;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  .usa-alert__text {
-    @include u-margin-y(0);
-  }
-
-  .usa-link {
-    @include set-link-from-bg(
-      $bgcolor,
-      $theme-alert-link-reverse-color,
-      $theme-alert-link-color,
-      $context: "Alert (#{$name})"
-    );
-  }
-
-  .usa-list {
-    padding-left: 2ch;
-  }
-
-  .usa-alert__heading {
-    @include typeset($theme-alert-font-family, "lg", 1);
-    margin-top: 0;
-    margin-bottom: units(1);
-  }
-
-  .usa-alert__text:only-child {
-    @include u-padding-y(0);
-  }
-}
-
+// Variant - no icon
 @mixin alert-styles-no-icon {
   &:before {
     display: none;
@@ -137,6 +120,20 @@
   padding-left: units($theme-site-margins-mobile-width);
   @include at-media($theme-site-margins-breakpoint) {
     padding-left: units($theme-site-margins-width);
+  }
+}
+
+
+// Variant - slim
+@mixin add-slim-alert-icon {
+  &:before {
+    background-size: $alert-slim-icon-size;
+    height: $alert-slim-icon-size;
+    top: units($theme-alert-padding-y * 0.5);
+    width: $alert-slim-icon-size;
+    @supports (mask: url("")) {
+      mask-size: $alert-slim-icon-size;
+    }
   }
 }
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -68,7 +68,7 @@
 }
 
 // Set status styles for alert wrapper/background
-@mixin alert-status-styles-background($name) {
+@mixin alert-status-wrapper-styles($name) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(
     $bgcolor,
@@ -83,7 +83,7 @@
 
 // Set status styles for alert content
 // added to __body element
-@mixin alert-status-styles($name, $icon) {
+@mixin alert-status-body-styles($name, $icon) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(
     $bgcolor,

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -107,10 +107,6 @@
 
   .usa-alert__text {
     @include u-margin-y(0);
-
-    a {
-      @include typeset-link;
-    }
   }
 
   .usa-link {

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -142,10 +142,10 @@
     display: none;
   }
 
-    padding-left: units($theme-site-margins-mobile-width);
-    @include at-media($theme-site-margins-breakpoint) {
-      padding-left: units($theme-site-margins-width);
-    }
+  padding-left: units($theme-site-margins-mobile-width);
+  @include at-media($theme-site-margins-breakpoint) {
+    padding-left: units($theme-site-margins-width);
+  }
 }
 
 @mixin alert-styles-slim {
@@ -153,11 +153,9 @@
     @include u-padding-y(1);
     @include add-slim-alert-icon;
 
-    padding-left: units($theme-site-margins-mobile-width) +
-      $alert-slim-icon-size + units(1.5);
+    padding-left: units($theme-site-margins-mobile-width) + $alert-slim-icon-size;
     @include at-media($theme-site-margins-breakpoint) {
-      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size +
-        units(1.5);
+      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size;
     }
   }
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -59,15 +59,11 @@
 
   > .usa-list,
   .usa-alert__body > .usa-list {
-    padding-left: 0;
+    padding-left: 2ch;
 
     &:last-child {
       margin-bottom: 0;
     }
-  }
-
-  .usa-list {
-    padding-left: 2ch;
   }
 }
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -11,7 +11,7 @@
 @use "../typography/typeset.scss" as *;
 @use "../helpers/set-link-from-bg" as *;
 
-// Common alert styles
+// Base alert styles
 @mixin alert-styles {
   $bgcolor: "base-lightest";
   $banner-text-color-token: get-color-token-from-bg(
@@ -25,6 +25,10 @@
   border-left: units($theme-alert-bar-width) solid color("base-light");
   color: color($banner-text-color-token);
 
+  * + & {
+    margin-top: units(2);
+  }
+
   .usa-alert__body {
     @include border-box-sizing;
     @include typeset($theme-alert-font-family);
@@ -32,41 +36,40 @@
     @include u-maxw($theme-site-alert-max-width);
     @include u-padding-y($theme-alert-padding-y);
     @include u-padding-x($theme-site-margins-mobile-width);
-
-    padding-left: units($theme-site-margins-mobile-width);
     @include at-media($theme-site-margins-breakpoint) {
       padding-left: 2 * $alert-icon-optical-padding;
     }
+
     position: relative;
+  }
 
-    .usa-alert__text {
-      @include u-margin-y(0);
+  .usa-alert__text {
+    @include u-margin-y(0);
 
-      &:only-child {
-        @include u-padding-y(0);
-      }
-    }
-
-    .usa-alert__heading {
-      @include typeset($theme-alert-font-family, "lg", 1);
-      margin-top: 0;
-      margin-bottom: units(1);
-    }
-
-    > .usa-list {
-      padding-left: 0;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
-
-    .usa-list {
-      padding-left: 2ch;
+    &:only-child {
+      @include u-padding-y(0);
     }
   }
-}
 
+  .usa-alert__heading {
+    @include typeset($theme-alert-font-family, "lg", 1);
+    margin-top: 0;
+    margin-bottom: units(1);
+  }
+
+  > .usa-list,
+  .usa-alert__body > .usa-list {
+    padding-left: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .usa-list {
+    padding-left: 2ch;
+  }
+}
 
 // Set status styles for alert wrapper/background
 @mixin alert-status-styles-background($name) {
@@ -83,6 +86,7 @@
 }
 
 // Set status styles for alert content
+// added to __body element
 @mixin alert-status-styles($name, $icon) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -12,7 +12,7 @@
 @use "../helpers/set-link-from-bg" as *;
 
 // Set styles for alert wrapper/background
-@mixin alert-status-styles-background($name, $icon) {
+@mixin alert-status-styles-background($name) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
   $banner-text-color-token: get-color-token-from-bg(
     $bgcolor,
@@ -26,18 +26,8 @@
   color: color($banner-text-color-token);
 }
 
-// Set styles for alert content
-@mixin alert-status-styles($name, $icon) {
-  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-  $banner-text-color-token: get-color-token-from-bg(
-    $bgcolor,
-    $theme-alert-text-reverse-color,
-    $theme-alert-text-color,
-    $context: "Alert (#{$name})"
-  );
-  @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
+@mixin alert-styles {
   @include border-box-sizing;
-  @include set-text-and-bg($bgcolor);
   @include typeset($theme-alert-font-family);
   @include u-margin-x("auto");
   @include u-maxw($theme-site-alert-max-width);
@@ -65,15 +55,6 @@
     margin-bottom: units(1);
   }
 
-  .usa-link {
-    @include set-link-from-bg(
-      $bgcolor,
-      $theme-alert-link-reverse-color,
-      $theme-alert-link-color,
-      $context: "Alert (#{$name})"
-    );
-  }
-
   > .usa-list {
     padding-left: 0;
 
@@ -84,6 +65,28 @@
 
   .usa-list {
     padding-left: 2ch;
+  }
+}
+
+// Set styles for alert content
+@mixin alert-status-styles($name, $icon) {
+  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (#{$name})"
+  );
+  @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
+  @include set-text-and-bg($bgcolor);
+
+  .usa-link {
+    @include set-link-from-bg(
+      $bgcolor,
+      $theme-alert-link-reverse-color,
+      $theme-alert-link-color,
+      $context: "Alert (#{$name})"
+    );
   }
 }
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -46,7 +46,7 @@
 
   position: relative;
   padding-left: units($theme-alert-icon-size) +
-  (2 * $alert-icon-optical-padding);
+    (2 * $alert-icon-optical-padding);
   @include at-media($theme-site-margins-breakpoint) {
     @include u-padding-x($theme-site-margins-width * 2);
   }
@@ -122,7 +122,6 @@
     padding-left: 2 * $alert-icon-optical-padding;
   }
 }
-
 
 // Variant - slim
 @mixin add-slim-alert-icon {

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -99,7 +99,7 @@
   @include set-text-and-bg($bgcolor);
 
   padding-left: units($theme-alert-icon-size) +
-    (2 * $alert-icon-optical-padding);
+    ($alert-icon-optical-padding);
   @include at-media($theme-site-margins-breakpoint) {
     @include u-padding-x($theme-site-margins-width * 2);
   }
@@ -123,13 +123,13 @@
     "height": $theme-alert-icon-size,
   );
 
-  &:before {
+  &::before {
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
     display: block;
     height: $theme-alert-icon-size;
     // padding - optical spacing value
-    left: $alert-icon-optical-padding;
+    left: units($theme-site-margins-mobile-width - $theme-alert-bar-width);
     position: absolute;
     top: units($theme-alert-padding-y * 0.75);
     @include at-media($theme-site-margins-breakpoint) {
@@ -145,7 +145,7 @@
       display: none;
     }
 
-    padding-left: units($theme-site-margins-mobile-width);
+    padding-left: units($theme-site-margins-mobile-width - $theme-alert-bar-width);
     @include at-media($theme-site-margins-breakpoint) {
       padding-left: 2 * $alert-icon-optical-padding;
     }
@@ -170,7 +170,7 @@
     @include u-padding-y(1);
     @include add-slim-alert-icon;
 
-    padding-left: $alert-slim-icon-size + (2 * $alert-icon-optical-padding);
+    padding-left: $alert-slim-icon-size + $alert-icon-optical-padding;
     @include at-media($theme-site-margins-breakpoint) {
       padding-left: units($theme-site-margins-width) + $alert-slim-icon-size;
     }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -3,14 +3,19 @@
 @use "../../variables/project-alerts" as *;
 @use "../../settings" as *;
 @use "../../functions" as *;
+@use "./at-media" as *;
+@use "./border-box-sizing" as *;
+@use "./set-text-and-bg" as *;
 @use "../general/icon" as *;
-@use "../utilities/padding" as *;
+@use "../utilities" as *;
+@use "../typography/typeset.scss" as *;
 @use "../helpers/set-link-from-bg" as *;
 
 @mixin add-slim-alert-icon {
   &:before {
     background-size: $alert-slim-icon-size;
-    height: units(5);
+    height: $alert-slim-icon-size;
+    top: units(1);
     width: $alert-slim-icon-size;
     @supports (mask: url("")) {
       mask-size: $alert-slim-icon-size;
@@ -27,19 +32,42 @@
     "height": $theme-alert-icon-size,
   );
 
+  $alert-icon-left: $theme-site-margins-width - $theme-alert-bar-width;
+
   &:before {
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
     display: block;
-    height: (2 * units($theme-alert-padding-y)) + units(3);
+    height: $theme-alert-icon-size;
     // padding - optical spacing value
-    left: $alert-icon-optical-padding;
+    left: units($alert-icon-left);
     position: absolute;
-    top: 0;
+    top: units($theme-alert-padding-y * .75);
   }
-  &.usa-alert--slim {
-    @include add-slim-alert-icon;
+}
+
+@mixin site-alert-margins {
+  &:before {
+    left: units($theme-site-margins-mobile-width);
+    @include at-media($theme-site-margins-breakpoint) {
+      left: units($theme-site-margins-width);
+    }
   }
+}
+
+@mixin alert-status-styles-background($name, $icon) {
+  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (#{$name})"
+  );
+
+  background-color: color($bgcolor);
+  border-left: units($theme-alert-bar-width) solid color("base-light");
+  border-left-color: color($name);
+  color: color($banner-text-color-token);
 }
 
 @mixin alert-status-styles($name, $icon) {
@@ -51,10 +79,39 @@
     $context: "Alert (#{$name})"
   );
 
+
+  position: relative;
+  @include border-box-sizing;
+  @include u-padding-y($theme-alert-padding-y);
+  @include u-padding-x($theme-site-margins-mobile-width);
+
+  @include at-media($theme-site-margins-breakpoint) {
+    @include u-padding-x($theme-site-margins-width * 2);
+  }
+
+  @include u-margin-x("auto");
+  @include u-maxw($theme-site-alert-max-width);
+
+  @include typeset($theme-alert-font-family);
+  @include set-text-and-bg($bgcolor);
   @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
-  background-color: color($bgcolor);
-  border-left-color: color($name);
-  color: color($banner-text-color-token);
+
+  > .usa-list,
+  .usa-alert__body > .usa-list {
+    padding-left: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .usa-alert__text {
+    @include u-margin-y(0);
+
+    a {
+      @include typeset-link;
+    }
+  }
 
   .usa-link {
     @include set-link-from-bg(
@@ -65,13 +122,42 @@
     );
   }
 
-  &.usa-alert--no-icon {
-    &:before {
-      display: none;
-    }
+  .usa-list {
+    padding-left: 2ch;
+  }
 
-    .usa-alert__body {
-      padding-left: units($theme-alert-padding-x);
+  .usa-alert__heading {
+    @include typeset($theme-alert-font-family, "lg", 1);
+    margin-top: 0;
+    margin-bottom: units(1);
+  }
+
+  .usa-alert__text:only-child {
+    @include u-padding-y(0);
+  }
+}
+
+@mixin alert-styles-no-icon {
+  &:before {
+    display: none;
+  }
+
+    padding-left: units($theme-site-margins-mobile-width);
+    @include at-media($theme-site-margins-breakpoint) {
+      padding-left: units($theme-site-margins-width);
+    }
+}
+
+@mixin alert-styles-slim {
+  .usa-alert__body {
+    @include u-padding-y(1);
+    @include add-slim-alert-icon;
+
+    padding-left: units($theme-site-margins-mobile-width) +
+      $alert-slim-icon-size + units(1.5);
+    @include at-media($theme-site-margins-breakpoint) {
+      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size +
+        units(1.5);
     }
   }
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -11,21 +11,7 @@
 @use "../typography/typeset.scss" as *;
 @use "../helpers/set-link-from-bg" as *;
 
-// Set styles for alert wrapper/background
-@mixin alert-status-styles-background($name) {
-  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-  $banner-text-color-token: get-color-token-from-bg(
-    $bgcolor,
-    $theme-alert-text-reverse-color,
-    $theme-alert-text-color,
-    $context: "Alert (#{$name})"
-  );
-
-  background-color: color($bgcolor);
-  border-left: units($theme-alert-bar-width) solid color($name);
-  color: color($banner-text-color-token);
-}
-
+// Common alert styles
 @mixin alert-styles {
   @include border-box-sizing;
   @include typeset($theme-alert-font-family);
@@ -35,11 +21,6 @@
   @include u-padding-x($theme-site-margins-mobile-width);
 
   position: relative;
-  padding-left: units($theme-alert-icon-size) +
-    (2 * $alert-icon-optical-padding);
-  @include at-media($theme-site-margins-breakpoint) {
-    @include u-padding-x($theme-site-margins-width * 2);
-  }
 
   .usa-alert__text {
     @include u-margin-y(0);
@@ -68,6 +49,34 @@
   }
 }
 
+@mixin alert-styles-background {
+  $bgcolor: "base-lightest";
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (default)"
+  );
+
+  background-color: color($bgcolor);
+  border-left: units($theme-alert-bar-width) solid color("base-light");
+  color: color($banner-text-color-token);
+}
+
+// Set styles for alert wrapper/background
+@mixin alert-status-styles-background($name) {
+  $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $banner-text-color-token: get-color-token-from-bg(
+    $bgcolor,
+    $theme-alert-text-reverse-color,
+    $theme-alert-text-color,
+    $context: "Alert (#{$name})"
+  );
+
+  background-color: color($bgcolor);
+  border-left: units($theme-alert-bar-width) solid color($name);
+}
+
 // Set styles for alert content
 @mixin alert-status-styles($name, $icon) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
@@ -79,6 +88,12 @@
   );
   @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
   @include set-text-and-bg($bgcolor);
+
+  padding-left: units($theme-alert-icon-size) +
+    (2 * $alert-icon-optical-padding);
+  @include at-media($theme-site-margins-breakpoint) {
+    @include u-padding-x($theme-site-margins-width * 2);
+  }
 
   .usa-link {
     @include set-link-from-bg(

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -70,12 +70,6 @@
 // Set status styles for alert wrapper/background
 @mixin alert-status-wrapper-styles($name) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
-  $banner-text-color-token: get-color-token-from-bg(
-    $bgcolor,
-    $theme-alert-text-reverse-color,
-    $theme-alert-text-color,
-    $context: "Alert (#{$name})"
-  );
 
   background-color: color($bgcolor);
   border-left-color: color($name);
@@ -94,8 +88,7 @@
   @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
   @include set-text-and-bg($bgcolor);
 
-  padding-left: units($theme-alert-icon-size) +
-    ($alert-icon-optical-padding);
+  padding-left: units($theme-alert-icon-size) + ($alert-icon-optical-padding);
   @include at-media($theme-site-margins-breakpoint) {
     @include u-padding-x($theme-site-margins-width * 2);
   }
@@ -141,7 +134,9 @@
       display: none;
     }
 
-    padding-left: units($theme-site-margins-mobile-width - $theme-alert-bar-width);
+    padding-left: units(
+      $theme-site-margins-mobile-width - $theme-alert-bar-width
+    );
     @include at-media($theme-site-margins-breakpoint) {
       padding-left: 2 * $alert-icon-optical-padding;
     }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -40,9 +40,12 @@
     display: block;
     height: $theme-alert-icon-size;
     // padding - optical spacing value
-    left: units($alert-icon-left);
+    left: $alert-icon-optical-padding;
     position: absolute;
     top: units($theme-alert-padding-y * .75);
+    @include at-media($theme-site-margins-breakpoint){
+      left: units($alert-icon-left);
+    }
   }
 }
 
@@ -79,11 +82,13 @@
     $context: "Alert (#{$name})"
   );
 
-
   position: relative;
   @include border-box-sizing;
   @include u-padding-y($theme-alert-padding-y);
   @include u-padding-x($theme-site-margins-mobile-width);
+
+  padding-left: units($theme-alert-icon-size) +
+        (2 * $alert-icon-optical-padding);
 
   @include at-media($theme-site-margins-breakpoint) {
     @include u-padding-x($theme-site-margins-width * 2);
@@ -149,7 +154,7 @@
     @include u-padding-y(1);
     @include add-slim-alert-icon;
 
-    padding-left: units($theme-site-margins-mobile-width) + $alert-slim-icon-size;
+    padding-left: $alert-slim-icon-size + (2 * $alert-icon-optical-padding);
     @include at-media($theme-site-margins-breakpoint) {
       padding-left: units($theme-site-margins-width) + $alert-slim-icon-size;
     }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -42,18 +42,9 @@
     // padding - optical spacing value
     left: $alert-icon-optical-padding;
     position: absolute;
-    top: units($theme-alert-padding-y * .75);
-    @include at-media($theme-site-margins-breakpoint){
-      left: units($alert-icon-left);
-    }
-  }
-}
-
-@mixin site-alert-margins {
-  &:before {
-    left: units($theme-site-margins-mobile-width);
+    top: units($theme-alert-padding-y * 0.75);
     @include at-media($theme-site-margins-breakpoint) {
-      left: units($theme-site-margins-width);
+      left: units($alert-icon-left);
     }
   }
 }
@@ -88,7 +79,7 @@
   @include u-padding-x($theme-site-margins-mobile-width);
 
   padding-left: units($theme-alert-icon-size) +
-        (2 * $alert-icon-optical-padding);
+    (2 * $alert-icon-optical-padding);
 
   @include at-media($theme-site-margins-breakpoint) {
     @include u-padding-x($theme-site-margins-width * 2);

--- a/packages/uswds-core/src/styles/variables/project-alerts.scss
+++ b/packages/uswds-core/src/styles/variables/project-alerts.scss
@@ -3,7 +3,7 @@
 @use "../settings";
 @use "../functions/units/units" as *;
 
-// Icon settings used in: _usa-alert, _usa-site-alert, and alert-status-styles
+// Icon settings used in: _usa-alert, _usa-site-alert, and alert-status-body-styles
 $alert-slim-icon-size: units(3);
 $alert-icon-optical-factor: math.div(units(settings.$theme-alert-icon-size), 6);
 $alert-icon-optical-padding: units(settings.$theme-alert-padding-x) -


### PR DESCRIPTION
## Summary
Updated the alignment of the alert and site-alert component content to visually match alignment with banner content. 

## Related issue
Closes [#4642](https://github.com/uswds/uswds/issues/4642)

## Preview link
Preview link: [Alert comparison test](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-alert-icon-alignment/?path=/story/components-alert--alert-comparison)

## Problem statement
Design elements like icons and text should align to make it easier for users to scan content. However, the alert, site-alert, and banner components all align along different vertical lines, which can cause visual disruption. 

## Solution
Left-aligning all items that use the `add-responsive-site-margins` mixin along the same vertical line will enable users to more easily scan content. 

### Before
![image](https://user-images.githubusercontent.com/93996430/186020209-39713066-5bd1-4ac2-9865-669f5f383731.png)

### After
![image](https://user-images.githubusercontent.com/93996430/186021550-2b87abd5-52cf-480b-aac9-ac35e93652d8.png)

## Major changes
1. Removed usa-site-alert's dependency on usa-alert. This was done by consolidating all shared styles in uswds-core mixins.
2. Visually aligned the content in both components with the content in usa-banner. 

## Testing and review
To test:
1. Confirm that alert variant styles match existing display. Note: The alignment is expected to be different, but colors, typography, padding, etc should be the same. 
1. Confirm that styles left-align with other components like banner and footer
1. Confirm that alignment looks good in multiple browsers at multiple widths.
1. Confirm that you can disable all styles in usa-alert and still have proper display of usa-site-alert (and vice versa)

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:scss` to format code.
- [x] Run `npm test` and confirm that all tests pass.