### PR TITLE
USWDS - Footer: Remove grid dependency.

### DIFF
--- a/packages/usa-footer/_index.scss
+++ b/packages/usa-footer/_index.scss
@@ -1,6 +1,5 @@
 // dependencies
 @forward "uswds-fonts";
-@forward "usa-layout-grid";
 @forward "usa-input";
 @forward "usa-form";
 @forward "usa-label";

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -28,11 +28,99 @@ $-chevron-expand-more: map-merge(
   @include typeset($theme-footer-font-family);
   overflow: hidden;
 
-  > .grid-container {
+  // Grid styles ported over to remove dependency
+  .grid-container {
     @include grid-container($theme-footer-max-width);
   }
-}
 
+  .grid-row {
+    @include grid-row;
+
+    // Gaps
+    &.grid-gap {
+      @include grid-gap;
+    }
+
+    &.grid-gap-1 {
+      @include grid-gap(1);
+    }
+
+    &.grid-gap-2 {
+      @include grid-gap(2);
+    }
+
+    &.grid-gap-4 {
+      @include grid-gap(4);
+    }
+
+    // Gaps: Mobile Large
+    /* stylelint-disable */
+    @include at-media("mobile-lg") {
+      &.mobile-lg\:grid-gap-2 {
+        @include grid-gap(2);
+      }
+    }
+    /* stylelint-enable */
+
+    // Columns
+    [class*="grid-col"] {
+      @include u-position(relative);
+      @include u-width(full);
+      box-sizing: border-box;
+    }
+
+    .grid-col-auto {
+      @include grid-col("auto");
+    }
+
+    // Columns: Mobile Large
+    /* stylelint-disable */
+    @include at-media("mobile-lg") {
+      .mobile-lg\:grid-col-auto {
+        @include grid-col("auto");
+      }
+
+      .mobile-lg\:grid-col-4 {
+        @include grid-col(4);
+      }
+
+      .mobile-lg\:grid-col-6 {
+        @include grid-col(6);
+      }
+
+      .mobile-lg\:grid-col-8 {
+        @include grid-col(8);
+      }
+
+      .mobile-lg\:grid-col-12 {
+        @include grid-col(12);
+      }
+    }
+
+    // Columns: Tablet
+    @include at-media("tablet") {
+      .tablet\:grid-col-4 {
+        @include grid-col(4);
+      }
+
+      .tablet\:grid-col-8 {
+        @include grid-col(8);
+      }
+    }
+
+    // Columns: Desktop
+    @include at-media("desktop") {
+      .desktop\:grid-col-auto {
+        @include grid-col("auto");
+      }
+
+      .desktop\:grid-col-3 {
+        @include grid-col(3);
+      }
+    }
+    /* stylelint-enable */
+  }
+}
 .usa-footer__return-to-top {
   @include u-padding-y(2.5);
   line-height: line-height($theme-footer-font-family, 1);


### PR DESCRIPTION
# Summary

**Removed grid dependency from Footer package.** Now you no longer need to use the usa-layout-grid package with usa-footer resulting in a much smaller package size.

## Breaking change

Not a breaking change. Only CSS refactored. 


## Related issue

Closes #5287

## Related pull requests

TBD

_Note: Remove layout-grid from the [dependency lists](https://designsystem.digital.gov/components/footer/#package) from doc site._


## Problem statement

The footer currently has the layout-grid dependency although very little of it is used. This adds additional, unnecessary file weight.


## Solution

Removed the grid layout dependency and brought layout styles into the footer directly. 

Possible limitation: I only brought in the column sizes that are needed to support the three variations of the footer (default, slim, big) at all the breakpoints. If alternate layouts are  desired, addition styles would need to be added. For example, changing the number of columns or how wide the link columns span in the big footer. 


## Testing and review

Existing unit test still completes successfully. 
Compared the unminified CSS size of the Footer before and after changes: 63kb -> ~40kb 

### Isolate Footer package
- In `uswds/_index.scss` remove all packages besides `usa-banner`
- Check `dist/css/uswds.css` filesize
- Validate appearance of all footer variations at all breakpoints are acceptable


~~Looking for feedback, please:~~

- ~~Existing footer styles has reference to "disclosure button styles". I didn't remove them, but don't see them in any template markup. Are these needed?~~
- ~~I updated existing styles to use utility mixins as opposed to native CSS properties. It was mixed before, is there a preference?~~  
- ~~As mentioned in the possible limitations above, I only brought in the columns that are used for the footer variations. If this is the right approach, I can make a mixin to output these in a more concise, readable way.~~ 
- ~~I make use of the 'gap' property for flexbox items. This is not supported in IE11 but all other supported browsers. USWDS v3 states IE11 support was dropped. Is this ok?~~
- ~~FYI: I also separated the logo lockup and address into includes as the markup was the same for multiple footer variations.~~

~~FYI: @mejiaj~~



<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
