### PR TITLE
USWDS - Remove unnecessary single quote in sortable table aria-labels 

### DIFF
--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -199,7 +199,7 @@ $navigate_far_next: map-merge(
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   @media (forced-colors: active) {
     &:not([disabled]):hover {
       outline: $border-high-contrast;

--- a/packages/usa-search/src/styles/_usa-search.scss
+++ b/packages/usa-search/src/styles/_usa-search.scss
@@ -43,7 +43,7 @@ $search-icon: (
       &:focus {
         outline-offset: 0;
       }
-      
+
       &::before {
         @include at-media("mobile-lg") {
           content: none;

--- a/packages/usa-table/src/index.js
+++ b/packages/usa-table/src/index.js
@@ -77,7 +77,7 @@ const updateSortLabel = (header) => {
     header.getAttribute(SORTED) === ASCENDING ||
     header.getAttribute(SORTED) === DESCENDING ||
     false;
-  const headerLabel = `${headerName}', sortable column, currently ${
+  const headerLabel = `${headerName}, sortable column, currently ${
     isSorted
       ? `${sortedAscending ? `sorted ${ASCENDING}` : `sorted ${DESCENDING}`}`
       : "unsorted"


### PR DESCRIPTION
# Summary
Fixed a typo in the sortable table JavaScript that caused the `aria-label` in table headers to have an unnecessary single quote.

This PR also includes  fixes for a couple `lintSass` errors. (A couple of files just needed to have some extra spaces removed.)

## Breaking change
This is not a breaking change.

## Related issue

Closes #5261

## Related pull requests
Changelog entry: https://github.com/uswds/uswds-site/pull/2098

## Preview link

Preview link: [Sortable table component ](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-table-extra-quote/?path=/story/components-table--sortable)

## Problem statement
Due to a typo, the `index.js` script creates an `aria-label` with an unncessary single quote in sortable table headers.

## Solution
Removed the single quote from the `index.js` script.

## Testing and review
Confirm that the aria labels for sortable table headers have no single quote after the header name.

For example, the table header for the first column in the first example should have 
```
aria-label="Name, sortable column, currently unsorted"
```

instead of the previous:
```
aria-label="Name', sortable column, currently unsorted"
```