### PR TITLE
USWDS - Settings: Update sass map pattern

### DIFF
--- a/packages/usa-icon-list/src/styles/_usa-icon-list.scss
+++ b/packages/usa-icon-list/src/styles/_usa-icon-list.scss
@@ -107,7 +107,7 @@ $icon-list-breakpoints: map-merge($this-null, $system-breakpoints);
     $prefix: "";
   }
   // Or the standard prefix if the breakpoint is output
-  @else if map.get($theme-utility-breakpoints, $mq-key) {
+  @else if map.get($theme-utility-breakpoints-complete, $mq-key) {
     $prefix: "#{$mq-key}#{$separator}";
   }
 

--- a/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
+++ b/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
@@ -22,7 +22,7 @@ $namespace-grid: ns("grid");
 
 // responsive containers...
 @each $mq-key, $mq-value in $system-breakpoints {
-  @if map.get($theme-utility-breakpoints, $mq-key) {
+  @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}container {
         $props: append-important($grid-global, desktop);
@@ -57,7 +57,7 @@ $namespace-grid: ns("grid");
 
   // responsive column gaps
   @each $mq-key, $mq-value in $system-breakpoints {
-    @if map.get($theme-utility-breakpoints, $mq-key) {
+    @if map.get($theme-utility-breakpoints-complete, $mq-key) {
       @include at-media($mq-key) {
         @each $gap-key,
           $gap-val in map-deep-get($system-properties, gap, standard)
@@ -104,7 +104,7 @@ $namespace-grid: ns("grid");
 
 // responsive columns
 @each $mq-key, $mq-value in $system-breakpoints {
-  @if map.get($theme-utility-breakpoints, $mq-key) {
+  @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}col {
         $props: append-important($grid-global, fill);
@@ -143,7 +143,7 @@ $namespace-grid: ns("grid");
 
 // responsive offsets
 @each $mq-key, $mq-value in $system-breakpoints {
-  @if map.get($theme-utility-breakpoints, $mq-key) {
+  @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @each $width-key, $width-value in $system-layout-grid-widths {
       @include at-media($mq-key) {
         .#{$mq-key}#{$separator}#{$namespace-grid}offset-#{$width-key} {

--- a/packages/uswds-core/_functionsOLD.scss
+++ b/packages/uswds-core/_functionsOLD.scss
@@ -298,11 +298,11 @@ namespace is set to output
 @function ns($type) {
   $type: smart-quote($type);
 
-  @if not map-deep-get($theme-namespace, $type, output) {
+  @if not map-deep-get($theme-namespace-complete, $type, output) {
     @return "";
   }
 
-  @return map-deep-get($theme-namespace, $type, namespace);
+  @return map-deep-get($theme-namespace-complete, $type, namespace);
 }
 
 /*

--- a/packages/uswds-core/src/styles/functions/output/ns.scss
+++ b/packages/uswds-core/src/styles/functions/output/ns.scss
@@ -14,11 +14,11 @@ namespace is set to output
 @function ns($type) {
   $type: smart-quote($type);
 
-  @if not map-deep-get(settings.$theme-namespace, $type, output) {
+  @if not map-deep-get(settings.$theme-namespace-complete, $type, output) {
     @return "";
   }
 
-  @return map-deep-get(settings.$theme-namespace, $type, namespace);
+  @return map-deep-get(settings.$theme-namespace-complete, $type, namespace);
 }
 
 // @debug ns("grid");

--- a/packages/uswds-core/src/styles/mixins/_utility-builder.scss
+++ b/packages/uswds-core/src/styles/mixins/_utility-builder.scss
@@ -369,7 +369,7 @@ through all possible variants
 
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
   @each $media-key, $media-value in $our-breakpoints {
-    @if map.get($theme-utility-breakpoints, $media-key) {
+    @if map.get($theme-utility-breakpoints-complete, $media-key) {
       @include at-media($media-key) {
         @include these-utilities($utilities, $media-key);
       }

--- a/packages/uswds-core/src/styles/settings/_settings-general.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-general.scss
@@ -15,6 +15,8 @@ https://designsystem.digital.gov/design-tokens
 ----------------------------------------
 */
 
+@use "sass:map";
+
 /*
 ----------------------------------------
 Image path
@@ -45,7 +47,8 @@ Namespace
 ----------------------------------------
 */
 
-$theme-namespace: (
+$theme-namespace: () !default;
+$theme-namespace-complete: map.deep-merge((
   "grid": (
     namespace: "grid-",
     output: true,
@@ -54,7 +57,7 @@ $theme-namespace: (
     namespace: "u-",
     output: false,
   ),
-) !default;
+), $theme-namespace) !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/styles/settings/_settings-general.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-general.scss
@@ -48,16 +48,19 @@ Namespace
 */
 
 $theme-namespace: () !default;
-$theme-namespace-complete: map.deep-merge((
-  "grid": (
-    namespace: "grid-",
-    output: true,
+$theme-namespace-complete: map.deep-merge(
+  (
+    "grid": (
+      namespace: "grid-",
+      output: true,
+    ),
+    "utility": (
+      namespace: "u-",
+      output: false,
+    ),
   ),
-  "utility": (
-    namespace: "u-",
-    output: false,
-  ),
-), $theme-namespace) !default;
+  $theme-namespace
+) !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -15,6 +15,8 @@ https://designsystem.digital.gov/utilities
 ----------------------------------------
 */
 
+@use "sass:map";
+
 $utilities-use-important: false !default;
 $output-these-utilities: default !default;
 
@@ -29,7 +31,7 @@ used by utilities or layout grid
 */
 
 $theme-utility-breakpoints: () !default;
-$theme-utility-breakpoints-complete: map-merge((
+$theme-utility-breakpoints-complete: map.merge((
   // 160px:
   "card": false,
   // 240px:

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -72,518 +72,575 @@ Settings
 ----------------------------------------
 */
 
-$add-aspect-settings: (
+$add-aspect-settings: () !default;
+$add-aspect-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $add-aspect-settings) !default;
 
-$add-list-reset-settings: (
+$add-list-reset-settings: () !default;
+$add-list-reset-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $add-list-reset-settings) !default;
 
-$align-items-settings: (
+$align-items-settings: () !default;
+$align-items-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $align-items-settings) !default;
 
-$align-self-settings: (
+$align-self-settings: () !default;
+$align-self-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $align-self-settings) !default;
 
-$background-color-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-) !default;
-
-$border-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-) !default;
-
-$border-color-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-) !default;
-
-$border-radius-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$border-style-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$border-width-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$bottom-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$box-shadow-settings: (
+$background-color-settings: () !default;
+$background-color-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: true,
   visited: false,
-) !default;
+), $background-color-settings) !default;
 
-$circle-settings: (
+$border-settings: () !default;
+$border-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: true,
+  visited: false,
+), $border-settings) !default;
+
+$border-color-settings: () !default;
+$border-color-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: true,
+  visited: false,
+), $border-color-settings) !default;
+
+$border-radius-settings: () !default;
+$border-radius-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $border-radius-settings) !default;
+
+$border-style-settings: () !default;
+$border-style-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $border-style-settings) !default;
 
-$clearfix-settings: (
+$border-width-settings: () !default;
+$border-width-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $border-width-settings) !default;
 
-$color-settings: (
+$bottom-settings: () !default;
+$bottom-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $bottom-settings) !default;
+
+$box-shadow-settings: () !default;
+$box-shadow-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: true,
   visited: false,
-) !default;
+), $box-shadow-settings) !default;
 
-$cursor-settings: (
+$circle-settings: () !default;
+$circle-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $circle-settings) !default;
 
-$display-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$flex-settings: (
+$clearfix-settings: () !default;
+$clearfix-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $clearfix-settings) !default;
 
-$flex-direction-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$flex-wrap-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$float-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$font-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$font-family-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$font-feature-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$font-style-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$font-weight-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$height-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$justify-content-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$left-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$letter-spacing-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$line-height-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$margin-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$max-height-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$max-width-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$measure-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$min-height-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$min-width-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$opacity-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$order-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$outline-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$outline-color-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$overflow-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$padding-settings: (
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$pin-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$position-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$right-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$square-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$text-align-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$text-decoration-settings: (
+$color-settings: () !default;
+$color-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: true,
   visited: false,
-) !default;
+), $color-settings) !default;
 
-$text-decoration-color-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-) !default;
-
-$text-indent-settings: (
+$cursor-settings: () !default;
+$cursor-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $cursor-settings) !default;
 
-$text-transform-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$top-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$vertical-align-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$whitespace-settings: (
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-) !default;
-
-$width-settings: (
+$display-settings: () !default;
+$display-settings-complete: map.merge((
   output: true,
   responsive: true,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $display-settings) !default;
 
-$z-index-settings: (
+$flex-settings: () !default;
+$flex-settings-complete: map.merge((
   output: true,
   responsive: false,
   active: false,
   focus: false,
   hover: false,
   visited: false,
-) !default;
+), $flex-settings) !default;
+
+$flex-direction-settings: () !default;
+$flex-direction-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $flex-direction-settings) !default;
+
+$flex-wrap-settings: () !default;
+$flex-wrap-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $flex-wrap-settings) !default;
+
+$float-settings: () !default;
+$float-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $float-settings) !default;
+
+$font-settings: () !default;
+$font-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $font-settings) !default;
+
+$font-family-settings: () !default;
+$font-family-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $font-family-settings) !default;
+
+$font-feature-settings: () !default;
+$font-feature-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $font-feature-settings) !default;
+
+$font-style-settings: () !default;
+$font-style-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $font-style-settings) !default;
+
+$font-weight-settings: () !default;
+$font-weight-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $font-weight-settings) !default;
+
+$height-settings: () !default;
+$height-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $height-settings) !default;
+
+$justify-content-settings: () !default;
+$justify-content-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $justify-content-settings) !default;
+
+$left-settings: () !default;
+$left-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $left-settings) !default;
+
+$letter-spacing-settings: () !default;
+$letter-spacing-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $letter-spacing-settings) !default;
+
+$line-height-settings: () !default;
+$line-height-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $line-height-settings) !default;
+
+$margin-settings: () !default;
+$margin-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $margin-settings) !default;
+
+$max-height-settings: () !default;
+$max-height-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $max-height-settings) !default;
+
+$max-width-settings: () !default;
+$max-width-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $max-width-settings) !default;
+
+$measure-settings: () !default;
+$measure-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $measure-settings) !default;
+
+$min-height-settings: () !default;
+$min-height-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $min-height-settings) !default;
+
+$min-width-settings: () !default;
+$min-width-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $min-width-settings) !default;
+
+$opacity-settings: () !default;
+$opacity-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $opacity-settings) !default;
+
+$order-settings: () !default;
+$order-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $order-settings) !default;
+
+$outline-settings: () !default;
+$outline-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $outline-settings) !default;
+
+$outline-color-settings: () !default;
+$outline-color-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $outline-color-settings) !default;
+
+$overflow-settings: () !default;
+$overflow-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $overflow-settings) !default;
+
+$padding-settings: () !default;
+$padding-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $padding-settings) !default;
+
+$pin-settings: () !default;
+$pin-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+),$pin-settings ) !default;
+
+$position-settings: () !default;
+$position-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $position-settings) !default;
+
+$right-settings: () !default;
+$right-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $right-settings) !default;
+
+$square-settings: () !default;
+$square-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $square-settings) !default;
+
+$text-align-settings: () !default;
+$text-align-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $text-align-settings) !default;
+
+$text-decoration-settings: () !default;
+$text-decoration-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: true,
+  visited: false,
+), $text-decoration-settings) !default;
+
+$text-decoration-color-settings: () !default;
+$text-decoration-color-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: true,
+  visited: false,
+), $text-decoration-color-settings) !default;
+
+$text-indent-settings: () !default;
+$text-indent-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $text-indent-settings) !default;
+
+$text-transform-settings: () !default;
+$text-transform-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $text-transform-settings) !default;
+
+$top-settings: () !default;
+$top-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $top-settings) !default;
+
+$vertical-align-settings: () !default;
+$vertical-align-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $vertical-align-settings) !default;
+
+$whitespace-settings: () !default;
+$whitespace-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $whitespace-settings) !default;
+
+$width-settings: () !default;
+$width-settings-complete: map.merge((
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $width-settings) !default;
+
+$z-index-settings: () !default;
+$z-index-settings-complete: map.merge((
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+), $z-index-settings) !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -28,7 +28,8 @@ used by utilities or layout grid
 ----------------------------------------
 */
 
-$theme-utility-breakpoints: (
+$theme-utility-breakpoints-override: () !default;
+$theme-utility-breakpoints: map-merge((
   // 160px:
   "card": false,
   // 240px:
@@ -47,8 +48,9 @@ $theme-utility-breakpoints: (
   "desktop-lg": false,
   // 1400px:
   "widescreen": false
-) !default;
+), $theme-utility-breakpoints-override) !default;
 
+// $theme-utility-breakpoints: map-merge($theme-utility-breakpoints, $theme-utility-breakpoints-override) !default;
 /*
 ----------------------------------------
 Global colors

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -31,26 +31,29 @@ used by utilities or layout grid
 */
 
 $theme-utility-breakpoints: () !default;
-$theme-utility-breakpoints-complete: map.merge((
-  // 160px:
-  "card": false,
-  // 240px:
-  "card-lg": false,
-  // 320px:
-  "mobile": false,
-  // 480px:
-  "mobile-lg": true,
-  // 640px:
-  "tablet": true,
-  // 880px:
-  "tablet-lg": false,
-  // 1024px:
-  "desktop": true,
-  // 1200px:
-  "desktop-lg": false,
-  // 1400px:
-  "widescreen": false
-), $theme-utility-breakpoints) !default;
+$theme-utility-breakpoints-complete: map.merge(
+  (
+    // 160px:
+    "card": false,
+    // 240px:
+    "card-lg": false,
+    // 320px:
+    "mobile": false,
+    // 480px:
+    "mobile-lg": true,
+    // 640px:
+    "tablet": true,
+    // 880px:
+    "tablet-lg": false,
+    // 1024px:
+    "desktop": true,
+    // 1200px:
+    "desktop-lg": false,
+    // 1400px:
+    "widescreen": false
+  ),
+  $theme-utility-breakpoints
+) !default;
 
 /*
 ----------------------------------------
@@ -73,574 +76,745 @@ Settings
 */
 
 $add-aspect-settings: () !default;
-$add-aspect-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $add-aspect-settings) !default;
+$add-aspect-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $add-aspect-settings
+) !default;
 
 $add-list-reset-settings: () !default;
