### PR TITLE
USWDS - Tooltip: Fix tooltip component impacting content layout

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -5,7 +5,6 @@ const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const isElementInViewport = require("../../uswds-core/src/js/utils/is-in-viewport");
 
 const TOOLTIP = `.${PREFIX}-tooltip`;
-const TOOLTIP_TRIGGER = `.${PREFIX}-tooltip__trigger`;
 const TOOLTIP_TRIGGER_CLASS = `${PREFIX}-tooltip__trigger`;
 const TOOLTIP_CLASS = `${PREFIX}-tooltip`;
 const TOOLTIP_BODY_CLASS = `${PREFIX}-tooltip__body`;

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -307,6 +307,26 @@ const hideToolTip = (tooltipBody) => {
 };
 
 /**
+ * Handles events to activate tooltip.
+ * @param {MouseEvent|KeyboardEvent} event Mouseover or focusin event initiating activation.
+ */
+const onTooltipActivate = (event) => {
+  const { trigger, body } = getTooltipElements(event.currentTarget);
+
+  showToolTip(body, trigger, trigger.dataset.position);
+};
+
+/**
+ * Handles events to deactivate tooltip.
+ * @param {MouseEvent|KeyboardEvent} event Mouseout or focusout event initiating deactivation.
+ */
+const onTooltipDeactivate = (event) => {
+  const { body } = getTooltipElements(event.currentTarget);
+
+  hideToolTip(body);
+};
+
+/**
  * Setup the tooltip component
  * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
  */
@@ -353,37 +373,25 @@ const setUpAttributes = (tooltipTrigger) => {
   return { tooltipBody, position, tooltipContent, wrapper };
 };
 
+/**
+ * Set up tooltip trigger event handlers.
+ * @param {HTMLElement} tooltipTrigger The element that creates the tooltip
+ */
+const setUpEvents = (tooltipTrigger) => {
+  tooltipTrigger.addEventListener("mouseover", onTooltipActivate);
+  tooltipTrigger.addEventListener("focusin", onTooltipActivate);
+  tooltipTrigger.addEventListener("mouseout", onTooltipDeactivate);
+  tooltipTrigger.addEventListener("focusout", onTooltipDeactivate);
+};
+
 // Setup our function to run on various events
 const tooltip = behavior(
-  {
-    "mouseover focusin": {
-      [TOOLTIP](e) {
-        const trigger = e.target;
-        const elementType = trigger.nodeName;
-
-        // Initialize tooltip if it hasn't already
-        if (elementType === "BUTTON" && trigger.hasAttribute("title")) {
-          setUpAttributes(trigger);
-        }
-      },
-      [TOOLTIP_TRIGGER](e) {
-        const { trigger, body } = getTooltipElements(e.target);
-
-        showToolTip(body, trigger, trigger.dataset.position);
-      },
-    },
-    "mouseout focusout": {
-      [TOOLTIP_TRIGGER](e) {
-        const { body } = getTooltipElements(e.target);
-
-        hideToolTip(body);
-      },
-    },
-  },
+  {},
   {
     init(root) {
       selectOrMatches(TOOLTIP, root).forEach((tooltipTrigger) => {
         setUpAttributes(tooltipTrigger);
+        setUpEvents(tooltipTrigger);
       });
     },
     setup: setUpAttributes,

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -5,8 +5,6 @@ const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const isElementInViewport = require("../../uswds-core/src/js/utils/is-in-viewport");
 
 const TOOLTIP = `.${PREFIX}-tooltip`;
-const TOOLTIP_TRIGGER_CLASS = `${PREFIX}-tooltip__trigger`;
-const TOOLTIP_CLASS = `${PREFIX}-tooltip`;
 const TOOLTIP_BODY_CLASS = `${PREFIX}-tooltip__body`;
 const SET_CLASS = "is-set";
 const VISIBLE_CLASS = "is-visible";
@@ -149,6 +147,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
 
     setPositionClass("bottom");
     e.style.left = `50%`;
+    e.style.top = `100%`;
     e.style.margin = `${TRIANGLE_SIZE}px 0 0 -${leftMargin / 2}px`;
   };
 
@@ -167,9 +166,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
 
     setPositionClass("right");
     e.style.top = `50%`;
-    e.style.left = `${
-      tooltipTrigger.offsetLeft + tooltipTrigger.offsetWidth + TRIANGLE_SIZE
-    }px`;
+    e.style.left = `${tooltipTrigger.offsetWidth + TRIANGLE_SIZE}px`;
     e.style.margin = `-${topMargin / 2}px 0 0 0`;
   };
 
