### PR TITLE
USWDS - Banner: Allow banner to init without accordion requirement

### DIFF
--- a/packages/usa-accordion/src/index.js
+++ b/packages/usa-accordion/src/index.js
@@ -6,7 +6,7 @@ const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 
 const ACCORDION = `.${PREFIX}-accordion, .${PREFIX}-accordion--bordered`;
-const BUTTON = `.${PREFIX}-accordion__button[aria-controls]`;
+const BUTTON = `.${PREFIX}-accordion__button[aria-controls]:not(.usa-banner__button)`;
 const EXPANDED = "aria-expanded";
 const MULTISELECTABLE = "data-allow-multiple";
 

--- a/packages/usa-accordion/src/index.js
+++ b/packages/usa-accordion/src/index.js
@@ -6,7 +6,8 @@ const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 
 const ACCORDION = `.${PREFIX}-accordion, .${PREFIX}-accordion--bordered`;
-const BUTTON = `.${PREFIX}-accordion__button[aria-controls]:not(.usa-banner__button)`;
+const BANNER_BUTTON = `.${PREFIX}-banner__button`;
+const BUTTON = `.${PREFIX}-accordion__button[aria-controls]:not(${BANNER_BUTTON})`;
 const EXPANDED = "aria-expanded";
 const MULTISELECTABLE = "data-allow-multiple";
 

--- a/packages/usa-banner/src/index.js
+++ b/packages/usa-banner/src/index.js
@@ -8,6 +8,10 @@ const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
 const BANNER_BUTTON = `${HEADER} [aria-controls]`;
 
+/**
+ * Toggle Banner display and class.
+ * @param {Event} event
+ */
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
   const trigger = event.target.closest(BANNER_BUTTON);

--- a/packages/usa-banner/src/index.js
+++ b/packages/usa-banner/src/index.js
@@ -1,17 +1,33 @@
 const behavior = require("../../uswds-core/src/js/utils/behavior");
+const select = require("../../uswds-core/src/js/utils/select");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
+const toggle = require("../../uswds-core/src/js/utils/toggle");
 
 const HEADER = `.${PREFIX}-banner__header`;
 const EXPANDED_CLASS = `${PREFIX}-banner__header--expanded`;
+const BANNER_BUTTON = `${HEADER} [aria-controls]`;
 
 const toggleBanner = function toggleEl(event) {
   event.preventDefault();
+  const trigger = event.target.closest(BANNER_BUTTON);
+
+  toggle(trigger);
   this.closest(HEADER).classList.toggle(EXPANDED_CLASS);
 };
 
-module.exports = behavior({
-  [CLICK]: {
-    [`${HEADER} [aria-controls]`]: toggleBanner,
+module.exports = behavior(
+  {
+    [CLICK]: {
+      [BANNER_BUTTON]: toggleBanner,
+    },
   },
-});
+  {
+    init(root) {
+      select(BANNER_BUTTON, root).forEach((button) => {
+        const expanded = button.getAttribute(EXPANDED_CLASS) === "true";
+        toggle(button, expanded);
+      });
+    },
+  }
+);

--- a/packages/usa-banner/src/test/banner.spec.js
+++ b/packages/usa-banner/src/test/banner.spec.js
@@ -1,7 +1,6 @@
 const assert = require("assert");
 const fs = require("fs");
 const banner = require("../index");
-const accordion = require("../../../usa-accordion/src/index");
 
 const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
 const EXPANDED = "aria-expanded";
@@ -27,12 +26,10 @@ tests.forEach(({ name, selector: containerSelector }) => {
       button = body.querySelector(".usa-banner__button");
       content = body.querySelector(".usa-banner__content");
       banner.on(containerSelector());
-      accordion.on(containerSelector());
     });
 
     afterEach(() => {
       banner.off(containerSelector());
-      accordion.off(containerSelector());
       body.innerHTML = "";
     });
 


### PR DESCRIPTION
# Summary

**USA Banner now initializes by itself.** Initialize banner with `banner.on()` method. 

It's no longer necessary to import and call `accordion.on()` to initialize banner.

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
-->

## Breaking change

This is not a breaking change.


## Related issue

Closes #5179.


## Related pull requests

Changelog PR: uswds/uswds-site#2301.

## Preview link

| Current (`develop`) | Feature branch      |
| :------------------ | :------------------ |
| [Accordion Default] | [Accordion Preview] |
| [Banner Default]    | [Banner Preview]    |
| [Test Default]      | [Test Preview]      |

[Accordion Default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-accordion--default
[Accordion Preview]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-banner-init/?path=/story/components-accordion--default
[Banner Default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-banner--default
[Banner Preview]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-banner-init/?path=/story/components-banner--default
[Test Default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-accordion--test-icons
[Test Preview]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-banner-init/?path=/story/components-accordion--test-icons


All components should work without conflicts.

## Problem statement

Banner didn't have an init method and relied on accordion to toggle content.

## Solution

Banner and accordion JS are separated; with banner being able to initialize and toggle on its own.

## Major changes

Toggle added to banner & accordion ignores banner button - [27181af](https://github.com/uswds/uswds/commit/27181af2e75ef43e5af098fdc08e4f82d899f56f).

## Testing and review

- Visit preview links
- Components should work individually
- Components should work without conflicts in the `Test` variants.

**Additionally**
- Visit [uswds/uswds-sandbox#jm-test-uswds-5179](https://github.com/uswds/uswds-sandbox/tree/jm-test-uswds-5179)
- Run `npm install`
- Visit `http://localhost:8080/accordion-react/`
- Components should initialize alone & work without conflicts

**Checklist**
- [ ] Components should initialize by themselves with import.
- [ ] There should be no regressions in compiled scripts `uswds.js`.


<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
