### PR TITLE
USWDS-5316 - USWDS - Icons: Confirm if legacy attributes still required

### DIFF
--- a/packages/usa-collection/src/usa-collection--only-headers.twig
+++ b/packages/usa-collection/src/usa-collection--only-headers.twig
@@ -6,7 +6,7 @@
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
-          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
+          <svg class="usa-icon position-relative bottom-neg-2px" role="img">
             <use xlink:href="./img/sprite.svg#public"></use>
           </svg>
           Digital.gov
@@ -21,7 +21,7 @@
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
-          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
+          <svg class="usa-icon position-relative bottom-neg-2px" role="img">
             <use xlink:href="./img/sprite.svg#public"></use>
           </svg>
           U.S. Web Design System
@@ -43,7 +43,7 @@
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
-          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
+          <svg class="usa-icon position-relative bottom-neg-2px" role="img">
             <use xlink:href="./img/sprite.svg#public"></use>
           </svg>
           18F
@@ -58,7 +58,7 @@
       </h3>
       <ul class="usa-collection__meta" aria-label="More information">
         <li class="usa-collection__meta-item position-relative">
-          <svg class="usa-icon position-relative bottom-neg-2px" aria-hidden="true" role="img">
+          <svg class="usa-icon position-relative bottom-neg-2px" role="img">
             <use xlink:href="./img/sprite.svg#public"></use>
           </svg>
           Performance.gov

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -148,7 +148,7 @@
   <label class="usa-label" for="example-input-prefix">Input prefix</label>
   <div class="usa-input-group">
     <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <svg role="img" class="usa-icon">
         <use xlink:href="./img/sprite.svg#credit_card"></use>
       </svg>
     </div>

--- a/packages/usa-icon-list/src/usa-icon-list.twig
+++ b/packages/usa-icon-list/src/usa-icon-list.twig
@@ -8,7 +8,7 @@
   {% for item in items %}
   <li class="usa-icon-list__item">
     <div class="usa-icon-list__icon {% if item.icon.color %} text-{{ item.icon.color }}{% endif %}">
-      <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}" aria-hidden="true" role="img">
+      <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}" role="img">
         <use xlink:href="{{ img_path }}/sprite.svg#{{ item.icon.name }}"></use>
       </svg>
     </div>

--- a/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.twig
+++ b/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.twig
@@ -1,14 +1,14 @@
 <div>
   <p class="font-sans-2xl line-height-body-1 text-bold margin-y-0">
     An icon relative to font size
-    <svg class="usa-icon bottom-neg-05" aria-hidden="true" focusable="false" role="img">
+    <svg class="usa-icon bottom-neg-05" role="img">
       <use xlink:href="{{ img_path }}/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
 
   <p class="">
     An icon relative to font size
-    <svg class="usa-icon bottom-neg-2px" aria-hidden="true" focusable="false" role="img">
+    <svg class="usa-icon bottom-neg-2px" role="img">
       <use xlink:href="{{ img_path }}/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
@@ -26,7 +26,7 @@
         <tr>
           <th><code>.usa-icon--size-{{ item.units }}</code></th>
           <td>
-            <svg class="usa-icon usa-icon--size-{{ item.units }}" aria-hidden="true" focusable="false" role="img">
+            <svg class="usa-icon usa-icon--size-{{ item.units }}" role="img">
               <use xlink:href="{{ img_path }}/sprite.svg#accessibility_new"></use>
             </svg>
           </td>

--- a/packages/usa-icon/src/usa-icon.twig
+++ b/packages/usa-icon/src/usa-icon.twig
@@ -7,7 +7,7 @@
 {% for item in icons.items %}
   <div role="region" aria-atomic="true" class="font-sans-xl position-relative icon-example border-1px border-base-lighter hover:text-white hover:bg-primary-vivid hover:border-primary-darker " data-meta="{{ item.name }} {{ item.meta }}" aria-label="{{ item.name }} icon.">
     <button type="button" onclick="copyHTML(this)" class="bg-transparent cursor-pointer text-no-underline text-black display-flex width-card height-card flex-align-center flex-align-center border-0 flex-column flex-justify-center padding-2  hover:text-white" aria-label="Copy icon to clipboard" style="-webkit-user-select: text; -moz-user-select: text; -ms-user-select: text; user-select: text;">
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <svg class="usa-icon"  role="img">
         <use xlink:href="{{ icons.img_path }}/sprite.svg#{{ item.name }}"></use>
       </svg>
       <span class="font-sans-3xs margin-top-2 display-block" aria-hidden="true">{{ item.name }}</span>

--- a/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
+++ b/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
@@ -2,7 +2,7 @@
   <label class="usa-label" for="example-input-prefix">Credit card number</label>
   <div class="usa-input-group">
     <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <svg role="img" class="usa-icon">
         <use xlink:href="./img/sprite.svg#credit_card"></use>
       </svg>
     </div>
@@ -21,7 +21,7 @@
   <label class="usa-label" for="example-input-prefix-error">Credit card number (Error)</label>
   <div class="usa-input-group usa-input-group--error">
     <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <svg role="img" class="usa-icon">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="./img/sprite.svg#credit_card"></use>
       </svg>
     </div>

--- a/packages/usa-modal/src/test/template.html
+++ b/packages/usa-modal/src/test/template.html
@@ -44,7 +44,7 @@
       </div>
     </div>
     <button type="button" id="close-button" class="usa-button usa-modal__close" aria-label="close this window" data-close-modal>
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <svg class="usa-icon" role="img">
         <use xlink:href="{{ uswds.path }}/img/sprite.svg#close"></use>
       </svg>
       Close

--- a/packages/usa-modal/src/test/test-patterns/test-usa-modal--nested-forms.twig
+++ b/packages/usa-modal/src/test/test-patterns/test-usa-modal--nested-forms.twig
@@ -1,5 +1,5 @@
 {% set close_icon %}
-  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <svg class="usa-icon" role="img">
     <use xlink:href="./img/sprite.svg#{{ close_button.icon_type | default("close") }}"></use>
   </svg>
 {% endset %}

--- a/packages/usa-modal/src/usa-modal.twig
+++ b/packages/usa-modal/src/usa-modal.twig
@@ -1,5 +1,5 @@
 {% set close_icon %}
-  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <svg class="usa-icon" role="img">
     <use xlink:href="./img/sprite.svg#{{ close_button.icon_type | default("close") }}"></use>
   </svg>
 {% endset %}

--- a/packages/usa-pagination/src/includes/_pagination-arrow.twig
+++ b/packages/usa-pagination/src/includes/_pagination-arrow.twig
@@ -15,7 +15,7 @@
       aria-label="{{ link_attrs.aria_label }}"
     >
       {% if direction is same as('previous') %}
-        <svg class="usa-icon" aria-hidden="true" role="img">
+        <svg class="usa-icon" role="img">
           {# Global variable not applying #}
           <use xlink:href="./img/sprite.svg#navigate_before"></use>
         </svg>
@@ -24,7 +24,7 @@
         {{ pagination[direction]['label'] }}
       </span>
       {% if direction is same as('next') %}
-        <svg class="usa-icon" aria-hidden="true" role="img">
+        <svg class="usa-icon" role="img">
           {# Global variable not applying #}
           <use xlink:href="./img/sprite.svg#navigate_next"></use>
         </svg>


### PR DESCRIPTION
### What change does this PR introduce?
Removes aria-hidden and focusable="false" attributes from all svgs as there are no visible changes that these attributes introduce 

### Why was this change needed?
closes  https://github.com/uswds/uswds/issues/5316

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
