### PR TITLE
USWDS - Validation: Allow textareas to use validation (Enhancement)

### DIFF
--- a/packages/usa-validation/src/index.js
+++ b/packages/usa-validation/src/index.js
@@ -3,7 +3,8 @@ const validate = require("../../uswds-core/src/js/utils/validate-input");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 
-const VALIDATE_INPUT = "input[data-validation-element]";
+const VALIDATE_INPUT =
+  "input[data-validation-element],textarea[data-validation-element]";
 const CHECKLIST_ITEM = `.${PREFIX}-checklist__item`;
 
 // Trigger validation on input change

--- a/packages/usa-validation/src/test/template-textarea.html
+++ b/packages/usa-validation/src/test/template-textarea.html
@@ -1,0 +1,13 @@
+<div>
+  <ul class="usa-checklist" id="textarea_validation_list">
+    <li class="usa-checklist__item" data-validator="empty">Cannot by empty</li>
+  </ul>
+  <textarea
+    class="usa-textarea"
+    id="comment"
+    name="comment"
+    aria-describedby="textarea_validation_list"
+    data-validate-empty="\S"
+    data-validation-element="textarea_validation_list"
+  ></textarea>
+</div>

--- a/packages/usa-validation/src/test/validator-textarea.spec.js
+++ b/packages/usa-validation/src/test/validator-textarea.spec.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const validator = require("../index");
+
+const TEMPLATE = fs.readFileSync(
+  path.join(__dirname, "/template-textarea.html")
+);
+
+const TEXTAREA_SELECTOR = "[data-validation-element]";
+const VALIDATORS = "[data-validator]";
+const VALIDATOR_SUMMARY = "[data-validation-status]";
+const CHECKED_CLASS = "usa-checklist__item--checked";
+
+const textareaSelector = () => document.querySelector(TEXTAREA_SELECTOR);
+
+const keyup = (el) => {
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+};
+
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "textarea", selector: textareaSelector },
+];
+
+tests.forEach(({ name, selector: containerSelector }) => {
+  describe(`validator component initialized at ${name}`, () => {
+    const { body } = document;
+
+    let validated;
+    let validators;
+
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+
+      validator.on(containerSelector());
+
+      validated = textareaSelector();
+      validators = Array.from(document.querySelectorAll(VALIDATORS));
+    });
+
+    afterEach(() => {
+      validator.off(containerSelector());
+      body.textContent = "";
+    });
+
+    describe("initialization", () => {
+      it("creates a hidden span element for accessibility status summary readout", () => {
+        if (validators) {
+          assert.notStrictEqual(
+            document.querySelector(VALIDATOR_SUMMARY),
+            null
+          );
+        }
+      });
+    });
+
+    describe("validation state", () => {
+      it(`adds .${CHECKED_CLASS} for all successful validations`, () => {
+        validated.value = "This is one great comment!";
+        keyup(validated);
+        validators.forEach((checkbox) => {
+          assert.strictEqual(checkbox.classList.contains(CHECKED_CLASS), true);
+        });
+      });
+
+      it(`removes .${CHECKED_CLASS} for failed validations`, () => {
+        validated.value = "";
+        keyup(validated);
+        validators.forEach((checkbox) => {
+          const checked = checkbox.classList.contains(CHECKED_CLASS);
+          if (checkbox.getAttribute("data-validator") === "empty") {
+            assert.strictEqual(checked, false);
+          } else {
+            assert.strictEqual(checked, true);
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/usa-validation/src/usa-validation--textarea.twig
+++ b/packages/usa-validation/src/usa-validation--textarea.twig
@@ -1,0 +1,16 @@
+<form class="usa-form">
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend usa-legend--large">Enter a comment</legend>
+    <div class="usa-alert usa-alert--info usa-alert--validation">
+      <div class="usa-alert__body">
+        <h3 class="usa-alert__heading">Comment requirements</h3>
+        <ul class="usa-checklist" id="validate-comment">
+          <li class="usa-checklist__item" data-validator="empty">Cannot be empty</li>
+        </ul>
+      </div>
+    </div>
+    <label class="usa-label" for="code">Comment</label>
+    <textarea class="usa-textarea" id="comment" name="comment" data-validate-empty="\S" data-validation-element="validate-comment"></textarea>
+    <input class="usa-button" type="submit" value="Submit code">
+  </fieldset>
+</form>

--- a/packages/usa-validation/src/usa-validation.stories.js
+++ b/packages/usa-validation/src/usa-validation.stories.js
@@ -1,9 +1,12 @@
 import Component from "./usa-validation.twig";
+import TextareaComponent from "./usa-validation--textarea.twig";
 
 export default {
   title: "Components/Validation",
 };
 
 const Template = (args) => Component(args);
+const TextareaTemplate = (args) => TextareaComponent(args);
 
-export const Validation = Template.bind({});
+export const InputValidation = Template.bind({});
+export const TextareaValidation = TextareaTemplate.bind({});


### PR DESCRIPTION
# Summary

**Textarea components can use validation** Now you can use validation on textareas, just like you do on inputs.


## Breaking change

This is not a breaking change.

## Related issue

Closes #4702


## Problem statement

Currently, validation can only be used on `input` elements. This solves most validation needs. However, `textarea` is a form element in which validation might be desired (e.g. not empty, minimal number of characters or words.)


## Solution

1. Current selector for validation is `input[data-validation-element]`
2. Updated validation logic to include `textarea[data-validation-element]`



## Testing and review

_Share recommended methods for reviewing this change._
<!--
1. Describe the tests that you ran to verify your changes,
2. Provide instructions to reproduce these tests, and
3. Clarify the type of feedback you are looking for at this phase.
-->

1. Added `textarea` to tests

## Dependency updates
None.

