### PR TITLE
USWDS - Packages: Prevent nested node_modules from being included in publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     ".browserslistrc",
     "CONTRIBUTING.md",
     "gulpfile.js",
-    "webpack.twig.config.js"
+    "webpack.twig.config.js",
+    "!node_modules"
   ],
   "module": "./dist/js/uswds.min.js",
   "exports": {


### PR DESCRIPTION
# Summary

**Reduce the size of the published package.** Extraneous dependencies will no longer be included in the published package, making it smaller and faster to install.

## Problem statement

NPM packages should be limited to include only its own files, defining dependencies where additional packages may be required, with the expectation that the downstream consumer project would install those dependencies automatically. Furthermore, development-only dependencies should not be included in the published artifact.

The current published `@uswds/uswds` version (3.4.1) includes a `node_modules` directory of development dependencies in its `uswds-core` subfolder:

https://unpkg.com/browse/@uswds/uswds@3.4.1/packages/uswds-core/node_modules/

While NPM will not include `node_modules` at the top-level of the published package, because this project is structured as a monorepository of packages, a subfolder of `node_modules` may be published if it exists in one of the monorepository packages.

## Solution

Explicitly exclude `node_modules` from NPM publish using the existing `package.json` `files` directive, as a negation.

Technically this behavior is [documented as being undefined](https://github.com/npm/cli/wiki/Files-&-Ignores), but there's not an alternative recommendation to ignore files in an otherwise-allowlisted path.

## Testing and review

1. `mkdir -p packages/uswds-core/node_modules/foo`
2. `touch packages/uswds-core/node_modules/foo/bar.txt`
3. `npm publish --dry-run`
4. Observe that the output list of files does not include `packages/uswds-core/node_modules/foo/bar.txt`