### PR TITLE
USWDS - Card: Update breakpoint classes

### DIFF
--- a/packages/usa-card/src/content/usa-card~flag.json
+++ b/packages/usa-card/src/content/usa-card~flag.json
@@ -4,7 +4,7 @@
   "cards": [
     {
       "title": "Default flag",
-      "classes_override": "desktop:grid-col-6",
+      "classes_override": "widescreen:grid-col-6",
       "flag_direction": "",
       "media": {
         "media_classes": "",
@@ -16,7 +16,7 @@
     },
     {
       "title": "Flag media right inset",
-      "classes_override": "desktop:grid-col-6",
+      "classes_override": "widescreen:grid-col-6",
       "flag_direction": "right",
       "media": {
         "media_classes": "usa-card__media--inset",

--- a/packages/usa-card/src/content/usa-card~standard.json
+++ b/packages/usa-card/src/content/usa-card~standard.json
@@ -1,6 +1,6 @@
 {
   "modifier": "",
-  "default_classes": "tablet:grid-col-4",
+  "default_classes": "tablet-lg:grid-col-6 widescreen:grid-col-4",
   "cards": [
     {
       "title": "Card",


### PR DESCRIPTION
# Summary

**Updated the grid breakpoints in the card template.** This improves the display of the component on designsystem.digital.gov.

## Breaking change

This is not a breaking change. 

>**Note**
> While this change does affect markup, it not affect the component itself. Instead the markup change is related only to the wrapping grid breakpoints in the Twig template that is used for the component review on uswds-site. 

## Related issue

Closes #5541

## Related pull requests

> **Warning**
> This change uses grid breakpoints that are not included in the default configuration. To successfully change the presentation in uswds-site, we will also need to update the Sass in the uswds-site repo in this PR:

[ uswds-site PR: Sass changes and changelog entry](https://github.com/uswds/uswds-site/pull/2299)

## Preview link
- [Demo card page on uswds-site](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-card-grid-fix/components/card/#card-preview-content)
- [Card component - standard](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-card-grid-fix/?path=/story/components-card--default)
- [Card component - flag](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-card-grid-fix/?path=/story/components-card--flag)

## Problem statement
The [card component preview page](https://designsystem.digital.gov/components/card/) shows cards that get too narrow and elements within the cards overlap at various browser widths. 

![image](https://github.com/uswds/uswds/assets/93996430/829f2f51-e5ee-410c-94cf-83bd3863cdde)

## Solution

Adjusting the grid breakpoints in the card template will allow for better presentation on uswds-site. This change does not affect the card component itself, only the grid elements that surround it. 

>**Note**
> This PR does not update the classes in `usa-card.json` or `usa-card~media.json` because the related templates are not currently displayed on uswds-site.

## Testing and review
1. Visit the [demo card component page](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/al-card-grid-fix/components/card/#card-preview-content) 
1. Adjust the screen width from mobile to widescreen. 
1. Confirm that both the default cards and flag cards present well and the correct breakpoints have been chosen. 


