### PR TITLE
USWDS - Remove broken NASA style guide link

### DIFF
--- a/docs/WHO_IS_USING_USWDS.md
+++ b/docs/WHO_IS_USING_USWDS.md
@@ -85,7 +85,6 @@ Below are a list of websites and applications currently using the U.S. Web Desig
 - [MyMedicare](https://www.mymedicare.gov/)
 - [NASA Glenn Research Center](https://www1.grc.nasa.gov)
 - [NASA Human Computer Interaction Group](https://hci.arc.nasa.gov)
-- [NASA Web Style Guide](https://app.frontify.com/d/NZPXDvjOcz5x/nasa-web-style-guide)
 - [National Agricultural Statistics Service - USDA](https://release.nass.usda.gov/)
 - [National Archives and Records Administration](https://archives.gov)
 - [National Archives Museum](https://museum.archives.gov/)


### PR DESCRIPTION
## Summary
Removed the link to the NASA Web Style Guide. This link returns a 404 error and no suitable replacement was found. 

## Breaking change
This is not a breaking change. 

## Related issue


## Preview link
Preview link: N/A

## Testing and review
- Confirm that `npm run proof` runs without error. 
- Confirm that no alternative link for the NASA Web Style Guide exists. 