-$add-list-reset-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $add-list-reset-settings) !default;
+$add-list-reset-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $add-list-reset-settings
+) !default;
 
 $align-items-settings: () !default;
-$align-items-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $align-items-settings) !default;
+$align-items-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $align-items-settings
+) !default;
 
 $align-self-settings: () !default;
-$align-self-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $align-self-settings) !default;
+$align-self-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $align-self-settings
+) !default;
 
 $background-color-settings: () !default;
-$background-color-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $background-color-settings) !default;
+$background-color-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $background-color-settings
+) !default;
 
 $border-settings: () !default;
-$border-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $border-settings) !default;
+$border-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $border-settings
+) !default;
 
 $border-color-settings: () !default;
-$border-color-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $border-color-settings) !default;
+$border-color-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $border-color-settings
+) !default;
 
 $border-radius-settings: () !default;
-$border-radius-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $border-radius-settings) !default;
+$border-radius-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $border-radius-settings
+) !default;
 
 $border-style-settings: () !default;
-$border-style-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $border-style-settings) !default;
+$border-style-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $border-style-settings
+) !default;
 
 $border-width-settings: () !default;
-$border-width-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $border-width-settings) !default;
+$border-width-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $border-width-settings
+) !default;
 
 $bottom-settings: () !default;
-$bottom-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $bottom-settings) !default;
+$bottom-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $bottom-settings
+) !default;
 
 $box-shadow-settings: () !default;
