### PR TITLE
USWDS - Tooltip: Fix negative margin offset calculations

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -142,6 +142,12 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
   const positionBottom = (e) => {
     resetPositionStyles(e);
 
+    const bottomMargin = calculateMarginOffset(
+      "bottom",
+      e.offsetHeight,
+      tooltipTrigger
+    );
+
     const leftMargin = calculateMarginOffset(
       "left",
       e.offsetWidth,
@@ -149,8 +155,10 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     );
 
     setPositionClass("bottom");
-    e.style.left = `50%`;
-    e.style.margin = `${TRIANGLE_SIZE}px 0 0 ${-leftMargin / 2}px`;
+    e.style.left = `50%`; // center the element
+    e.style.bottom = `-${TRIANGLE_SIZE}px`; // consider the pseudo element
+    // apply our margins based on the offset
+    e.style.margin = `0 0 ${-bottomMargin}px ${-leftMargin / 2}px`;
   };
 
   /**

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -132,7 +132,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     e.style.left = `50%`; // center the element
     e.style.top = `-${TRIANGLE_SIZE}px`; // consider the pseudo element
     // apply our margins based on the offset
-    e.style.margin = `-${topMargin}px 0 0 -${leftMargin / 2}px`;
+    e.style.margin = `${-topMargin}px 0 0 ${-leftMargin / 2}px`;
   };
 
   /**
@@ -150,7 +150,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
 
     setPositionClass("bottom");
     e.style.left = `50%`;
-    e.style.margin = `${TRIANGLE_SIZE}px 0 0 -${leftMargin / 2}px`;
+    e.style.margin = `${TRIANGLE_SIZE}px 0 0 ${-leftMargin / 2}px`;
   };
 
   /**
@@ -171,7 +171,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     e.style.left = `${
       tooltipTrigger.offsetLeft + tooltipTrigger.offsetWidth + TRIANGLE_SIZE
     }px`;
-    e.style.margin = `-${topMargin / 2}px 0 0 0`;
+    e.style.margin = `${topMargin / -2}px 0 0 0`;
   };
 
   /**
@@ -199,7 +199,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     setPositionClass("left");
     e.style.top = `50%`;
     e.style.left = `-${TRIANGLE_SIZE}px`;
-    e.style.margin = `-${topMargin / 2}px 0 0 ${
+    e.style.margin = `${-topMargin / 2}px 0 0 ${
       tooltipTrigger.offsetLeft > e.offsetWidth ? leftMargin : -leftMargin
     }px`; // adjust the margin
   };

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -171,7 +171,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     e.style.left = `${
       tooltipTrigger.offsetLeft + tooltipTrigger.offsetWidth + TRIANGLE_SIZE
     }px`;
-    e.style.margin = `${topMargin / -2}px 0 0 0`;
+    e.style.margin = `${-topMargin / 2}px 0 0 0`;
   };
 
   /**

--- a/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
+++ b/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
@@ -122,9 +122,7 @@
 <ul>
   <li>The tooltip should be positioned accounting for any offsets that might apply from the trigger</li>
 </ul>
-<button type="button" class="{{ tooltip.classes }} margin-top-1" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
-<button type="button" class="{{ tooltip.classes }} margin-top-2" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
-<button type="button" class="{{ tooltip.classes }} margin-top-3" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
-<button type="button" class="{{ tooltip.classes }} margin-top-4" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
-<button type="button" class="{{ tooltip.classes }} margin-top-5" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
-<button type="button" class="{{ tooltip.classes }} margin-top-6" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-1" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top with margin-top-1</button>
+<button type="button" class="{{ tooltip.classes }} margin-bottom-1" data-position="bottom" data-classes="{{ tooltip.util_classes }}" title="Bottom">Show on bottom with margin-bottom-1</button>
+<button type="button" class="{{ tooltip.classes }} margin-left-1" data-position="left" data-classes="{{ tooltip.util_classes }}" title="Left">Show on left with margin-left-1</button>
+<button type="button" class="{{ tooltip.classes }} margin-right-1" data-position="right" data-classes="{{ tooltip.util_classes }}" title="Right">Show on right with margin-right-1</button>

--- a/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
+++ b/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
@@ -116,3 +116,15 @@
     <button type="button" class="{{ tooltip.classes }}" data-position="right" title="A longer Top tooltip that is longer than appx 320px" data-classes="{{ tooltip.util_classes }}" title="">Show on Right</button>
   </div>
 </div>
+<h2>With trigger positioning offsets</h2>
+<hr/>
+<p>In this scenario:</p>
+<ul>
+  <li>The tooltip should be positioned accounting for any offsets that might apply from the trigger</li>
+</ul>
+<button type="button" class="{{ tooltip.classes }} margin-top-1" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-2" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-3" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-4" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-5" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>
+<button type="button" class="{{ tooltip.classes }} margin-top-6" data-position="top" data-classes="{{ tooltip.util_classes }}" title="Top">Show on top</button>


### PR DESCRIPTION
# Summary

**Improves tooltip positioning.** Fixes issues which can occur in some cases with tooltip button positioning.

## Preview link

Preview link (local Storybook): http://localhost:6006/?path=/story/components-tooltip--test

## Problem statement

The Tooltip component's logic for calculating offsets incorrectly assumes that offsets will always be positive numbers, resulting in invalid style assignments when the offsets are negative.

This causes the tooltips to not appear flush with the trigger.

Screenshot:

![image](https://user-images.githubusercontent.com/1779930/235181028-ce852c1e-44c8-43d3-aaab-c35e6307545e.png)

Example:

```js
// Ok! 😀
const topMargin = 10;
const leftMargin = 10;
e.style.margin = `-${topMargin}px 0 0 -${leftMargin / 2}px`;
// "-10px 0 0 -5px"

// Not Ok! 😭
const topMargin = -10;
const leftMargin = -10;
e.style.margin = `-${topMargin}px 0 0 -${leftMargin / 2}px`;
// "--10px 0 0 --5px"
```

## Solution

The solution is to move the negation to the interpolated value, not the string template.

```js
// Ok! 😀
const topMargin = 10;
const leftMargin = 10;
e.style.margin = `${-topMargin}px 0 0 ${leftMargin / -2}px`;
// "-10px 0 0 -5px"

// Still Ok! 😌
const topMargin = -10;
const leftMargin = -10;
e.style.margin = `${-topMargin}px 0 0 ${leftMargin / -2}px`;
// "10px 0 0 5px"
```

## Testing and review

Check that the newly-added examples to [the Tooltip Test story](http://localhost:6006/?path=/story/components-tooltip--test) all show the tooltip flush with the button.