### PR TITLE
Query the DOM for .usa-modal-wrapper before building or destroying mo…

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -303,10 +303,12 @@ modal = {
   focusTrap: null,
   toggleModal,
   on(root) {
-    this.init(root);
+    if (!document.querySelector(".usa-modal-wrapper"))
+      this.init(root);
   },
   off(root) {
-    this.teardown(root);
+    if (document.querySelector(".usa-modal-wrapper"))
+      this.teardown(root);
   }
 };
 


### PR DESCRIPTION
## Title line template: [Modal]: Check DOM before on() and off() to make the modals more robust in JS frameworks


## Description

Query the DOM for .usa-modal-wrapper before building or destroying modals. This is useful for JS frameworks (React, Vue, Angular) where modal components are dynamically created, to avoid extra inits and bad teardown calls
