### PR TITLE
USWDS - Pagination: Fix ellipsis and background colors

### DIFF
--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -169,7 +169,6 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 .usa-pagination__overflow {
   align-items: center;
   align-self: stretch;
-  color: color("gray-50");
   display: inherit;
   user-select: none;
   padding: units($pagination-margin-padding);

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -169,10 +169,10 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 .usa-pagination__overflow {
   align-items: center;
   align-self: stretch;
+  color: color("gray-50");
   display: inherit;
   user-select: none;
   padding: units($pagination-margin-padding);
-  opacity: 0.5;
 }
 
 // ---------------------------------

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -29,7 +29,7 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 .usa-pagination {
   @include u-margin-y($pagination-margin-y);
   @include typeset($theme-pagination-font-family);
-  @include set-text-and-bg (
+  @include set-text-and-bg(
     $theme-pagination-background-color,
     $context: $pagination-context
   );

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -29,6 +29,10 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 .usa-pagination {
   @include u-margin-y($pagination-margin-y);
   @include typeset($theme-pagination-font-family);
+  @include set-text-and-bg (
+    $theme-pagination-background-color,
+    $context: $pagination-context
+  );
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
# Summary
Updated the ellipsis color to meet color contrast requirements. 

Updated styles to respect the value added to `$theme-pagination-background-color`. 

## Breaking change

This is a potentially breaking change. 
The Design System now respects the value for `$theme-pagination-background-color`. Users should confirm that pagination colors display as expected.

## Related issue

Closes #5188

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2160)

## Preview link

Preview link: [Pagination component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-pagination-ellipsis/?path=/story/components-pagination--default)

## Problem statement

The ellipsis elements on the pagination component use opacity to lighten the color. Additionally, the color contrast is 3.31:1, which does not meet color contrast requirements.

Additionally, the background of pagination component does not respect the color added to `$theme-pagination-background-color`.

## Solution

Update the color of the `usa-pagination__overflow` element to use a lighter gray color instead of opacity. 

Set the background and text colors of the pagination component. 

## Testing and review
- Confirm that changing the value of `$theme-pagination-background-color` changes the pagination background color
- Confirm that the new ellipsis color meets requirements against various background colors
- Confirm that the darker default ellipsis color works well in the component
- Confirm the changelog PR looks good