### PR TITLE
USWDS - Button: define default type in JSON

### DIFF
--- a/packages/usa-button/src/content/usa-button.json
+++ b/packages/usa-button/src/content/usa-button.json
@@ -2,5 +2,6 @@
   "modifier": "",
   "text": "Default",
   "is_demo": true,
-  "aria_disabled": false
+  "aria_disabled": false,
+  "type": "button"
 }


### PR DESCRIPTION
# Summary

Specifies `type` in `usa-button.json` to fix html component code

## Breaking change
This is **not** a breaking change.

## Related issue

Closes #5246

## Preview link
[Button: storybook →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-html-button-type/?path=/story/components-button--default)
[Demo USWDS site with correct button type showing →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-html-button-type/components/button/#component-preview)

## Problem statement
Our html component code for `usa-button` would display an empty `type` attribute for `usa-button`

```html
<button type="" class="usa-button usa-button--base">Default</button>
```

Expected:
```html
<button type="button" class="usa-button usa-button--base">Default</button>
```

## Solution

Add the default type attribute to the `usa-button` json file so that webpack correctly fills the variable in the twig file.

Before, this value was being set by storybook controls, which do not seem to make their way to the html templates once they're built.

## Testing and review
1. Visit the [button preview](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-html-button-type/?path=/story/components-button--default) and make sure storybook type controls are working as expected 
2. Visit html-templates/usa-button.html and check for correct type attribute
3. Check other button variants for the same

View change on site
1. Visit [test site repo button component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-html-button-type/components/button/#component-preview)
2. Check component code and make sure the correct button type is showing

<img width="646" alt="image" src="https://user-images.githubusercontent.com/25211650/233463807-734f3dce-a51f-436a-884b-6d7252c8fa77.png">


### Note
This seems to be the most direct way to populate this field, but it does override the `defaultValue` field within the storybook controls.

If you change `defaultValue` within `usa-button.stories.js`, the default button story will always default to `type="button"` while the other variants will change to the set value. This can still be changed using the radio buttons though!

Currently, the `defaultValue` _is_ button so the desired preview is still maintained. I just wanted to flag it in case!

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm test` and confirm that all tests pass.
