### PR TITLE
USWDS - Bug: Possible duplicate Banner lock icon

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -1,13 +1,3 @@
-{% set lock %}
-  <span class="icon-lock">
-    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false">
-      <title id="banner-lock-title">Lock</title>
-      <desc id="banner-lock-description">Locked padlock icon</desc>
-      <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/>
-    </svg>
-  </span>
-{% endset %}
-
 <section class="usa-banner" aria-label="{{ banner.aria_label }}">
   <div class="usa-accordion">
     <header class="usa-banner__header">
@@ -36,7 +26,12 @@
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="./img/icon-https.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
-            <p><strong>{{ https.heading }}</strong><br/>{{ https.pretext | trim | raw }} ({{ lock }}) {{ https.posttext | trim | raw }}</p>
+            <p>
+              <strong>{{ https.heading }}</strong><br/>
+              {{ https.pretext | trim | raw }} 
+              ( <img class="usa-banner__lock-image" src="./img/lock.svg" role="img" alt="" aria-hidden="true"> ) 
+              {{ https.posttext | trim | raw }}
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Use banner lock SVG icon instead of inline template for consistency and to avoid confusion. 

## Breaking change
This is not a breaking change.

## Related issue
closes [#5303](https://github.com/uswds/uswds/issues/5303)

## Loom video
[loom video](https://www.loom.com/share/9c0513c7ded9458f8e0a9987a7db137a)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
