### PR TITLE
USWDS - Table: Allow stacked table to be readable with VoiceOver + Safari combo

### DIFF
--- a/packages/uswds-core/src/styles/mixins/general/table.scss
+++ b/packages/uswds-core/src/styles/mixins/general/table.scss
@@ -148,7 +148,6 @@ $table-unsorted-icon-color: get-color-token-from-bg(
   tr {
     border-bottom: units(0.5) solid color($theme-table-border-color);
     border-top-width: 0;
-    display: block;
     width: 100%;
     th:first-child,
     td:first-child {


### PR DESCRIPTION
# Summary

Fixed a bug that prevented VoiceOver from reading stacked table content while using Safari.

## Breaking change

This is not a breaking change

## Related issue

Closes https://github.com/uswds/uswds/issues/5434

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2264)

## Preview link

[Stacked table →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-stacked-table-voice-over-fix/?path=/story/components-table-stacked--default)

## Problem statement

Specifically when using **VoiceOver** on **Safari**, tables with `display: block` on the <tr> are skipped or read as empty.

This is caused by a well known bug[^1] which causes tables with `display` properties to break accessibility with screen readers.

[^1]: https://adrianroselli.com/2022/07/its-mid-2022-and-browsers-mostly-safari-still-break-accessibility-via-display-properties.html

This bug used to affect most browsers, but in recent years has been resolved. Safari seems to be the only browser still affected by this. At the time of this PRs creation the referenced article was last updated: `August 14th, 2023.`

Additional mdn doc PR with a well organzied list of associated bugs: https://github.com/mdn/browser-compat-data/issues/19994

## Solution

I was able to improve the screen reader experience by removing `display: block` from stacked table `tr` tags.

Now, VoiceOver + Safari can properly navigate through the stacked table’s content and read it’s values

### Differences

There is one slight difference between the way VO + Safari read the table data compared to other browsers.

Other browsers will read cells data labels with “column # of #” depending on how many data cells there are in each row. In our example, this would be “column 1 of 3” for example.

Safari now reads this as “Column 1 of 1”. While this differs from the other browsers, it is considered accurate because there is only one column.

The downside is that it doesn’t let the user know how many “columns” (if table wasn't stacked) are within the said “row”.

VoiceOver ****will**** correctly read out how many “rows” (sections) of the stacked table there are.

This is caused by a Safari bug 
> Tables with display: block on the <td> and <th> give the wrong column count.[^2]
[^2]: https://github.com/mdn/browser-compat-data/issues/19994

## Testing and review

### Confirm existence of bug

1. Visit [develop branch stacked table variant **********on Safari********** →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-table-stacked--default)
2. Activate VoiceOver
3. Attempt to navigate table using keyboard inputs
   - Note that VO key + up/down arrows will [jump between rows](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts#vo-mac-tables:~:text=Move%20up%20or%20down%20in%20a%20column)
5. Visit the stacked table variant on ****another browser****
6. Confirm proper readouts

### Confirm improvement

1. Visit [preview **********************on Safari →**********************](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-stacked-table-voice-over-fix/?path=/story/components-table-stacked--default)
2. Confirm no visual regression
3. Attempt to navigate the table with VoiceOver and keyboard inputs
4. Confirm you are able to access all cell information
5. Repeat for ******************************another browser******************************
7. Confirm no unexpected changes

### Testing checklist

- [ ]  Stacked table is now accessible using ********VoiceOver + Safari********
- [ ]  Confirm we’re comfortable with the readout addressing each row as a single column
- [ ]  No unexpected changes to other browsers
- [ ]  No visual regressions