### PR TITLE
USWDS - Utilities: Generate font-[family]-[size] classes

### DIFF
--- a/packages/uswds-utilities/src/styles/utility-fonts.scss
+++ b/packages/uswds-utilities/src/styles/utility-fonts.scss
@@ -23,7 +23,7 @@ $if-important: "";
         "default" or
         list.index($output-these-utilities, "font")
     ) and
-    map.get($font-settings, "output") ==
+    map.get($font-settings-complete, "output") ==
     true
 ) {
   @each $face, $stack in $project-font-stacks {


### PR DESCRIPTION
<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

Fixed a bug that caused `font-[family]-[size]` utility classes to not generate font-family rules. 


## Breaking change

This is not a breaking change.

## Related issue

Closes #5385

## Related PR
[Changelog PR](https://github.com/uswds/uswds-site/pull/2208)

## Problem statement

1. Using `.font-[family]-[size]` utility class should set both the normalized size and family of the font.
2. Currently, using `.font-[family]-[size]` utility class _only_ sets the normalized size and _not_ the family of the font.
3. To correctly style text in the current state, a workaround would be to set both `.font-[family]` and `.font-[family]-[size]` instead of the single, latter class. 


## Solution

As part of the 3.5.0 release, utility settings were updates to include `[setting]-complete` lists that merged the original, "non-complete" with it. However, the font utility that generates the `font-[family]-[size]` classes was looking at the original, "non-complete" list and not the updated merged list. This PR updates the `$font-settings` to `$font-settings-complete` to correctly generate the classes.


## Testing and review

1. Validate `.font-[family]-[size]` alone correctly sizes and uses the right font. 


Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [X] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.

