### PR TITLE
USWDS - Nav: Fix padding in nav submenus

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -384,6 +384,7 @@ $expand-less-icon: map-merge(
 
   @include at-media($theme-header-min-width) {
     @include add-list-reset;
+    @include u-padding-y(1);
     background-color: color("primary-darker");
     width: units("card-lg");
     position: absolute;
@@ -397,10 +398,10 @@ $expand-less-icon: map-merge(
   .usa-nav__submenu-item {
     @include at-media($theme-header-min-width) {
       a {
+        @include u-padding-x(2);
         color: color("white");
         line-height: line-height($theme-navigation-font-family, 3);
         display: block;
-        padding: units(1);
 
         &:focus {
           outline-offset: units("neg-05");


### PR DESCRIPTION
Fixes #5417.

# Summary

_Provide a one or two sentence summary of the update that can be used in the changelog._
<!--
A successful summary is written in the past tense and includes:
**Make padding in nav submenus consistent with the nav menu buttons.** USWDS 3 reduced the padding in nav submenus. Restore the USWDS 2 appearance.
See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
-->

## Breaking change

I'm not sure if this is considered a breaking change. Probably not.

## Related issue

Closes #5417.

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

USWDS 2 had some padding in nav submenus so that the submenu items were visually aligned with the nav menu button itself (see https://github.com/uswds/uswds/blob/v2.13.3/src/stylesheets/components/_navigation.scss#L374). This padding was removed in USWDS 3, and the nav submenus look off.

## Solution

This PR adds a smidge of padding to restore the USWDS 2 appearance of nav submenus.

## Testing and review

I tested this visually in my own site (https://gcn.nasa.gov).

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
