### PR TITLE
USWDS - Combobox: Keyboard selection compliance update. Resolves #5161

### DIFF
--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -646,11 +646,11 @@ const handleDownFromListOption = (event) => {
 };
 
 /**
- * Handle the tab event from an list option element within the combo box component.
+ * Handle the space event from an list option element within the combo box component.
  *
  * @param {KeyboardEvent} event An event within the combo box component
  */
-const handleTabFromListOption = (event) => {
+const handleSpaceFromListOption = (event) => {
   selectItem(event.target);
   event.preventDefault();
 };
@@ -779,7 +779,7 @@ const comboBox = behavior(
         ArrowDown: handleDownFromListOption,
         Down: handleDownFromListOption,
         Enter: handleEnterFromListOption,
-        Tab: handleTabFromListOption,
+        " ": handleSpaceFromListOption,
         "Shift+Tab": noop,
       }),
     },

--- a/packages/usa-combo-box/src/test/combo-box.spec.js
+++ b/packages/usa-combo-box/src/test/combo-box.spec.js
@@ -399,7 +399,7 @@ tests.forEach(({name, selector: containerSelector}) => {
         );
       });
 
-      it("should select the focused list item in the list when pressing tab on a focused item", () => {
+      it("should select the focused list item in the list when pressing space on a focused item", () => {
         select.value = "cantaloupe";
         input.value = "berry";
         EVENTS.input(input);
@@ -411,7 +411,7 @@ tests.forEach(({name, selector: containerSelector}) => {
           "should focus the first item in the list"
         );
 
-        EVENTS.keydownTab(focusedOption);
+        EVENTS.keydownSpace(focusedOption);
 
         assert.strictEqual(
           select.value,

--- a/packages/usa-combo-box/src/test/events.js
+++ b/packages/usa-combo-box/src/test/events.js
@@ -69,6 +69,18 @@ EVENTS.keydownTab = (el) => {
 };
 
 /**
+ * send a keydown Space event
+ * @param {HTMLElement} el the element to sent the event to
+ */
+EVENTS.keydownSpace = (el) => {
+  const evt = new KeyboardEvent("keydown", {
+    bubbles: true,
+    key: " ",
+  });
+  el.dispatchEvent(evt);
+};
+
+/**
  * send a keydown ArrowDown event
  * @param {HTMLElement} el the element to sent the event to
  */


### PR DESCRIPTION
## Summary
Updates Combobox JS to allow Tab and Spacebar keyboard inputs to operate as expected within combobox drowdowns

## Breaking change
This is **potentially** a breaking change if developers instruct users to make a selection via tab.

## Related issue
Closes [USWDS-Site uswds/uswds#5161](https://github.com/uswds/uswds/issues/5161)

## Preview link
[Combobox →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-combobox-tab-space-fix/iframe.html?args=&globals=&id=components-form-inputs-combo-box--default&viewMode=story)

## Problem statement
Keyboard users should expect consistent behaviour when navigating with a combobox component. Users should be able to use `Tab` to escape the combobox selection without making a choice, and `Space` to select the current highlighted option when within the dropdown menu.

Currently, we include JS that captures the tab event and uses it to select a highlighted combobox option instead of escaping the element.

Pressing the spacebar currently causes the combobox to scroll, rather than selecting the highlighted element as expected.

## Solution
I've replaced the Tab functionality with the Spacebar. Now both elements behave as expected when within the combobox dropdown menu

## Testing and review
1. The combobox story or a page with a combobox component
2. Navigate to the component using your keyboard
3. Use the up and down arrows to make a selection
4. Press tab to escape the combobox
5. Check that the combobox is no longer selected and that no selection was made
6. Return to the combobox and repeat step 3
7. Press the spacebar
8. Check that a selection was made

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
