### PR TITLE
USWDS - Links: Fix external link icon issues

### DIFF
--- a/packages/uswds-core/src/styles/mixins/general/external-link.scss
+++ b/packages/uswds-core/src/styles/mixins/general/external-link.scss
@@ -15,18 +15,14 @@ $icon-object: (
 
 @mixin external-link($contrast-bg: "default") {
   display: inline;
-  padding-right: $external-link-size;
-  position: relative;
 
   &::after {
     @include add-color-icon($icon-object, $contrast-bg);
-    background-position: center;
-    content: "\00a0";
-    // Use following inline styling to prevent icon splitting over line breaks
-    display: inline-block;
-    height: $external-link-size;
-    margin-left: units(2px);
+    content: "";
+    display: inline;
     margin-top: 0.7ex;
-    position: absolute;
+    margin-left: 2px;
+    padding-left: 1.75ex;
+    vertical-align: middle;
   }
 }

--- a/packages/uswds-core/src/styles/mixins/general/external-link.scss
+++ b/packages/uswds-core/src/styles/mixins/general/external-link.scss
@@ -9,22 +9,22 @@ $icon-object: (
   "height": $external-link-size,
   "svg-height": 24,
   "svg-width": 24,
+  "position-x": center,
+  "position-y": 4px,
 );
 
 @mixin external-link($contrast-bg: "default") {
-  display: inline-block;
-  padding-right: $external-link-size;
-  position: relative;
+  display: inline;
 
+  // Uses `unset` for height/width because it's an inline element.
+  // Sizing is set via background/mask size properties.
   &::after {
     @include add-color-icon($icon-object, $contrast-bg);
-    background-position: center;
-    content: "";
-    // Use following inline styling to prevent icon splitting over line breaks
-    display: inline-block;
-    height: $external-link-size;
-    margin-left: units(2px);
+    content: "\00a0";
+    display: inline; // Prevents icon splitting over line breaks
+    height: unset;
     margin-top: 0.7ex;
-    position: absolute;
+    width: unset;
+    word-spacing: $external-link-size; // Sets the width of the pseudoelement
   }
 }

--- a/packages/uswds-core/src/styles/mixins/general/external-link.scss
+++ b/packages/uswds-core/src/styles/mixins/general/external-link.scss
@@ -10,21 +10,23 @@ $icon-object: (
   "svg-height": 24,
   "svg-width": 24,
   "position-x": center,
-  "position-y": 4px,
+  "position-y": center,
 );
 
 @mixin external-link($contrast-bg: "default") {
   display: inline;
+  padding-right: $external-link-size;
+  position: relative;
 
-  // Uses `unset` for height/width because it's an inline element.
-  // Sizing is set via background/mask size properties.
   &::after {
     @include add-color-icon($icon-object, $contrast-bg);
+    background-position: center;
     content: "\00a0";
-    display: inline; // Prevents icon splitting over line breaks
-    height: unset;
+    // Use following inline styling to prevent icon splitting over line breaks
+    display: inline-block;
+    height: $external-link-size;
+    margin-left: units(2px);
     margin-top: 0.7ex;
-    width: unset;
-    word-spacing: $external-link-size; // Sets the width of the pseudoelement
+    position: absolute;
   }
 }

--- a/packages/uswds-core/src/styles/mixins/general/icon.scss
+++ b/packages/uswds-core/src/styles/mixins/general/icon.scss
@@ -129,7 +129,7 @@
   $position-y: if(
     map.has-key($icon-object, "position-y"),
     map.get($icon-object, "position-y"),
-    bottom
+    center
   );
   $position-x: if(
     map.has-key($icon-object, "position-x"),

--- a/packages/uswds-core/src/styles/mixins/general/icon.scss
+++ b/packages/uswds-core/src/styles/mixins/general/icon.scss
@@ -78,7 +78,7 @@
 // the mixin will pick IE11-compatible svgs named
 // [base]-[variant].svg based on the specified background-color
 //
-// @param {Map} - $icon-object - name, svg-height, svg-width, height, container-height, container-width, color, color-variant, color-hover, rotate, path, background-p
+// @param {Map} - $icon-object - name, svg-height, svg-width, height, container-height, container-width, color, color-variant, color-hover, rotate, path, position-x, position-y
 // @param {String} - $contrast-bg - Color token
 @mixin add-color-icon($icon-object, $contrast-bg: "default") {
   $filename-base: map.get($icon-object, "name");

--- a/packages/uswds-core/src/styles/mixins/general/icon.scss
+++ b/packages/uswds-core/src/styles/mixins/general/icon.scss
@@ -158,7 +158,8 @@
   @supports (mask: url("")) {
     background: none;
     background-color: if($color == currentColor, $color, color($color));
-    mask-image: url("#{$path}/usa-icons/#{$filename-base}.svg");
+    mask-image: url("#{$path}/usa-icons/#{$filename-base}.svg"),
+      linear-gradient(transparent, transparent);
     mask-repeat: no-repeat;
     mask-position: $position-x $position-y;
     mask-size: $width $height;

--- a/packages/uswds-core/src/styles/mixins/general/icon.scss
+++ b/packages/uswds-core/src/styles/mixins/general/icon.scss
@@ -77,7 +77,9 @@
 // ($base, $variant, $variant-alt, $bg)
 // the mixin will pick IE11-compatible svgs named
 // [base]-[variant].svg based on the specified background-color
-
+//
+// @param {Map} - $icon-object - name, svg-height, svg-width, height, container-height, container-width, color, color-variant, color-hover, rotate, path, background-p
+// @param {String} - $contrast-bg - Color token
 @mixin add-color-icon($icon-object, $contrast-bg: "default") {
   $filename-base: map.get($icon-object, "name");
   $svg-height: map.get($icon-object, "svg-height");
@@ -124,6 +126,16 @@
     map.get($icon-object, "path"),
     $theme-image-path
   );
+  $position-y: if(
+    map.has-key($icon-object, "position-y"),
+    map.get($icon-object, "position-y"),
+    bottom
+  );
+  $position-x: if(
+    map.has-key($icon-object, "position-x"),
+    map.get($icon-object, "position-x"),
+    center
+  );
   $ie11-variant: get-color-token-from-bg($contrast-bg, "white", "black");
   $filename-ie11: if(
     $ie11-variant == "white",
@@ -131,12 +143,10 @@
     "usa-icons/#{$filename-base}.svg"
   );
 
-  $mask-props: url("#{$path}/usa-icons/#{$filename-base}.svg") no-repeat center /
-    contain;
-  $image-props: url("#{$path}/#{$filename-ie11}") no-repeat center / contain;
-
-  // Default background shorthand for browsers that don't support mask or supports.
-  background: $image-props;
+  background-image: url("#{$path}/#{$filename-ie11}");
+  background-repeat: no-repeat;
+  background-position: $position-x $position-y;
+  background-size: $width $height;
   display: inline-block;
   height: if($container-height, $container-height, $height);
   width: if($container-width, $container-width, $width);
@@ -148,7 +158,12 @@
   @supports (mask: url("")) {
     background: none;
     background-color: if($color == currentColor, $color, color($color));
-    mask: $mask-props;
+    mask-image: url("#{$path}/usa-icons/#{$filename-base}.svg");
+    mask-repeat: no-repeat;
+    mask-position: $position-x $position-y;
+    mask-size: $width $height;
+    mask-repeat: no-repeat;
+
     @if $color-hover {
       &:hover {
         background-color: color($color-hover);


### PR DESCRIPTION
## Description
[uswds-1918-2022-11-21 at 14.50.09.webm](https://user-images.githubusercontent.com/3385219/203156036-88d6368e-aa69-4e9d-8e4c-4c329218c30c.webm)

**Fixed icon wrapping and safari display issues in external links.** Improved wrapping so icon doesn't break on its own and causes display issues with punctuation. There's also an improved way for getting around Safari display issues (transparent gradient). Closes #4977.

**`add-color-icon` mixin now allows more control over positioning.** The `$icon-object` that gets passed to `add-color-icon` mixin now takes attributes for x and y positioning. These are used for both background and mask positioning. 

**Defaults**
- **position-y**: center
- **position-x**: center

## Additional information

This has been a tricky issue to debug and fix. The original attempt (#3395) later caused a background bleed issue in Safari (#4439). Now both issues _should_ be resolved.

### Link and icon wrapping bug

Both the link and pseudoelement have been made inline elements. The icon sizing is controlled via `padding-left` and background/mask size.

### Safari display bug

**Icon with transparent gradient on mask**
![image](https://user-images.githubusercontent.com/3385219/203156483-52477352-f9f4-474a-acd9-28090e37ede9.png)

Background bleeding has been resolved by adding a transparent linear gradient to masks.

**Related issues**
- #3395
- #4439


### Browsers tested

- [x] Safari 16
- [x] Edge 107.0.1418.42 (chromium)
- [x] Firefox 108


## How to test

I've also created a [test branch](https://github.com/uswds/uswds-site/pull/1918) in Site you can use for additional testing.

- There shouldn't be any visual regressions in external links
- There shouldn't be any visual regressions with external links in Safari
- There shouldn't be any visual regressions in external link background image fallback
- Punctuation shouldn't break into it's own line following external link
- External link icon shouldn't break into it's own line

---

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [x] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
