### PR TITLE
USWDS - Site Alert - Repair top margin, broken by #4922

### DIFF
--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -13,6 +13,10 @@ $alert-icons: (
 
 .usa-alert {
   @include alert-styles;
+
+  * + & {
+    margin-top: units(2);
+  }
 }
 
 @each $name, $icon in $alert-icons {

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -25,10 +25,6 @@
   border-left: units($theme-alert-bar-width) solid color("base-light");
   color: color($banner-text-color-token);
 
-  * + & {
-    margin-top: units(2);
-  }
-
   .usa-alert__body {
     @include border-box-sizing;
     @include typeset($theme-alert-font-family);


### PR DESCRIPTION
# Summary

**Removed the top margin from the site alert component.**

PR #4922 added a top margin to the site alert, which looks wrong when a site alert immediately follows a gov banner.

## Breaking change

This is not a breaking change.

## Related PR
[Changelog PR](https://github.com/uswds/uswds-site/pull/2324)

## Preview link

This affects https://test.gcn.nasa.gov.

### USWDS 3.1.0

![uswds-3 1 0](https://github.com/uswds/uswds/assets/728407/7641f23f-ab78-4228-a5e2-9dc0bd9da572)

### USWDS 3.6.1, before this patch

![before](https://github.com/uswds/uswds/assets/728407/e659b549-7ce1-4be7-a303-f930297a4f19)

### After this patch

![after](https://github.com/uswds/uswds/assets/728407/7c1a679e-50c8-4e45-bf42-f18644499cb0)

## Problem statement

The site alert should not have any top margin. It didn't before USWDS 3.6.1. The margin looks like a glitch when a site alert immediately follows a gov banner.

## Solution

Move the top margin back from the mixin to _usa-alert.scss so that applies to alerts but not site alerts.

## Testing and review

I tested this locally to produce the screenshots above.

## Dependency updates

None.