### PR TITLE
USWDS - Header: Add 'none' spacing token

### DIFF
--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -101,5 +101,6 @@ $system-spacing: (
   "special": (
     0: 0,
     "auto": auto,
+    "none": none,
   ),
 );


### PR DESCRIPTION
## Summary
Added a `none` token to the spacing defaults. 

## Breaking change
This is not a breaking change.

## Related issue
Closes #4851

## Preview link
Preview link: 

## Problem statement
Setting `$theme-header-max-width: "none",` throws the following error `npx gulp compile`:

```
node_modules/@uswds/uswds/packages/uswds-core/src/styles/functions/units/units.scss
Error: ("1px": 1px, "2px": 2px, "05": 0.25rem, 1: 0.5rem, "105": 0.75rem, 2: 1rem, "205": 1.25rem, 3: 1.5rem, "neg-1px": -1px, "neg-2px": -2px, "neg-05": -0.25rem, "neg-1": -0.5rem, "neg-105": -0.75rem, "neg-2": -1rem, "neg-205": -1.25rem, "neg-3": -1.5rem, 4: 2rem, 5: 2.5rem, 6: 3rem, 7: 3.5rem, 8: 4rem, 9: 4.5rem, 10: 5rem, 15: 7.5rem, "neg-4": -2rem, "neg-5": -2.5rem, "neg-6": -3rem, "neg-7": -3.5rem, "neg-8": -4rem, "neg-9": -4.5rem, "neg-10": -5rem, "neg-15": -7.5rem, "card": 10rem, "card-lg": 15rem, "mobile": 20rem, "mobile-lg": 30rem, "tablet": 40rem, "tablet-lg": 55rem, "desktop": 64rem, "desktop-lg": 75rem, "widescreen": 87.5rem, 0: 0, "auto": auto) isn't a valid CSS value.
   ╷
28 │       vars.$project-spacing-standard
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  node_modules/@uswds/uswds/packages/uswds-core/src/styles/functions/units/units.scss 28:7    units()
  node_modules/@uswds/uswds/packages/usa-header/src/styles/_usa-megamenu.scss 15:10           outer-megamenu()
  node_modules/@uswds/uswds/packages/usa-header/src/styles/_usa-megamenu.scss 52:7            @content
  node_modules/@uswds/uswds/packages/uswds-core/src/styles/mixins/helpers/at-media.scss 20:7  at-media()
  node_modules/@uswds/uswds/packages/usa-header/src/styles/_usa-megamenu.scss 51:5            @forward
  node_modules/@uswds/uswds/packages/usa-header/src/styles/_index.scss 5:1                    @forward
  sass/_uswds-packages.scss 27:1                                                              @import
  sass/uswds.scss 6:9                                                                         root stylesheet
```

## Solution
Users should be able to remove the max-width on the header. Adding a token for `none` creates this capability. 

## Testing and review
In a test project, confirm that configuring `uswds-core` with `$theme-header-max-width: "none"` does not cause an error and creates the expected visual. 