### PR TITLE
USWDS - Section / Dark Background: Use consistent styling for dark background links

### DIFF
--- a/packages/usa-dark-background/src/styles/_usa-dark-background.scss
+++ b/packages/usa-dark-background/src/styles/_usa-dark-background.scss
@@ -1,5 +1,7 @@
 @use "uswds-core" as *;
 
+$background-context: "Background";
+
 .usa-dark-background {
   background-color: color("base-darker");
 
@@ -9,6 +11,10 @@
   }
 
   a {
-    @include set-link-from-bg("base-darker");
+    @include set-link-from-bg(
+      "base-darker",
+      $theme-link-reverse-color,
+      $context: $background-context
+    );
   }
 }

--- a/packages/usa-dark-background/src/styles/_usa-dark-background.scss
+++ b/packages/usa-dark-background/src/styles/_usa-dark-background.scss
@@ -9,18 +9,6 @@
   }
 
   a {
-    color: color($theme-link-reverse-color);
-
-    &:hover {
-      color: color($theme-link-reverse-hover-color);
-    }
-
-    &:active {
-      color: color($theme-link-reverse-active-color);
-    }
-
-    &:visited {
-      color: color($theme-link-reverse-color);
-    }
+    @include set-link-from-bg("base-darker");
   }
 }

--- a/packages/usa-dark-background/src/styles/_usa-dark-background.scss
+++ b/packages/usa-dark-background/src/styles/_usa-dark-background.scss
@@ -11,12 +11,16 @@
   a {
     color: color($theme-link-reverse-color);
 
-    &:visited {
-      color: color($theme-link-reverse-color);
-    }
-
     &:hover {
       color: color($theme-link-reverse-hover-color);
+    }
+
+    &:active {
+      color: color($theme-link-reverse-active-color);
+    }
+
+    &:visited {
+      color: color($theme-link-reverse-color);
     }
   }
 }

--- a/packages/usa-section/src/content/usa-section.json
+++ b/packages/usa-section/src/content/usa-section.json
@@ -1,5 +1,5 @@
 {
   "modifier": "",
   "title": "A default section",
-  "text": "The section component visually separates your content from other parts of the page."
+  "text": "Lorem ipsum dolor sit amet, <a class=\"usa-link\" href=\"javascript:void(0);\">consectetur adipiscing</a> elit, sed do eiusmod."
 }

--- a/packages/usa-section/src/content/usa-section~dark.json
+++ b/packages/usa-section/src/content/usa-section~dark.json
@@ -1,5 +1,5 @@
 {
   "modifier": "usa-section--dark",
   "title": "A dark section",
-  "text": "The section component visually separates your content from other parts of the page."
+  "text": "Lorem ipsum dolor sit amet, <a class=\"usa-link\" href=\"javascript:void(0);\">consectetur adipiscing</a> elit, sed do eiusmod."
 }

--- a/packages/usa-section/src/content/usa-section~light.json
+++ b/packages/usa-section/src/content/usa-section~light.json
@@ -1,5 +1,5 @@
 {
   "modifier": "usa-section--light",
   "title": "A light section",
-  "text": "The section component visually separates your content from other parts of the page."
+  "text": "Lorem ipsum dolor sit amet, <a class=\"usa-link\" href=\"javascript:void(0);\">consectetur adipiscing</a> elit, sed do eiusmod."
 }

--- a/packages/usa-section/src/styles/_usa-section.scss
+++ b/packages/usa-section/src/styles/_usa-section.scss
@@ -1,5 +1,7 @@
 @use "uswds-core" as *;
 
+$section-context: "Section";
+
 .usa-section {
   @include border-box-sizing;
   @include u-padding-y($theme-site-margins-width);
@@ -33,6 +35,10 @@
   }
 
   a {
-    @include set-link-from-bg("primary-darker");
+    @include set-link-from-bg(
+      "primary-darker",
+      $theme-link-reverse-color,
+      $context: $section-context
+    );
   }
 }

--- a/packages/usa-section/src/styles/_usa-section.scss
+++ b/packages/usa-section/src/styles/_usa-section.scss
@@ -33,18 +33,6 @@
   }
 
   a {
-    color: color($theme-link-reverse-color);
-
-    &:hover {
-      color: color($theme-link-reverse-hover-color);
-    }
-
-    &:active {
-      color: color($theme-link-reverse-active-color);
-    }
-
-    &:visited {
-      color: color($theme-link-reverse-color);
-    }
+    @include set-link-from-bg("primary-darker");
   }
 }

--- a/packages/usa-section/src/styles/_usa-section.scss
+++ b/packages/usa-section/src/styles/_usa-section.scss
@@ -42,5 +42,9 @@
     &:active {
       color: color($theme-link-reverse-active-color);
     }
+
+    &:visited {
+      color: color($theme-link-reverse-color);
+    }
   }
 }


### PR DESCRIPTION
# Summary

**Use consistent link styling for links in dark background content.** Previously, `usa-section--dark` and `usa-dark-background` did not have consistent styling for links.

## Related discussion

See related discussion in our application at https://github.com/18F/identity-dev-docs/pull/367#discussion_r1364004777

## Solution

Provides the complete set of link pseudo classes between `usa-section--dark` and `usa-dark-background`:

Before:

State|`usa-section--dark`|`usa-dark-background`
---|---|---
Initial|✅|✅ 
`:hover`|✅|✅
`:active`|✅|❌
`:visited`|❌|✅

After:

State|`usa-section--dark`|`usa-dark-background`
---|---|---
Initial|✅|✅ 
`:hover`|✅|✅
`:active`|✅|✅
`:visited`|✅|✅
