### PR TITLE
Combo box list keyboard navigation additions

### DIFF
--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -689,6 +689,53 @@ const handleUpFromListOption = (event) => {
 };
 
 /**
+ * Handle the home and end keypress events
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ * @param {boolean} home True when the home (or page up) key was pressed. False
+ * when the end (or page down) key was pressed
+ */
+const handleHomeOrEnd = (event, home) => {
+  const { comboBoxEl } = getComboBoxContext(event.target);
+  const options = comboBoxEl.querySelectorAll(".usa-combo-box__list li");
+  const index = home ? 0 : options.length - 1;
+  highlightOption(comboBoxEl, options[index]);
+  event.preventDefault();
+};
+
+/**
+ * Handle a press of the home key within the combo box list
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleHomeFromListOption = (event) => {
+  handleHomeOrEnd(event, true);
+};
+
+/**
+ * Handle a press of the page up key within the combo box list
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handlePageUpFromListOption = handleHomeFromListOption;
+
+/**
+ * Handle a press of the end key within the combo box list
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handleEndFromListOption = (event) => {
+  handleHomeOrEnd(event, false);
+};
+
+/**
+ * Handle a press of the page down key within the combo box list
+ *
+ * @param {KeyboardEvent} event An event within the combo box component
+ */
+const handlePageDownFromListOption = handleEndFromListOption;
+
+/**
  * Select list option on the mouseover event.
  *
  * @param {MouseEvent} event The mouseover event
@@ -781,6 +828,10 @@ const comboBox = behavior(
         Enter: handleEnterFromListOption,
         Tab: handleTabFromListOption,
         "Shift+Tab": noop,
+        Home: handleHomeFromListOption,
+        PageUp: handlePageUpFromListOption,
+        End: handleEndFromListOption,
+        PageDown: handlePageDownFromListOption,
       }),
     },
     input: {

--- a/packages/usa-combo-box/src/test/combo-box-keypresses.spec.js
+++ b/packages/usa-combo-box/src/test/combo-box-keypresses.spec.js
@@ -1,0 +1,88 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const ComboBox = require("../index");
+const EVENTS = require("./events");
+
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, "/combo-box-keypresses.template.html")
+);
+
+const comboBoxSelector = () => document.querySelector(".usa-combo-box");
+
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "combo box", selector: comboBoxSelector },
+];
+
+tests.forEach(({ name, selector: containerSelector }) => {
+  describe(`Combo box initialized at ${name}`, () => {
+    describe("combo box component - keypresses", () => {
+      const { body } = document;
+
+      let root;
+      let comboBox;
+      let input;
+      let select;
+      let list;
+
+      const highlightedOption = () =>
+        list.querySelector(".usa-combo-box__list-option--focused");
+
+      const assertHighlighted = (text, message) => {
+        assert.strictEqual(highlightedOption().textContent, text, message);
+      };
+
+      beforeEach(() => {
+        body.innerHTML = TEMPLATE;
+        root = containerSelector();
+        ComboBox.on(root);
+        comboBox = comboBoxSelector();
+        input = root.querySelector(".usa-combo-box__input");
+        select = root.querySelector(".usa-combo-box__select");
+        list = root.querySelector(".usa-combo-box__list");
+
+        EVENTS.click(input);
+        assert.ok(!list.hidden, "should show the option list");
+        assertHighlighted("Blackberry", "should highlight Blackberry");
+        EVENTS.keydownArrowDown(input);
+        assertHighlighted("Blackberry", "should highlight Blackberry");
+      });
+
+      afterEach(() => {
+        ComboBox.off(root);
+        body.textContent = "";
+      });
+
+      it("should highlight the next option when down arrow is pressed", () => {
+        EVENTS.keydownArrowDown(highlightedOption());
+        assertHighlighted("Blood orange", "should highlight next item");
+      });
+
+      it("should highlight the previous option when up arrow is pressed", () => {
+        EVENTS.keydownArrowUp(highlightedOption());
+        assertHighlighted("Banana", "should highlight previous item");
+      });
+
+      it("should highlight the top option when the home key is pressed", () => {
+        EVENTS.keydownHome(highlightedOption());
+        assertHighlighted("Apple", "should highlight top option");
+      });
+
+      it("should highlight the top option when the page up key is pressed", () => {
+        EVENTS.keydownPageUp(highlightedOption());
+        assertHighlighted("Apple", "should highlight top option");
+      });
+
+      it("should highlight the bottom option when the end key is pressed", () => {
+        EVENTS.keydownEnd(highlightedOption());
+        assertHighlighted("Yuzu", "should highlight bottom option");
+      });
+
+      it("should highlight the bottom option when the page down key is pressed", () => {
+        EVENTS.keydownPageDown(highlightedOption());
+        assertHighlighted("Yuzu", "should highlight bottom option");
+      });
+    });
+  });
+});

--- a/packages/usa-combo-box/src/test/combo-box-keypresses.template.html
+++ b/packages/usa-combo-box/src/test/combo-box-keypresses.template.html
@@ -1,0 +1,72 @@
+<form class="usa-form">
+  <label class="usa-label" for="fruit">Select a fruit</label>
+  <div class="usa-combo-box" data-default-value="blackberry">
+    <select id="fruit" name="fruit" class="usa-select">
+      <option value>Select a fruit</option>
+      <option value="apple">Apple</option>
+      <option value="apricot">Apricot</option>
+      <option value="avocado">Avocado</option>
+      <option value="banana">Banana</option>
+      <option value="blackberry">Blackberry</option>
+      <option value="blood orange">Blood orange</option>
+      <option value="blueberry">Blueberry</option>
+      <option value="boysenberry">Boysenberry</option>
+      <option value="breadfruit">Breadfruit</option>
+      <option value="buddhas hand citron">Buddha's hand citron</option>
+      <option value="cantaloupe">Cantaloupe</option>
+      <option value="clementine">Clementine</option>
+      <option value="crab apple">Crab apple</option>
+      <option value="currant">Currant</option>
+      <option value="cherry">Cherry</option>
+      <option value="custard apple">Custard apple</option>
+      <option value="coconut">Coconut</option>
+      <option value="cranberry">Cranberry</option>
+      <option value="date">Date</option>
+      <option value="dragonfruit">Dragonfruit</option>
+      <option value="durian">Durian</option>
+      <option value="elderberry">Elderberry</option>
+      <option value="fig">Fig</option>
+      <option value="gooseberry">Gooseberry</option>
+      <option value="grape">Grape</option>
+      <option value="grapefruit">Grapefruit</option>
+      <option value="guava">Guava</option>
+      <option value="honeydew melon">Honeydew melon</option>
+      <option value="jackfruit">Jackfruit</option>
+      <option value="kiwifruit">Kiwifruit</option>
+      <option value="kumquat">Kumquat</option>
+      <option value="lemon">Lemon</option>
+      <option value="lime">Lime</option>
+      <option value="lychee">Lychee</option>
+      <option value="mandarine">Mandarine</option>
+      <option value="mango">Mango</option>
+      <option value="mangosteen">Mangosteen</option>
+      <option value="marionberry">Marionberry</option>
+      <option value="nectarine">Nectarine</option>
+      <option value="orange">Orange</option>
+      <option value="papaya">Papaya</option>
+      <option value="passionfruit">Passionfruit</option>
+      <option value="peach">Peach</option>
+      <option value="pear">Pear</option>
+      <option value="persimmon">Persimmon</option>
+      <option value="plantain">Plantain</option>
+      <option value="plum">Plum</option>
+      <option value="pineapple">Pineapple</option>
+      <option value="pluot">Pluot</option>
+      <option value="pomegranate">Pomegranate</option>
+      <option value="pomelo">Pomelo</option>
+      <option value="quince">Quince</option>
+      <option value="raspberry">Raspberry</option>
+      <option value="rambutan">Rambutan</option>
+      <option value="soursop">Soursop</option>
+      <option value="starfruit">Starfruit</option>
+      <option value="strawberry">Strawberry</option>
+      <option value="tamarind">Tamarind</option>
+      <option value="tangelo">Tangelo</option>
+      <option value="tangerine">Tangerine</option>
+      <option value="ugli fruit">Ugli fruit</option>
+      <option value="watermelon">Watermelon</option>
+      <option value="white currant">White currant</option>
+      <option value="yuzu">Yuzu</option>
+    </select>
+  </div>
+</form>

--- a/packages/usa-combo-box/src/test/events.js
+++ b/packages/usa-combo-box/src/test/events.js
@@ -4,7 +4,7 @@ const EVENTS = {};
 
 /**
  * send a click event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.click = (el) => {
   const evt = new MouseEvent("click", {
@@ -17,7 +17,7 @@ EVENTS.click = (el) => {
 
 /**
  * send a focusout event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.focusout = (el) => {
   const evt = new Event("focusout", {
@@ -29,7 +29,7 @@ EVENTS.focusout = (el) => {
 
 /**
  * send a keydown Enter event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  * @returns {{preventDefaultSpy: sinon.SinonSpy<[], void>}}
  */
 EVENTS.keydownEnter = (el) => {
@@ -45,7 +45,7 @@ EVENTS.keydownEnter = (el) => {
 
 /**
  * send a keydown Escape event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.keydownEscape = (el) => {
   const evt = new KeyboardEvent("keydown", {
@@ -58,7 +58,7 @@ EVENTS.keydownEscape = (el) => {
 
 /**
  * send a keydown Tab event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.keydownTab = (el) => {
   const evt = new KeyboardEvent("keydown", {
@@ -70,7 +70,7 @@ EVENTS.keydownTab = (el) => {
 
 /**
  * send a keydown ArrowDown event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.keydownArrowDown = (el) => {
   const evt = new KeyboardEvent("keydown", {
@@ -82,7 +82,7 @@ EVENTS.keydownArrowDown = (el) => {
 
 /**
  * send a keydown ArrowUp event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.keydownArrowUp = (el) => {
   const evt = new KeyboardEvent("keydown", {
@@ -93,8 +93,56 @@ EVENTS.keydownArrowUp = (el) => {
 };
 
 /**
+ * send a keydown Home event
+ * @param {HTMLElement} el the element to send the event to
+ */
+EVENTS.keydownHome = (el) => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: "Home",
+  });
+  el.dispatchEvent(evt);
+};
+
+/**
+ * send a keydown End event
+ * @param {HTMLElement} el the element to send the event to
+ */
+EVENTS.keydownEnd = (el) => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: "End",
+  });
+  el.dispatchEvent(evt);
+};
+
+/**
+ * send a keydown PageUp event
+ * @param {HTMLElement} el the element to send the event to
+ */
+EVENTS.keydownPageUp = (el) => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: "PageUp",
+  });
+  el.dispatchEvent(evt);
+};
+
+/**
+ * send a keydown PageDown event
+ * @param {HTMLElement} el the element to send the event to
+ */
+EVENTS.keydownPageDown = (el) => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: "PageDown",
+  });
+  el.dispatchEvent(evt);
+};
+
+/**
  * send an input event
- * @param {HTMLElement} el the element to sent the event to
+ * @param {HTMLElement} el the element to send the event to
  */
 EVENTS.input = (el) => {
   el.dispatchEvent(new KeyboardEvent("input", { bubbles: true }));


### PR DESCRIPTION
In a combo box option list, the user can press Home or PageUp to jump to the top option, and End or PageDown to jump to the bottom option.

## Description

Resolves #3498.

Adds a new test suite at `packages/usa-combo-box/src/test/combo-box-keypresses.spec.js`.

## Additional information

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free. **(N/A)**
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
