### PR TITLE
USWDS: Header: Add fix for Safari-only header bug

### DIFF
--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -81,9 +81,11 @@ const toggleNonNavItems = (active) => {
 const toggleNav = (active) => {
   const { body } = document;
   const safeActive = typeof active === "boolean" ? active : !isActive();
+
+  // Detect Safari and add a body class for a Safari-only CSS bug fix.
+  // More details in https://github.com/uswds/uswds/pull/5443
   const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
   const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
-
   if (isSafari && isNotChrome) {
     body.classList.add("is-safari");
   }

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -89,13 +89,10 @@ const setSafariScrollPosition = (body) => {
   const isNotChrome = !navigator.userAgent.includes("Chrome");
   const currentScrollPosition = `-${window.scrollY}px`;
   if (isSafari && isNotChrome) {
-    body.style.setProperty(
-      "--scrolltop",
-      currentScrollPosition
-    );
+    body.style.setProperty("--scrolltop", currentScrollPosition);
     body.classList.add("is-safari");
   }
-}
+};
 
 const toggleNav = (active) => {
   const { body } = document;

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -89,7 +89,10 @@ const toggleNav = (active) => {
   const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
   const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
   if (isSafari && isNotChrome) {
-    body.style.setProperty('--scrolltop', `${-(document.documentElement.scrollTop)}px`);
+    body.style.setProperty(
+      "--scrolltop",
+      `${-document.documentElement.scrollTop}px`
+    );
     body.classList.add("is-safari");
   }
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -35,8 +35,10 @@ let nonNavElements;
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
 // Detect Safari
-// Note: Chrome also reports the Safari userAgent so this check specifically excludes Chrome.
-const isSafari = navigator.userAgent.includes("Safari") && !navigator.userAgent.includes("Chrome");
+// Note: Chrome also reports the Safari userAgent so this specifically excludes Chrome.
+const isSafari =
+  navigator.userAgent.includes("Safari") &&
+  !navigator.userAgent.includes("Chrome");
 const SCROLLBAR_WIDTH = ScrollBarWidth();
 const INITIAL_PADDING = window
   .getComputedStyle(document.body)

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -34,6 +34,9 @@ let navActive;
 let nonNavElements;
 
 const isActive = () => document.body.classList.contains(ACTIVE_CLASS);
+// Detect Safari
+// Note: Chrome also reports the Safari userAgent so this check specifically excludes Chrome.
+const isSafari = navigator.userAgent.includes("Safari") && !navigator.userAgent.includes("Chrome");
 const SCROLLBAR_WIDTH = ScrollBarWidth();
 const INITIAL_PADDING = window
   .getComputedStyle(document.body)
@@ -79,18 +82,25 @@ const toggleNonNavItems = (active) => {
 };
 
 /**
- * Detect Safari and add body class and top position for a Safari-only CSS bug fix.
- * Note: Both Safari and Chrome report the Safari userAgent,
- * so this script specifically checks for "not Chrome".
+ * Detect Safari and add body class for a Safari-only CSS bug fix.
+ * More details in https://github.com/uswds/uswds/pull/5443
+ */
+const addSafariClass = () => {
+  if (isSafari) {
+    document.body.classList.add("is-safari");
+  }
+};
+
+/**
+ * Set the value for the --scrolltop CSS var when the mobile menu is open.
+ * This allows the CSS to lock the current scroll position in Safari
+ * when overflow-y is set to scroll.
  * More details in https://github.com/uswds/uswds/pull/5443
  */
 const setSafariScrollPosition = (body) => {
-  const isSafari = navigator.userAgent.includes("Safari");
-  const isNotChrome = !navigator.userAgent.includes("Chrome");
   const currentScrollPosition = `-${window.scrollY}px`;
-  if (isSafari && isNotChrome) {
+  if (isSafari) {
     body.style.setProperty("--scrolltop", currentScrollPosition);
-    body.classList.add("is-safari");
   }
 };
 
@@ -239,6 +249,7 @@ navigation = behavior(
         });
       }
 
+      addSafariClass();
       resize();
       window.addEventListener("resize", resize, false);
     },

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -81,6 +81,12 @@ const toggleNonNavItems = (active) => {
 const toggleNav = (active) => {
   const { body } = document;
   const safeActive = typeof active === "boolean" ? active : !isActive();
+  const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
+  const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
+
+  if (isSafari && isNotChrome) {
+    body.classList.add("is-safari");
+  }
 
   body.classList.toggle(ACTIVE_CLASS, safeActive);
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -82,13 +82,14 @@ const toggleNav = (active) => {
   const { body } = document;
   const safeActive = typeof active === "boolean" ? active : !isActive();
 
-  // Detect Safari and add a body class for a Safari-only CSS bug fix.
+  // Detect Safari and add body class and top position for a Safari-only CSS bug fix.
   // Note: Both Safari and Chrome report the Safari userAgent, so
   // this script specifically checks for "not Chrome".
   // More details in https://github.com/uswds/uswds/pull/5443
   const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
   const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
   if (isSafari && isNotChrome) {
+    body.style.setProperty('--scrolltop', `${-(document.documentElement.scrollTop)}px`);
     body.classList.add("is-safari");
   }
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -78,23 +78,30 @@ const toggleNonNavItems = (active) => {
   }
 };
 
+/**
+ * Detect Safari and add body class and top position for a Safari-only CSS bug fix.
+ * Note: Both Safari and Chrome report the Safari userAgent,
+ * so this script specifically checks for "not Chrome".
+ * More details in https://github.com/uswds/uswds/pull/5443
+ */
+const setSafariScrollPosition = (body) => {
+  const isSafari = navigator.userAgent.includes("Safari");
+  const isNotChrome = !navigator.userAgent.includes("Chrome");
+  const currentScrollPosition = `-${window.scrollY}px`;
+  if (isSafari && isNotChrome) {
+    body.style.setProperty(
+      "--scrolltop",
+      currentScrollPosition
+    );
+    body.classList.add("is-safari");
+  }
+}
+
 const toggleNav = (active) => {
   const { body } = document;
   const safeActive = typeof active === "boolean" ? active : !isActive();
 
-  // Detect Safari and add body class and top position for a Safari-only CSS bug fix.
-  // Note: Both Safari and Chrome report the Safari userAgent, so
-  // this script specifically checks for "not Chrome".
-  // More details in https://github.com/uswds/uswds/pull/5443
-  const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
-  const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;
-  if (isSafari && isNotChrome) {
-    body.style.setProperty(
-      "--scrolltop",
-      `${-document.documentElement.scrollTop}px`
-    );
-    body.classList.add("is-safari");
-  }
+  setSafariScrollPosition(body);
 
   body.classList.toggle(ACTIVE_CLASS, safeActive);
 

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -83,6 +83,8 @@ const toggleNav = (active) => {
   const safeActive = typeof active === "boolean" ? active : !isActive();
 
   // Detect Safari and add a body class for a Safari-only CSS bug fix.
+  // Note: Both Safari and Chrome report the Safari userAgent, so
+  // this script specifically checks for "not Chrome".
   // More details in https://github.com/uswds/uswds/pull/5443
   const isSafari = navigator.userAgent.indexOf("Safari") !== -1;
   const isNotChrome = navigator.userAgent.indexOf("Chrome") === -1;

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -482,8 +482,10 @@ $safari-header-bug-min-width: calc(
   units($theme-header-max-width) - px-to-rem(15px)
 );
 
-.usa-js-mobile-nav--active.is-safari {
-  overflow-y: scroll;
-  position: fixed;
-  top: var(--scrolltop, 0);
+@media (min-width: $safari-header-bug-min-width) {
+  .usa-js-mobile-nav--active.is-safari {
+    overflow-y: scroll;
+    position: fixed;
+    top: var(--scrolltop, 0);
+  }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -476,15 +476,12 @@ $expand-less-icon: map-merge(
 
 // Safari-only fix that forces a vertical scrollbar when mobile header is opened.
 // Applies only to the 16px before the width declared in $theme-header-max-width.
-// This fix preserves the scrollbar to prevent the menu from unexpectedly closing
-// due to the mismatch of how Safari calculates window width when scroll bars are present.
-@supports (background: -webkit-named-image(i)) {
-  // 1rem is the approximate value of the Safari scrollbar
-  $safari-header-bug-min-width: calc(units($theme-header-max-width) - 1rem);
+// More details in https://github.com/uswds/uswds/pull/5443
+// Note: 1rem is the approximate width of the Safari scrollbar
+$safari-header-bug-min-width: calc(units($theme-header-max-width) - 1rem);
 
-  @media (min-width: $safari-header-bug-min-width) {
-    .usa-js-mobile-nav--active {
-      overflow: scroll;
-    }
+@media (min-width: $safari-header-bug-min-width) {
+  .usa-js-mobile-nav--active.is-safari {
+    overflow: scroll;
   }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -484,7 +484,8 @@ $safari-header-bug-min-width: calc(
 
 @media (min-width: $safari-header-bug-min-width) {
   .usa-js-mobile-nav--active.is-safari {
-    overflow: scroll;
+    overflow-y: scroll;
     position: fixed;
+    top: var(--scrolltop, 0);
   }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -474,8 +474,9 @@ $expand-less-icon: map-merge(
   overflow: hidden;
 }
 
-// Safari-only fix that forces a vertical scrollbar when mobile header is opened.
-// Fix is only needed in the 15px immediately preceding $theme-header-max-width.
+// Safari-only fix that forces a vertical scrollbar when mobile menu is open.
+// Only needed in the 15px immediately preceding $theme-header-max-width.
+//
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
 $safari-header-bug-min-width: calc(

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -482,10 +482,8 @@ $safari-header-bug-min-width: calc(
   units($theme-header-max-width) - px-to-rem(15px)
 );
 
-@media (min-width: $safari-header-bug-min-width) {
-  .usa-js-mobile-nav--active.is-safari {
-    overflow-y: scroll;
-    position: fixed;
-    top: var(--scrolltop, 0);
-  }
+.usa-js-mobile-nav--active.is-safari {
+  overflow-y: scroll;
+  position: fixed;
+  top: var(--scrolltop, 0);
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -473,3 +473,18 @@ $expand-less-icon: map-merge(
 .usa-js-mobile-nav--active {
   overflow: hidden;
 }
+
+// Safari-only fix that forces a vertical scrollbar when mobile header is opened.
+// Applies only to the 16px before the width declared in $theme-header-max-width.
+// This fix preserves the scrollbar to prevent the menu from unexpectedly closing
+// due to the mismatch of how Safari calculates window width when scroll bars are present.
+@supports (background: -webkit-named-image(i)) {
+  // 1rem is the approximate value of the Safari scrollbar
+  $safari-header-bug-min-width: calc(units($theme-header-max-width) - 1rem);
+
+  @media (min-width: $safari-header-bug-min-width) {
+    .usa-js-mobile-nav--active {
+      overflow: scroll;
+    }
+  }
+}

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -485,5 +485,6 @@ $safari-header-bug-min-width: calc(
 @media (min-width: $safari-header-bug-min-width) {
   .usa-js-mobile-nav--active.is-safari {
     overflow: scroll;
+    position: fixed;
   }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -475,10 +475,12 @@ $expand-less-icon: map-merge(
 }
 
 // Safari-only fix that forces a vertical scrollbar when mobile header is opened.
-// Applies only to the 16px before the width declared in $theme-header-max-width.
+// Fix is only needed in the 15px immediately preceding $theme-header-max-width.
+// Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-// Note: 1rem is the approximate width of the Safari scrollbar
-$safari-header-bug-min-width: calc(units($theme-header-max-width) - 1rem);
+$safari-header-bug-min-width: calc(
+  units($theme-header-max-width) - px-to-rem(15px)
+);
 
 @media (min-width: $safari-header-bug-min-width) {
   .usa-js-mobile-nav--active.is-safari {

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -486,6 +486,7 @@ $safari-header-bug-min-width: calc(
   .usa-js-mobile-nav--active.is-safari {
     overflow-y: scroll;
     position: fixed;
+    // --scrolltop set with JS with zero as fallback.
     top: var(--scrolltop, 0);
   }
 }


### PR DESCRIPTION
# Summary

Fixed a Safari-only bug that caused the mobile menu to unexpectedly close at a narrow range of window widths.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5371 

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2251)

## Preview link

Preview link: [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-header-bug/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story)

## Problem statement

In Safari, the mobile header panel will unexpectedly close when opened in a narrow range of window widths. This issue happens when the mobile menu is opened in windows widths within the 15px preceding the `$theme-header-max-width` breakpoint. With the default `"desktop"` value of ` 1024px, this issue happens at window widths of 1009px - 1023px.

The issue is demonstrated in this GIF when testing the range right before the `"desktop"` breakpoint: 

![safari-bug (2)](https://github.com/uswds/uswds/assets/107004823/6d1db477-5977-4a15-8c8f-0fc89c9c37c5)

### Known Safari bug
This issue happens in Safari because it does not include the width of the vertical scrollbar when it calculates the width of the viewport. (See this [open webkit bug report](https://bugs.webkit.org/show_bug.cgi?id=52653)). This means that in Safari, the registered viewport width will change depending on the presence or absence of a vertical scrollbar. 

In USWDS, opening the mobile menu removes the vertical scrollbar on `<body>` because its overflow is set to hidden. When this scrollbar disappears, Safari updates the value of the viewport size to be 15px (the width of the scrollbar) wider than the original value. If this new viewport width registers as a "desktop" width, the CSS will show the desktop view of the header. 

For example, if you trigger the mobile menu at an original viewport width of 1020px, Safari will reset value of the viewport width to 1035px once the menu is opened. Because this new width is greater than the default `$theme-header-max-width` value of 1024px, the CSS turns on desktop menu display.

## Solution
To resolve this, this PR forces Safari to keep the the body's vertical scrollbar when the mobile menu is open. This fix is applied _only_ to Safari and _only_ to the affected 15px of screen width (by default, 1009-1024px). 

Forcing the scrollbar at these window widths prevents Safari from changing its width definition when the mobile menu is open, which removes confusion about which version of the header navigation to show. 

> **Warning**
> The main body content will be scrollable in this 15px range window range when the mobile menu is open. Allowing the main content to scroll is not the ideal user experience, but was determined to be the lowest risk option. We also considered a JS-only solution in https://github.com/uswds/uswds/pull/5410 but did not pursue that path because it had a higher risk of unintended consequences. 

>**Note**
> This script checks specifically for "not Chrome" because the Chrome browser reports having both Chrome and Safari userAgent. More details in this [MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name_and_version).

## Testing and review

Review:     
- Consider if allowing vertical scroll for these 15px is a reasonable cost for this solution
- Confirm that this change _only_ affects Safari and _only_ at the affected screen widths (by default, 1009px-1024px)
- Confirm that the `is-safari` class is added to Safari only
- Confirm the code meets standards
- Confirm the changelog looks good

Use Storybook to test that the mobile menu opens in Safari:
1. Open the [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-header-bug/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in Safari
1. Resize the window to somewhere between 1009px-1024px
1. Click the "Menu" button to open the mobile navigation panel
1. Confirm that the mobile header successfully opens as expected

Use Storybook to test that this does not affect other browsers:
1. Open the [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-header-bug/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in other browsers
1. Resize the window to somewhere between 1009px-1024px
1. Click the "Menu" button to open the mobile navigation panel
1. Confirm that the main page content is not scrollable