### PR TITLE
USWDS - Step Indicator: Fix accessibility issues

### DIFF
--- a/packages/usa-step-indicator/src/styles/_usa-step-indicator.scss
+++ b/packages/usa-step-indicator/src/styles/_usa-step-indicator.scss
@@ -17,8 +17,6 @@ $step-indicator-counter-size-sm: 3;
     2
   );
   background-color: color($step-indicator-background-color);
-  display: flex;
-  flex-direction: column-reverse;
   margin-bottom: units($step-indicator-margin-bottom);
   margin-left: math.div(units($theme-step-indicator-segment-gap), -2);
   margin-right: math.div(units($theme-step-indicator-segment-gap), -2);

--- a/packages/usa-step-indicator/src/styles/_usa-step-indicator.scss
+++ b/packages/usa-step-indicator/src/styles/_usa-step-indicator.scss
@@ -17,6 +17,8 @@ $step-indicator-counter-size-sm: 3;
     2
   );
   background-color: color($step-indicator-background-color);
+  display: flex;
+  flex-direction: column-reverse;
   margin-bottom: units($step-indicator-margin-bottom);
   margin-left: math.div(units($theme-step-indicator-segment-gap), -2);
   margin-right: math.div(units($theme-step-indicator-segment-gap), -2);

--- a/packages/usa-step-indicator/src/usa-step-indicator.twig
+++ b/packages/usa-step-indicator/src/usa-step-indicator.twig
@@ -1,16 +1,4 @@
 <div class="usa-step-indicator {{ modifier }}" aria-label="progress">
-  <ol class="usa-step-indicator__segments"{% if noLabels %} aria-hidden="true"{% endif %}>
-    {% for step in steps %}
-      <li class="usa-step-indicator__segment{% if step.status == "complete" %} usa-step-indicator__segment--complete{% endif %}{% if step.status == "current" %} usa-step-indicator__segment--current{% endif %}"{% if step.status == "current" and showLabels %} aria-current="true"{% endif %}>
-        {% if step.label %}
-          <span class="usa-step-indicator__segment-label">{{ step.label }}
-            {% if step.status == "complete" %}<span class="usa-sr-only">completed</span>{% endif %}
-            {% if step.status == "incomplete" %}<span class="usa-sr-only">not completed</span>{% endif %}
-          </span>
-        {% endif %}
-      </li>
-    {% endfor %}
-  </ol>
   <div class="usa-step-indicator__header">
     <h4 class="usa-step-indicator__heading">
       <span class="usa-step-indicator__heading-counter">
@@ -21,4 +9,17 @@
       <span class="usa-step-indicator__heading-text">Supporting documents</span>
     </h4>
   </div>
+
+  <ol class="usa-step-indicator__segments" role="list"{% if showLabels == false %} aria-hidden="true"{% endif %}>
+    {% for step in steps %}
+      <li class="usa-step-indicator__segment{% if step.status == "complete" %} usa-step-indicator__segment--complete{% endif %}{% if step.status == "current" %} usa-step-indicator__segment--current{% endif %}"{% if step.status == "current" and showLabels %} aria-current="true"{% endif %} role="listitem">
+        {% if step.label %}
+          <span class="usa-step-indicator__segment-label">{{ step.label }}
+            {% if step.status == "complete" %}<span class="usa-sr-only">completed</span>{% endif %}
+            {% if step.status == "incomplete" %}<span class="usa-sr-only">not completed</span>{% endif %}
+          </span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ol>
 </div>

--- a/packages/usa-step-indicator/src/usa-step-indicator.twig
+++ b/packages/usa-step-indicator/src/usa-step-indicator.twig
@@ -1,15 +1,4 @@
-<div class="usa-step-indicator {{ modifier }}" aria-label="progress">
-  <div class="usa-step-indicator__header">
-    <h4 class="usa-step-indicator__heading">
-      <span class="usa-step-indicator__heading-counter">
-        <span class="usa-sr-only">Step</span>
-        <span class="usa-step-indicator__current-step">{{ currentStep }}</span>
-        <span class="usa-step-indicator__total-steps">of {{ steps.length }}</span>
-      </span>
-      <span class="usa-step-indicator__heading-text">Supporting documents</span>
-    </h4>
-  </div>
-
+<div class="usa-step-indicator {{ modifier }}"{% if showLabels %} aria-labelledby="step-counter-progress-label"{% endif %}>
   <ol class="usa-step-indicator__segments" role="list"{% if showLabels == false %} aria-hidden="true"{% endif %}>
     {% for step in steps %}
       <li class="usa-step-indicator__segment{% if step.status == "complete" %} usa-step-indicator__segment--complete{% endif %}{% if step.status == "current" %} usa-step-indicator__segment--current{% endif %}"{% if step.status == "current" and showLabels %} aria-current="true"{% endif %} role="listitem">
@@ -22,4 +11,14 @@
       </li>
     {% endfor %}
   </ol>
+  <div class="usa-step-indicator__header">
+    <h4 class="usa-step-indicator__heading"{% if showLabels %} id="step-counter-progress-label"{% endif %}>
+      <span class="usa-step-indicator__heading-counter">
+        <span class="usa-sr-only">Step</span>
+        <span class="usa-step-indicator__current-step">{{ currentStep }}</span>
+        <span class="usa-step-indicator__total-steps">of {{ steps.length }}</span>
+      </span>
+      <span class="usa-step-indicator__heading-text">Supporting documents</span>
+    </h4>
+  </div>
 </div>


### PR DESCRIPTION
<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

**Improved screenreader read out.** Screen readers will now read the header area first before the state of the step indicator. Additionally fixes a bug in Safari/VoiceOver that doesn't announce list element. (#5294)


## Breaking change

~~:warning: This is a breaking change.~~

~~The structure of the markup was updated to put the header before the step indicators in the DOM so that screen readers read it first. CSS then reverts the visual of this to maintain the existing presentation for all variations.~~

Refactored to not be a breaking change. 

## Related issue

Closes #5294 

## Related pull requests

None.

## Problem statement

1. Screen readers read the progress of the step indicators before the title of the component in the header area which was identified as an issue in an accessibility audit in 2021.
2. Lists that use `list-style:none` do not get recognized as lists in Safari/VoiceOver.


## Solution

~~1. Reorder the markup so the title/header is read first and progress of the step indicator is next. Add styling that keeps current visual display order.~~
1. Added `aria-labelledby` to point to the progress header text
2. Added `role="list"` and `role="listitem"` to progress indicator list for better screen reader compatibility.

## Testing and review

1. Screen readers should now read the title of the component first before the step indicators.
2. Screen readers should identify the progress indicators as a list when focused on.


- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
