### PR TITLE
USWDS - Link: Add text-indent rule to external link mixin

### DIFF
--- a/packages/uswds-core/src/styles/mixins/general/external-link.scss
+++ b/packages/uswds-core/src/styles/mixins/general/external-link.scss
@@ -15,6 +15,7 @@ $icon-object: (
   display: inline-block;
   padding-right: $external-link-size;
   position: relative;
+  text-indent: initial;
 
   &::after {
     @include add-color-icon($icon-object, $contrast-bg);


### PR DESCRIPTION
## Summary
Added `text-indent:initial` to the `external-link` mixin. 

## Breaking change
This is not a breaking change.

## Related issue

## Preview link
Preview link: [Link component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-external-link-indent/?path=/story/components-link--link)

## Problem statement
In lists (`.usa-content-list ol li`), external links present incorrectly. Example from https://github.com/uswds/uswds-site/pull/1851: 
![image](https://user-images.githubusercontent.com/93996430/215519001-72bee4d1-6ddb-4021-a2c4-fe61e87ee432.png)

## Solution

## Testing and review
