### PR TITLE
USWDS - Banner: Add accordion dependency

### DIFF
--- a/packages/usa-accordion/src/index.js
+++ b/packages/usa-accordion/src/index.js
@@ -82,10 +82,18 @@ const accordion = behavior(
   },
   {
     init(root) {
-      select(BUTTON, root).forEach((button) => {
-        const expanded = button.getAttribute(EXPANDED) === "true";
-        toggleButton(button, expanded);
-      });
+      // Check if Banner has previously initialized accordion.
+      if (!this.hasInit) {
+        select(BUTTON, root).forEach((button) => {
+          const expanded = button.getAttribute(EXPANDED) === "true";
+          toggleButton(button, expanded);
+        });
+
+        this.hasInit = true;
+      }
+    },
+    teardown() {
+      this.hasInit = false;
     },
     ACCORDION,
     BUTTON,
@@ -93,6 +101,7 @@ const accordion = behavior(
     hide: hideButton,
     toggle: toggleButton,
     getButtons: getAccordionButtons,
+    hasInit: this.hasInit || false
   }
 );
 

--- a/packages/usa-banner/src/index.js
+++ b/packages/usa-banner/src/index.js
@@ -5,7 +5,6 @@ const accordion = require("../../usa-accordion/src/index");
 
 const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
-const BUTTON = `.${PREFIX}-banner__button[aria-controls]`;
 
 /**
  * Toggle expanded banner class.
@@ -14,7 +13,7 @@ const BUTTON = `.${PREFIX}-banner__button[aria-controls]`;
  */
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
-  this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
+  event.target.closest(HEADER).classList.toggle(EXPANDED_CLASS);
 };
 
 const banner = behavior(
@@ -25,13 +24,18 @@ const banner = behavior(
   },
   {
     init(root) {
-      const bannerButtons = root.querySelectorAll(BUTTON);
-
-      bannerButtons.forEach((button) => {
-        const parentBanner = button.closest(accordion.ACCORDION);
-
-        accordion.on(parentBanner);
-      });
+      // Initialize accordion if it hasn't already.
+      // Required for modular import of Banner.
+      if (!accordion.hasInit) {
+        accordion.on(root);
+        accordion.hasInit = true;
+      }
+    },
+    teardown(root) {
+      if (accordion.hasInit) {
+        accordion.off(root);
+        accordion.hasInit = false;
+      }
     },
   }
 );

--- a/packages/usa-banner/src/index.js
+++ b/packages/usa-banner/src/index.js
@@ -1,17 +1,30 @@
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
+// const select = require("../../uswds-core/src/js/utils/select");
+const accordion = require("../../usa-accordion/src/index");
 
 const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
+// const EXPANDED = "aria-expanded";
+// const BUTTON = `.${PREFIX}-banner__button[aria-controls]`;
 
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
   this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
 };
 
-module.exports = behavior({
-  [CLICK]: {
-    [`${HEADER} [aria-controls]`]: toggleBanner,
+const banner = behavior(
+  {
+    [CLICK]: {
+      [`${HEADER} [aria-controls]`]: toggleBanner,
+    },
   },
-});
+  {
+    init(root) {
+      accordion.on(root);
+    }
+  }
+);
+
+module.exports = banner;

--- a/packages/usa-banner/src/index.js
+++ b/packages/usa-banner/src/index.js
@@ -1,14 +1,17 @@
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
-// const select = require("../../uswds-core/src/js/utils/select");
 const accordion = require("../../usa-accordion/src/index");
 
 const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
-// const EXPANDED = "aria-expanded";
-// const BUTTON = `.${PREFIX}-banner__button[aria-controls]`;
+const BUTTON = `.${PREFIX}-banner__button[aria-controls]`;
 
+/**
+ * Toggle expanded banner class.
+ *
+ * @param {*} event - The clicked banner button.
+ */
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
   this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
@@ -22,8 +25,14 @@ const banner = behavior(
   },
   {
     init(root) {
-      accordion.on(root);
-    }
+      const bannerButtons = root.querySelectorAll(BUTTON);
+
+      bannerButtons.forEach((button) => {
+        const parentBanner = button.closest(accordion.ACCORDION);
+
+        accordion.on(parentBanner);
+      });
+    },
   }
 );
 

--- a/packages/usa-banner/src/test/banner.spec.js
+++ b/packages/usa-banner/src/test/banner.spec.js
@@ -1,7 +1,6 @@
 const assert = require("assert");
 const fs = require("fs");
 const banner = require("../index");
-const accordion = require("../../../usa-accordion/src/index");
 
 const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
 const EXPANDED = "aria-expanded";
