### PR TITLE
USWDS - Core: Deprecate font-smoothing mixins

### DIFF
--- a/packages/usa-dark-background/src/styles/_usa-dark-background.scss
+++ b/packages/usa-dark-background/src/styles/_usa-dark-background.scss
@@ -1,7 +1,6 @@
 @use "uswds-core" as *;
 
 .usa-dark-background {
-  @include add-knockout-font-smoothing;
   background-color: color("base-darker");
 
   p,

--- a/packages/uswds-core/src/styles/_deprecated.scss
+++ b/packages/uswds-core/src/styles/_deprecated.scss
@@ -26,3 +26,14 @@ $output-all-utilities: true !default;
 @mixin embed-container($height, $width) {
   padding-bottom: math.percentage(math.div($height, $width));
 }
+
+$font-smoothing-warning: "Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.";
+
+// Deprecated in 3.5.0
+@mixin add-knockout-font-smoothing {
+  @warn $font-smoothing-warning;
+}
+
+@mixin no-knockout-font-smoothing {
+  @warn $font-smoothing-warning;
+}

--- a/packages/uswds-core/src/styles/mixins/general/_index.scss
+++ b/packages/uswds-core/src/styles/mixins/general/_index.scss
@@ -3,7 +3,6 @@
 @forward "add-bar";
 @forward "add-checkbox-placeholder";
 @forward "add-kerning";
-@forward "add-knockout-font-smoothing";
 @forward "add-responsive-site-margins";
 @forward "add-success-mark";
 @forward "button-disabled";

--- a/packages/uswds-core/src/styles/mixins/general/add-knockout-font-smoothing.scss
+++ b/packages/uswds-core/src/styles/mixins/general/add-knockout-font-smoothing.scss
@@ -1,9 +1,0 @@
-@mixin add-knockout-font-smoothing {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@mixin no-knockout-font-smoothing {
-  -moz-osx-font-smoothing: inherit;
-  -webkit-font-smoothing: inherit;
-}

--- a/packages/uswds-core/src/styles/mixins/general/button-disabled.scss
+++ b/packages/uswds-core/src/styles/mixins/general/button-disabled.scss
@@ -1,8 +1,6 @@
-@use "./add-knockout-font-smoothing" as *;
 @use "../../functions" as *;
 
 @mixin button-disabled {
-  @include add-knockout-font-smoothing;
   background-color: color("disabled");
   color: color("white");
   cursor: auto;

--- a/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
+++ b/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
@@ -3,10 +3,8 @@
 @use "../../mixins/utilities" as *;
 @use "../typography/usa-prose" as *;
 @use "../typography/typeset" as *;
-@use "add-knockout-font-smoothing" as *;
 
 @mixin button-unstyled {
-  @include no-knockout-font-smoothing;
   @include typeset-link;
   background-color: transparent;
   border: 0;
@@ -42,7 +40,6 @@
   &:disabled,
   &[aria-disabled="true"],
   &.usa-button--disabled {
-    @include no-knockout-font-smoothing;
     background-color: transparent;
     box-shadow: none;
     text-decoration: underline;


### PR DESCRIPTION
# Summary

**Font-smoothing is deprecated.** Older technique, no longer applies, for improved font rendering on dark backgrounds.

## Breaking change

This is not a breaking change.

## Related issue

Closes [#5180](https://github.com/uswds/uswds/issues/5180).

## Related pull requests

[Site changelog and style updates](https://github.com/uswds/uswds-site/pull/2066)

~Need to update documentation.~

## Preview link

Preview link: [Buttons](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-remove-font-smoothing/?path=/story/components-button--outline-inverse)


## Problem statement

1. Font smoothing is an older non-standard technique that's no longer recommended, [see MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth).
2. We should remove support for this feature as it no longer applies & we're moving away from legacy browser support.
3. This is an opportunity to remove code that no longer applies and stay closer to modern web standards.

## Solution

1. Moved mixins (`add-knockout-font-smoothing` & `no-knockout-font-smoothing`) to `_deprecated.scss`
2. Replaced previous styles with warning via `@warn` - `Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.`
3. Removed any use of mixins in SASS

<details><summary>Warning user receives</summary>

```bash
Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.
    node_modules/@uswds/uswds/packages/uswds-core/src/styles/_deprecated.scss 38:3  no-knockout-font-smoothing()
    css/custom-styles/_site-header.scss 324:5                                       @import
    css/_uswds-theme-custom-styles.scss 5:9                                         @import
    css/uswds-custom.scss 12:9                                                      root stylesheet

Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.
    node_modules/@uswds/uswds/packages/uswds-core/src/styles/_deprecated.scss 34:3  add-knockout-font-smoothing()
    css/_uswds-theme-custom-styles.scss 1476:3                                      @import
    css/uswds-custom.scss 12:9                                                      root stylesheet

Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.
    node_modules/@uswds/uswds/packages/uswds-core/src/styles/_deprecated.scss 34:3  add-knockout-font-smoothing()
    css/_uswds-theme-custom-styles.scss 1572:3                                      @import
    css/uswds-custom.scss 12:9                                                      root stylesheet

Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.
    node_modules/@uswds/uswds/packages/uswds-core/src/styles/_deprecated.scss 34:3  add-knockout-font-smoothing()
    css/_uswds-theme-custom-styles.scss 1701:3                                      @import
    css/uswds-custom.scss 12:9                                                      root stylesheet

Warning: Font smoothing was deprecated in USWDS 3.5.0. Please remove any references to it.
    node_modules/@uswds/uswds/packages/uswds-core/src/styles/_deprecated.scss 34:3  add-knockout-font-smoothing()
    css/_uswds-theme-custom-styles.scss 1902:5                                      @import
    css/uswds-custom.scss 12:9        
```

</details> 


### Components that used this feature:
- usa-dark-background
- `@mixin button-disabled `
- `@mixin button-unstyled`

## Testing and review

1. There shouldn't be any mention of `add-knockout-font-smoothing` & `no-knockout-font-smoothing` in SASS (except in deprecated file).
2. Calling the mixins will result in a SASS warning.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

---

- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:scss` to format any Sass updates.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
