### PR TITLE
USWDS - In-Page Navigation: Fix error when clicking link starting with number

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -232,7 +232,7 @@ const createInPageNav = (inPageNavEl) => {
  * @param {HTMLElement} el An element within the in-page nav component
  */
 const handleClickFromLink = (el) => {
-  const elementToScrollTo = document.querySelector(el.hash);
+  const elementToScrollTo = document.getElementById(el.hash.slice(1));
   handleScrollToSection(elementToScrollTo);
 };
 

--- a/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
+++ b/packages/usa-in-page-navigation/src/test/in-page-navigation.spec.js
@@ -132,6 +132,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         "h2 ~ h3 > .usa-anchor#section-1-1",
         "h2 ~ h3 ~ h3 > .usa-anchor#section-1-2-2",
         "h2 ~ h3 ~ h3 ~ h3 > .usa-anchor#section-1-3",
+        "h2 ~ h3 ~ h3 ~ h3 ~ h3 > .usa-anchor[id='1-4-section-1-4']",
       ].every((selector) => document.querySelector(selector));
 
       assert(ok);
@@ -165,6 +166,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     it("does not scroll to section on initialization", () => {
       assert.equal(window.scroll.called, false);
+    });
+
+    it("handles headings starting with a number", () => {
+      const firstLink = theNav.querySelector("a[href='#1-4-section-1-4']");
+      firstLink.click();
+
+      assert(window.scroll.calledOnceWith(sinon.match({ top: 880 })));
     });
 
     context("with initial hash URL", () => {

--- a/packages/usa-in-page-navigation/src/test/template.html
+++ b/packages/usa-in-page-navigation/src/test/template.html
@@ -10,6 +10,8 @@
     <p id="section-1-2">Section 1.2 content</p>
     <h3>? Section 1.3.</h3>
     <p>Section 1.3 content</p>
+    <h3>1.4 Section 1.4</h3>
+    <p>Section 1.4 content</p>
   </main>
 
   <aside class="usa-in-page-nav" data-title-text="On this page" data-title-heading-level="h4" data-scroll-offset="20"></aside>


### PR DESCRIPTION
# Summary

**Fix an error when clicking a link starting with a number.** Certain links would not scroll as expected when clicked.

## Related issue

Fixes #5199

## Problem statement

See #5199

## Solution

This implements the first of the proposed options outlined at https://github.com/uswds/uswds/issues/5199#issuecomment-1485125100 .

This has a few advantages, in that it limits the scope of the changes and maintains backwards compatibility. The only downside that I can consider is that these IDs are still technically not valid for use as CSS selectors, in case someone would need to reference it as such. As demonstrated in the included tests, a workaround is to reference the ID as using an attribute selector (e.g. `[id="1-installation"]`).

## Testing and review

1. Run Mocha tests
2. Perhaps this could be incorporated into demo content so it could be observed in the Storybook preview?