@@ -27,12 +26,10 @@ tests.forEach(({ name, selector: containerSelector }) => {
       button = body.querySelector(".usa-banner__button");
       content = body.querySelector(".usa-banner__content");
       banner.on(containerSelector());
-      accordion.on(containerSelector());
     });
 
     afterEach(() => {
       banner.off(containerSelector());
-      accordion.off(containerSelector());
       body.innerHTML = "";
     });
 


### PR DESCRIPTION
# Summary

**Banner initializes without external dependencies.** USA banner module now initializes on it's own without the user having to separately initialize accordion.

> **Note**
>Because accordion classes are used within banner we have to initialize accordion from within banner. This means that a user could initialize accordion and expect their banners to work and vice versa.
>
>We don't see this issue when projects import `uswds.js` because it includes accordion already. Now you should be able to import banner and only banner and have it work as expected.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5179. 

## Related pull requests

1. Need to create changelog entry in banner in `uswds-site`.
2. Also need to update [interactive components spreadsheet 🔒](https://docs.google.com/spreadsheets/d/1fAGnDf1qPdMin2je2RNFBCpMPGbLXs6RZxcKH-KzaxM/edit#gid=0)


## Preview link

Preview link: [Banner init test](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-banner-init-test/iframe.html?args=&id=components-banner--test&viewMode=story)

## Problem statement

1. Banner should initialize **without** user having to import and init accordion.
2. Banner should work independently, meaning one **shouldn't** trigger another
3. Banner **shouldn't** initialize or have any effect on USA Accordion

## Solution

1. Banner JS now imports accordion [4550a41].
2. Created a setting (`hasInit - boolean`) in accordion to check if `accordion.init()` has run.
3. Call `accordion.init()` in banner if it hasn't. Allows us to import Banner modularly without user having to import and initialize accordion.
4. Removed accordion import dependency in unit test [41144b0].
5. ~Banner **only** initializes accordion on individual banners.~

### Alternatives

1. Remove `usa-accordion` dependency and use `toggle.js` utility to recreate functionality.
2. Update banner guidance to note accordion dependency.

1. ~**Run `accordion.on()` on banner init.** This will also init accordions on the page, which will cause issues for users.~
3. ~**Import toggle and selectors from accordion.** We'd be recreating accordion functionality. More code reuse, but no real performance benefit.~

## Major changes

Banner script now imports accordion. Meaning users can follow [Guidance](https://designsystem.digital.gov/documentation/developers/#js-customization-2:~:text=import%20accordion%20from%20%22%40uswds/uswds/js/usa%2Daccordion%22%3B) to import banner via 

```js
import banner from "@uswds/uswds/js/usa-banner"
```

Initialize it with `banner.on()` and have component work properly. There are some new changes behind the scenes to check if accordion has initialized.

## Testing and review

<details><summary>Traditional site</summary>
<p></p>

1. Check out testing branch `jm-banner-init-test`
3. Start StorybookJS `npm start`
6. Visit [Banner init test page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-banner-init-test/iframe.html?args=&id=components-banner--test&viewMode=story)
7. Accordion & banner should work without any issues
8. Accordion should only initialize once
9. Locally, visit `uswds-core/src/js/start.js`
10. Init **Banner** only, everything should work
11. Init **Accordion** only, everything should work
12. Init **all** components, components should work without conflicts
13. Run `npm run test:unit`; banner & accordion should only contain their respective scripts & run without errors
</details> 

<details><summary>Frameworks</summary>
<p></p>

1. Visit [uswds/uswds-sandbox at jm-test-uswds-5179](https://github.com/uswds/uswds-sandbox/tree/jm-test-uswds-5179)
2. Run `npm install`
3. Run `npm start`
4. Accordion and banner should work without conflicts.
5. Import **only** banner; component should initialize accordion.
6. Import both banner and accordion. Both components should work without conflicts.
</details> 



### Additional information
- _Additional instructions in [start.js 21-27](https://github.com/uswds/uswds/blob/e499670aaaaf8af76df3c428f2e10b5e893c8c81/packages/uswds-core/src/js/start.js#L21-L27)_
- Created branch in uswds-sandbox [`jm-test-uswds-5179`] for additional testing

<details><summary>Previous testing instructions</summary>

Keeping for historical record.

1. Visit preview link for [Banner init test](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-banner-init-test/iframe.html?args=&id=components-banner--test&viewMode=story)
14. Each banner should work
15. One banner should have no effect on another
16. Accordion component **should not** work. If so, it would mean that banner is unexpectedly initializing accordions. In projects this would cause unintended side effects.
17. `npm run test:unit` should run without errors.

</details> 

## Compiled package size

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| uswds.js | 798KB | 801KB   |
| uswds.min.js     | 87KB  |   87KB  |

<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:scss` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