-$box-shadow-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $box-shadow-settings) !default;
+$box-shadow-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $box-shadow-settings
+) !default;
 
 $circle-settings: () !default;
-$circle-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $circle-settings) !default;
+$circle-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $circle-settings
+) !default;
 
 $clearfix-settings: () !default;
-$clearfix-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $clearfix-settings) !default;
+$clearfix-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $clearfix-settings
+) !default;
 
 $color-settings: () !default;
-$color-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $color-settings) !default;
+$color-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $color-settings
+) !default;
 
 $cursor-settings: () !default;
-$cursor-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $cursor-settings) !default;
+$cursor-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $cursor-settings
+) !default;
 
 $display-settings: () !default;
-$display-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $display-settings) !default;
+$display-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $display-settings
+) !default;
 
 $flex-settings: () !default;
-$flex-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $flex-settings) !default;
+$flex-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $flex-settings
+) !default;
 
 $flex-direction-settings: () !default;
-$flex-direction-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $flex-direction-settings) !default;
+$flex-direction-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $flex-direction-settings
+) !default;
 
 $flex-wrap-settings: () !default;
-$flex-wrap-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $flex-wrap-settings) !default;
+$flex-wrap-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $flex-wrap-settings
+) !default;
 
 $float-settings: () !default;
-$float-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $float-settings) !default;
+$float-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $float-settings
+) !default;
 
 $font-settings: () !default;
-$font-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $font-settings) !default;
+$font-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $font-settings
+) !default;
 
 $font-family-settings: () !default;
-$font-family-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $font-family-settings) !default;
+$font-family-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $font-family-settings
+) !default;
 
 $font-feature-settings: () !default;
-$font-feature-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $font-feature-settings) !default;
+$font-feature-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $font-feature-settings
+) !default;
 
 $font-style-settings: () !default;
-$font-style-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $font-style-settings) !default;
+$font-style-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $font-style-settings
+) !default;
 
 $font-weight-settings: () !default;
