### PR TITLE
Update README references to 3.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The `@uswds/uswds` module is now installed as a dependency. You can use the comp
 ### Install the package directly from GitHub
 If you’re using a framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the steps outlined in this section.
 
-1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.6.0/uswds-uswds-3.6.0.tgz) directly from the latest USWDS release and uncompress that file.
+1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.6.1/uswds-uswds-3.6.1.tgz) directly from the latest USWDS release and uncompress that file.
 
 2. Copy these files and folders into a relevant place in your project's code base. Here is an example structure for how this might look:
 


### PR DESCRIPTION
This simple PR updates the references in the README to `3.6.1` to prepare for the 3.6.1 release.