### PR TITLE
USWDS - Identifier: Use valid element for identity's aria label

### DIFF
--- a/packages/usa-identifier/src/usa-identifier.twig
+++ b/packages/usa-identifier/src/usa-identifier.twig
@@ -27,7 +27,7 @@
           {%- endif -%}
         </div>
       {%- endif -%}
-      <div class="usa-identifier__identity" aria-label="{{ masthead.description }}">
+      <section class="usa-identifier__identity" aria-label="{{ masthead.description }}">
         <p class="usa-identifier__identity-domain">{{ domain }}</p>
         <p class="usa-identifier__identity-disclaimer">
           {{ masthead.content }}
@@ -51,7 +51,7 @@
           . {{ masthead.taxpayer_disclaimer.content }}
           {%- endif -%}
         </p>
-      </div>
+      </section>
     </div>
   </section>
   <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="{{ required_links.aria_label }}">


### PR DESCRIPTION
## Description

Use valid element for Identifier identity aria label. Accessibility error from invalid attribute on div is now fixed. Closes #4952.

## Additional information

Alternative was to use `role="complementary"`, but that could cause additional a11y issues with user's websites.

There should be no regression in component.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [ ] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
