### PR TITLE
USWDS - Banner: Adjust mobile banner focus outline to render in viewport

### DIFF
--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -229,6 +229,11 @@ $banner-icon-close: (
 
   @include at-media-max("tablet") {
     width: 100%;
+
+    &:enabled:focus {
+      // adjust outline to render within the viewport
+      outline-offset: units(-0.5);
+    }
   }
 
   @include at-media("tablet") {


### PR DESCRIPTION
## Description

Resolves issue where the banner focus outline isn't visible on three sides for mobile devices - [link to issue](https://github.com/uswds/uswds/issues/5012).

## Additional information

A screenshot of the new focus style.

<img width="335" alt="image" src="https://user-images.githubusercontent.com/18164832/199768338-448c1350-02d4-4e32-83a4-754b999e7bba.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
