### PR TITLE
USWDS - Modal: Implement behaviors and add conditional initialization

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -309,24 +309,16 @@ modal = behavior(
         });
     },
     teardown(root) {
-      if (document.querySelector(`.${WRAPPER_CLASSNAME}`)) {
-        selectOrMatches(MODAL, root).forEach((modalWindow) => {
-          cleanUpModal(modalWindow);
-          const modalId = modalWindow.id;
+      selectOrMatches(MODAL, root).forEach((modalWindow) => {
+        cleanUpModal(modalWindow);
+        const modalId = modalWindow.id;
 
-          document.querySelectorAll(`[aria-controls="${modalId}"]`)
-            .forEach((item) => item.removeEventListener("click", toggleModal));
-        });
-      }
+        document.querySelectorAll(`[aria-controls="${modalId}"]`)
+          .forEach((item) => item.removeEventListener("click", toggleModal));
+      });
     },
     focusTrap: null,
     toggleModal,
-    on(root) {
-      this.init(root);
-    },
-    off(root) {
-      this.teardown(root);
-    }
   }
 );
 

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -290,7 +290,7 @@ modal = behavior(
         }
 
           // Query all openers and closers including the overlay
-          selectOrMatches(`[aria-controls="${modalId}"]`, root).forEach((modalTrigger) => {
+          selectOrMatches(`[aria-controls="${modalId}"]`, document).forEach((modalTrigger) => {
             // If modalTrigger is an anchor...
             if (modalTrigger.nodeName === "A") {
               // Turn anchor links into buttons for screen readers
@@ -315,7 +315,7 @@ modal = behavior(
         cleanUpModal(modalWindow);
         const modalId = modalWindow.id;
 
-        selectOrMatches(`[aria-controls="${modalId}"]`, root)
+        selectOrMatches(`[aria-controls="${modalId}"]`, document)
           .forEach((modalTrigger) => modalTrigger.removeEventListener("click", toggleModal));
       });
     },

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -285,9 +285,11 @@ modal = behavior(
     init(root) {
       selectOrMatches(MODAL, root).forEach((modalWindow) => {
         const modalId = modalWindow.id;
-        if (modalId) {
-          setUpModal(modalWindow);
+        if (!modalId) {
+          return;
         }
+
+        setUpModal(modalWindow);
 
           // Query all openers and closers including the overlay
           selectOrMatches(`[aria-controls="${modalId}"]`, document).forEach((modalTrigger) => {
@@ -312,8 +314,11 @@ modal = behavior(
     },
     teardown(root) {
       selectOrMatches(MODAL, root).forEach((modalWindow) => {
-        cleanUpModal(modalWindow);
         const modalId = modalWindow.id;
+        if (!modalId) {
+          return;
+        }
+        cleanUpModal(modalWindow);
 
         selectOrMatches(`[aria-controls="${modalId}"]`, document)
           .forEach((modalTrigger) => modalTrigger.removeEventListener("click", toggleModal));

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -285,7 +285,9 @@ modal = behavior(
     init(root) {
         selectOrMatches(MODAL, root).forEach((modalWindow) => {
           const modalId = modalWindow.id;
-          setUpModal(modalWindow);
+          if (modalId) {
+            setUpModal(modalWindow);
+          }
 
           // this will query all openers and closers including the overlay
           document.querySelectorAll(`[aria-controls="${modalId}"]`).forEach((item) => {

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -290,20 +290,20 @@ modal = behavior(
           }
 
           // Query all openers and closers including the overlay
-          document.querySelectorAll(`[aria-controls="${modalId}"]`).forEach((item) => {
+          selectOrMatches(`[aria-controls="${modalId}"]`, root).forEach((modalTrigger) => {
             // Turn anchor links into buttons for screen readers
-            if (item.nodeName === "A") {
-              item.setAttribute("role", "button");
-              item.addEventListener("click", (e) => e.preventDefault());
+            if (modalTrigger.nodeName === "A") {
+              modalTrigger.setAttribute("role", "button");
+              modalTrigger.addEventListener("click", (e) => e.preventDefault());
             }
 
             // Can uncomment when aria-haspopup="dialog" is supported
             // https://a11ysupport.io/tech/aria/aria-haspopup_attribute
             // Most screen readers support aria-haspopup, but might announce
             // as opening a menu if "dialog" is not supported.
-            // item.setAttribute("aria-haspopup", "dialog");
+            // modalTrigger.setAttribute("aria-haspopup", "dialog");
 
-            item.addEventListener("click", toggleModal);
+            modalTrigger.addEventListener("click", toggleModal);
           });
         });
     },
@@ -312,8 +312,8 @@ modal = behavior(
         cleanUpModal(modalWindow);
         const modalId = modalWindow.id;
 
-        document.querySelectorAll(`[aria-controls="${modalId}"]`)
-          .forEach((item) => item.removeEventListener("click", toggleModal));
+        selectOrMatches(`[aria-controls="${modalId}"]`, root)
+          .forEach((modalTrigger) => modalTrigger.removeEventListener("click", toggleModal));
       });
     },
     focusTrap: null,

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -1,6 +1,7 @@
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const FocusTrap = require("../../uswds-core/src/js/utils/focus-trap");
 const ScrollBarWidth = require("../../uswds-core/src/js/utils/scrollbar-width");
+const behavior = require("../../uswds-core/src/js/utils/behavior");
 
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 
@@ -278,51 +279,53 @@ const cleanUpModal = (baseComponent) => {
   modalWrapper.parentElement.removeChild(modalWrapper);
 };
 
-modal = {
-  init(root) {
-    selectOrMatches(MODAL, root).forEach((modalWindow) => {
-      const modalId = modalWindow.id;
-      setUpModal(modalWindow);
+modal = behavior(
+  {},
+  {
+    init(root) {
+        selectOrMatches(MODAL, root).forEach((modalWindow) => {
+          const modalId = modalWindow.id;
+          setUpModal(modalWindow);
 
-      // this will query all openers and closers including the overlay
-      document
-        .querySelectorAll(`[aria-controls="${modalId}"]`)
-        .forEach((item) => {
-          // Turn anchor links into buttons because of
-          // VoiceOver on Safari
-          if (item.nodeName === "A") {
-            item.setAttribute("role", "button");
-            item.addEventListener("click", (e) => e.preventDefault());
-          }
+          // this will query all openers and closers including the overlay
+          document.querySelectorAll(`[aria-controls="${modalId}"]`).forEach((item) => {
+            // Turn anchor links into buttons because of
+            // VoiceOver on Safari
+            if (item.nodeName === "A") {
+              item.setAttribute("role", "button");
+              item.addEventListener("click", (e) => e.preventDefault());
+            }
 
-          // Can uncomment when aria-haspopup="dialog" is supported
-          // https://a11ysupport.io/tech/aria/aria-haspopup_attribute
-          // Most screen readers support aria-haspopup, but might announce
-          // as opening a menu if "dialog" is not supported.
-          // item.setAttribute("aria-haspopup", "dialog");
+            // Can uncomment when aria-haspopup="dialog" is supported
+            // https://a11ysupport.io/tech/aria/aria-haspopup_attribute
+            // Most screen readers support aria-haspopup, but might announce
+            // as opening a menu if "dialog" is not supported.
+            // item.setAttribute("aria-haspopup", "dialog");
 
-          item.addEventListener("click", toggleModal);
+            item.addEventListener("click", toggleModal);
+          });
         });
-    });
-  },
-  teardown(root) {
-    selectOrMatches(MODAL, root).forEach((modalWindow) => {
-      cleanUpModal(modalWindow);
-      const modalId = modalWindow.id;
+    },
+    teardown(root) {
+      if (document.querySelector(`.${WRAPPER_CLASSNAME}`)) {
+        selectOrMatches(MODAL, root).forEach((modalWindow) => {
+          cleanUpModal(modalWindow);
+          const modalId = modalWindow.id;
 
-      document
-        .querySelectorAll(`[aria-controls="${modalId}"]`)
-        .forEach((item) => item.removeEventListener("click", toggleModal));
-    });
-  },
-  focusTrap: null,
-  toggleModal,
-  on(root) {
-    this.init(root);
-  },
-  off(root) {
-    this.teardown(root);
-  },
-};
+          document.querySelectorAll(`[aria-controls="${modalId}"]`)
+            .forEach((item) => item.removeEventListener("click", toggleModal));
+        });
+      }
+    },
+    focusTrap: null,
+    toggleModal,
+    on(root) {
+      this.init(root);
+    },
+    off(root) {
+      this.teardown(root);
+    }
+  }
+);
 
 module.exports = modal;

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -291,9 +291,12 @@ modal = behavior(
 
           // Query all openers and closers including the overlay
           selectOrMatches(`[aria-controls="${modalId}"]`, root).forEach((modalTrigger) => {
-            // Turn anchor links into buttons for screen readers
+            // If modalTrigger is an anchor...
             if (modalTrigger.nodeName === "A") {
+              // Turn anchor links into buttons for screen readers
               modalTrigger.setAttribute("role", "button");
+
+              // Prevent modal triggers from acting like links
               modalTrigger.addEventListener("click", (e) => e.preventDefault());
             }
 

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -289,10 +289,9 @@ modal = behavior(
             setUpModal(modalWindow);
           }
 
-          // this will query all openers and closers including the overlay
+          // Query all openers and closers including the overlay
           document.querySelectorAll(`[aria-controls="${modalId}"]`).forEach((item) => {
-            // Turn anchor links into buttons because of
-            // VoiceOver on Safari
+            // Turn anchor links into buttons for screen readers
             if (item.nodeName === "A") {
               item.setAttribute("role", "button");
               item.addEventListener("click", (e) => e.preventDefault());


### PR DESCRIPTION
# Summary

**Implements behaviors utility and queries DOM before initialization**. Now `modal` follows the pattern set by other dynamically created components by using the behaviors utility. Additionally, the component will query the DOM before building the component to prevent errors caused by multiple initializations being called. This is beneficial for component-level initialization.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5062 

## Preview link
[Modal (federalist preview)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-modal-behavior/iframe.html?args=&id=components-modal--default&viewMode=story)

[Test repo (Follow instructions below)](https://github.com/rachidatecs/uswds-modals)

## Problem statement

When using modern JS frameworks such as Angular or React, calling on the component to initialize multiple times caused the modal's functionality to break. The error occurred because the initialization process selects all `usa-modal` divs and rebuilds them using their ID. The newly generated div removes the ID and moves it to the wrapper. 

Once initialization is called again, it selects the new `usa-modal` div _without_ the ID, which causes build errors due to the ID being `null`

## Solution

1. During initialization, check for previously declared `modalId`before running `setUpModal` function

## Testing and review

1. Checkout this PR
2. Confirm modal js follows standard dynamic component patterns regarding behaviors util
3. Run `npm link`
4. Clone this [test repo](https://github.com/rachidatecs/uswds-modals)
5. Run `npm install` `npm run start`
6. Confirm error on the mulitple modals page
7. Return to code and run `npm link @uswds/uswds`
8. Inspect multiple modal page and confirm modals are working

## Notes

Output HTML before change:
![image](https://user-images.githubusercontent.com/25211650/228368343-57d05c9c-6289-4630-9bc4-67d5db10043f.png)

After:
![image](https://user-images.githubusercontent.com/25211650/228368855-42ea34cd-f5ae-4fc3-be1e-7373ff4ab967.png)


Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.


