### PR TITLE
USWDS - Banner: Add aria-hidden to flag icon

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -1,8 +1,8 @@
 {% set lock %}
   <span class="icon-lock">
-    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false">
+    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false">
       <title id="banner-lock-title">Lock</title>
-      <desc id="banner-lock-description">A locked padlock</desc>
+      <desc id="banner-lock-description">Locked padlock icon</desc>
       <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/>
     </svg>
   </span>

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -13,7 +13,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
+          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
           <p class="usa-banner__header-text">{{ banner.text }}</p>


### PR DESCRIPTION
## Summary
Added `aria-hidden="true"` to the flag icon in the banner component. 

## Related issue
Closes #4912

## Preview link
Preview link: [Banner component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.app.cloud.gov/preview/uswds/uswds/al-flag-aria/?path=/story/components-banner--default)

## Problem statement
The flag icon in the banner component is purely decorative and there is no need to announce its presence to those using screen readers. 

## Solution
Adding `aria-hidden` to the icon will hide the icon from screen readers.

Please note: I did not hide the lock icon as suggested in the issue because it conveys meaning in this case.

## Testing and review
This component was tested on:
VoiceOver on Safari, Chrome, Firefox, and Edge for Mac

Please confirm that the flag icon is hidden from the screen readers available to you. 

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
