### PR TITLE
USWDS - Card: Fix $theme-card-padding-y calculations

### DIFF
--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -78,9 +78,9 @@
 // Header
 // ---------------------------------
 .usa-card__header {
-  @include u-padding-bottom(math.div($theme-card-padding-y, 2));
   @include u-padding-top($theme-card-padding-perimeter);
   @include u-padding-x($theme-card-padding-perimeter);
+  padding-bottom: math.div(units($theme-card-padding-y), 2);
 
   &:last-child {
     @include u-padding-bottom($theme-card-padding-perimeter);
@@ -129,7 +129,8 @@
 .usa-card__body {
   @include u-flex("fill");
   @include u-padding-x($theme-card-padding-perimeter);
-  @include u-padding-y(math.div($theme-card-padding-y, 2));
+  padding-bottom: math.div(units($theme-card-padding-y), 2);
+  padding-top: math.div(units($theme-card-padding-y), 2);
   // IE 11
   flex-basis: auto;
 
@@ -151,8 +152,8 @@
 // ---------------------------------
 .usa-card__footer {
   @include u-padding-bottom($theme-card-padding-perimeter);
-  @include u-padding-top(math.div($theme-card-padding-y, 2));
   @include u-padding-x($theme-card-padding-perimeter);
+  padding-top: math.div(units($theme-card-padding-y), 2);
 }
 
 .usa-card__footer .usa-button:only-of-type {
@@ -290,11 +291,11 @@
 
     &.usa-card--header-first {
       .usa-card__header {
-        @include u-padding-bottom(math.div($theme-card-padding-y, 2));
+        padding-bottom: math.div(units($theme-card-padding-y), 2);
       }
 
       .usa-card__body {
-        @include u-padding-top(math.div($theme-card-padding-y, 2));
+        padding-top: math.div(units($theme-card-padding-y), 2);
       }
 
       .usa-card__media--inset {


### PR DESCRIPTION
# Summary

**Fixed a bug that prevented `$theme-card-padding-y` from accepting expected token values.**

## Breaking change

This is not a breaking change.

## Related issue

Closes #5515

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2317)

## Preview link

[Card component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-card-padding-calc/?path=/story/components-card--default)

## Problem statement
When setting custom values for `$theme-card-padding-y`, some values that the system says are acceptable cause an error. 

For example: `$theme-card-padding-y: 15` results in the following error: 
```
Error: "`7.5` is not a valid `padding` token. You should correct this. Standard `padding` tokens:  1px, 2px, 05, 1, 105, 2, 205, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0"
   ╷
25 │     padding-#{$side}: get-uswds-value("padding", $value...) #{$important};
   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  packages/uswds-core/src/styles/mixins/utilities/_padding.scss 25:23  padding-n()
  packages/uswds-core/src/styles/mixins/utilities/_padding.scss 50:3   u-padding-bottom()
  packages/usa-card/src/styles/_usa-card.scss 81:3                     @forward
  usa-card/src/_index.scss 4:1                                         @forward
  packages/uswds/_index.scss 20:1                                      @forward
  src/stylesheets/uswds.scss 3:1                                       root stylesheet 
```

This problem occurs because the `u-padding` mixins accept only known unit tokens. The current calculations perform division on the setting value before running it through the mixin, which means that the mixins are not always receiving acceptable unit values. For example, when `$theme-card-padding-y` is defined with 15, the mixin receives the value of 7.5, which is not a mapped unit value.

## Solution
When the padding value must be divided, we should not use `u-padding` mixins and instead directly define the CSS padding property.

## Testing and review

1. Confirm that the `$theme-card-padding-y` setting accepts all listed padding token values without error:  1px, 2px, 05, 1, 105, 2, 205, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0.
1. Confirm that all math performed on `$theme-card-padding-y` are not used in mixins. 
1. Confirm that the setting updates the visual presentation as expected.
1. Confirm that there are no visual regressions.