### PR TITLE
USWDS - Button: Remove aria_disabled control

### DIFF
--- a/packages/usa-button/src/content/usa-button.json
+++ b/packages/usa-button/src/content/usa-button.json
@@ -2,6 +2,5 @@
   "modifier": "",
   "text": "Default",
   "is_demo": true,
-  "aria_disabled": false,
   "type": "button"
 }


### PR DESCRIPTION
# Summary

Removed the outdated `aria_disabled` data item from the button story. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5395

## Related pull requests

No changelog needed since this is an internal-facing change. 

## Preview link

[Button component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-remove-aria-disabled-control/?path=/story/components-button--default)

## Problem statement
The button story templates were refactored in https://github.com/uswds/uswds/pull/5063 to remove the conditional check for `aria_disabled`. However, the `usa-button.json` file still has the outdated `aria_disabled` data item. 

## Solution

Removed the outdated `aria_disabled` data item from the button story. 

All other `aria_disabled` data references for button were removed in https://github.com/uswds/uswds/pull/5063. It appears as though this one was accidentally left out.

## Testing and review
- Confirm that there is no need for the `aria-disabled` data item
- Confirm that the `aria_disabled` data item (and Storybook control) were removed