### PR TITLE
USWDS - Card: Fix `$theme-card-border-width` calculation errors

### DIFF
--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -187,7 +187,7 @@
 .usa-card__media--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
-  @include u-margin-x(units($theme-card-border-width) * -1);
+  margin-inline: units($theme-card-border-width) * -1;
 }
 
 .usa-card__header--exdent,
@@ -199,7 +199,7 @@
 }
 
 .usa-card__media--exdent {
-  @include u-margin-x(units($theme-card-border-width) * -1);
+  margin-top: units(-$theme-card-border-width);
 
   .usa-card__img {
     @include u-radius-top($theme-card-border-radius);
@@ -268,9 +268,7 @@
     }
 
     .usa-card__media--exdent {
-      @include u-margin-left(units($theme-card-border-width) * -1);
-      @include u-margin-right(0);
-      @include u-margin-y(units($theme-card-border-width) * -1);
+      margin: units($theme-card-border-width) * -1;
 
       .usa-card__img {
         @include u-radius-left($theme-card-border-radius);
@@ -336,14 +334,9 @@
         @include u-margin-right($theme-card-flag-image-width);
       }
 
-      .usa-card__media--exdent {
-        @include u-margin-right(units($theme-card-border-width) * -1);
-        @include u-margin-left(0);
-
-        .usa-card__img {
-          @include u-radius(0);
-          @include u-radius-right($theme-card-border-radius);
-        }
+      .usa-card__img {
+        @include u-radius(0);
+        @include u-radius-right($theme-card-border-radius);
       }
     }
   }

--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -187,7 +187,7 @@
 .usa-card__media--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
-  @include u-margin-x(-$theme-card-border-width);
+  @include u-margin-x(units($theme-card-border-width)  * -1);
 }
 
 .usa-card__header--exdent,
