### PR TITLE
In-page nav - Add customizable data- attribute for which heading[s] gets queried

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -8,6 +8,7 @@ const { CLICK } = require("../../uswds-core/src/js/events");
 const CURRENT_CLASS = `${PREFIX}-current`;
 const IN_PAGE_NAV_TITLE = "On this page";
 const IN_PAGE_NAV_HEADING_LEVEL = "h4";
+const IN_PAGE_NAV_OFFSET_TOP = 0;
 const IN_PAGE_NAV_CLASS = `${PREFIX}-in-page-nav`;
 const IN_PAGE_NAV_ANCHOR_CLASS = `${PREFIX}-anchor`;
 const IN_PAGE_NAV_NAV_CLASS = `${IN_PAGE_NAV_CLASS}__nav`;
@@ -96,9 +97,13 @@ const getSectionId = (value) => {
  * @param {HTMLElement} - Id value with the number sign removed
  */
 const handleScrollToSection = (el) => {
+  const inPageNavEl = document.querySelector(`.${IN_PAGE_NAV_CLASS}`);
+  const inPageNavOffsetTop =
+    inPageNavEl.dataset.offsetTop || IN_PAGE_NAV_OFFSET_TOP;
+
   window.scroll({
     behavior: "smooth",
-    top: el.offsetTop,
+    top: el.offsetTop - inPageNavOffsetTop,
     block: "start",
   });
 };
@@ -112,6 +117,7 @@ const createInPageNav = (inPageNavEl) => {
   const inPageNavTitleText = inPageNavEl.dataset.title || IN_PAGE_NAV_TITLE;
   const inPageNavHeadingLevel =
     inPageNavEl.dataset.headingLevel || IN_PAGE_NAV_HEADING_LEVEL;
+
   const sectionHeadings = getSectionHeadings();
   const inPageNav = document.createElement("nav");
   inPageNav.setAttribute("aria-label", inPageNavTitleText);

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -6,6 +6,7 @@ const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const { CLICK } = require("../../uswds-core/src/js/events");
 
 const CURRENT_CLASS = `${PREFIX}-current`;
+const IN_PAGE_NAV_HEADINGS = "h2 h3";
 const IN_PAGE_NAV_TITLE = "On this page";
 const IN_PAGE_NAV_HEADING_LEVEL = "h4";
 const IN_PAGE_NAV_OFFSET_TOP = 0;
@@ -52,12 +53,20 @@ const setActive = (el) => {
 /**
  * Return a node list of section headings
  *
+ * @param {String} headings A string of one or more headings to query for
  * @return {HTMLElement[]} - An array of DOM nodes
  */
-const getSectionHeadings = () => {
-  const sectionHeadings = document.querySelectorAll(
-    `${MAIN_ELEMENT} h2, ${MAIN_ELEMENT} h3`
-  );
+const getSectionHeadings = (headings) => {
+  const headingList = headings.indexOf(" ") ? headings.split(" ") : headings;
+  const headingArr = [];
+
+  headingList.forEach((heading) => {
+    headingArr.push(`${MAIN_ELEMENT} ${heading}`);
+  });
+
+  const headingListNew = headingArr.join(",");
+  const sectionHeadings = document.querySelectorAll(headingListNew);
+
   return sectionHeadings;
 };
 
@@ -115,10 +124,12 @@ const handleScrollToSection = (el) => {
  */
 const createInPageNav = (inPageNavEl) => {
   const inPageNavTitleText = inPageNavEl.dataset.title || IN_PAGE_NAV_TITLE;
+  const inPageNavHeadings =
+    inPageNavEl.dataset.headings || IN_PAGE_NAV_HEADINGS;
   const inPageNavHeadingLevel =
     inPageNavEl.dataset.headingLevel || IN_PAGE_NAV_HEADING_LEVEL;
 
-  const sectionHeadings = getSectionHeadings();
+  const sectionHeadings = getSectionHeadings(inPageNavHeadings);
   const inPageNav = document.createElement("nav");
   inPageNav.setAttribute("aria-label", inPageNavTitleText);
   inPageNav.classList.add(IN_PAGE_NAV_NAV_CLASS);

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -7,6 +7,7 @@ const { CLICK } = require("../../uswds-core/src/js/events");
 
 const CURRENT_CLASS = `${PREFIX}-current`;
 const IN_PAGE_NAV_HEADINGS = "h2 h3";
+const IN_PAGE_NAV_VALID_HEADINGS = ["h1", "h2", "h3", "h4", "h5", "h6"];
 const IN_PAGE_NAV_TITLE = "On this page";
 const IN_PAGE_NAV_HEADING_LEVEL = "h4";
 const IN_PAGE_NAV_OFFSET_TOP = 0;
@@ -61,6 +62,11 @@ const getSectionHeadings = (headings) => {
   const headingArr = [];
 
   headingList.forEach((heading) => {
+    if (!IN_PAGE_NAV_VALID_HEADINGS.includes(heading)) {
+      throw new Error(
+        `Invalid heading type: ${heading}. Please use one or more of the following: ${IN_PAGE_NAV_VALID_HEADINGS}`
+      );
+    }
     headingArr.push(`${MAIN_ELEMENT} ${heading}`);
   });
 

--- a/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
+++ b/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
@@ -33,11 +33,13 @@ const assertHidden = (el, hidden) => {
   );
 };
 
+const inPageNavSelector = () => document.querySelector(".usa-in-page-nav");
+
 const tests = [
   { name: "document.body", selector: () => document.body },
   {
     name: "in page nav",
-    selector: () => document.querySelector(".usa-in-page-nav"),
+    selector: inPageNavSelector,
   },
 ];
 
@@ -46,8 +48,11 @@ tests.forEach(({ name, selector: containerSelector }) => {
     const { body } = document;
     document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
 
+    let root;
     let theNav;
     let theList;
+    const getInPageNavEl = (query) =>
+      root.querySelector(`.usa-in-page-nav${query ? ` ${query}` : ""}`);
 
     before(() => {
       const observe = sinon.spy();
@@ -57,7 +62,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     beforeEach(() => {
       body.innerHTML = TEMPLATE;
-
+      root = document.querySelector(".usa-in-page-nav-container");
       theNav = document.querySelector(THE_NAV);
       theList = document.querySelector(PRIMARY_CONTENT_SELECTOR);
 
@@ -79,10 +84,18 @@ tests.forEach(({ name, selector: containerSelector }) => {
       assertHidden(theNav, true);
     });
 
-    it("show on larger screens", () => {
+    it("shows on larger screens", () => {
       resizeTo(400);
       resizeTo(1024);
       assertHidden(theList, false);
+    });
+
+    it("reads the custom heading elements in the data-headings attribute", () => {
+      assert.strictEqual(
+        getInPageNavEl().dataset.headings,
+        "h2 h3",
+        "reads the correct headings"
+      );
     });
   });
 });

--- a/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
+++ b/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
@@ -44,7 +44,7 @@ const tests = [
 ];
 
 tests.forEach(({ name, selector: containerSelector }) => {
-  describe.only(`in-page navigation initialized at ${name}`, () => {
+  describe(`in-page navigation initialized at ${name}`, () => {
     const { body } = document;
     document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
 

--- a/packages/usa-in-page-navigation/src/test/template.html
+++ b/packages/usa-in-page-navigation/src/test/template.html
@@ -10,7 +10,7 @@
     <p>Section 1.2. content</p>
   </main>
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4">
+  <aside class="usa-in-page-nav" data-headings="h2 h3" data-title="On this page" data-heading-level="h4">
     <nav aria-label="In-page navigation">
       <h4 class="usa-in-page-nav__heading">On this page</h4>
       <ul class="usa-in-page-nav__list">

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
@@ -3,7 +3,7 @@
   {% set list_item_class = 'usa-in-page-nav__item' %}
   {% set current_class = 'usa-current' %}
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4" data-offset-top="20"></aside>
+  <aside class="usa-in-page-nav" data-headings="h2 h3" data-title="On this page" data-heading-level="h4" data-offset-top="20"></aside>
 
   <main id="main-content" class="main-content">
     {% if heading %}

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.twig
@@ -3,7 +3,7 @@
   {% set list_item_class = 'usa-in-page-nav__item' %}
   {% set current_class = 'usa-current' %}
 
-  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4"></aside>
+  <aside class="usa-in-page-nav" data-title="On this page" data-heading-level="h4" data-offset-top="20"></aside>
 
   <main id="main-content" class="main-content">
     {% if heading %}

--- a/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
+++ b/packages/usa-input-mask/src/test/input-mask-alphanumeric.spec.js
@@ -24,7 +24,7 @@ const tests = [
 ];
 
 tests.forEach(({ name, selector: containerSelector }) => {
-  describe.only(`input mask component initialized at ${name}`, () => {
+  describe(`input mask component initialized at ${name}`, () => {
     const { body } = document;
 
     let root;


### PR DESCRIPTION
This implements the feature detailed here:
https://github.com/uswds/uswds/issues/5030

This is an important one that will allow for the customization of what headings should be queried when the in-page nav is being dynamically built.

A developer will be able to easily add the data- attribute `data-headings` to the aside element in the HTML to define which headings get queried.

Some examples include:
`data-headings="h2"`
`data-headings="h2 h3"`
`data-headings="h2 h3 h4"`
`data-headings="h1 h2"`

**The headings should be listed with a space in between.**

NOTE: This is most likely needed ASAP for the USWDS documentation site since including all h3s in the query is problematic on some of the pages... It might be better to use `data-headings="h2"` so only h2s are built in the in-page nav. Let's discuss.
