### PR TITLE
USWDS - Validation: Update data-validation-element

### DIFF
--- a/packages/usa-validation/src/usa-validation.twig
+++ b/packages/usa-validation/src/usa-validation.twig
@@ -11,7 +11,7 @@
       </div>
     </div>
     <label class="usa-label" for="code">Code</label>
-    <input class="usa-input" id="code" name="code" type="text" data-validate-uppercase="[A-Z]" data-validate-numerical="\d" data-validation-element="#validate-code">
+    <input class="usa-input" id="code" name="code" type="text" data-validate-uppercase="[A-Z]" data-validate-numerical="\d" data-validation-element="validate-code">
     <input class="usa-button" type="submit" value="Submit code">
   </fieldset>
 </form>


### PR DESCRIPTION
## Summary
This PR removes the hash (`#`) in the `data-validation-element` in the validation twig file. 

## Problem statement
The validation component is causing pa11y-ci errors in uswds-site.

## Solution
Removing the hash from the `data-validation-element` prevents pa11y-ci errors because the value for the `data-validation-element` is now being passed into the value for`aria-controls`. `aria-controls` does not know what to do with the hash, so it was causing the error. 

Tested in USWDS-Site PR: https://github.com/uswds/uswds-site/pull/1844

## Additional notes
Noting that running pa11y on the current `use-3.2.0` validation page does not return an error, but pa11y-ci reports one. 

Command:
```
pa11y https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/use-3.2.0/components/validation/
```

If this change is accepted, I will update the guidance on https://designsystem.digital.gov/components/validation/