### PR TITLE
USWDS - Input mask: Fix hover state

### DIFF
--- a/packages/usa-input-mask/src/styles/_usa-input-mask.scss
+++ b/packages/usa-input-mask/src/styles/_usa-input-mask.scss
@@ -24,7 +24,7 @@
 
   @media (forced-colors: active) {
     border: none;
-    color: color(GrayText);
+    color: color(ButtonText);
   }
 }
 

--- a/packages/usa-input-mask/src/styles/_usa-input-mask.scss
+++ b/packages/usa-input-mask/src/styles/_usa-input-mask.scss
@@ -18,6 +18,7 @@
     visibility: hidden;
 
     @media (forced-colors: active) {
+      color: color(ButtonText);
       font-style: normal;
       visibility: visible;
     }
@@ -25,7 +26,6 @@
 
   @media (forced-colors: active) {
     border: none;
-    color: color(ButtonText);
   }
 }
 

--- a/packages/usa-input-mask/src/styles/_usa-input-mask.scss
+++ b/packages/usa-input-mask/src/styles/_usa-input-mask.scss
@@ -18,6 +18,7 @@
     visibility: hidden;
 
     @media (forced-colors: active) {
+      font-style: normal;
       visibility: visible;
     }
   }

--- a/packages/usa-input-mask/src/styles/_usa-input-mask.scss
+++ b/packages/usa-input-mask/src/styles/_usa-input-mask.scss
@@ -16,6 +16,10 @@
 
   i {
     visibility: hidden;
+
+    @media (forced-colors: active) {
+      visibility: visible;
+    }
   }
 
   @media (forced-colors: active) {

--- a/packages/usa-input-mask/src/styles/_usa-input-mask.scss
+++ b/packages/usa-input-mask/src/styles/_usa-input-mask.scss
@@ -17,12 +17,16 @@
   i {
     visibility: hidden;
   }
+
+  @media (forced-colors: active) {
+    border: none;
+    color: color(GrayText);
+  }
 }
 
 .usa-masked,
 .usa-input-mask--content {
   @include border-box-sizing;
-  @include u-disabled;
   background-color: transparent;
   padding: units(1);
 }


### PR DESCRIPTION
# Summary

Fixed a bug that caused the hover state to show disabled styling. 

Improved legibility in forced colors mode.

## Breaking change
This is not a breaking change.

## Related issue

Closes #5376

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2183)

## Preview link

Preview link: [Input mask](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-input-mask-disabled/?path=/story/components-form-inputs-text-input-mask--ssn)

## Problem statement
1. The input mask component mistakenly receives disabled styles on hover.
2. The input mask is not legible in forced colors mode. The `usa-input-mask--content` element hides the input text. Example:

    ![image](https://github.com/uswds/uswds/assets/93996430/b7c3c329-b153-4efd-931e-5762be26fb1c)

## Solution
This solution fixes two separate items:
1. Removed the disabled styles on hover in default view mode. This issue originated in PR https://github.com/uswds/uswds/pull/5295 in [this commit](https://github.com/uswds/uswds/pull/5295/commits/d746e06e784cce26b65243b07a35dd57feb4cc7a#diff-a70e9936a0b46822ab4884ad6ec0842b5954c1e0b9c6f7c14239eedde66a890cR25). The `u-disabled` mixin appears to have been mistakenly added to the default component state. 
1. Made the component legible in forced colors mode. This was done by making the text inside `usa-input-mask--content` visible. 
    >
    > **Note**
    > The experience in forced colors mode works but is not perfect. The cursor is mostly hidden behind `usa-input-mask--content`.  Because this is a high priority issue, the style issue is small, and the path for fixing is not clear, I recommend that if we want to fix this we should address these styling tweaks in a follow-on issue. 

## Testing and review
In standard viewing mode: 
1.  Confirm the hover state does not show disabled styles
1. Confirm that `disabled` and `aria-disabled` states look as expected

In forced colors mode:
1. Confirm the component visually shows the text added to the input
1.  Confirm the hover state does not show disabled styles
1. Confirm that `disabled` and `aria-disabled` states look as expected