@@ -199,7 +199,7 @@
 }
 
 .usa-card__media--exdent {
-  @include u-margin-top(-$theme-card-border-width);
+  @include u-margin-x(units($theme-card-border-width)  * -1);
 
   .usa-card__img {
     @include u-radius-top($theme-card-border-radius);
@@ -215,7 +215,7 @@
   }
 
   .usa-card__header--exdent {
-    @include u-margin-top(-$theme-card-border-width);
+    @include u-margin-x(units($theme-card-border-width)  * -1);
     @include u-radius-top($theme-card-border-radius);
   }
 
@@ -268,9 +268,9 @@
     }
 
     .usa-card__media--exdent {
-      @include u-margin-left(-$theme-card-border-width);
+      @include u-margin-left(units($theme-card-border-width)  * -1);
       @include u-margin-right(0);
-      @include u-margin-y(-$theme-card-border-width);
+      @include u-margin-y(units($theme-card-border-width)  * -1);
 
       .usa-card__img {
         @include u-radius-left($theme-card-border-radius);
@@ -337,7 +337,7 @@
       }
 
       .usa-card__media--exdent {
-        @include u-margin-right(-$theme-card-border-width);
+        @include u-margin-right(units($theme-card-border-width)  * -1);
         @include u-margin-left(0);
 
         .usa-card__img {

--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -183,12 +183,14 @@
 // ---------------------------------
 
 // Exdent
+.usa-card__header--exdent,
 .usa-card__media--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
   margin-inline: units($theme-card-border-width) * -1;
 }
 
+.usa-card__header--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
   > * {
@@ -210,6 +212,11 @@
   .usa-card__header {
     @include card-inner-radius;
     @include u-padding-bottom($theme-card-padding-y);
+  }
+
+  .usa-card__header--exdent {
+    @include u-radius-top($theme-card-border-radius);
+    margin-top: units($theme-card-border-width) * -1;
   }
 
   .usa-card__media--inset {

--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -197,7 +197,7 @@
 }
 
 .usa-card__media--exdent {
-  margin-top: units(-$theme-card-border-width);
+  margin-top: units($theme-card-border-width) * -1;
 
   .usa-card__img {
     @include u-radius-top($theme-card-border-radius);

--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -187,7 +187,7 @@
 .usa-card__media--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
-  @include u-margin-x(units($theme-card-border-width)  * -1);
+  @include u-margin-x(units($theme-card-border-width) * -1);
 }
 
 .usa-card__header--exdent,
@@ -199,7 +199,7 @@
 }
 
 .usa-card__media--exdent {
-  @include u-margin-x(units($theme-card-border-width)  * -1);
+  @include u-margin-x(units($theme-card-border-width) * -1);
 
   .usa-card__img {
     @include u-radius-top($theme-card-border-radius);
@@ -215,7 +215,7 @@
   }
 
   .usa-card__header--exdent {
-    @include u-margin-x(units($theme-card-border-width)  * -1);
+    @include u-margin-x(units($theme-card-border-width) * -1);
     @include u-radius-top($theme-card-border-radius);
   }
 
@@ -268,9 +268,9 @@
     }
 
     .usa-card__media--exdent {
-      @include u-margin-left(units($theme-card-border-width)  * -1);
+      @include u-margin-left(units($theme-card-border-width) * -1);
       @include u-margin-right(0);
-      @include u-margin-y(units($theme-card-border-width)  * -1);
+      @include u-margin-y(units($theme-card-border-width) * -1);
 
       .usa-card__img {
         @include u-radius-left($theme-card-border-radius);
@@ -337,7 +337,7 @@
       }
 
       .usa-card__media--exdent {
-        @include u-margin-right(units($theme-card-border-width)  * -1);
+        @include u-margin-right(units($theme-card-border-width) * -1);
         @include u-margin-left(0);
 
         .usa-card__img {

--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -183,14 +183,12 @@
 // ---------------------------------
 
 // Exdent
-.usa-card__header--exdent,
 .usa-card__media--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
   margin-inline: units($theme-card-border-width) * -1;
 }
 
-.usa-card__header--exdent,
 .usa-card__body--exdent,
 .usa-card__footer--exdent {
   > * {
@@ -212,11 +210,6 @@
   .usa-card__header {
     @include card-inner-radius;
     @include u-padding-bottom($theme-card-padding-y);
-  }
-
-  .usa-card__header--exdent {
-    @include u-margin-x(units($theme-card-border-width) * -1);
-    @include u-radius-top($theme-card-border-radius);
   }
 
   .usa-card__media--inset {

--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -99,7 +99,7 @@ $system-spacing: (
     // 1400px
   ),
   "special": (
-    0: 0,
+    0: spacing-multiple(0),
     "auto": auto,
     "none": none,
   ),


### PR DESCRIPTION
# Summary

Resolves errors based around setting `$theme-card-border-width` to `0` or string tokens.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5162 

## Related pull requests

[Changelog entry →](https://github.com/uswds/uswds-site/pull/2127)

## Preview link

[Card storybook preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-card-border-width-0/iframe.html?args=&id=components-card--default&viewMode=story)
[Test repo →](https://github.com/uswds/uswds-sandbox/tree/cm-card-border-width-test)

## Problem statement

### Setting `$theme-card-border-width` to zero

This caused errors when setting the card radius using the `calc()` function because `calc()` cannot take unitless numbers[^1]

![Screenshot 2023-02-23 at 11 20 30 AM](https://user-images.githubusercontent.com/87388914/220974358-7df31e45-7543-4c88-b2d7-82ffe33f8691.png)

### Setting `$theme-card-border-width` to a string token

Exdent variants of card use the variable to set a negative border width the following calculation:

```scss
@include u-margin-x(-$theme-card-border-width);
```

When using a string token like `"05"`, this results in `u-margin-x(-"05")` which breaks the margin function because it is not a valid USWDS token

![image](https://github.com/uswds/uswds/assets/25211650/d14d8a55-a4ec-4f23-96a4-2a3d0a83342d)


## Solution

1. Update `$system-spacing.special` 0 value from `0: 0` to `0: spacing-multiple(0)`
   - This falls in line with other `$system-spacing` tokens 
      - `"05": spacing-multiple(0.5)`
      - `1: spacing-multiple(1),`
   - `units()` is the only function that references `$project-spacing-standard`
   - Resolves this issue anywhere `units(0)` is used within a `calc()` function
      - Across USWDS, sass interpolation (`#{}`) is used within `calc()` to maintain the `rem` unit passed in by the `units()` function
      - `#{units($theme-card-border-width)} ` results in `0rem`
      - Other references to `units(0)` still result in unitless `0`
2. Update method to get negative margins to work with string token values
   - Changed to a solution found in `_footer.scss`
   - Works with all width tokens mentioned in `_border`
3. Swap `u-margin` mixins for native solutions where `$theme-card-border-width` is passed in.
   - The margin mixins expect USWDS tokens and will flag an error when it doesn't receive one
```diff
- @include u-margin-x(-$theme-card-border-width);
+ magin-inline: units($theme-site-margins-mobile-width * -1); 
```

## Testing and review

1. Confirm bugs exist 
    - On `develop`, set `$theme-card-border-width` to `0`
    - Inspect `.usa-card__img` and verify `calc()` is not working correctly
    - Set `$theme-card-border-width` to `"05"` _(or another string token)_ 
    - Inspect build error
2. Checkout [USWDS-Sandbox test repo →](https://github.com/uswds/uswds-sandbox/tree/cm-card-border-width-test)
     - Recent changes have been pushed to this branch, make sure you pull the latest
7. `$theme-card-border-width` will be set to `0` by default
8. Inspect `.usa-card__img` and verify `calc()` is working correctly
9. Go to `_uswds-theme.scss` and set `$theme-card-border-width` to `"05"`
10. Verify that there are no build errors
11. Inspect `.usa-card__media--exdent` class and check negative margins are set correctly

### Testing Checklist
- [ ] `$theme-card-border-width: 0` does not break `calc()` function on `.usa-card__img`
- [ ] `$theme-card-border-width: "05"` does not cause build errors
- [ ] No unwanted visual regression 

[^1]: https://sass-lang.com/documentation/values/calculations#:~:text=Other%20calculations%20don%E2%80%99t%20allow%20unitless%20numbers%20to%20be%20added%20to%2C%20subtracted%20from%2C%20or%20compared%20to%20numbers%20with%20units.

### Additional info

I discovered an existing visual bug when setting the border to a large value. I created a ticket at #5401

---

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
