### PR TITLE
USWDS - Button Group: Improve appearance of segmented button text wrapping

### DIFF
--- a/packages/usa-button-group/src/usa-button-group--test-text-wrapping.twig
+++ b/packages/usa-button-group/src/usa-button-group--test-text-wrapping.twig
@@ -1,0 +1,11 @@
+<ul class="usa-button-group usa-button-group--segmented">
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button">Button</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button Extra</button>
+  </li>
+  <li class="usa-button-group__item">
+    <button type="button" class="usa-button usa-button--outline">Button</button>
+  </li>
+</ul>

--- a/packages/usa-button-group/src/usa-button-group.stories.js
+++ b/packages/usa-button-group/src/usa-button-group.stories.js
@@ -1,4 +1,5 @@
 import Component from "./usa-button-group.twig";
+import TestTextWrappingComponent from "./usa-button-group--test-text-wrapping.twig";
 import { DefaultContent, SegmentedContent } from "./content";
 
 export default {
@@ -22,9 +23,12 @@ export default {
 };
 
 const Template = (args) => Component(args);
+const TestTextWrappingTemplate = (args) => TestTextWrappingComponent(args);
 
 export const Default = Template.bind({});
 Default.args = DefaultContent;
 
 export const Segmented = Template.bind({});
 Segmented.args = SegmentedContent;
+
+export const TestTextWrapping = TestTextWrappingTemplate.bind({});


### PR DESCRIPTION
# Summary

**Improve appearance of segmented button text wrapping.** When segmented button group text wraps, the height of all buttons will now update to match.

## Preview link

Local storybook link: http://localhost:6006/?path=/story/components-button-group--test-text-wrapping

## Problem statement

Currently, if a segmented Button Group includes buttons with text long enough to wrap, only the button with the longer text will wrap, which avoids the segmented group from appearing as a single grouped collection.

## Solution

Add flex and grid styling to force buttons to grow together and align text as vertically centered.

Before|After
---|---
![localhost_6006__path=_story_components-button-group--test-text-wrapping](https://github.com/uswds/uswds/assets/1779930/0e864130-5a1b-4ad8-a610-14a7b9da632f)|![localhost_6006__path=_story_components-button-group--segmented](https://github.com/uswds/uswds/assets/1779930/f32349c0-3d4f-4c48-8c7a-96ebd227cbc7)
