### PR TITLE
USWDS - Core: Remove commented code from utility builder

### DIFF
--- a/packages/uswds-core/src/styles/mixins/_utility-builder.scss
+++ b/packages/uswds-core/src/styles/mixins/_utility-builder.scss
@@ -140,20 +140,6 @@ future version of Sass' warning.
       $media-prefix
     );
   }
-
-  // And add the responsive prefixes, if applicable
-
-  /*
-  @if map-deep-get($utility, settings, responsive) {
-    @include render-media-queries(
-      $utility,
-      $selector,
-      $property,
-      $value,
-      $val-props
-    );
-  }
-  */
 }
 
 /*


### PR DESCRIPTION
# Summary

Reduce size of compiled CSS when comments aren't explicitly excluded.

## Problem statement

When compiling USWDS without optimization configured to remove comments, the output includes 1500 instances of the following snippet of code (one for each utility class):

```css
/*
@if map-deep-get($utility, settings, responsive) {
  @include render-media-queries(
    $utility,
    $selector,
    $property,
    $value,
    $val-props
  );
}
*/
```

This unnecessarily inflates the size of the compiled output, and may cause extra work for the compilation itself.

## Solution

Remove unused code.

## Testing and review

```
mkdir tmp-uswds
cd tmp-uswds
npm init -y
npm i @uswds/uswds
brew install sass/sass/sass
echo "@forward 'uswds'; @use 'uswds-core' as *;" > styles.scss
sass --load-path=node_modules/@uswds/uswds/packages styles.scss | wc -c
```

Before: 1336223 bytes (1336.2kb)
After: 657293 bytes (657.3kb)
Diff: 678930 bytes (-50.8%)