### PR TITLE
USWDS - Tooltip: Add opacity:0 to initial state

### DIFF
--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -26,7 +26,7 @@ $triangle-size: 5px;
   color: color($theme-tooltip-font-color);
   display: none;
   font-size: size("ui", $theme-tooltip-font-size);
-  opacity: 0;
+  opacity: 0; // Required for recalculating position.
   padding: units(1);
   pointer-events: none;
   width: auto;

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -26,6 +26,7 @@ $triangle-size: 5px;
   color: color($theme-tooltip-font-color);
   display: none;
   font-size: size("ui", $theme-tooltip-font-size);
+  opacity: 0;
   padding: units(1);
   pointer-events: none;
   width: auto;


### PR DESCRIPTION
# Summary

**Restored the `opacity: 0` style rule to the tooltip body's initial state.** This prevents the component from flickering if its position needs to be recalculated. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #4458

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2265)

## Preview link

[Tooltip component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-tooltip-opacity-0/?path=/story/components-tooltip--tooltip)

## Problem statement
To prevent flickering in the tooltip component, the tooltip is programmed to receive an opacity shift slightly after the tooltip positioning is set. [This comment](https://github.com/uswds/uswds/blob/develop/packages/usa-tooltip/src/index.js#L36-L37) explains that the initial state should be set to `opacity: 0` so that any position changes will occur when the component is visibly hidden. 

However, the tooltip does not receive an initial style of 0 opacity, which can result in flickering.

It looks like this CSS declaration used to exist, but was possibly removed by mistake when refactoring how the tooltip positioning works (see the code changes in [this PR](https://github.com/uswds/uswds/pull/4062/files#diff-db6545d240cf59c3fa7f1d5249e4c31f85afba05625594e10a762044b98c54fbL31)).

## Solution

Reinstating the initial `opacity: 0` style rule should allow the `is-visible` class to perform as expected and prevent flickering in the tooltip. 

## Testing and review
- Open the tooltip component and confirm that the tooltip toggles visibility as expected.
- Confirm that toggling the `is-visible` class in web inspector shows and hides the component as expected.
