### PR TITLE
Remove v2 tag 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,10 @@ jobs:
           name: Build the USWDS package
           command: npm run release
       - run:
-          name: Publish to NPM with `uswds-2.x` tag
+          name: Publish to NPM
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --tag uswds-2.x
+            npm publish --tag
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Publish to NPM
           command: |
             npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --tag
+            npm publish
 
 workflows:
   version: 2


### PR DESCRIPTION
It was a mistake to add a tag to the v2 releases in the `uswds` package since — post USWDS 3.0 — the canonical USWDS package is `@uswds/uswds`. V2 is, in fact, the latest release in the `uswds` package.