### PR TITLE
USWDS - Prefix/Suffix: Error on HTML build

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "federalist": "npm run build && npm run build:storybook",
     "start": "npm run start:storybook",
     "test": "snyk test && npm run lint && gulp typecheck && gulp test",
-    "test:ci": "npm run lint && gulp test && npm run test:a11y",
+    "test:ci": "npm run lint && gulp test && npm run test:a11y && npm run build:html",
     "test:a11y": "build-storybook && axe-storybook",
     "test:sass": "gulp sassTests",
     "test:unit": "gulp unitTests",

--- a/packages/usa-accordion/src/index.js
+++ b/packages/usa-accordion/src/index.js
@@ -101,7 +101,7 @@ const accordion = behavior(
     hide: hideButton,
     toggle: toggleButton,
     getButtons: getAccordionButtons,
-    hasInit: this.hasInit || false
+    hasInit: this.hasInit || false,
   }
 );
 

--- a/packages/usa-input-prefix-suffix/src/usa-input-prefix-suffix.stories.js
+++ b/packages/usa-input-prefix-suffix/src/usa-input-prefix-suffix.stories.js
@@ -10,12 +10,16 @@ export default {
       options: ["none", "disabled", "aria-disabled"],
     },
   },
+  args: {
+    disabled_state: "none",
+  },
 };
 
 const PrefixTemplate = (args) => prefix(args);
 const SuffixTemplate = (args) => suffix(args);
 
 export const Prefix = PrefixTemplate.bind({});
+
 export const PrefixDisabled = PrefixTemplate.bind({});
 PrefixDisabled.args = {
   disabled_state: "disabled",

--- a/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
+++ b/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
@@ -31,6 +31,7 @@
       class="usa-input"
       pattern="[0-9]*"
       inputmode="numeric"
+    >
   </div>
   {% endif %}
 </form>

--- a/packages/usa-input-prefix-suffix/src/usa-input-suffix.twig
+++ b/packages/usa-input-prefix-suffix/src/usa-input-suffix.twig
@@ -3,7 +3,8 @@
   <div class="usa-input-group usa-input-group--sm">
     <input type="text" id="example-input-suffix" class="usa-input" pattern="[0-9]*" inputmode="numeric"
     {% if disabled_state == "disabled"%} disabled{%- endif %}
-    {% if disabled_state == "aria-disabled"%} aria-disabled="true"{%- endif %}>
+    {% if disabled_state == "aria-disabled"%} aria-disabled="true"{%- endif %}
+    >
     <div class="usa-input-suffix" aria-hidden="true">
       lbs.
     </div>


### PR DESCRIPTION
# Summary

**Fixed input prefix/suffix templates.** This PR does the following:
- Adds a missing closing tag on input prefix. 
- Sets default argument for `disabled_state` in StorybookJS.
- CI tests now check for successful HTML build (via `npm run build:html`).

## Breaking change

This is not a breaking change.

## Related issue

Closes #5309.


## Related pull requests

Unsure if changelog update is required.

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

Input prefix was causing a HTML build error because of a missing closing tag.

<details><summary>HTML build error</summary>
<p></p>

```bash
❯ npm run build:html

> @uswds/uswds@3.4.1 build:html
> webpack build --config ./webpack.twig.config.js && npm run prettier:html

ERROR in   Error: Parse Error: <input type="text" id="example-input-prefix-error" class="usa-input" pattern="[0-9]*" inp  utmode="numeric" </div>
```
</details> 

## Solution

1. Added closing tag to input prefix [018df5a].
2. Set default arg for `disabled_state` in story [431805a].
3. Updated CI tests to check for HTML build errors in the future [da51d88].

## Major changes

Only major change is NPM script `test:ci` now checks for HTML build issues.

## Testing and review

1. On `develop` run `build:html` to confirm error.
2. On this branch, run `build:html` to confirm the fix.
3. There should be no regression to input prefix story.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
