### PR TITLE
Remove .only from in-page nav and input mask alphanumeric

### DIFF
--- a/packages/usa-in-page-navigation/src/test/template.html
+++ b/packages/usa-in-page-navigation/src/test/template.html
@@ -1,15 +1,4 @@
 <div class="usa-in-page-nav-container">
-  <main id="main-content" class="main-content">
-    <h1>In page navigation test heading</h1>
-
-    <h2><a id="section_0" class="usa-anchor-tag"></a>Section 1</h2>
-    <p></p>
-    <h3><a id="section_1" class="usa-anchor-tag"></a>Section 1.1</h3>
-    <p>Section 1.1 content</p>
-    <h3><a id="section_2" class="usa-anchor-tag"></a>Section 1.2</h3>
-    <p>Section 1.2. content</p>
-  </main>
-
   <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4">
     <nav aria-label="In-page navigation">
       <h4 class="usa-in-page-nav__heading">On this page</h4>
@@ -20,4 +9,12 @@
       </ul>
     </nav>
   </aside>
+  <main id="main-content" class="main-content">
+    <h1>In page navigation test heading</h1>
+    <h2><a id="section_0" class="usa-anchor-tag"></a>Section 1</h2>
+    <h3><a id="section_1" class="usa-anchor-tag"></a>Section 1.1</h3>
+    <p>Section 1.1 content</p>
+    <h3><a id="section_2" class="usa-anchor-tag"></a>Section 1.2</h3>
+    <p>Section 1.2. content</p>
+  </main>
 </div>

--- a/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
+++ b/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
@@ -24,7 +24,7 @@ const tests = [
 ];
 
 tests.forEach(({ name, selector: containerSelector }) => {
-  describe.only(`input mask component initialized at ${name}`, () => {
+  describe(`input mask component initialized at ${name}`, () => {
     const { body } = document;
 
     let root;


### PR DESCRIPTION
The .only method was mistakenly left in two unit tests. This PR removes them.