### PR TITLE
USWDS - Header: Consistent nav data is passed in Header

### DIFF
--- a/packages/usa-header/src/usa-header--extended/usa-header--extended-megamenu.json
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended-megamenu.json
@@ -1,6 +1,7 @@
 {
   "title": "Extended header with mega-menu",
   "modifier": "usa-header--extended",
+  "id_prefix": "extended-megamenu",
   "nav": {
     "menu": {
       "label": "Menu"

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended.json
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended.json
@@ -1,6 +1,7 @@
 {
   "modifier": "usa-header--extended",
   "title": "Extended header",
+  "id_prefix": "extended",
   "nav": {
     "menu": {
       "label": "Menu"

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended.json
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended.json
@@ -6,6 +6,7 @@
       "label": "Menu"
     },
     "aria_label": "Primary navigation",
+    "megamenu": false,
     "items": [
       {
         "label": "<Current section>",

--- a/packages/usa-header/src/usa-header.json
+++ b/packages/usa-header/src/usa-header.json
@@ -1,6 +1,7 @@
 {
   "modifier": "",
   "title": "Basic header",
+  "id_prefix": "basic",
   "nav": {
     "menu": {
       "label": "Menu"

--- a/packages/usa-header/src/usa-header.json
+++ b/packages/usa-header/src/usa-header.json
@@ -5,6 +5,7 @@
     "menu": {
       "label": "Menu"
     },
+    "megamenu": false,
     "aria_label": "Primary navigation",
     "close": {
       "label": "Close"

--- a/packages/usa-header/src/usa-header.stories.js
+++ b/packages/usa-header/src/usa-header.stories.js
@@ -29,7 +29,6 @@ Default.args = DefaultContent;
 export const Megamenu = Template.bind({});
 Megamenu.args = {
   ...MegamenuContent,
-  megamenu: true,
 };
 
 export const Extended = ExtendedTemplate.bind({});
@@ -44,7 +43,6 @@ Extended.args = {
 export const ExtendedMegamenu = ExtendedTemplate.bind({});
 ExtendedMegamenu.args = {
   ...ExtendedMegamenuContent,
-  megamenu: true,
   navSecondaryContent: {
     ...navSecondaryContent,
     search: true,

--- a/packages/usa-header/src/usa-header.twig
+++ b/packages/usa-header/src/usa-header.twig
@@ -3,10 +3,10 @@
   <div class="usa-nav-container">
     {% include "@components/usa-header/src/_includes/usa-navbar.twig" %}
     {% if nav %}
-      <nav aria-label="{{ nav.aria_label }}" class="usa-nav">
-        {% include "@components/usa-nav/src/usa-nav__primary/usa-nav__primary.twig" %}
-        {% include "@components/usa-search/src/usa-search.twig" with search.settings %}
-      </nav>
+    <nav aria-label="{{ nav.aria_label }}" class="usa-nav">
+      {% include "@components/usa-nav/src/usa-nav__primary/usa-nav__primary.twig" %}
+      {% include "@components/usa-search/src/usa-search.twig" with search.settings %}
+    </nav>
     {% endif %}
   </div>
 </header>

--- a/packages/usa-header/src/usa-header~megamenu.json
+++ b/packages/usa-header/src/usa-header~megamenu.json
@@ -1,6 +1,7 @@
 {
   "modifier": "usa-header--megamenu",
   "title": "Basic with mega-menu",
+  "id_prefix": "megamenu",
   "nav": {
     "menu": {
       "label": "Menu"

--- a/packages/usa-nav/src/usa-nav__primary/_primary-menu-macro.twig
+++ b/packages/usa-nav/src/usa-nav__primary/_primary-menu-macro.twig
@@ -50,7 +50,7 @@
         {% endif %}
       {% else %}
         <a
-          href="{{ item.href }}"
+          href="{{ item.href | default("javascript:void(0);") }}"
           {% if menu_level == 0 %} class="usa-nav-link" {% endif %}
         >
           {% if megamenu %}

--- a/packages/usa-nav/src/usa-nav__primary/usa-nav-primary.stories.js
+++ b/packages/usa-nav/src/usa-nav__primary/usa-nav-primary.stories.js
@@ -13,5 +13,8 @@ Default.args = Content;
 export const Megamenu = Template.bind({});
 Megamenu.args = {
   ...Content,
-  megamenu: true,
+  nav: {
+    ...Content.nav,
+    megamenu: true,
+  },
 };

--- a/packages/usa-nav/src/usa-nav__primary/usa-nav__primary.json
+++ b/packages/usa-nav/src/usa-nav__primary/usa-nav__primary.json
@@ -1,7 +1,7 @@
 {
   "modifier": "usa-nav__primary",
   "nav": {
-    "megamenu": true,
+    "megamenu": false,
     "close": {
       "label": "Close"
     },

--- a/packages/usa-nav/src/usa-nav__primary/usa-nav__primary.twig
+++ b/packages/usa-nav/src/usa-nav__primary/usa-nav__primary.twig
@@ -4,4 +4,4 @@
   <img src="{{ img_path }}/usa-icons/close.svg" role="img" alt="{{ nav.close.label }}">
 </button>
 
-{{ menus.menu_links(nav.items, 0, megamenu) }}
+{{ menus.menu_links(nav.items, 0, nav.megamenu) }}


### PR DESCRIPTION
# Summary

Fixed an issue with inconsistent megamenu data being passed to navigation component. This was causing issues on compiling templates with `npm run build:html` and the markup in Site's code examples.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5305.

## Related pull requests

Changelog entry PR - https://github.com/uswds/uswds-site/pull/2111.

## Preview link

Preview link:

- [Primary navigation with megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-extended-megamenu-bug-5305/?path=/story/components-header-partials-primary--megamenu).
- [Header megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-extended-megamenu-bug-5305/?path=/story/components-header--megamenu).
- [Header extended megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-extended-megamenu-bug-5305/?path=/story/components-header--extended-megamenu).
- Rest of [headers](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-extended-megamenu-bug-5305/?path=/story/components-header--default) to ensure there are no regressions.

## Problem statement

The `megamenu` boolean was sometimes passed as top-level setting and other times nested in `nav` object.  This was displaying properly in StorybookJS, but broke on `npm run build:html` because storybook functionality is separate from twig compile for site.

## Solution

The `megamenu` setting is now nested in `nav` object consistently. Any overrides to toggle will need to be done inside of `nav` object.

## Major changes

Megamenu is no longer a top-level setting for header (this can be changed, but most templates already had nested setting).

## Testing and review

1. Ensure there are no visual regressions in Headers
2. Run `npm run build:html` and ensure the rendered markup is correct. For example, `usa-header--extended-megamenu.html` submenu's **should** have these classes `usa-nav__submenu usa-megamenu`.
3. Ensure usa-logo ID has the correct prefix.
4. Ensure link `href`'s aren't empty.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
