### PR TITLE
USWDS - Tooltip: Add top as default position

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -315,10 +315,14 @@ const setUpAttributes = (tooltipTrigger) => {
   const tooltipContent = tooltipTrigger.getAttribute("title");
   const wrapper = document.createElement("span");
   const tooltipBody = document.createElement("span");
-  const position = tooltipTrigger.getAttribute("data-position")
-    ? tooltipTrigger.getAttribute("data-position")
-    : "top";
   const additionalClasses = tooltipTrigger.getAttribute("data-classes");
+  let position = tooltipTrigger.getAttribute("data-position");
+
+  // Apply default position if not set as attribute
+  if (!position) {
+    position = "top";
+    tooltipTrigger.setAttribute("data-position", position);
+  }
 
   // Set up tooltip attributes
   tooltipTrigger.setAttribute("aria-describedby", tooltipID);


### PR DESCRIPTION
# Summary

**Added default positioning.** Updated the default position to "top" if `data-position` attribute is not specified.


## Breaking change
This is not a breaking change.

## Related issue

Closes #5218


## Problem statement

1. Tooltip should appear on "top" when `data-position` omitted
2. Tooltip appears incorrectly positioned (at bottom left, with triangle pointing down)
3. If `data-position` is not specified, tooltip appears on broken


## Solution

1. Detect if `data-position` on trigger is set
2. Use set position or "top" if not


## Testing and review

1. Used this markup to test: `<button type="button" class="usa-button usa-tooltip" title="Show me correctly">Show on top</button>`
2. I didn't add this variation into the examples, but let me know if that is desired.  
