### PR TITLE
USWDS - Forms: Remove high-contrast disabled border from %block-input-styles

### DIFF
--- a/packages/usa-input/src/styles/_usa-input.scss
+++ b/packages/usa-input/src/styles/_usa-input.scss
@@ -7,9 +7,12 @@
   &:disabled,
   &[aria-disabled="true"] {
     @include u-disabled;
-    @include u-disabled-high-contrast-border;
     // Fix for Safari
     -webkit-text-fill-color: color($theme-color-text-on-disabled);
+
+    @media (forced-colors: active) {
+      @include u-disabled-high-contrast-border;
+    }
   }
 }
 

--- a/packages/usa-input/src/styles/_usa-input.scss
+++ b/packages/usa-input/src/styles/_usa-input.scss
@@ -7,12 +7,9 @@
   &:disabled,
   &[aria-disabled="true"] {
     @include u-disabled;
+    @include u-disabled-high-contrast-border;
     // Fix for Safari
     -webkit-text-fill-color: color($theme-color-text-on-disabled);
-
-    @media (forced-colors: active) {
-      @include u-disabled-high-contrast-border;
-    }
   }
 }
 

--- a/packages/uswds-core/src/styles/placeholders/_forms.scss
+++ b/packages/uswds-core/src/styles/placeholders/_forms.scss
@@ -17,7 +17,6 @@ $input-select-margin-right: 1.5;
 
 %block-input-styles {
   @include u-border(1px, "base-dark");
-  @include u-disabled-high-contrast-border;
   appearance: none;
   border-radius: 0;
   color: color("ink"); // standardize on firefox


### PR DESCRIPTION
# Summary

Removed high-contrast disabled border from block-input-styles placeholder. Now the disabled border color only shows when the element is correctly disabled.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5396

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2204)

## Preview link

Preview link:
- [Text input →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-fix-hc-input-borders/iframe.html?args=&id=components-form-inputs-text-input--input)
- [Combobox →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-fix-hc-input-borders/iframe.html?args=&id=components-form-inputs-combo-box--default)
- [Input mask →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-fix-hc-input-borders/iframe.html?args=&id=components-form-inputs-text-input-mask--ssn)

## Problem statement

Text input form elements in high contrast mode display the disabled border by default.

## Solution

Removed the disabled high contrast border mixin from the `%block-input-styles` placeholder. This prevents the disabled border by default for text input elements.

## Testing and review

1. Visit any text input form element
2. Turn on forced-colors mode via the render tab within devTools (or whatever your preferred method is)
3. Confirm the input border matches text color
4. Activate the elements disabled state
5. Confirm that the element's border color changes to the disabled color.

### Testing checklist

- [ ] Confirm text input elements do not have disabled border by default
- [ ] Confirm that disabled border is correctly applied to disabled input elements


<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
