### PR TITLE
USWDS - Button: Theme settings for customization

### DIFF
--- a/packages/usa-button/src/usa-button.stories.js
+++ b/packages/usa-button/src/usa-button.stories.js
@@ -31,6 +31,16 @@ export default {
       options: ["button", "reset", "submit"],
       control: { type: "radio" },
     },
+    margin: {
+      name: "margin",
+      type: "string",
+      defaultValue: "0",
+    },
+    fontWeight: {
+      name: "font-weight",
+      type: "number",
+      defaultValue: 500,
+    },
   },
 };
 

--- a/packages/usa-button/src/usa-button.twig
+++ b/packages/usa-button/src/usa-button.twig
@@ -3,19 +3,19 @@
 {% endif %}
 
 {% if is_demo and 'usa-button--big' not in modifier %}
-  <button type="{{ type }}" class="usa-button {{ modifier }}">Default</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }} usa-button--hover">Hover</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }} usa-button--active">Active</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }} usa-focus">Focus</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }}" disabled>Disabled</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }}" aria-disabled="true">aria-disabled</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }} usa-button--unstyled">Unstyled button</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }}" style="font-weight:{{fontWeight}}">Default</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-button--hover" style="font-weight:{{fontWeight}}">Hover</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-button--active" style="font-weight:{{fontWeight}}">Active</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-focus" style="font-weight:{{fontWeight}}">Focus</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}" disabled>Disabled</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}" aria-disabled="true">aria-disabled</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} style="font-weight:{{fontWeight}}" usa-button--unstyled">Unstyled button</button>
 {% else %}
-  <button type="{{ type }}" class="usa-button {{ modifier }}">{{ text }}</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}">{{ text }}</button>
   {% if is_demo and 'usa-button--big' in modifier %}
-    <button type="{{ type }}" class="usa-button {{ modifier }}" disabled>Disabled</button>
-    <button type="{{ type }}" class="usa-button {{ modifier }}" aria-disabled="true">aria-disabled</button>
-    <button type="{{ type }}" class="usa-button {{ modifier }} usa-button--unstyled">Unstyled button</button>
+    <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}" disabled>Disabled</button>
+    <button type="{{ type }}" class="usa-button {{ modifier }}{{ margin }}" style="font-weight:{{fontWeight}}" aria-disabled="true">aria-disabled</button>
+    <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-button--unstyled" style="font-weight:{{fontWeight}}">Unstyled button</button>
   {% endif %}
 {% endif %}
 

--- a/packages/usa-button/src/usa-button.twig
+++ b/packages/usa-button/src/usa-button.twig
@@ -9,7 +9,7 @@
   <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-focus" style="font-weight:{{fontWeight}}">Focus</button>
   <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}" disabled>Disabled</button>
   <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}" aria-disabled="true">aria-disabled</button>
-  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} style="font-weight:{{fontWeight}}" usa-button--unstyled">Unstyled button</button>
+  <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }} usa-button--unstyled" style="font-weight:{{fontWeight}}">Unstyled button</button>
 {% else %}
   <button type="{{ type }}" class="usa-button {{ modifier }} {{ margin }}" style="font-weight:{{fontWeight}}">{{ text }}</button>
   {% if is_demo and 'usa-button--big' in modifier %}


### PR DESCRIPTION
 ### What change does this PR introduce?
This feature enables users to customize buttons to override things like margin and font-weight without CSS overrides to the class

 ### Why was this change needed?
closes https://github.com/uswds/uswds/issues/5307

### Other information

Happy hacking! 🎉

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.