### PR TITLE
USWDS - Modal: Remove padding style rules after modal close

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -125,10 +125,11 @@ function toggleModal(event) {
   // Account for content shifting from body overflow: hidden
   // We only check paddingRight in case apps are adding other properties
   // to the body element
-  body.style.paddingRight =
-    body.style.paddingRight === TEMPORARY_PADDING
-      ? INITIAL_PADDING
-      : TEMPORARY_PADDING;
+  if(body.style.paddingRight === TEMPORARY_PADDING){
+    body.removeAttribute("style");
+  } else{
+    body.style.paddingRight = TEMPORARY_PADDING;
+  }
 
   // Handle the focus actions
   if (safeActive && openFocusEl) {
@@ -165,7 +166,6 @@ function toggleModal(event) {
     returnFocus.focus();
     modal.focusTrap.update(safeActive);
   }
-
   return safeActive;
 }
 

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -134,7 +134,7 @@ function toggleModal(event) {
   // Temporarily increase body padding to include the width of the scrollbar.
   // This accounts for the content shift when the scrollbar is removed on modal open.
   if (body.style.paddingRight === TEMPORARY_BODY_PADDING) {
-    body.removeAttribute("style");
+    body.style.removeProperty("padding-right");
   } else {
     body.style.paddingRight = TEMPORARY_BODY_PADDING;
   }

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -96,11 +96,11 @@ function toggleModal(event) {
     // If it doesn't have an ID, make one
     // Store id as data attribute on modal
     if (clickedElement.hasAttribute(OPENER_ATTRIBUTE)) {
-      if (clickedElement.getAttribute("id") === null) {
+      if (this.getAttribute("id") === null) {
         originalOpener = `modal-${Math.floor(Math.random() * 900000) + 100000}`;
-        clickedElement.setAttribute("id", originalOpener);
+        this.setAttribute("id", originalOpener);
       } else {
-        originalOpener = clickedElement.getAttribute("id");
+        originalOpener = this.getAttribute("id");
       }
       targetModal.setAttribute("data-opener", originalOpener);
     }

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -42,7 +42,7 @@ const onMenuClose = () => {
  * Set the value for temporary body padding that will be applied when the modal is open.
  * Value is created by checking for initial body padding and adding the width of the scrollbar.
  */
-const getTemporaryBodyPadding = () => {
+const setTemporaryBodyPadding = () => {
   INITIAL_BODY_PADDING = window
     .getComputedStyle(document.body)
     .getPropertyValue("padding-right");
@@ -50,7 +50,7 @@ const getTemporaryBodyPadding = () => {
     parseInt(INITIAL_BODY_PADDING.replace(/px/, ""), 10) +
     parseInt(SCROLLBAR_WIDTH.replace(/px/, ""), 10)
   }px`;
-}
+};
 
 /**
  *  Toggle the visibility of a modal window
@@ -196,7 +196,7 @@ const setUpModal = (baseComponent) => {
   // Create placeholder where modal is for cleanup
   const originalLocationPlaceHolder = document.createElement("div");
 
-  getTemporaryBodyPadding();
+  setTemporaryBodyPadding();
 
   originalLocationPlaceHolder.setAttribute(`data-placeholder-for`, modalID);
   originalLocationPlaceHolder.style.display = "none";

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -125,9 +125,9 @@ function toggleModal(event) {
   // Account for content shifting from body overflow: hidden
   // We only check paddingRight in case apps are adding other properties
   // to the body element
-  if(body.style.paddingRight === TEMPORARY_PADDING){
+  if (body.style.paddingRight === TEMPORARY_PADDING) {
     body.removeAttribute("style");
-  } else{
+  } else {
     body.style.paddingRight = TEMPORARY_PADDING;
   }
 

--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -276,9 +276,11 @@ modal = {
     selectOrMatches(MODAL, root).forEach((modalWindow) => {
       const modalId = modalWindow.id;
       setUpModal(modalWindow);
-      // Check for any initial body padding
-      // and add the width of the scrollbar
-      // This is used when the modal is open
+
+      // Set the value for temporary body padding
+      // that will be applied when the modal is open.
+      // Value is created by checking for initial body padding
+      // and adding the width of the scrollbar.
       const initialBodyPadding = window
         .getComputedStyle(document.body)
         .getPropertyValue("padding-right");


### PR DESCRIPTION
# Summary
**Updated how the modal JavaScript resets body padding.** Now the component will rely on the CSS to reset the body padding rather than injecting an inline style with JavaScript. 

**Improved body padding detection in modal JavaScript.** The JS now checks for body padding after the modal has been set up. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5361

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2273)

## Preview link

- [Modal component in Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-storybook-modal-padding/iframe.html?args=&id=components-modal--default&viewMode=story)
- [uswds-sandbox test integration](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/al-test-modal-padding/pages/modal/)
- [uswds-site test integration](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-test-modal-padding/components/modal/)

## Problem statement
When the modal opens, it adds a temporary padding to the body to account for the missing scrollbar. When the modal closes, it is expected that the padding resets to the body's initial padding definition. For example, the Storybook body has an initial padding value of `1rem`, and the expectation is that the body styles would return to `1rem` when the modal is closed. However, in the current state in Storybook, the modal JS changes the body padding to `0px` when the modal is closed.

This appears to only happen in Storybook and could not be replicated in `uswds-sandbox` or `uswds-site`. I believe it is related to how Storybook initializes. 

## Solution

1. The JavaScript now reverts back to the original CSS styling when the modal is closed, rather than declaring another inline style. Here is a description of the before and after (note the change in the last step of the process):
    - In `develop`, the component changes the body padding using the following methods:
        - The initial body padding is set with CSS (For example, 12px)
        - Once the modal is activated, the JS adds an inline style rule to the body element that updates the padding to include the width of the scrollbar (For example, 27px).
        - Then when the modal is closed the **_JS resets the definition of the inline style rule to the the initial value of 12px_**. 
    - In this PR, the component changes the body padding using the following methods:
        - The initial body padding is set with CSS (For example, 12px)
        - Once the modal is activated, the JS adds an inline style rule to the body element that updates the padding to include the width of the scrollbar (For example, 27px).
        - Then when the modal is closed the JS **_removes the padding style rule that it added and the padding is defined with the original CSS again._**
2. The JavaScript now explicitly checks for body padding style during the modal is set up. This allowed the JS to recognize the body padding in Storybook.
    - :warning: I am not sure if this move comes with any downsides. I'd appreciate input!

## Testing and review
- Confirm that the body padding behaves as expected when the modal is opened/closed.
- Confirm no regressions in modal behavior. 
- Consider if there is any risk to this change.

In [Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-storybook-modal-padding/iframe.html?args=&id=components-modal--default&viewMode=story):
1. Resize the window to 450px
2. Check the initial padding on the body element (Should be 1em, defined in the CSS)
3. Open the modal
4. Check the updated padding on the body element (Should be 32px, defined in an inline style rule)
    - Note: The 32px value is created by adding 17px (the computed padding on the body) and 15px (the computed width of the scrollbar)
6. Close the modal
7. Confirm that the inline body padding style was removed and that the body padding is restored to the original value, defined by the CSS (1em)

In the [sandbox demo](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/al-test-modal-padding/pages/modal/) or [USWDS-site demo](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-test-modal-padding/components/modal/):
1. Check the initial padding on the body element (Should be 38px, defined in the CSS)
2. Open the modal
4. Check the updated padding on the body element (Should be 53px, defined in an inline style rule)
6. Close the modal
7. Confirm that the body padding is restored to the original value (Should be 38px, defined in the CSS)
