### PR TITLE
USWDS - Checkbox and radio: Update tile color definitions

### DIFF
--- a/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
@@ -32,8 +32,8 @@
     1
   );
   $input-border-alpha: -0;
-  $color-input-disabled: color("gray-20");
-  $color-input-disabled--weak: color("gray-10");
+  $tile-border-color: color("gray-20");
+  $tile-border-color--disabled: color("gray-10");
   $input-darkmode: if(
     color.lightness(color($input-bg-color)) < 50%,
     true,
@@ -70,7 +70,7 @@
     &:disabled,
     &[aria-disabled="true"] {
       @include format-label {
-        color: color("gray-50");
+        color: color("disabled");
 
         @media (forced-colors: active) {
           color: GrayText;
@@ -79,14 +79,14 @@
       @include format-input {
         background-color: color($input-bg-color);
         box-shadow: 0 0 0 units($theme-input-select-border-width)
-          $color-input-disabled;
+        color("disabled");
       }
     }
     &--tile {
       @include format-label {
         background-color: color($input-bg-color);
         border: units($theme-input-tile-border-width) solid
-          $color-input-disabled;
+          $tile-border-color;
         color: color($input-text-color);
       }
       &:checked {
@@ -105,7 +105,7 @@
       &:disabled,
       &[aria-disabled="true"] {
         @include format-label {
-          border-color: $color-input-disabled--weak;
+          border-color: $tile-border-color--disabled;
         }
 
         &:checked {
@@ -135,7 +135,7 @@
       &:checked:disabled,
       &:checked[aria-disabled="true"] {
         @include format-input {
-          background-color: $color-input-disabled;
+          background-color: color("disabled");
           @media (forced-colors: active) {
             background-color: color(GrayText);
           }
@@ -161,8 +161,8 @@
       &:checked:disabled,
       &:checked[aria-disabled="true"] {
         @include format-input {
-          background-color: $color-input-disabled;
-          box-shadow: 0 0 0 2px $color-input-disabled,
+          background-color: color("disabled");
+          box-shadow: 0 0 0 2px color("disabled"),
             inset 0 0 0 2px color($input-bg-color);
 
           @media (forced-colors: active) {

--- a/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
@@ -79,14 +79,13 @@
       @include format-input {
         background-color: color($input-bg-color);
         box-shadow: 0 0 0 units($theme-input-select-border-width)
-        color("disabled");
+          color("disabled");
       }
     }
     &--tile {
       @include format-label {
         background-color: color($input-bg-color);
-        border: units($theme-input-tile-border-width) solid
-          $tile-border-color;
+        border: units($theme-input-tile-border-width) solid $tile-border-color;
         color: color($input-text-color);
       }
       &:checked {

--- a/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
@@ -32,8 +32,8 @@
     1
   );
   $input-border-alpha: -0;
-  $color-input-disabled: color("disabled");
-  $color-input-disabled--weak: color("disabled-lighter");
+  $color-input-disabled: color("gray-20");
+  $color-input-disabled--weak: color("gray-10");
   $input-darkmode: if(
     color.lightness(color($input-bg-color)) < 50%,
     true,
@@ -70,7 +70,7 @@
     &:disabled,
     &[aria-disabled="true"] {
       @include format-label {
-        color: $color-input-disabled;
+        color: color("gray-50");
 
         @media (forced-colors: active) {
           color: GrayText;


### PR DESCRIPTION
# Summary

**Updated radio and checkbox tile styling to have lighter borders.**

This change reverts border color styles to be more similar to what they were in 3.4.0 and _could_ help with comprehension for users with visual processing disorders. 

> **Note**
> This is the first part of the effort to make checkbox and radio tile styles more accessible to users with visual processing disorders. We will need to dive deeper into what we can do to reduce visual noise so that the content is easier to focus on. Issue #5487 tracks the larger effort for this. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5490

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2270)

## Preview link

- [Radio tile](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-radio-tile-color/?path=/story/components-form-inputs-radio--radio-tile)
- [Checkbox tile](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-radio-tile-color/?path=/story/components-form-inputs-checkbox--disabled-tile)
- [Disabled form inputs](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-radio-tile-color/?path=/story/patterns-forms--disabled-form-elements)

## Problem statement
In release 3.5.0, we updated disabled styles for our form elements, which inadvertently darkened the color of the borders on the checkbox and radio tile boxes. This color changed increased the visual noise, which can have a negative impact on users with visual processing disorder.

Reference: [Color definition change in 3.5.0](https://github.com/uswds/uswds/pull/5063/files#diff-b6aedd118f192b4c3488b079a0e2bd509dbff00384cd41aa894430acb9fecdeaR35-R36)

## Solution
The tile borders are not actually representing disabled states, so we can make the component more resilient by defining the border colors with system tokens instead.

The disabled states will continue to use disabled color tokens ("disabled"/"gray-50") and will now meet color contrast requirements.

![image](https://github.com/uswds/uswds/assets/93996430/f6456652-a2e4-4713-84f9-c803eef57de2)

## Testing and review
- Confirm that tile border styles more closely align with those found in [release-3.4.0](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/release-3.4.0/?path=/story/components-form-inputs-radio--radio-tile)
    - Note: Disabled states will look darker than in 3.4.0. This is expected. Disabled styles should meet contrast standards and also align with other current disabled form inputs. 
- Confirm that the switch from disabled state colors to system colors make sense. 
- Confirm no unexpected visual regressions
