### PR TITLE
USWDS - header: Fix Safari scrollbar bug

### DIFF
--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -78,6 +78,12 @@ const toggleNonNavItems = (active) => {
   }
 };
 
+function disableTouchScroll(e){
+  e.preventDefault();
+  e.stopPropagation();
+  return false;
+}
+
 /**
  * Lock the current window position when the mobile menu is open.
  *
@@ -92,6 +98,8 @@ const toggleScrollLock = (body) => {
 
   if (isMenuActive) {
     window.onscroll = () => window.scroll(xPos, yPos);
+    document.querySelector('body').addEventListener('touchmove', disableTouchScroll, {passive: false});
+
     document.body.style.overflow = "auto";
   } else {
     window.onscroll = "";

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -78,11 +78,41 @@ const toggleNonNavItems = (active) => {
   }
 };
 
+/**
+ * Lock the window position when the mobile menu is activated.
+ * This prevents a Safari-only bug by preserving the vertical scrollbar
+ * and instead locking scroll by forcing current window position.
+ * More detail in https://github.com/uswds/uswds/issues/5371
+ */
+const toggleScrollLock = (body) => {
+  const xPos = window.scrollX;
+  const yPos = window.scrollY;
+  const isMenuOpen = body.classList.contains(ACTIVE_CLASS);
+
+  if (isMenuOpen) {
+    // If menu is open, lock the window in its current position
+    window.onscroll = () => window.scroll(xPos, yPos);
+    // Preserve the vertical scrollbar with CSS to maintain original window width
+    document.body.style.overflow = "auto";
+  } else {
+    // If menu is closed, allow scrolling
+    window.onscroll = "";
+  }
+};
+
 const toggleNav = (active) => {
   const { body } = document;
   const safeActive = typeof active === "boolean" ? active : !isActive();
+  const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
+  const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
 
   body.classList.toggle(ACTIVE_CLASS, safeActive);
+
+  // Lock the window position when the mobile menu is activated in Safari.
+  // Because Chrome reports as both Chrome and Safari, this statement must explicitly exclude Chrome
+  if (isSafari && isNotChrome) {
+    toggleScrollLock(body);
+  }
 
   select(TOGGLES).forEach((el) =>
     el.classList.toggle(VISIBLE_CLASS, safeActive)

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -78,32 +78,36 @@ const toggleNonNavItems = (active) => {
   }
 };
 
+/**
+ * Disable scroll on touch devices
+ */
 const disableTouchScroll = (e) => {
   e.preventDefault();
   e.stopPropagation();
   return false;
-}
+};
 
 /**
  * Lock the current window position when the mobile menu is open.
  *
  * This is a Safari-only bug fix that preserves the current window width
- * by showing the vertical scrollbar but preventing scroll.
+ * by showing the vertical scrollbar but preventing scroll by locking current position.
  * More detail in https://github.com/uswds/uswds/issues/5371
  */
 const toggleScrollLock = (body) => {
-  const xPos = window.scrollX;
-  const yPos = window.scrollY;
+  const xCurrentPos = window.scrollX;
+  const yCurrentPos = window.scrollY;
   const isMenuActive = body.classList.contains(ACTIVE_CLASS);
 
   if (isMenuActive) {
-    window.onscroll = () => window.scroll(xPos, yPos);
-    body.addEventListener('touchmove', disableTouchScroll, {passive: false});
-
     document.body.style.overflow = "auto";
+    window.onscroll = () => window.scroll(xCurrentPos, yCurrentPos);
+    body.addEventListener("touchmove", disableTouchScroll, { passive: false });
   } else {
     window.onscroll = "";
-    body.removeEventListener('touchmove', disableTouchScroll, {passive: false});
+    body.removeEventListener("touchmove", disableTouchScroll, {
+      passive: false,
+    });
   }
 };
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -78,7 +78,7 @@ const toggleNonNavItems = (active) => {
   }
 };
 
