### PR TITLE
Avoid unit math on settings until after configured unit resolved

### DIFF
--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -184,7 +184,7 @@ $banner-icon-close: (
 }
 
 .usa-banner__header--expanded {
-  padding-right: units($size-touch-target + 1);
+  padding-right: units($size-touch-target) + units(1);
 
   @include at-media("tablet") {
     background-color: transparent;

--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -68,7 +68,7 @@ $banner-icon-close: (
   font-size: font-size($theme-banner-font-family, 4);
   overflow: hidden;
   padding-bottom: units(2);
-  padding-left: units($theme-site-margins-mobile-width - 1);
+  padding-left: units($theme-site-margins-mobile-width) - units(1);
   padding-top: units(0.5);
   width: 100%;
 

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -118,11 +118,11 @@
     display: block;
     height: $theme-alert-icon-size;
     // padding - optical spacing value
-    left: units($theme-site-margins-mobile-width - $theme-alert-bar-width);
+    left: units($theme-site-margins-mobile-width) - units($theme-alert-bar-width);
     position: absolute;
-    top: units($theme-alert-padding-y * 0.75);
+    top: units($theme-alert-padding-y) * 0.75;
     @include at-media($theme-site-margins-breakpoint) {
-      left: units($theme-site-margins-width - $theme-alert-bar-width);
+      left: units($theme-site-margins-width) - units($theme-alert-bar-width);
     }
   }
 }
@@ -148,7 +148,7 @@
   &:before {
     background-size: $alert-slim-icon-size;
     height: $alert-slim-icon-size;
-    top: units($theme-alert-padding-y * 0.5);
+    top: units($theme-alert-padding-y) * 0.5;
     width: $alert-slim-icon-size;
     @supports (mask: url("")) {
       mask-size: $alert-slim-icon-size;


### PR DESCRIPTION
## Summary

Attempts to fix #5075 by avoiding math on configurable settings values which could result in an invalid unit token. The effect should be the same, but ensures that the configurable unit value is resolved before attempting any math on it.

## Related issue

Fixes #5075

## Problem statement

Developers should be able to configure settings to any valid unit and the build should pass.

## Solution

Resolves configured unit value before performing math on it.