-$font-weight-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $font-weight-settings) !default;
+$font-weight-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $font-weight-settings
+) !default;
 
 $height-settings: () !default;
-$height-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $height-settings) !default;
+$height-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $height-settings
+) !default;
 
 $justify-content-settings: () !default;
-$justify-content-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $justify-content-settings) !default;
+$justify-content-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $justify-content-settings
+) !default;
 
 $left-settings: () !default;
-$left-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $left-settings) !default;
+$left-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $left-settings
+) !default;
 
 $letter-spacing-settings: () !default;
-$letter-spacing-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $letter-spacing-settings) !default;
+$letter-spacing-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $letter-spacing-settings
+) !default;
 
 $line-height-settings: () !default;
-$line-height-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $line-height-settings) !default;
+$line-height-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $line-height-settings
+) !default;
 
 $margin-settings: () !default;
-$margin-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $margin-settings) !default;
+$margin-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $margin-settings
+) !default;
 
 $max-height-settings: () !default;
-$max-height-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $max-height-settings) !default;
+$max-height-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $max-height-settings
+) !default;
 
 $max-width-settings: () !default;
-$max-width-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $max-width-settings) !default;
+$max-width-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $max-width-settings
+) !default;
 
 $measure-settings: () !default;
-$measure-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $measure-settings) !default;
+$measure-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $measure-settings
+) !default;
 
 $min-height-settings: () !default;
-$min-height-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $min-height-settings) !default;
+$min-height-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $min-height-settings
+) !default;
 
 $min-width-settings: () !default;
-$min-width-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $min-width-settings) !default;
+$min-width-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $min-width-settings
+) !default;
 
 $opacity-settings: () !default;
-$opacity-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $opacity-settings) !default;
+$opacity-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $opacity-settings
+) !default;
 
 $order-settings: () !default;
-$order-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $order-settings) !default;
+$order-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $order-settings
+) !default;
 
 $outline-settings: () !default;
-$outline-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $outline-settings) !default;
+$outline-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $outline-settings
+) !default;
 
 $outline-color-settings: () !default;
-$outline-color-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $outline-color-settings) !default;
+$outline-color-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $outline-color-settings
+) !default;
 
 $overflow-settings: () !default;
-$overflow-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $overflow-settings) !default;
+$overflow-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $overflow-settings
+) !default;
 
 $padding-settings: () !default;
-$padding-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $padding-settings) !default;
+$padding-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $padding-settings
+) !default;
 
 $pin-settings: () !default;
-$pin-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-),$pin-settings ) !default;
+$pin-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $pin-settings
+) !default;
 
 $position-settings: () !default;
-$position-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $position-settings) !default;
+$position-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $position-settings
+) !default;
 
 $right-settings: () !default;
-$right-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $right-settings) !default;
+$right-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $right-settings
+) !default;
 
 $square-settings: () !default;
-$square-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $square-settings) !default;
+$square-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $square-settings
+) !default;
 
 $text-align-settings: () !default;
-$text-align-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $text-align-settings) !default;
+$text-align-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $text-align-settings
+) !default;
 
 $text-decoration-settings: () !default;
-$text-decoration-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $text-decoration-settings) !default;
+$text-decoration-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $text-decoration-settings
+) !default;
 
 $text-decoration-color-settings: () !default;
-$text-decoration-color-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: true,
-  visited: false,
-), $text-decoration-color-settings) !default;
+$text-decoration-color-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: true,
+    visited: false,
+  ),
+  $text-decoration-color-settings
+) !default;
 
 $text-indent-settings: () !default;
-$text-indent-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $text-indent-settings) !default;
+$text-indent-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $text-indent-settings
+) !default;
 
 $text-transform-settings: () !default;
-$text-transform-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $text-transform-settings) !default;
+$text-transform-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $text-transform-settings
+) !default;
 
 $top-settings: () !default;
-$top-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $top-settings) !default;
+$top-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $top-settings
+) !default;
 
 $vertical-align-settings: () !default;
-$vertical-align-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $vertical-align-settings) !default;
+$vertical-align-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $vertical-align-settings
+) !default;
 
 $whitespace-settings: () !default;
-$whitespace-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $whitespace-settings) !default;
+$whitespace-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $whitespace-settings
+) !default;
 
 $width-settings: () !default;
-$width-settings-complete: map.merge((
-  output: true,
-  responsive: true,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $width-settings) !default;
+$width-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: true,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $width-settings
+) !default;
 
 $z-index-settings: () !default;
-$z-index-settings-complete: map.merge((
-  output: true,
-  responsive: false,
-  active: false,
-  focus: false,
-  hover: false,
-  visited: false,
-), $z-index-settings) !default;
+$z-index-settings-complete: map.merge(
+  (
+    output: true,
+    responsive: false,
+    active: false,
+    focus: false,
+    hover: false,
+    visited: false,
+  ),
+  $z-index-settings
+) !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -28,8 +28,8 @@ used by utilities or layout grid
 ----------------------------------------
 */
 
