### PR TITLE
USWDS - Scripts: Remove format-tokens script

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "scripts": {
     "build": "gulp",
-    "format-tokens": "node ./src/utils/style-format.js --file './packages/uswds-tokens/colors' --output './packages/uswds-core/src/styles/tokens/color'",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:js": "eslint packages/**/**/*.js",
     "lint:sass": "gulp lintSass",


### PR DESCRIPTION
# Summary

Removed unused `format-tokens` script from `package.json`.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5486

## Problem statement

While experimenting with token conversion, we noticed an outdated `format-tokens` script existed in our `package.json` file. 

The script previously used the `style-format.js` utility to output our color tokens. The utility seems to have been removed during `3.0.0` beta work in https://github.com/uswds/uswds/pull/4635

Specifically this PR: https://github.com/uswds/uswds/pull/4634
This commit: https://github.com/uswds/uswds/commit/d8e323423d815d9e4890d192d16e0c921a9fe186

## Solution

After discussing in issue triage 9/7/23 we decided to just remove the unused script. 

As we progress #5437 we will make decision on if we need to replace this script with an updated approach.

## Testing and review

1. Confirm `style-format.js` is no longer used.
2. Build branch and assets.
3. Confirm no build errors.
4. Confirm there are no unintended visual regressions.

### Testing checklist

- [ ]  Script is unused and uneeded.
- [ ]  Tokens do not rely on this script.
- [ ]  There are no regressions caused by removing this script.