### PR TITLE
USWDS - Tooltip: Fix handling of children icons

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -307,6 +307,26 @@ const hideToolTip = (tooltipBody) => {
 };
 
 /**
+ * Handles events to activate tooltip.
+ * @param {MouseEvent|KeyboardEvent} event Mouseover or focusin event initiating activation.
+ */
+const onTooltipActivate = (event) => {
+  const { trigger, body } = getTooltipElements(event.currentTarget);
+
+  showToolTip(body, trigger, trigger.dataset.position);
+};
+
+/**
+ * Handles events to deactivate tooltip.
+ * @param {MouseEvent|KeyboardEvent} event Mouseout or focusout event initiating deactivation.
+ */
+const onTooltipDeactivate = (event) => {
+  const { body } = getTooltipElements(event.currentTarget);
+
+  hideToolTip(body);
+};
+
+/**
  * Setup the tooltip component
  * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
  */
@@ -357,37 +377,25 @@ const setUpAttributes = (tooltipTrigger) => {
   return { tooltipBody, position, tooltipContent, wrapper };
 };
 
+/**
+ * Set up tooltip trigger event handlers.
+ * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
+ */
+const setUpEvents = (tooltipTrigger) => {
+  tooltipTrigger.addEventListener("mouseover", onTooltipActivate);
+  tooltipTrigger.addEventListener("focusin", onTooltipActivate);
+  tooltipTrigger.addEventListener("mouseout", onTooltipDeactivate);
+  tooltipTrigger.addEventListener("focusout", onTooltipDeactivate);
+};
+
 // Setup our function to run on various events
 const tooltip = behavior(
-  {
-    "mouseover focusin": {
-      [TOOLTIP](e) {
-        const trigger = e.target;
-        const elementType = trigger.nodeName;
-
-        // Initialize tooltip if it hasn't already
-        if (elementType === "BUTTON" && trigger.hasAttribute("title")) {
-          setUpAttributes(trigger);
-        }
-      },
-      [TOOLTIP_TRIGGER](e) {
-        const { trigger, body } = getTooltipElements(e.target);
-
-        showToolTip(body, trigger, trigger.dataset.position);
-      },
-    },
-    "mouseout focusout": {
-      [TOOLTIP_TRIGGER](e) {
-        const { body } = getTooltipElements(e.target);
-
-        hideToolTip(body);
-      },
-    },
-  },
+  {},
   {
     init(root) {
       selectOrMatches(TOOLTIP, root).forEach((tooltipTrigger) => {
         setUpAttributes(tooltipTrigger);
+        setUpEvents(tooltipTrigger);
       });
     },
     setup: setUpAttributes,

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -5,7 +5,6 @@ const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const isElementInViewport = require("../../uswds-core/src/js/utils/is-in-viewport");
 
 const TOOLTIP = `.${PREFIX}-tooltip`;
-const TOOLTIP_TRIGGER = `.${PREFIX}-tooltip__trigger`;
 const TOOLTIP_TRIGGER_CLASS = `${PREFIX}-tooltip__trigger`;
 const TOOLTIP_CLASS = `${PREFIX}-tooltip`;
 const TOOLTIP_BODY_CLASS = `${PREFIX}-tooltip__body`;

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -329,7 +329,7 @@ const onTooltipDeactivate = (event) => {
  * Setup the tooltip component
  * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
  */
-const setUpAttributes = (tooltipTrigger) => {
+const setup = (tooltipTrigger) => {
   const tooltipID = `tooltip-${Math.floor(Math.random() * 900000) + 100000}`;
   const tooltipContent = tooltipTrigger.getAttribute("title");
   const wrapper = document.createElement("span");
@@ -373,18 +373,12 @@ const setUpAttributes = (tooltipTrigger) => {
   // place the text in the tooltip
   tooltipBody.textContent = tooltipContent;
 
-  return { tooltipBody, position, tooltipContent, wrapper };
-};
-
-/**
- * Set up tooltip trigger event handlers.
- * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
- */
-const setUpEvents = (tooltipTrigger) => {
   tooltipTrigger.addEventListener("mouseover", onTooltipActivate);
   tooltipTrigger.addEventListener("focusin", onTooltipActivate);
   tooltipTrigger.addEventListener("mouseout", onTooltipDeactivate);
   tooltipTrigger.addEventListener("focusout", onTooltipDeactivate);
+
+  return { tooltipBody, position, tooltipContent, wrapper };
 };
 
 // Setup our function to run on various events
@@ -392,12 +386,9 @@ const tooltip = behavior(
   {},
   {
     init(root) {
-      selectOrMatches(TOOLTIP, root).forEach((tooltipTrigger) => {
-        setUpAttributes(tooltipTrigger);
-        setUpEvents(tooltipTrigger);
-      });
+      selectOrMatches(TOOLTIP, root).forEach(setup);
     },
-    setup: setUpAttributes,
+    setup,
     getTooltipElements,
     show: showToolTip,
     hide: hideToolTip,

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -11,11 +11,6 @@ $triangle-size: 5px;
 
 .usa-tooltip__trigger {
   cursor: pointer;
-
-  > svg {
-    display: block;
-    pointer-events: none;
-  }
 }
 
 .usa-tooltip__body,

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -11,6 +11,10 @@ $triangle-size: 5px;
 
 .usa-tooltip__trigger {
   cursor: pointer;
+
+  > svg {
+    pointer-events: none;
+  }
 }
 
 .usa-tooltip__body,

--- a/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
+++ b/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
@@ -116,3 +116,19 @@
     <button type="button" class="{{ tooltip.classes }}" data-position="right" title="A longer Top tooltip that is longer than appx 320px" data-classes="{{ tooltip.util_classes }}" title="">Show on Right</button>
   </div>
 </div>
+<h2>For a button including an icon</h2>
+<hr/>
+<p>In this scenario:
+  <ul>
+    <li>Icons shouldn't interfere with the display of the tooltip</li>
+    <li>Icons should not visualy regress by tooltip trigger markup</li>
+  </ul>
+</p>
+<div class="padding-8">
+  <button type="button" class="{{ tooltip.classes }}" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">
+    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <use xlink:href="./img/sprite.svg#arrow_upward"></use>
+    </svg>
+    Show on top
+  </button>
+</div>

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -48,8 +48,30 @@ tests.forEach(({ name, selector: containerSelector }) => {
       assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
     });
 
+    it("tooltip is visible when mousing over", () => {
+      const event = new MouseEvent("mouseover", { bubbles: true });
+      tooltipTrigger.dispatchEvent(event);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
+    it("tooltip is visible when mousing over child", () => {
+      const icon = document.createElement("img");
+      tooltipTrigger.appendChild(icon);
+      const event = new MouseEvent("mouseover", { bubbles: true });
+      icon.dispatchEvent(event);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
     it("tooltip is hidden on blur", () => {
       tooltipTrigger.blur();
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    });
+
+    it("tooltip is hidden when mousing out", () => {
+      const mouseOverEvent = new MouseEvent("mouseover", { bubbles: true });
+      const mouseOutEvent = new MouseEvent("mouseout", { bubbles: true });
+      tooltipTrigger.dispatchEvent(mouseOverEvent);
+      tooltipTrigger.dispatchEvent(mouseOutEvent);
       assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
     });
 


### PR DESCRIPTION
# Summary

**Fixes issues when using icons inside a tooltip button.** Resolved errors resulting from moving the cursor over the icon, as well as improve compatibility with icon styling.

## Preview link

Preview link (local Storybook): http://localhost:6006/?path=/story/components-tooltip--test 

## Problem statement

This seeks to address several issues:

- Errors result when moving the cursor over content inside a tooltip trigger, such as an icon. You can demonstrate this by mousing over icons in the project's own [Tooltip Test story](http://localhost:6006/?path=/story/components-tooltip--test) ([see screenshot](https://user-images.githubusercontent.com/1779930/235170171-44bed292-9e46-4565-8980-047f50f98f71.png))
   - `Uncaught TypeError: Cannot read properties of null (reading 'classList')`
- The tooltip's SVG element selector styles (`.usa-tooltip__trigger > svg`) can introduce undesirable side-effects when applying tooltip behaviors to a button which includes both an icon and text (e.g. like in #4493, [see screenshot of effects](https://user-images.githubusercontent.com/1779930/235170756-dba27841-7f68-4f36-ac25-d5cc2b6f04a9.png))
- Using `mouseover` events with `behavior`/`receptor`'s event delegation implementation is likely to have a negative performance impact, since `mouseover` events are likely being handled thousands of times on a page for user interactions unrelated to tooltips
   - Example: Try entering `document.addEventListener('mouseover', () => console.log('mouseover'));` into your developer tools console on this page and mousing over the page
   - Similar to what's described in "Additional information" of #4256

## Solution

The proposed solution leverages event bubbling of targeted event handlers to address all of the above issues:

- When event handler is bound to the trigger element, `currentTarget` can be used as a guaranteed reference to the tooltip trigger, addressing the errors mentioned above
- Similarly, event bubbling removes the need for styles which remove `pointer-events` from an icon, which are assumed to have been needed since otherwise the icon would potentially block events meant for the trigger
- Binding the events to the trigger elements avoids unnecessary handling of noisy `mouseover` / `mouseout` events for elements on the page unrelated to the tooltip

## Testing and review

1. Confirm in the [Tooltip Test preview](http://localhost:6006/?path=/story/components-tooltip--test) that:
   1. No errors occur when mousing over any of the tooltips, including over icons in the footer links
   2. The tooltips appear as expected