### PR TITLE
USWDS - Step indicator: Fix color contrast on pending items

### DIFF
--- a/packages/uswds-core/src/styles/settings/_settings-components.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-components.scss
@@ -180,7 +180,7 @@ $theme-step-indicator-heading-font-size: "lg" !default;
 $theme-step-indicator-heading-font-size-small: "md" !default;
 $theme-step-indicator-label-font-size: "sm" !default;
 $theme-step-indicator-min-width: "tablet" !default;
-$theme-step-indicator-segment-color-pending: "base-lighter" !default;
+$theme-step-indicator-segment-color-pending: "gray-40" !default;
 $theme-step-indicator-segment-color-complete: "primary-darker" !default;
 $theme-step-indicator-segment-color-current: "primary" !default;
 $theme-step-indicator-segment-gap: 2px !default;


### PR DESCRIPTION
## Summary
Updated the default value for `$theme-step-indicator-segment-color-pending` from `base-lighter` to `gray-40`. Now, the graphical elements related to pending items meet accessibility standards for contrast ratio. 

## Related issue
Closes #4836 

## Preview link
Preview link: [Step indicator page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-step-indicator-contrast/?path=/story/components-step-indicator--default)

## Problem statement
Meaningful graphical objects must have a color contrast ratio of at least 3:1. However, the pending items in the step indicator have a contrast ratio of only 1.25.

## Solution
Updating the default value of `$theme-step-indicator-segment-color-pending` from `base-lighter` (#e6e6e6) to `gray-40` (#919191) creates a color contrast of 3.15, which passes [standards for graphical objects](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html#graphical-objects). 

---

Before opening this PR, make sure you’ve done whichever of these applies to you:

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