-function disableTouchScroll(e){
+const disableTouchScroll = (e) => {
   e.preventDefault();
   e.stopPropagation();
   return false;
@@ -98,11 +98,12 @@ const toggleScrollLock = (body) => {
 
   if (isMenuActive) {
     window.onscroll = () => window.scroll(xPos, yPos);
-    document.querySelector('body').addEventListener('touchmove', disableTouchScroll, {passive: false});
+    body.addEventListener('touchmove', disableTouchScroll, {passive: false});
 
     document.body.style.overflow = "auto";
   } else {
     window.onscroll = "";
+    body.removeEventListener('touchmove', disableTouchScroll, {passive: false});
   }
 };
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -79,23 +79,21 @@ const toggleNonNavItems = (active) => {
 };
 
 /**
- * Lock the window position when the mobile menu is activated.
- * This prevents a Safari-only bug by preserving the vertical scrollbar
- * and instead locking scroll by forcing current window position.
+ * Lock the current window position when the mobile menu is open.
+ *
+ * This is a Safari-only bug fix that preserves the current window width
+ * by showing the vertical scrollbar but preventing scroll.
  * More detail in https://github.com/uswds/uswds/issues/5371
  */
 const toggleScrollLock = (body) => {
   const xPos = window.scrollX;
   const yPos = window.scrollY;
-  const isMenuOpen = body.classList.contains(ACTIVE_CLASS);
+  const isMenuActive = body.classList.contains(ACTIVE_CLASS);
 
-  if (isMenuOpen) {
-    // If menu is open, lock the window in its current position
+  if (isMenuActive) {
     window.onscroll = () => window.scroll(xPos, yPos);
-    // Preserve the vertical scrollbar with CSS to maintain original window width
     document.body.style.overflow = "auto";
   } else {
-    // If menu is closed, allow scrolling
     window.onscroll = "";
   }
 };


### PR DESCRIPTION
# Summary

Fixed a Safari-only bug that caused the mobile menu to unexpectedly close at a narrow range of screen widths. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5371

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2222)

## Preview link

[Documentation template](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-header-safari-scrollbar/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story)

## Problem statement

In Safari, the mobile header panel will unexpectedly close when opened in a narrow range of window widths. This issue happens when the mobile menu is opened in windows widths that are approximately 14px less than the `$theme-header-max-width` breakpoint. With the default `"desktop"` value of ` 1024px, this issue happens at window widths of 1009px - 1023px.

The issue is demonstrated in this GIF when testing the right below the `"desktop"` window range: 

![safari-bug (2)](https://github.com/uswds/uswds/assets/107004823/6d1db477-5977-4a15-8c8f-0fc89c9c37c5)

### Known Safari bug
This issue happens in Safari because it does not include the width of the vertical scrollbar when it calculates the width of the viewport. (See this [open webkit bug report](https://bugs.webkit.org/show_bug.cgi?id=52653)). This means that in Safari, the registered viewport width will change depending on the presence or absence of a vertical scrollbar. 

In USWDS, opening the mobile menu removes the vertical scrollbar on `<body>` because its overflow is set to hidden. When this scrollbar disappears, Safari updates the value of the viewport size to be approximately 15px (the width of the scrollbar) wider than the original value. If this new viewport width registers as a "desktop" width, the CSS will show the desktop view of the header. 

For example, if you trigger the mobile menu at an original viewport width of 1020px, Safari will reset value of the viewport width to ~1035px once the menu is opened. Because this new width is greater than the default `$theme-header-max-width` value of 1024px, the CSS turns on desktop menu display.

## Solution
To resolve this, this PR keeps the the body's vertical scrollbar in Safari when the mobile menu is opened and instead locks scrolling with JavaScript.

:warning: Keeping the vertical scrollbar when the user cannot scroll does not create an ideal user experience. For this reason, this changed is applied only to Safari. Ideally I'd like to limit this to just the ~15px problem area, but I could not figure out how to reliably get the value of the Sass theme setting outside of setting a style in CSS and then grabbing it. 

## Testing and review
To confirm the error:
1. In Safari, open the [documentation template page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in a viewport that is 1020px wide. (Note that the issue will not appear on the [header component page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/iframe.html?args=&id=components-header--default&viewMode=story) because there is not enough content to create a vertical scrollbar)
2. Open the mobile menu by clicking the "Menu" button
3. Confirm that the menu closes unexpectedly

To test the solution in desktop environments:
1. In Safari, open the [new documentation template page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-header-safari-scrollbar/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in a viewport that is 1020px wide. 
1. Open the mobile menu by clicking the "Menu" button
1. Confirm that the menu behaves as expected:
    1. The menu stays open
    2. The body content is locked (with both keyboard and mouse interactions)
    3. The menu is scrollable
 
To test the solution in touch environments:
1. In iOS Safari, open the [new documentation template page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-header-safari-scrollbar/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story)
1. Open the mobile menu by clicking the "Menu" button
1. Confirm that the menu behaves as expected:
    1. The menu stays open
    2. The body content is locked

Review:     
1. Confirm the code meets standards
1. Confirm the changelog looks good