### PR TITLE
USWDS - Banner: Create clearer readout with aria

### DIFF
--- a/packages/templates/usa-base/includes/_banner.twig
+++ b/packages/templates/usa-base/includes/_banner.twig
@@ -4,7 +4,7 @@
       'id': 'gov-banner-default',
       'text': 'An official website of the United States government',
       'action': 'Here’s how you know',
-      'aria_label': 'Official government website'
+      'aria_label': 'Official website of the United States government'
     },
     'domain': {
       'heading': 'Official websites use .gov',

--- a/packages/usa-banner/src/content/usa-banner.json
+++ b/packages/usa-banner/src/content/usa-banner.json
@@ -3,7 +3,7 @@
     "id": "gov-banner-default",
     "text": "An official website of the United States government",
     "action": "Here’s how you know",
-    "aria_label": "Official government website"
+    "aria_label": "Official website of the United States government"
   },
   "domain": {
     "heading": "Official websites use .gov",

--- a/packages/usa-banner/src/content/usa-banner~mil.json
+++ b/packages/usa-banner/src/content/usa-banner~mil.json
@@ -3,7 +3,7 @@
     "id": "gov-banner-dot-mil",
     "text": "An official website of the United States government",
     "action": "Here’s how you know",
-    "aria_label": "Official government website,"
+    "aria_label": "Official website of the United States government,"
   },
   "domain": {
     "heading": "Official websites use .mil",

--- a/packages/usa-banner/src/test/template.html
+++ b/packages/usa-banner/src/test/template.html
@@ -3,7 +3,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">An official website of the United States government</p>

--- a/packages/usa-banner/src/test/template.html
+++ b/packages/usa-banner/src/test/template.html
@@ -1,13 +1,13 @@
-<div class="usa-banner">
+<div class="usa-banner" aria-label="Official website of the United States government">
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
           <img class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="U.S. flag">
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
+        <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">An official website of the United States government</p>
-          <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+          <p class="usa-banner__header-action">Here’s how you know</p>
         </div>
         <button type="button" class="usa-accordion__button usa-banner__button"
           aria-expanded="false"

--- a/packages/usa-banner/src/test/template.html
+++ b/packages/usa-banner/src/test/template.html
@@ -3,7 +3,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img aria-hidden="true" class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="../../dist/img/favicons/favicon-57.png" alt="">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">An official website of the United States government</p>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -13,7 +13,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">{{ banner.text }}</p>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -13,7 +13,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">{{ banner.text }}</p>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -13,7 +13,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
+          <img class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">{{ banner.text }}</p>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -1,8 +1,8 @@
 {% set lock %}
   <span class="icon-lock">
-    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false">
+    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false">
       <title id="banner-lock-title">Lock</title>
-      <desc id="banner-lock-description">A locked padlock</desc>
+      <desc id="banner-lock-description">Locked padlock icon</desc>
       <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/>
     </svg>
   </span>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -13,11 +13,11 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
+        <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">{{ banner.text }}</p>
-          <p class="usa-banner__header-action" aria-hidden="true">{{ banner.action }}</p>
+          <p class="usa-banner__header-action">{{ banner.action }}</p>
         </div>
         <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="{{ banner.id }}">
           <span class="usa-banner__button-text">{{ banner.action }}</span>


### PR DESCRIPTION
## Summary
1. **Updated the aria-label in English versions of usa-banner.** When read out on a screen reader, the statement "An official website of the United States government" can sound like "Unofficial website of the United States government".  To minimize confusion, we updated the component's aria-label to instead read  "Official website of the United States government".

2. **Added `aria-hidden` attribute to the flag icon in the banner component.** The flag icon in the banner component is purely decorative and we can safely remove it from the screen reader readout. 

## Related issue
This PR addresses two issues related to the banner screen reader experience:
Closes #4419
Closes #4912

## Preview link
Preview link: [Banner component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-banner-readout/?path=/story/components-banner--default)

## Problem statement
1. When read out on a screen reader, the statement "An official website of the United States government" can sound like "UNofficial website of the United States government". This introduces the risk of conveying a meaning opposite of what was intended. 
2. The flag icon in the banner component is purely decorative and there is no need to announce its presence to those using screen readers.

## Solution
Updating the aria-label gives us the ability to reduce confusion for those using screen readers without creating inconsistency in the visual presentation. Additionally, updating the aria for the icons in this component creates a simpler, clearer readout for screen readers.

Note: I did not hide the lock icon from the readout because I ruled that it added important context: an explanation that "A lock" means a lock icon. However, I did clarify the readout from "Lock, a locked padlock, image"  to "Locked padlock icon, image" (on VoiceOver). Flagging this because it could be determined that this icon is decorative as well. 

## Testing and review
This component was tested on:
- VoiceOver on Safari, Chrome, Firefox, and Edge for Mac
- VoiceOver Gestures in iOS safari

Please test on your available screen readers to confirm that the content is accessible and the experience is optimized.

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