@@ -190,7 +187,7 @@ const showToolTip = (tooltipBody, tooltipTrigger, position) => {
     const leftMargin = calculateMarginOffset(
       "left",
       tooltipTrigger.offsetLeft > e.offsetWidth
-        ? tooltipTrigger.offsetLeft - e.offsetWidth
+        ? -e.offsetWidth
         : e.offsetWidth,
       tooltipTrigger
     );
@@ -343,16 +340,6 @@ const setUpAttributes = (tooltipTrigger) => {
   tooltipTrigger.setAttribute("aria-describedby", tooltipID);
   tooltipTrigger.setAttribute("tabindex", "0");
   tooltipTrigger.removeAttribute("title");
-  tooltipTrigger.classList.remove(TOOLTIP_CLASS);
-  tooltipTrigger.classList.add(TOOLTIP_TRIGGER_CLASS);
-
-  // insert wrapper before el in the DOM tree
-  tooltipTrigger.parentNode.insertBefore(wrapper, tooltipTrigger);
-
-  // set up the wrapper
-  wrapper.appendChild(tooltipTrigger);
-  wrapper.classList.add(TOOLTIP_CLASS);
-  wrapper.appendChild(tooltipBody);
 
   // Apply additional class names to wrapper element
   if (additionalClasses) {
@@ -360,14 +347,13 @@ const setUpAttributes = (tooltipTrigger) => {
     classesArray.forEach((classname) => wrapper.classList.add(classname));
   }
 
-  // set up the tooltip body
+  // Set up the tooltip body
   tooltipBody.classList.add(TOOLTIP_BODY_CLASS);
   tooltipBody.setAttribute("id", tooltipID);
   tooltipBody.setAttribute("role", "tooltip");
   tooltipBody.setAttribute("aria-hidden", "true");
-
-  // place the text in the tooltip
   tooltipBody.textContent = tooltipContent;
+  tooltipTrigger.appendChild(tooltipBody);
 
   return { tooltipBody, position, tooltipContent, wrapper };
 };

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -5,7 +5,7 @@ $triangle-size: 5px;
 
 /* Tooltips */
 .usa-tooltip {
-  display: inline-block;
+  display: contents;
   position: relative;
 }
 

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -5,7 +5,6 @@ $triangle-size: 5px;
 
 /* Tooltips */
 .usa-tooltip {
-  display: contents;
   position: relative;
 }
 

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -6,9 +6,6 @@ $triangle-size: 5px;
 /* Tooltips */
 .usa-tooltip {
   position: relative;
-}
-
-.usa-tooltip__trigger {
   cursor: pointer;
 }
 

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -11,11 +11,6 @@ $triangle-size: 5px;
 
 .usa-tooltip__trigger {
   cursor: pointer;
-
-  > svg {
-    display: block;
-    pointer-events: none;
-  }
 }
 
 .usa-tooltip__body,

--- a/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
+++ b/packages/usa-tooltip/src/test/test-patterns/test-usa-tooltip-utilities.twig
@@ -116,3 +116,6 @@
     <button type="button" class="{{ tooltip.classes }}" data-position="right" title="A longer Top tooltip that is longer than appx 320px" data-classes="{{ tooltip.util_classes }}" title="">Show on Right</button>
   </div>
 </div>
+<div class="padding-8">
+  <button type="button" class="{{ tooltip.classes }} width-full" data-position="top" title="Top">Show on top</button>
+</div>

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -20,19 +20,12 @@ tests.forEach(({ name, selector: containerSelector }) => {
       body.innerHTML = TEMPLATE;
       tooltip.on(containerSelector());
       tooltipBody = body.querySelector(".usa-tooltip__body");
-      tooltipTrigger = body.querySelector(".usa-tooltip__trigger");
+      tooltipTrigger = body.querySelector(".usa-tooltip");
     });
 
     afterEach(() => {
       tooltip.off(containerSelector());
       body.textContent = "";
-    });
-
-    it("trigger is created", () => {
-      assert.strictEqual(
-        tooltipTrigger.getAttribute("class"),
-        "usa-button usa-tooltip__trigger"
-      );
     });
 
     it("title attribute on trigger is removed", () => {
@@ -80,7 +73,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       body.innerHTML = `<button class="usa-button usa-tooltip" title="Apricot &lt;img src='' onerror=alert('ouch')&gt;">Button</button>`;
       tooltip.on();
       tooltipBody = body.querySelector(".usa-tooltip__body");
-      tooltipTrigger = body.querySelector(".usa-tooltip__trigger");
+      tooltipTrigger = body.querySelector(".usa-tooltip");
       tooltip.on(body);
 
       // confirm we are not on the original template

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -48,8 +48,30 @@ tests.forEach(({ name, selector: containerSelector }) => {
       assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
     });
 
+    it("tooltip is visible when mousing over", () => {
+      const event = new MouseEvent("mouseover", { bubbles: true });
+      tooltipTrigger.dispatchEvent(event);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
+    it("tooltip is visible when mousing over child", () => {
+      const icon = document.createElement("img");
+      tooltipTrigger.appendChild(icon);
+      const event = new MouseEvent("mouseover", { bubbles: true });
+      icon.dispatchEvent(event);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
     it("tooltip is hidden on blur", () => {
       tooltipTrigger.blur();
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    });
+
+    it("tooltip is hidden when mousing out", () => {
+      const mouseOverEvent = new MouseEvent("mouseover", { bubbles: true });
+      const mouseOutEvent = new MouseEvent("mouseout", { bubbles: true });
+      tooltipTrigger.dispatchEvent(mouseOverEvent);
+      tooltipTrigger.dispatchEvent(mouseOutEvent);
       assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
     });
 


### PR DESCRIPTION
# Summary

**Improve tooltip compatibility with different content layouts.** Tooltips should no longer affect the layout appearance of its content, such as full-width content.

Fixes #5273

## Related pull requests

This incorporates the changes from #5263, which would ideally be merged separately.

## Preview link

Preview link (local Storybook): http://localhost:6006/?path=/story/components-tooltip--test

## Problem statement

See #5273

## Solution

This implements the second of the two "rethinking how the tooltip is positioned" suggestions mentioned in the "Additional context" of #5273:

>Or using the button itself as the relative container and moving the tooltip contents within the button

## Testing and review

Test in local preview: http://localhost:6006/?path=/story/components-tooltip--test

Verify no regressions in:

- Different positions
- Constrained viewport width where not enough room for horizontal tooltip ([see "Show on Right" example in Test Tooltip preview](http://localhost:6006/?path=/story/components-tooltip--test))

Additionally, confirm the new support for full-width buttons on the [Test Tooltip preview](http://localhost:6006/?path=/story/components-tooltip--test).