### PR TITLE
Alert: Remove invalid and redundant alert height style

### DIFF
--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -116,7 +116,6 @@
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
     display: block;
-    height: $theme-alert-icon-size;
     // padding - optical spacing value
     left: units($theme-site-margins-mobile-width) - units($theme-alert-bar-width);
     position: absolute;


### PR DESCRIPTION
# Summary

Removes an unnecessary assignment of `height` styling in the `add-alert-icon` mixin.

- This produces invalid styles because `$theme-alert-icon-size` is a unitless number (e.g. `2`) and should be wrapped with the `unit` function
- This is redundant anyways because the `height` is already assigned by the inclusion of `add-color-icon` mixin above using the `height` value from `$this-icon-object`

## Testing and review

Observe the issue by inspecting the `::before` pseudo-element of `.usa-alert__body` in the [Alert component preview page](https://designsystem.digital.gov/components/alert/).

![Screen Shot 2023-03-15 at 9 33 24 AM](https://user-images.githubusercontent.com/1779930/225324568-58f84985-b763-4917-907f-21c2e80a2c09.png)

The changes proposed in this pull request will cause the second (invalid) highlighted `height` style to be removed.