### PR TITLE
usa-header--extended usa-logo text width: Fixed to work with theme setting

### DIFF
--- a/packages/usa-header/src/styles/_usa-header.scss
+++ b/packages/usa-header/src/styles/_usa-header.scss
@@ -231,7 +231,7 @@ $z-index-overlay: 400;
     @include at-media($theme-header-min-width) {
       font-size: font-size($theme-header-font-family, "xl");
       margin: units(4) 0 units(3);
-      max-width: 50%;
+      max-width: $theme-header-logo-text-width;
     }
   }
 


### PR DESCRIPTION
## Description

USWDS documentation on header says there is a theme setting to adjust the logo text width. It does not work with header--extended. This fixes that. 
      max-width: $theme-header-logo-text-width;

[USWDS settings](https://designsystem.digital.gov/documentation/settings/) 

Verify where else this variable is used and if the default value needs to be updated. Documentation says default value is 33%, header-extended uses default value 50%.
