### PR TITLE
Implement offset top calibration data- attribute

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -8,6 +8,7 @@ const { CLICK } = require("../../uswds-core/src/js/events");
 const CURRENT_CLASS = `${PREFIX}-current`;
 const IN_PAGE_NAV_TITLE = "On this page";
 const IN_PAGE_NAV_HEADING_LEVEL = "h4";
+const IN_PAGE_NAV_OFFSET_TOP = 0;
 const IN_PAGE_NAV_CLASS = `${PREFIX}-in-page-nav`;
 const IN_PAGE_NAV_ANCHOR_CLASS = `${PREFIX}-anchor`;
 const IN_PAGE_NAV_NAV_CLASS = `${IN_PAGE_NAV_CLASS}__nav`;
@@ -96,9 +97,13 @@ const getSectionId = (value) => {
  * @param {HTMLElement} - Id value with the number sign removed
  */
 const handleScrollToSection = (el) => {
+  const inPageNavEl = document.querySelector(`.${IN_PAGE_NAV_CLASS}`);
+  const inPageNavOffsetTop =
+    inPageNavEl.dataset.offsetTop || IN_PAGE_NAV_OFFSET_TOP;
+
   window.scroll({
     behavior: "smooth",
-    top: el.offsetTop,
+    top: el.offsetTop - inPageNavOffsetTop,
     block: "start",
   });
 };
@@ -112,6 +117,7 @@ const createInPageNav = (inPageNavEl) => {
   const inPageNavTitleText = inPageNavEl.dataset.title || IN_PAGE_NAV_TITLE;
   const inPageNavHeadingLevel =
     inPageNavEl.dataset.headingLevel || IN_PAGE_NAV_HEADING_LEVEL;
+
   const sectionHeadings = getSectionHeadings();
   const inPageNav = document.createElement("nav");
   inPageNav.setAttribute("aria-label", inPageNavTitleText);

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -6,9 +6,9 @@ const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const { CLICK } = require("../../uswds-core/src/js/events");
 
 const CURRENT_CLASS = `${PREFIX}-current`;
-const IN_PAGE_NAV_TITLE = "On this page";
-const IN_PAGE_NAV_HEADING_LEVEL = "h4";
-const IN_PAGE_NAV_OFFSET_TOP = 0;
+const IN_PAGE_NAV_TITLE_TEXT = "On this page";
+const IN_PAGE_NAV_TITLE_HEADING_LEVEL = "h4";
+const IN_PAGE_NAV_SCROLL_OFFSET = 0;
 const IN_PAGE_NAV_CLASS = `${PREFIX}-in-page-nav`;
 const IN_PAGE_NAV_ANCHOR_CLASS = `${PREFIX}-anchor`;
 const IN_PAGE_NAV_NAV_CLASS = `${IN_PAGE_NAV_CLASS}__nav`;
@@ -98,12 +98,12 @@ const getSectionId = (value) => {
  */
 const handleScrollToSection = (el) => {
   const inPageNavEl = document.querySelector(`.${IN_PAGE_NAV_CLASS}`);
-  const inPageNavOffsetTop =
-    inPageNavEl.dataset.offsetTop || IN_PAGE_NAV_OFFSET_TOP;
+  const inPageNavScrollOffset =
+    inPageNavEl.dataset.scrollOffset || IN_PAGE_NAV_SCROLL_OFFSET;
 
   window.scroll({
     behavior: "smooth",
-    top: el.offsetTop - inPageNavOffsetTop,
+    top: el.offsetTop - inPageNavScrollOffset,
     block: "start",
   });
 };
@@ -114,16 +114,16 @@ const handleScrollToSection = (el) => {
  * @param {HTMLElement} inPageNavEl The in-page nav element
  */
 const createInPageNav = (inPageNavEl) => {
-  const inPageNavTitleText = inPageNavEl.dataset.title || IN_PAGE_NAV_TITLE;
-  const inPageNavHeadingLevel =
-    inPageNavEl.dataset.headingLevel || IN_PAGE_NAV_HEADING_LEVEL;
+  const inPageNavTitleText = inPageNavEl.dataset.titleText || IN_PAGE_NAV_TITLE_TEXT;
+  const inPageNavTitleHeadingLevel =
+    inPageNavEl.dataset.titleHeadingLevel || IN_PAGE_NAV_TITLE_HEADING_LEVEL;
 
   const sectionHeadings = getSectionHeadings();
   const inPageNav = document.createElement("nav");
   inPageNav.setAttribute("aria-label", inPageNavTitleText);
   inPageNav.classList.add(IN_PAGE_NAV_NAV_CLASS);
 
-  const inPageNavTitle = document.createElement(inPageNavHeadingLevel);
+  const inPageNavTitle = document.createElement(inPageNavTitleHeadingLevel);
   inPageNavTitle.classList.add(IN_PAGE_NAV_TITLE_CLASS);
   inPageNavTitle.setAttribute("tabindex", "0");
   inPageNavTitle.textContent = inPageNavTitleText;

--- a/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
+++ b/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
@@ -42,7 +42,7 @@ const tests = [
 ];
 
 tests.forEach(({ name, selector: containerSelector }) => {
-  describe.only(`in-page navigation initialized at ${name}`, () => {
+  describe(`in-page navigation initialized at ${name}`, () => {
     const { body } = document;
     document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
 

--- a/packages/usa-in-page-navigation/src/test/template.html
+++ b/packages/usa-in-page-navigation/src/test/template.html
@@ -10,7 +10,7 @@
     <p>Section 1.2. content</p>
   </main>
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4">
+  <aside class="usa-in-page-nav" data-title-text="On this page" data-title-heading-level="h4" data-scroll-offset="20">
     <nav aria-label="In-page navigation">
       <h4 class="usa-in-page-nav__heading">On this page</h4>
       <ul class="usa-in-page-nav__list">

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
@@ -3,7 +3,7 @@
   {% set list_item_class = 'usa-in-page-nav__item' %}
   {% set current_class = 'usa-current' %}
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4" data-offset-top="20"></aside>
+  <aside class="usa-in-page-nav" data-title-text="On this page" data-title-heading-level="h4" data-scroll-offset="20"></aside>
 
   <main id="main-content" class="main-content">
     {% if heading %}

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
@@ -3,7 +3,7 @@
   {% set list_item_class = 'usa-in-page-nav__item' %}
   {% set current_class = 'usa-current' %}
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4"></aside>
+  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4" data-offset-top="20"></aside>
 
   <main id="main-content" class="main-content">
     {% if heading %}

--- a/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
+++ b/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
@@ -24,7 +24,7 @@ const tests = [
 ];
 
 tests.forEach(({ name, selector: containerSelector }) => {
-  describe.only(`input mask component initialized at ${name}`, () => {
+  describe(`input mask component initialized at ${name}`, () => {
     const { body } = document;
 
     let root;


### PR DESCRIPTION
@thisisdano This PR addresses the in-page nav, scroll-to calibration issue. Now you can add a data- attribute "data-offset-top" to the `aside` element and the handleScrollToSection() function will subtract that to dial in the scroll-to target. For USWDS this will need to be dialed in to account for the tall header and sticky nav.

If the "data-offset-top" attribute is not present, 0 is the default.

<img width="447" alt="image" src="https://user-images.githubusercontent.com/19338309/200703848-09877824-2c1c-4bed-a0d6-6f61c582775c.png">

<img width="623" alt="image" src="https://user-images.githubusercontent.com/19338309/200703801-b33dcf22-e507-4aa1-a69f-330f2788b690.png">
