### PR TITLE
[usa-footer]: Preserve existing heading structure

### DIFF
--- a/packages/usa-footer/src/index.js
+++ b/packages/usa-footer/src/index.js
@@ -49,7 +49,6 @@ function toggleHtmlTag(isMobile) {
     // Create the new element
     const newElement = document.createElement(newElementType);
     newElement.setAttribute("class", currentElementClasses);
-    newElement.setAttribute("data-tag", preserveHtmlTag);
     newElement.classList.toggle(
       `${PREFIX}-footer__primary-link--button`,
       isMobile
@@ -57,6 +56,7 @@ function toggleHtmlTag(isMobile) {
     newElement.textContent = currentElement.textContent;
 
     if (isMobile) {
+      newElement.setAttribute("data-tag", currentElement.tagName);
       const menuId = `${PREFIX}-footer-menu-list-${Math.floor(
         Math.random() * 100000
       )}`;
@@ -87,15 +87,7 @@ module.exports = behavior(
     // export for use elsewhere
     HIDE_MAX_WIDTH,
 
-    init(root) {
-      const bigFooter = root.querySelector(SCOPE);
-      if (bigFooter) {
-        select(BUTTON, bigFooter).forEach((button) => {
-          // Preserve original html tag
-          button.setAttribute("data-tag", button.tagName);
-        });
-      }
-
+    init() {
       toggleHtmlTag(window.innerWidth < HIDE_MAX_WIDTH);
       this.mediaQueryList = window.matchMedia(
         `(max-width: ${HIDE_MAX_WIDTH - 0.1}px)`

--- a/packages/usa-footer/src/index.js
+++ b/packages/usa-footer/src/index.js
@@ -38,10 +38,10 @@ function toggleHtmlTag(isMobile) {
   }
 
   const primaryLinks = bigFooter.querySelectorAll(BUTTON);
-  const newElementType = isMobile ? "button" : "h4";
 
   primaryLinks.forEach((currentElement) => {
     const currentElementClasses = currentElement.getAttribute("class");
+    const newElementType = isMobile ? "button" : currentElement.tagName;
 
     // Create the new element
     const newElement = document.createElement(newElementType);

--- a/packages/usa-footer/src/index.js
+++ b/packages/usa-footer/src/index.js
@@ -1,4 +1,3 @@
-const select = require("../../uswds-core/src/js/utils/select");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");

--- a/packages/usa-footer/src/index.js
+++ b/packages/usa-footer/src/index.js
@@ -1,3 +1,4 @@
+const select = require("../../uswds-core/src/js/utils/select");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
@@ -41,11 +42,14 @@ function toggleHtmlTag(isMobile) {
 
   primaryLinks.forEach((currentElement) => {
     const currentElementClasses = currentElement.getAttribute("class");
-    const newElementType = isMobile ? "button" : currentElement.tagName;
+    const preserveHtmlTag = currentElement.getAttribute("data-tag");
+
+    const newElementType = isMobile ? "button" : preserveHtmlTag;
 
     // Create the new element
     const newElement = document.createElement(newElementType);
     newElement.setAttribute("class", currentElementClasses);
+    newElement.setAttribute("data-tag", preserveHtmlTag);
     newElement.classList.toggle(
       `${PREFIX}-footer__primary-link--button`,
       isMobile
@@ -83,7 +87,15 @@ module.exports = behavior(
     // export for use elsewhere
     HIDE_MAX_WIDTH,
 
-    init() {
+    init(root) {
+      const bigFooter = root.querySelector(SCOPE);
+      if (bigFooter) {
+        select(BUTTON, bigFooter).forEach((button) => {
+          // Preserve original html tag
+          button.setAttribute("data-tag", button.tagName);
+        });
+      }
+
       toggleHtmlTag(window.innerWidth < HIDE_MAX_WIDTH);
       this.mediaQueryList = window.matchMedia(
         `(max-width: ${HIDE_MAX_WIDTH - 0.1}px)`


### PR DESCRIPTION
## Description

Issue: Headings are not properly nested in the footer on [OSG priorities](https://www.hhs.gov/surgeongeneral/priorities/index.html) pages. The `usa-footer/src/index.js` file assumes the footer headings will always be `h4` elements. 

However, this assumes a specific heading structure that differs from a properly nested heading structure on the OSG priorities pages. 

## Additional information

* [Accessibility Guide: Headings](https://accessibility.18f.gov/headings/)
* Screenshot:
  <img width="844" alt="Screen Shot 2022-11-16 at 12 49 09 PM" src="https://user-images.githubusercontent.com/768965/202291033-c1acfbaf-c275-494f-8c05-a5033f5830e0.png">

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.

(👋 first PR! hello! thank you for your patience)