### PR TITLE
USWDS-5330 - USWDS - Feature: Use details element in USA Banner

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -7,24 +7,25 @@
     </svg>
   </span>
 {% endset %}
-
 <section class="usa-banner" aria-label="{{ banner.aria_label }}">
-  <div class="usa-accordion">
-    <header class="usa-banner__header">
-      <div class="usa-banner__inner">
-        <div class="grid-col-auto">
-          <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="">
+  <details open>
+    <summary>
+      <header class="usa-banner__header">
+        <div class="usa-banner__inner">
+          <div class="grid-col-auto">
+            <img aria-hidden="true" class="usa-banner__header-flag" src="./img/us_flag_small.png" alt="">
+          </div>
+          <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
+            <p class="usa-banner__header-action">{{ banner.action }}</p>
+            <p class="usa-banner__header-text">{{ banner.text }}</p>
+          </div>
+          <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="{{ banner.id }}">
+            <span class="usa-banner__button-text">{{ banner.action }}</span>
+          </button>
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
-          <p class="usa-banner__header-text">{{ banner.text }}</p>
-          <p class="usa-banner__header-action">{{ banner.action }}</p>
-        </div>
-        <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="{{ banner.id }}">
-          <span class="usa-banner__button-text">{{ banner.action }}</span>
-        </button>
-      </div>
-    </header>
-    <div class="usa-banner__content usa-accordion__content" id="{{ banner.id }}">
+      </header>
+    </summary>
+    <div class="usa-banner__content" id="{{ banner.id }}">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="./img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
@@ -41,5 +42,5 @@
         </div>
       </div>
     </div>
-  </div>
+  </details>
 </section>


### PR DESCRIPTION
### What change does this PR introduce?
Replaces the accordion  with <detail/>  in the banner component  
[Loom video ](https://www.loom.com/share/fc04e7cf98bd41c8977d5f9f4ec141ef?sid=7a5f95b1-d82c-4dc8-874a-16fe447ff16f)

### Why was this change needed?
closes  https://github.com/uswds/uswds/issues/5330

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
