### PR TITLE
USWDS - Breadcrumb: Allow text to wrap on wrap variants

### DIFF
--- a/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
+++ b/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
@@ -87,7 +87,6 @@ $breadcrumb-back-icon-aspect: (
 .usa-breadcrumb__list-item {
   @include sr-only;
   @include u-display("inline");
-  @include u-white-space("no-wrap");
 
   @include at-media-max($theme-breadcrumb-min-width) {
     @include u-white-space("wrap");

--- a/packages/usa-breadcrumb/src/usa-breadcrumb.twig
+++ b/packages/usa-breadcrumb/src/usa-breadcrumb.twig
@@ -16,7 +16,7 @@
       </a>
     </li>
     <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-      <span>September 2020 updates show progress on cross-agency and agency priority goals</span>
+      <span>Economically disadvantaged women-owned small business federal contracting program</span>
     </li>
   </ol>
 </nav>

--- a/packages/usa-breadcrumb/src/usa-breadcrumb.twig
+++ b/packages/usa-breadcrumb/src/usa-breadcrumb.twig
@@ -16,7 +16,7 @@
       </a>
     </li>
     <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-      <span>Women-owned small business federal contracting program</span>
+      <span>September 2020 updates show progress on cross-agency and agency priority goals</span>
     </li>
   </ol>
 </nav>


### PR DESCRIPTION
# Summary

Fixed a bug that prevented text from wrapping to a new line in the `.usa-breadcrumb--wrap` variant.

## Breaking change
This is not a breaking change.

## Related issue

Closes #5257

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2271)

## Preview link

- [Breadcrumb component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-breadcrumb-wrap/iframe.html?args=&id=components-breadcrumb--default&viewMode=story)
- [Breadcrumb component - Wrap variant](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-breadcrumb-wrap/iframe.html?args=&id=components-breadcrumb--wrap&viewMode=story)

## Problem statement
In the breadcrumb component, all list items (regardless of variant) receive a `white-space: nowrap` rule. This enables the expected behavior in the standard variant, but prevents text from wrapping In the `.usa-breadcrumb--wrap` variant.

## Solution
By removing the blanket `white-space: nowrap` rule from list items and instead relying only on the "no-wrap" rule applied to `.usa-breadcrumb__list` in the standard variant, we can re-enable text wrapping in the `.usa-breadcrumb--wrap` variant.

![image](https://github.com/uswds/uswds/assets/93996430/d404a82f-681c-4eaf-9aab-0e4d35cbc7f1)

## Testing and review
In a variety of browsers:
- Confirm that the breadcrumb text wraps as expected:
  1. Open the [breadcrumb wrap variant](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-breadcrumb-wrap/iframe.html?args=&id=components-breadcrumb--wrap&viewMode=story)
  2. Resize the window to ~550px wide
  3. Confirm that text wraps to a new line in the wrap variant and does not extend beyond the container. 
- Confirm that there are no regressions in the standard variant. 