-$theme-utility-breakpoints-override: () !default;
-$theme-utility-breakpoints: map-merge((
+$theme-utility-breakpoints: () !default;
+$theme-utility-breakpoints-complete: map-merge((
   // 160px:
   "card": false,
   // 240px:
@@ -48,9 +48,8 @@ $theme-utility-breakpoints: map-merge((
   "desktop-lg": false,
   // 1400px:
   "widescreen": false
-), $theme-utility-breakpoints-override) !default;
+), $theme-utility-breakpoints) !default;
 
-// $theme-utility-breakpoints: map-merge($theme-utility-breakpoints, $theme-utility-breakpoints-override) !default;
 /*
 ----------------------------------------
 Global colors

--- a/packages/uswds-utilities/src/styles/rules/add-aspect.scss
+++ b/packages/uswds-utilities/src/styles/rules/add-aspect.scss
@@ -46,7 +46,7 @@ $add-aspect: (
         isReadable: true,
       ),
     ),
-    settings: $add-aspect-settings,
+    settings: $add-aspect-settings-complete,
     property: "position",
     type: "object",
   ),

--- a/packages/uswds-utilities/src/styles/rules/add-list-reset.scss
+++ b/packages/uswds-utilities/src/styles/rules/add-list-reset.scss
@@ -34,7 +34,7 @@ $add-list-reset: (
         ),
       ),
     ),
-    settings: $add-list-reset-settings,
+    settings: $add-list-reset-settings-complete,
     property: "list-style",
     type: "object",
   ),

--- a/packages/uswds-utilities/src/styles/rules/align-items.scss
+++ b/packages/uswds-utilities/src/styles/rules/align-items.scss
@@ -27,7 +27,7 @@ $u-align-items: (
         get-palettes($align-items-palettes),
         $align-items-manual-values
       ),
-    settings: $align-items-settings,
+    settings: $align-items-settings-complete,
     property: "align-items",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/align-self.scss
+++ b/packages/uswds-utilities/src/styles/rules/align-self.scss
@@ -24,7 +24,7 @@ $u-align-self: (
     modifiers: null,
     values:
       map-collect(get-palettes($align-self-palettes), $align-self-manual-values),
-    settings: $align-self-settings,
+    settings: $align-self-settings-complete,
     property: "align-self",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/background-color.scss
+++ b/packages/uswds-utilities/src/styles/rules/background-color.scss
@@ -30,7 +30,7 @@ $u-background-color: (
         get-palettes($global-color-palettes),
         $background-color-manual-values
       ),
-    settings: $background-color-settings,
+    settings: $background-color-settings-complete,
     type: "utility",
   ),
 );

--- a/packages/uswds-utilities/src/styles/rules/border-color.scss
+++ b/packages/uswds-utilities/src/styles/rules/border-color.scss
@@ -31,7 +31,7 @@ $u-border-color: (
         get-palettes($global-color-palettes),
         $border-color-manual-values
       ),
-    settings: $border-color-settings,
+    settings: $border-color-settings-complete,
     type: "utility",
   ),
 );

--- a/packages/uswds-utilities/src/styles/rules/border-radius.scss
+++ b/packages/uswds-utilities/src/styles/rules/border-radius.scss
@@ -49,7 +49,7 @@ $u-border-radius: (
         get-palettes($border-radius-palettes),
         $border-radius-manual-values
       ),
-    settings: $border-radius-settings,
+    settings: $border-radius-settings-complete,
     type: "utility",
   ),
 );

--- a/packages/uswds-utilities/src/styles/rules/border-style.scss
+++ b/packages/uswds-utilities/src/styles/rules/border-style.scss
@@ -27,7 +27,7 @@ $u-border-style: (
         get-palettes($border-style-palettes),
         $border-style-manual-values
       ),
-    settings: $border-style-settings,
+    settings: $border-style-settings-complete,
     property: "border-style",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/border-width.scss
+++ b/packages/uswds-utilities/src/styles/rules/border-width.scss
@@ -41,7 +41,7 @@ $u-border-width: (
         get-palettes($border-width-palettes),
         $border-width-manual-values
       ),
-    settings: $border-width-settings,
+    settings: $border-width-settings-complete,
     property: "border",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/border.scss
+++ b/packages/uswds-utilities/src/styles/rules/border.scss
@@ -44,7 +44,7 @@ $u-border: (
     ),
     values: map-collect(get-palettes($border-palettes), $border-manual-values),
     valueAppend: " solid",
-    settings: $border-settings,
+    settings: $border-settings-complete,
     property: "border",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/bottom.scss
+++ b/packages/uswds-utilities/src/styles/rules/bottom.scss
@@ -25,7 +25,7 @@ $u-bottom: (
     base: "bottom",
     modifiers: null,
     values: map-collect(get-palettes($bottom-palettes), $bottom-manual-values),
-    settings: $bottom-settings,
+    settings: $bottom-settings-complete,
     property: "bottom",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/box-shadow.scss
+++ b/packages/uswds-utilities/src/styles/rules/box-shadow.scss
@@ -24,7 +24,7 @@ $u-box-shadow: (
     modifiers: null,
     values:
       map-collect(get-palettes($box-shadow-palettes), $box-shadow-manual-values),
-    settings: $box-shadow-settings,
+    settings: $box-shadow-settings-complete,
     property: "box-shadow",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/circle.scss
+++ b/packages/uswds-utilities/src/styles/rules/circle.scss
@@ -26,7 +26,7 @@ $u-circle: (
     base: "circle",
     modifiers: null,
     values: map-collect(get-palettes($circle-palettes), $circle-manual-values),
-    settings: $circle-settings,
+    settings: $circle-settings-complete,
     property: (
       height,
       width,

--- a/packages/uswds-utilities/src/styles/rules/clearfix.scss
+++ b/packages/uswds-utilities/src/styles/rules/clearfix.scss
@@ -30,7 +30,7 @@ $u-clearfix: (
         ),
       ),
     ),
-    settings: $clearfix-settings,
+    settings: $clearfix-settings-complete,
     property: "clear",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/color.scss
+++ b/packages/uswds-utilities/src/styles/rules/color.scss
@@ -30,7 +30,7 @@ $u-color: (
         get-palettes($global-color-palettes),
         $color-manual-values
       ),
-    settings: $color-settings,
+    settings: $color-settings-complete,
     property: "color",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/cursor.scss
+++ b/packages/uswds-utilities/src/styles/rules/cursor.scss
@@ -23,7 +23,7 @@ $u-cursor: (
     base: "cursor",
     modifiers: null,
     values: map-collect(get-palettes($cursor-palettes), $cursor-manual-values),
-    settings: $cursor-settings,
+    settings: $cursor-settings-complete,
     property: "cursor",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/display.scss
+++ b/packages/uswds-utilities/src/styles/rules/display.scss
@@ -23,7 +23,7 @@ $u-display: (
     base: "display",
     modifiers: null,
     values: map-collect(get-palettes($display-palettes), $display-manual-values),
-    settings: $display-settings,
+    settings: $display-settings-complete,
     property: "display",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/flex-direction.scss
+++ b/packages/uswds-utilities/src/styles/rules/flex-direction.scss
@@ -27,7 +27,7 @@ $u-flex-direction: (
         get-palettes($flex-direction-palettes),
         $flex-direction-manual-values
       ),
-    settings: $flex-direction-settings,
+    settings: $flex-direction-settings-complete,
     property: "flex-direction",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/flex-wrap.scss
+++ b/packages/uswds-utilities/src/styles/rules/flex-wrap.scss
@@ -24,7 +24,7 @@ $u-flex-wrap: (
     modifiers: null,
     values:
       map-collect(get-palettes($flex-wrap-palettes), $flex-wrap-manual-values),
-    settings: $flex-wrap-settings,
+    settings: $flex-wrap-settings-complete,
     property: "flex-wrap",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/flex.scss
+++ b/packages/uswds-utilities/src/styles/rules/flex.scss
@@ -29,7 +29,7 @@ $u-flex: (
     base: "flex",
     modifiers: null,
     values: map-collect(get-palettes($flex-palettes), $flex-manual-values),
-    settings: $flex-settings,
+    settings: $flex-settings-complete,
     property: "flex",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/float.scss
+++ b/packages/uswds-utilities/src/styles/rules/float.scss
@@ -23,7 +23,7 @@ $u-float: (
     base: "float",
     modifiers: null,
     values: map-collect(get-palettes($float-palettes), $float-manual-values),
-    settings: $float-settings,
+    settings: $float-settings-complete,
     property: "float",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/font-family.scss
+++ b/packages/uswds-utilities/src/styles/rules/font-family.scss
@@ -35,7 +35,7 @@ $u-font-family: (
         get-palettes($font-family-palettes),
         $font-family-manual-values
       ),
-    settings: $font-family-settings,
+    settings: $font-family-settings-complete,
     property: "font-family",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/font-feature.scss
+++ b/packages/uswds-utilities/src/styles/rules/font-feature.scss
@@ -28,7 +28,7 @@ $u-font-feature: (
         get-palettes($font-feature-palettes),
         $font-feature-manual-values
       ),
-    settings: $font-feature-settings,
+    settings: $font-feature-settings-complete,
     property: "font-feature-settings",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/font-style.scss
+++ b/packages/uswds-utilities/src/styles/rules/font-style.scss
@@ -26,7 +26,7 @@ $u-font-style: (
     modifiers: null,
     values:
       map-collect(get-palettes($font-style-palettes), $font-style-manual-values),
-    settings: $font-style-settings,
+    settings: $font-style-settings-complete,
     property: "font-style",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/font-weight.scss
+++ b/packages/uswds-utilities/src/styles/rules/font-weight.scss
@@ -27,7 +27,7 @@ $u-font-weight: (
         get-palettes($font-weight-palettes),
         $font-weight-manual-values
       ),
-    settings: $font-weight-settings,
+    settings: $font-weight-settings-complete,
     property: "font-weight",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/font.scss
+++ b/packages/uswds-utilities/src/styles/rules/font.scss
@@ -35,7 +35,7 @@ $u-font: (
     base: "font",
     modifiers: null,
     values: map-collect(get-palettes($font-palettes), $font-manual-values),
-    settings: $font-settings,
+    settings: $font-settings-complete,
     property: "font-size",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/height.scss
+++ b/packages/uswds-utilities/src/styles/rules/height.scss
@@ -23,7 +23,7 @@ $u-height: (
     base: "height",
     modifiers: null,
     values: map-collect(get-palettes($height-palettes), $height-manual-values),
-    settings: $height-settings,
+    settings: $height-settings-complete,
     property: "height",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/justify-content.scss
+++ b/packages/uswds-utilities/src/styles/rules/justify-content.scss
@@ -29,7 +29,7 @@ $u-justify-content: (
         get-palettes($justify-content-palettes),
         $justify-content-manual-values
       ),
-    settings: $justify-content-settings,
+    settings: $justify-content-settings-complete,
     property: "justify-content",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/left.scss
+++ b/packages/uswds-utilities/src/styles/rules/left.scss
@@ -25,7 +25,7 @@ $u-left: (
     base: "left",
     modifiers: null,
     values: map-collect(get-palettes($left-palettes), $left-manual-values),
-    settings: $left-settings,
+    settings: $left-settings-complete,
     property: "left",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/letter-spacing.scss
+++ b/packages/uswds-utilities/src/styles/rules/letter-spacing.scss
@@ -27,7 +27,7 @@ $u-letter-spacing: (
         get-palettes($letter-spacing-palettes),
         $letter-spacing-manual-values
       ),
-    settings: $letter-spacing-settings,
+    settings: $letter-spacing-settings-complete,
     property: "letter-spacing",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/line-height.scss
+++ b/packages/uswds-utilities/src/styles/rules/line-height.scss
@@ -27,7 +27,7 @@ $u-line-height: (
         get-palettes($line-height-palettes),
         $line-height-manual-values
       ),
-    settings: $line-height-settings,
+    settings: $line-height-settings-complete,
     property: "line-height",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/margin.scss
+++ b/packages/uswds-utilities/src/styles/rules/margin.scss
@@ -29,7 +29,7 @@ $u-margin: (
       noModifier: "",
     ),
     values: map-collect(get-palettes($margin-palettes), $margin-manual-values),
-    settings: $margin-settings,
+    settings: $margin-settings-complete,
     property: "margin",
     type: "utility",
   ),
@@ -48,7 +48,7 @@ $u-margin: (
         get-palettes($margin-vertical-palettes),
         $margin-manual-values
       ),
-    settings: $margin-settings,
+    settings: $margin-settings-complete,
     property: "margin",
     type: "utility",
   ),
@@ -67,7 +67,7 @@ $u-margin: (
         get-palettes($margin-horizontal-palettes),
         $margin-manual-values
       ),
-    settings: $margin-settings,
+    settings: $margin-settings-complete,
     property: "margin",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/max-height.scss
+++ b/packages/uswds-utilities/src/styles/rules/max-height.scss
@@ -24,7 +24,7 @@ $u-max-height: (
     modifiers: null,
     values:
       map-collect(get-palettes($max-height-palettes), $max-height-manual-values),
-    settings: $max-height-settings,
+    settings: $max-height-settings-complete,
     property: "max-height",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/max-width.scss
+++ b/packages/uswds-utilities/src/styles/rules/max-width.scss
@@ -24,7 +24,7 @@ $u-max-width: (
     modifiers: null,
     values:
       map-collect(get-palettes($max-width-palettes), $max-width-manual-values),
-    settings: $max-width-settings,
+    settings: $max-width-settings-complete,
     property: "max-width",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/measure.scss
+++ b/packages/uswds-utilities/src/styles/rules/measure.scss
@@ -25,7 +25,7 @@ $u-measure: (
     base: "measure",
     modifiers: null,
     values: map-collect(get-palettes($measure-palettes), $measure-manual-values),
-    settings: $measure-settings,
+    settings: $measure-settings-complete,
     property: "max-width",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/min-height.scss
+++ b/packages/uswds-utilities/src/styles/rules/min-height.scss
@@ -24,7 +24,7 @@ $u-min-height: (
     modifiers: null,
     values:
       map-collect(get-palettes($min-height-palettes), $min-height-manual-values),
-    settings: $min-height-settings,
+    settings: $min-height-settings-complete,
     property: "min-height",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/min-width.scss
+++ b/packages/uswds-utilities/src/styles/rules/min-width.scss
@@ -24,7 +24,7 @@ $u-min-width: (
     modifiers: null,
     values:
       map-collect(get-palettes($min-width-palettes), $min-width-manual-values),
-    settings: $min-width-settings,
+    settings: $min-width-settings-complete,
     property: "min-width",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/opacity.scss
+++ b/packages/uswds-utilities/src/styles/rules/opacity.scss
@@ -23,7 +23,7 @@ $u-opacity: (
     base: "opacity",
     modifiers: null,
     values: map-collect(get-palettes($opacity-palettes), $opacity-manual-values),
-    settings: $opacity-settings,
+    settings: $opacity-settings-complete,
     property: "opacity",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/order.scss
+++ b/packages/uswds-utilities/src/styles/rules/order.scss
@@ -26,7 +26,7 @@ $u-order: (
     base: "order",
     modifiers: null,
     values: map-collect(get-palettes($order-palettes), $order-manual-values),
-    settings: $order-settings,
+    settings: $order-settings-complete,
     property: "order",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/outline-color.scss
+++ b/packages/uswds-utilities/src/styles/rules/outline-color.scss
@@ -28,7 +28,7 @@ $u-outline-color: (
         get-palettes($global-color-palettes),
         $outline-color-manual-values
       ),
-    settings: $outline-color-settings,
+    settings: $outline-color-settings-complete,
     valuePrepend: null,
     valueAppend: null,
     property: "outline-color",

--- a/packages/uswds-utilities/src/styles/rules/outline.scss
+++ b/packages/uswds-utilities/src/styles/rules/outline.scss
@@ -25,7 +25,7 @@ $u-outline: (
     base: "outline",
     modifiers: null,
     values: map-collect(get-palettes($outline-palettes), $outline-manual-values),
-    settings: $outline-settings,
+    settings: $outline-settings-complete,
     valuePrepend: null,
     valueAppend: " solid",
     property: "outline",

--- a/packages/uswds-utilities/src/styles/rules/overflow.scss
+++ b/packages/uswds-utilities/src/styles/rules/overflow.scss
@@ -28,7 +28,7 @@ $u-overflow: (
     ),
     values:
       map-collect(get-palettes($overflow-palettes), $overflow-manual-values),
-    settings: $overflow-settings,
+    settings: $overflow-settings-complete,
     property: "overflow",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/padding.scss
+++ b/packages/uswds-utilities/src/styles/rules/padding.scss
@@ -40,7 +40,7 @@ $u-padding: (
       "left": "-left",
     ),
     values: map-collect(get-palettes($padding-palettes), $padding-manual-values),
-    settings: $padding-settings,
+    settings: $padding-settings-complete,
     property: "padding",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/pin.scss
+++ b/packages/uswds-utilities/src/styles/rules/pin.scss
@@ -97,7 +97,7 @@ $u-pin: (
         ),
       ),
     ),
-    settings: $pin-settings,
+    settings: $pin-settings-complete,
     property: "position",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/position.scss
+++ b/packages/uswds-utilities/src/styles/rules/position.scss
@@ -24,7 +24,7 @@ $u-position: (
     modifiers: null,
     values:
       map-collect(get-palettes($position-palettes), $position-manual-values),
-    settings: $position-settings,
+    settings: $position-settings-complete,
     property: "position",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/right.scss
+++ b/packages/uswds-utilities/src/styles/rules/right.scss
@@ -25,7 +25,7 @@ $u-right: (
     base: "right",
     modifiers: null,
     values: map-collect(get-palettes($right-palettes), $right-manual-values),
-    settings: $right-settings,
+    settings: $right-settings-complete,
     property: "right",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/square.scss
+++ b/packages/uswds-utilities/src/styles/rules/square.scss
@@ -30,7 +30,7 @@ $u-square: (
       ),
     ),
     values: map-collect(get-palettes($square-palettes), $square-manual-values),
-    settings: $square-settings,
+    settings: $square-settings-complete,
     property: "",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/text-align.scss
+++ b/packages/uswds-utilities/src/styles/rules/text-align.scss
@@ -24,7 +24,7 @@ $u-text-align: (
     modifiers: null,
     values:
       map-collect(get-palettes($text-align-palettes), $text-align-manual-values),
-    settings: $text-align-settings,
+    settings: $text-align-settings-complete,
     property: "text-align",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/text-decoration-color.scss
+++ b/packages/uswds-utilities/src/styles/rules/text-decoration-color.scss
@@ -28,7 +28,7 @@ $u-text-decoration-color: (
         get-palettes($global-color-palettes),
         $text-decoration-color-manual-values
       ),
-    settings: $text-decoration-color-settings,
+    settings: $text-decoration-color-settings-complete,
     property: "text-decoration-color",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/text-decoration.scss
+++ b/packages/uswds-utilities/src/styles/rules/text-decoration.scss
@@ -27,7 +27,7 @@ $u-text-decoration: (
         get-palettes($text-decoration-palettes),
         $text-decoration-manual-values
       ),
-    settings: $text-decoration-settings,
+    settings: $text-decoration-settings-complete,
     property: "text-decoration",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/text-indent.scss
+++ b/packages/uswds-utilities/src/styles/rules/text-indent.scss
@@ -27,7 +27,7 @@ $u-text-indent: (
         get-palettes($text-indent-palettes),
         $text-indent-manual-values
       ),
-    settings: $text-indent-settings,
+    settings: $text-indent-settings-complete,
     property: "text-indent",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/text-transform.scss
+++ b/packages/uswds-utilities/src/styles/rules/text-transform.scss
@@ -27,7 +27,7 @@ $u-text-transform: (
         get-palettes($text-transform-palettes),
         $text-transform-manual-values
       ),
-    settings: $text-transform-settings,
+    settings: $text-transform-settings-complete,
     property: "text-transform",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/top.scss
+++ b/packages/uswds-utilities/src/styles/rules/top.scss
@@ -25,7 +25,7 @@ $u-top: (
     base: "top",
     modifiers: null,
     values: map-collect(get-palettes($top-palettes), $top-manual-values),
-    settings: $top-settings,
+    settings: $top-settings-complete,
     property: "top",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/vertical-align.scss
+++ b/packages/uswds-utilities/src/styles/rules/vertical-align.scss
@@ -27,7 +27,7 @@ $u-vertical-align: (
         get-palettes($vertical-align-palettes),
         $vertical-align-manual-values
       ),
-    settings: $vertical-align-settings,
+    settings: $vertical-align-settings-complete,
     property: "vertical-align",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/whitespace.scss
+++ b/packages/uswds-utilities/src/styles/rules/whitespace.scss
@@ -24,7 +24,7 @@ $u-whitespace: (
     modifiers: null,
     values:
       map-collect(get-palettes($whitespace-palettes), $whitespace-manual-values),
-    settings: $whitespace-settings,
+    settings: $whitespace-settings-complete,
     property: "white-space",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/width.scss
+++ b/packages/uswds-utilities/src/styles/rules/width.scss
@@ -23,7 +23,7 @@ $u-width: (
     base: "width",
     modifiers: null,
     values: map-collect(get-palettes($width-palettes), $width-manual-values),
-    settings: $width-settings,
+    settings: $width-settings-complete,
     property: "width",
     type: "utility",
   ),

--- a/packages/uswds-utilities/src/styles/rules/z-index.scss
+++ b/packages/uswds-utilities/src/styles/rules/z-index.scss
@@ -25,7 +25,7 @@ $u-z-index: (
     base: "z",
     modifiers: null,
     values: map-collect(get-palettes($z-index-palettes), $z-index-manual-values),
-    settings: $z-index-settings,
+    settings: $z-index-settings-complete,
     property: "z-index",
     type: "utility",
   ),


### PR DESCRIPTION
# Summary

Updates sass map pattern to allow users to only define overrides while keeping defaults for the other values

## Breaking change

This is _potentially_ a breaking change.

## Related issue

Closes #5215

## Related pull requests

Update sass map instructions on utility pages: https://github.com/uswds/uswds-site/pull/2077

## Problem statement

Currently, if you choose to update a USWDS setting within a sass map, you must define each setting within the map even if you are keeping the default values for the other.

## Solution

We can use map-merge with a default values map to only replace updated settings keys without needing to redefine default values.

This solution
- Doesn't break existing sass map settings users have previously set
- _BUT_ if users left an element out of the map, (effectively disabling it) this PR would re-enable the default setting.

This PR updates `$theme-[map-name]`s to `$theme-[map-name]-complete` wherever the setting is called.

This allows users still use existing setting names, such as `$theme-utility-breakpoints`, to update which breakpoints are active, while using the `-complete` map to restore defaults to undefined elements.

> Note: I considered naming the `complete` maps as `-defaults` but I believe this makes less contextual sense wherever the maps are being called.

## Updated maps

- [x] `$theme-namespace`
- [x] `$theme-utility-breakpoints`
- [x] `$[utility-module]-settings` 

## Ignored maps

These maps were either, empty, set to `false` by default, or only had example values. In all three settings, we would want the users override to be the only value, which is currently how they are set up.

- `$theme-fontface-tokens`
- `$theme-font-[family]-src`
- `$[utility-module]-manual-calues`

## Testing and review

1. Checkout this [test uswds-sandbox repo](https://github.com/uswds/uswds-sandbox/tree/cm-breakpoint-map)
3. The test repo should already have this branch installed as it's USWDS package
4. Run `npm run start` on the test repo
5. View each test page and review instructions
7. Visit `_uswds-theme.scss` and expirament enabling/disabling different settings
8. Revisit index page in browser and view the changes
9. Confirm that
   - [ ] : Default breakpoints are working as expected
   - [ ] : Updating one breakpoint, doesn't deactivate the others
   - [ ] : Updated breakpoints work as expected
10. Look over all maps listed on the [settings](https://designsystem.digital.gov/documentation/settings/#general-settings-2) page
11. Inspect their default values in the USWDS settings and verify there aren't any additional updates to make

These tests are simple and mostly just enable different background colors as a quick visual feedback. Feel free to experiment with other utility settings to verify the new pattern is working!

### Default maps for reference:
 
**Breakpoints**

```scss
@use "uswds-core" with (
  $theme-utility-breakpoints: (
      "card": false,
      "card-lg": false,
      "mobile": false,
      "mobile-lg": true,
      "tablet": true,
      "tablet-lg": false,
      "desktop": true,
      "desktop-lg": false,
      "widescreen": false,
    )
);
```

**Namespace**
```scss
$theme-namespace: (
  "grid": (
    namespace: "grid-",
    output: true
  ),
  "utility": (
    namespace: "u-",
    output: false,
  ),
),
```

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:scss` to format any Sass updates.

