### PR TITLE
USWDS - Input Mask: Fix input mask for nested inputs

### DIFF
--- a/packages/usa-input-mask/src/index.js
+++ b/packages/usa-input-mask/src/index.js
@@ -7,7 +7,6 @@ const MASKED = `.${MASKED_CLASS}`;
 const MASK = `${PREFIX}-input-mask`;
 const MASK_CONTENT = `${MASK}--content`;
 const PLACEHOLDER = "placeholder";
-const CONTEXT = "form";
 
 // User defined Values
 const maskedNumber = "_#dDmMyY9";
@@ -35,7 +34,7 @@ const createMaskedInputShell = (input) => {
   content.textContent = placeholder;
 
   shell.appendChild(content);
-  input.closest(CONTEXT).insertBefore(shell, input);
+  input.parentNode.insertBefore(shell, input);
   shell.appendChild(input);
 };
 


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

Fixes span insert for masked inputs when target input is not a direct child of the form.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5517
<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here:
https://github.com/uswds/uswds/issues/new/choose.
-->

## Related pull requests

[Changelog PR →](https://github.com/uswds/uswds-site/pull/2658)

Also [resolved in Input Mask Version 2](https://github.com/uswds/uswds/pull/5227), however, it's unclear when that will be released.


## Preview link

Preview link: N/A

## Problem statement

The insert for the generated span to mask the input is currently targeted at the closest form `input.closest(CONTEXT).insertBefore(shell, input);` which works for the [example in the documentation](https://designsystem.digital.gov/components/input-mask/) because the input is a direct child of the form. However, when nested under any additional markup the insert fails (`The node before which the new node is to be inserted is not a child of this node.`).


## Solution

This change inserts the generated span in the input element's parent, not the closest form.

## Major changes

Just a bug fix.

## Testing and review

I did the following test locally

1. Rebuild the module (`npm run build`)
2. Initialized a new project using the updated module (`npx gulp init`)
3. Tested the same input markup that was previous broken and it worked

<!--
## Dependency updates

N/A

