### PR TITLE
USWDS - Outline: Fix broken `outline-05` utility

### DIFF
--- a/packages/uswds-core/src/styles/_properties.scss
+++ b/packages/uswds-core/src/styles/_properties.scss
@@ -9,6 +9,7 @@ USWDS Properties
 
 @use "./functions/general/map-collect" as *;
 @use "./functions/units/units" as *;
+@use "./functions/units/spacing-multiple" as *;
 @use "./functions/utilities/line-height" as *;
 // TODO: ^^^ s/b "functions/utilities/units"
 


### PR DESCRIPTION
## Summary
Fixed a compilation error for the `outline-05` utility.

## Breaking change
This is not a breaking change.

## Related issue
Closes #5078

## Preview link
Preview link:

## Problem statement
The outline utility was not able to read `spacing-multiple(05)`, which resulted in a CSS error and improper display. 

![image](https://user-images.githubusercontent.com/93996430/209023056-3f3c0892-8762-4110-adaa-8510b9171c72.png)

## Solution


## Testing and review
To test, confirm that the `outline-05` utility class, `u-outline('05')`, and `u-outline(0.5)` works as expected.