### PR TITLE
USWDS - Identifier: Update "An official website" screen reader text

### DIFF
--- a/packages/usa-identifier/src/content/usa-identifier.json
+++ b/packages/usa-identifier/src/content/usa-identifier.json
@@ -5,7 +5,8 @@
   "masthead": {
     "aria_label": "Agency identifier,",
     "description": "Agency description,",
-    "content": "An official website of the",
+    "content_prefix": "An",
+    "content": "official website of the",
     "parent": {
       "name": "<Parent agency>",
       "shortname": "<Parent shortname>",

--- a/packages/usa-identifier/src/content/usa-identifier~multiple-logos.json
+++ b/packages/usa-identifier/src/content/usa-identifier~multiple-logos.json
@@ -1,10 +1,12 @@
 {
   "modifier": "",
   "domain": "domain.gov",
+  "lang": "en",
   "masthead": {
     "aria_label": "Agency identifier,,,",
     "description": "Agency description,,,",
-    "content": "An official website of the",
+    "content_prefix": "An",
+    "content": "official website of the",
     "parent": {
       "name": "<Parent agency>",
       "shortname": "<Parent shortname>",

--- a/packages/usa-identifier/src/content/usa-identifier~no-logos.json
+++ b/packages/usa-identifier/src/content/usa-identifier~no-logos.json
@@ -5,7 +5,8 @@
   "masthead": {
     "aria_label": "Agency identifier,,",
     "description": "Agency description,,",
-    "content": "An official website of the",
+    "content_prefix": "An",
+    "content": "official website of the",
     "parent": {
       "name": "<Parent agency>",
       "shortname": "<Parent shortname>",

--- a/packages/usa-identifier/src/content/usa-identifier~taxpayer-disclaimer.json
+++ b/packages/usa-identifier/src/content/usa-identifier~taxpayer-disclaimer.json
@@ -5,7 +5,8 @@
   "masthead": {
     "aria_label": "Agency identifier,,,,",
     "description": "Agency description,,,,",
-    "content": "An official website of the",
+    "content_prefix": "An",
+    "content": "official website of the",
     "parent": {
       "name": "<Parent agency>",
       "shortname": "<Parent shortname>",

--- a/packages/usa-identifier/src/usa-identifier.twig
+++ b/packages/usa-identifier/src/usa-identifier.twig
@@ -30,6 +30,11 @@
       <section class="usa-identifier__identity" aria-label="{{ masthead.description }}">
         <p class="usa-identifier__identity-domain">{{ domain }}</p>
         <p class="usa-identifier__identity-disclaimer">
+        {% if masthead.content_prefix %}
+            <span aria-hidden="true">
+              {{ masthead.content_prefix }}
+            </span>
+          {% endif %}
           {{ masthead.content }}
           <a href="{{ placeholder_link }}">{{ masthead.parent.name |e }}</a>
           {% if masthead.agency.url %}


### PR DESCRIPTION
# Summary

**Updated the screen reader readout to say "Official" instead of "An official".** When read out on a screen reader, the statement "An official website of [Agency name]" can sound like "UNofficial website of [Agency name]". To minimize confusion, we hid the word "An" from screen readers with `aria-hidden`. 

## Breaking change

:warning: This requires a markup change for English-language implementations of the identifier. 

In English versions of the identifier component, users should update their markup to hide the word "An" from screen readers by wrapping the word in a span with an  `aria-hidden` attribute.

Before
```html
<p class="usa-identifier__identity-disclaimer">
    An official website of the <a href="">[Parent agency]</a>
</p>
```

After
```html
<p class="usa-identifier__identity-disclaimer">
    <span aria-hidden="true">An </span>official website of the <a href="">[Parent agency]</a>
</p>
```

## Related issue

Closes #5362

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2266)

## Preview link

- [Identifier component (Default)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-identifier-text/?path=/story/components-identifier--default)
- [Identifier (Multiple parents)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-identifier-text?path=/story/components-identifier--multiple-parents-and-logos)
- [Identifier (No logo)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-identifier-text?path=/story/components-identifier--no-logos)
- [Identifier (Taxpayer disclaimer)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-identifier-text/?path=/story/components-identifier--taxpayer-disclaimer)

## Problem statement
When read out on a screen reader, the statement "An official website of the [Agency name]" can sound like "UNofficial website of [Agency name]". 
 
## Solution
To minimize the impact on visual presentation, we created a screen reader-only solution that hides "An" from the readout. Instead the screen reader will now read out "official website of the [Agency name]".

## Testing and review

- Using a variety of browsers and screen readers, confirm that the screen reader readout is intuitive and makes sense.
- Confirm that the new aria change is added only to English versions of the component.
- Consider: Is it confusing that it is only for English implementations? Anything we should do to add clarity?
