### PR TITLE
USWDS: Fix broken alert alignment calculations

### DIFF
--- a/packages/usa-alert/src/styles/_usa-alert.scss
+++ b/packages/usa-alert/src/styles/_usa-alert.scss
@@ -22,6 +22,10 @@ $alert-icons: (
     .usa-alert__body {
       @include alert-status-body-styles($name, $icon);
     }
+
+    &.usa-alert--no-icon {
+      @include alert-styles-no-icon-content;
+    }
   }
 }
 

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -41,7 +41,7 @@
     'header': 'Info alert - slim, no icon',
     'alertModifier': 'usa-alert--info usa-alert--slim usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--info usa-site-alert--slim usa-site-alert--no-icon',
-    'aria': 'Site alert info,,'
+    'aria': 'Site alert info,,,'
   },
   {
     'header': 'Emergency alert',

--- a/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-comparison.twig
@@ -34,6 +34,13 @@
     'header': 'Info alert - no icon',
     'alertModifier': 'usa-alert--info usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--info usa-site-alert--no-icon',
+    'title': 'No icon',
+    'aria': 'Site alert info,,'
+  },
+  {
+    'header': 'Info alert - slim, no icon',
+    'alertModifier': 'usa-alert--info usa-alert--slim usa-alert--no-icon',
+    'siteModifier': 'usa-site-alert--info usa-site-alert--slim usa-site-alert--no-icon',
     'aria': 'Site alert info,,'
   },
   {
@@ -50,10 +57,16 @@
     'aria': 'Emergency alert info,'
   },
   {
+    'header': 'Emergency alert - slim, no icon',
+    'alertModifier': 'usa-alert--emergency usa-alert--slim usa-alert--no-icon',
+    'siteModifier': 'usa-site-alert--emergency usa-site-alert--slim usa-site-alert--no-icon',
+    'aria': 'Emergency alert info,,'
+  },
+  {
     'header': 'Emergency alert - no icon',
     'alertModifier': 'usa-alert--emergency usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--emergency usa-site-alert--no-icon',
-    'aria': 'Emergency alert info,,'
+    'aria': 'Emergency alert info,,,'
   }
 ] %}
 

--- a/packages/usa-alert/src/test/test-patterns/test-alert-in-template.twig
+++ b/packages/usa-alert/src/test/test-patterns/test-alert-in-template.twig
@@ -1,51 +1,53 @@
+
+
 {% set alerts = [
   {
-    'header': 'Info alert',
+    'header': 'Alert',
     'alertModifier': 'usa-alert--info',
     'siteModifier': 'usa-site-alert--info',
     'title': 'Informative status',
     'aria': 'Site alert info'
   },
   {
-    'header': 'Info alert - slim',
+    'header': 'Alert - slim',
     'alertModifier': 'usa-alert--info usa-alert--slim',
     'siteModifier': 'usa-site-alert--info usa-site-alert--slim',
     'aria': 'Site alert info,'
   },
   {
-    'header': 'Info alert - no icon',
+    'header': 'Alert - no icon',
     'alertModifier': 'usa-alert--info usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--info usa-site-alert--no-icon',
     'title': 'No icon',
     'aria': 'Site alert info,,'
   },
   {
-    'header': 'Info alert - slim, no icon',
+    'header': 'Alert - slim, no icon',
     'alertModifier': 'usa-alert--info usa-alert--slim usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--info usa-site-alert--slim usa-site-alert--no-icon',
     'aria': 'Site alert info,,,'
   },
   {
-    'header': 'Emergency alert',
+    'header': 'Alert - Emergency alert',
     'alertModifier': 'usa-alert--emergency',
     'siteModifier': 'usa-site-alert--emergency',
     'title': 'Informative status',
     'aria': 'Emergency alert info'
   },
   {
-    'header': 'Emergency alert - slim',
+    'header': 'Alert - slim',
     'alertModifier': 'usa-alert--emergency usa-alert--slim',
     'siteModifier': 'usa-site-alert--emergency usa-site-alert--slim',
     'aria': 'Emergency alert info,'
   },
   {
-    'header': 'Emergency alert - slim, no icon',
+    'header': 'Alert - slim, no icon',
     'alertModifier': 'usa-alert--emergency usa-alert--slim usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--emergency usa-site-alert--slim usa-site-alert--no-icon',
     'aria': 'Emergency alert info,,'
   },
   {
-    'header': 'Emergency alert - no icon',
+    'header': 'Alert - no icon',
     'alertModifier': 'usa-alert--emergency usa-alert--no-icon',
     'siteModifier': 'usa-site-alert--emergency usa-site-alert--no-icon',
     'aria': 'Emergency alert info,,,'
@@ -54,33 +56,34 @@
 
 {% include '@components/usa-banner/src/usa-banner.twig' %}
 
-{% for alert in alerts %}
-  <h3>{{ alert.header }}</h3>
-  <div class="usa-alert {{ alert.alertModifier }}">
-    <div class="usa-alert__body">
-      {% if alert.title %}<h4 class="usa-alert__heading">{{ alert.title }}</h4>{% endif %}
-      <p class="usa-alert__text">
-        Lorem ipsum dolor sit amet,
-        <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
-        elit, sed do eiusmod.
-      </p>
+{% include '@components/usa-site-alert/src/usa-site-alert.twig' %}
+
+<div class="usa-section">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="usa-layout-docs__sidenav desktop:grid-col-3">
+        {% include '@components/usa-sidenav/src/usa-sidenav.twig' %}
+      </div>
+
+      <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+
+        {% for alert in alerts %}
+          <div class="usa-alert {{ alert.alertModifier }}">
+            <div class="usa-alert__body">
+              {% if alert.title %}<h4 class="usa-alert__heading">{{ alert.title }}</h4>{% endif %}
+              <p class="usa-alert__text">
+                Lorem ipsum dolor sit amet,
+                <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a>
+                elit, sed do eiusmod.
+              </p>
+            </div>
+          </div>
+        {% endfor %}
+
+        {% include "@components/usa-type-setting/src/usa-type-setting--line-length.twig" %}
+      </main>
     </div>
   </div>
-  <hr/>
-  <section
-    class="usa-site-alert {{ alert.siteModifier }}"
-    aria-label="{{ alert.aria }}"
-  >
-    <div class="usa-alert">
-      <div class="usa-alert__body">
-        {% if alert.title %}<h3 class="usa-alert__heading">{{ alert.title }}</h3>{% endif %}
-        <p class="usa-alert__text">
-          Additional context and followup information including
-          <a class="usa-link" href="javascript:void(0);">a link</a>.
-        </p>
-      </div>
-    </div>
-  </section>
-{% endfor %}
+</div>
 
-{% include '@components/usa-footer/src/usa-footer.twig' with footer %}
+{% include '@components/usa-footer/src/usa-footer.twig' %}

--- a/packages/usa-alert/src/usa-alert.stories.js
+++ b/packages/usa-alert/src/usa-alert.stories.js
@@ -1,6 +1,11 @@
 import Component from "./usa-alert.twig";
 import TestComponent from "./test/test-patterns/test-usa-alert-lists.twig";
 import ComparisonComponent from "./test/test-patterns/test-alert-comparison.twig";
+import onPageComponent from "./test/test-patterns/test-alert-in-template.twig";
+import BannerContent from "../../usa-banner/src/content/usa-banner.json";
+import FooterContent from "../../usa-footer/src/usa-footer.json";
+import SiteAlertContent from "../../usa-site-alert/src/content/usa-site-alert~info.json";
+import SidenavContent from "../../usa-sidenav/src/usa-sidenav.json";
 
 import {
   DefaultContent,
@@ -21,6 +26,7 @@ export default {
 const Template = (args) => Component(args);
 const TestTemplate = (args) => TestComponent(args);
 const ComparisonTemplate = (args) => ComparisonComponent(args);
+const onPageTemplate = (args) => onPageComponent(args);
 
 export const Default = Template.bind({});
 Default.args = DefaultContent;
@@ -51,4 +57,16 @@ Warning.args = WarningContent;
 
 export const Test = TestTemplate.bind({});
 
-export const AlertComparison = ComparisonTemplate.bind({});
+export const AlertComponentsComparison = ComparisonTemplate.bind({});
+AlertComponentsComparison.args = {
+  ...BannerContent,
+  ...FooterContent,
+}
+
+export const AlertInTemplate = onPageTemplate.bind({});
+AlertInTemplate.args = {
+  ...BannerContent,
+  ...FooterContent,
+  ...SidenavContent,
+  ...SiteAlertContent
+}

--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -14,11 +14,17 @@ $site-alert-icons: (
 }
 
 @each $name, $icon in $site-alert-icons {
-  .usa-site-alert--#{$name} .usa-alert {
-    @include alert-status-wrapper-styles($name);
+  .usa-site-alert--#{$name} {
+    &.usa-site-alert--no-icon .usa-alert .usa-alert__body {
+      @include alert-styles-no-icon-content;
+    }
 
-    .usa-alert__body {
-      @include alert-status-body-styles($name, $icon);
+    .usa-alert {
+      @include alert-status-wrapper-styles($name);
+
+      .usa-alert__body {
+        @include alert-status-body-styles($name, $icon);
+      }
     }
   }
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -11,6 +11,13 @@
 @use "../typography/typeset.scss" as *;
 @use "../helpers/set-link-from-bg" as *;
 
+// For left content alignment at desktop widths,
+// remove half of the width of the alert bar from the site margin
+$alert-content-left-spacing: calc(
+  units($theme-site-margins-width) - (units($theme-alert-bar-width) / 2)
+);
+$alert-icon-text-gap: units(1);
+
 // Base alert styles
 @mixin alert-styles {
   $bgcolor: "base-lightest";
@@ -35,10 +42,6 @@
     @include u-margin-x("auto");
     @include u-maxw($theme-site-alert-max-width);
     @include u-padding-y($theme-alert-padding-y);
-    @include u-padding-x($theme-site-margins-mobile-width);
-    @include at-media($theme-site-margins-breakpoint) {
-      padding-left: 2 * $alert-icon-optical-padding;
-    }
 
     position: relative;
   }
@@ -48,6 +51,16 @@
 
     &:only-child {
       @include u-padding-y(0);
+    }
+  }
+
+  .usa-alert__heading,
+  .usa-alert__text {
+    margin-left: calc(units($theme-site-margins-mobile-width) + units($theme-alert-icon-size) + $alert-icon-text-gap);
+    @include at-media($theme-site-margins-breakpoint) {
+      margin-left: calc(
+        $alert-content-left-spacing + units($theme-alert-icon-size) + $alert-icon-text-gap
+      );
     }
   }
 
@@ -70,9 +83,14 @@
 // Set status styles for alert wrapper/background
 @mixin alert-status-wrapper-styles($name) {
   $bgcolor: if($name != "emergency", "#{$name}-lighter", $name);
+  $border-width: if($name != "emergency", $theme-alert-bar-width, 0);
 
   background-color: color($bgcolor);
   border-left-color: color($name);
+
+  @include at-media-max($theme-site-margins-breakpoint) {
+    border-left-width: units($border-width);
+  }
 }
 
 // Set status styles for alert content
@@ -87,12 +105,6 @@
   );
   @include add-alert-icon($icon, $banner-text-color-token, $bgcolor);
   @include set-text-and-bg($bgcolor);
-
-  padding-left: units($theme-alert-icon-size) + ($alert-icon-optical-padding);
-  @include at-media($theme-site-margins-breakpoint) {
-    padding-left: units($theme-site-margins-width) * 2;
-    padding-right: units($theme-site-margins-width) * 2;
-  }
 
   .usa-link {
     @include set-link-from-bg(
@@ -117,15 +129,11 @@
     @include add-color-icon($this-icon-object, $bgcolor);
     content: "";
     display: block;
-    // padding - optical spacing value
-    left: units($theme-site-margins-mobile-width) -
-      units($theme-alert-bar-width);
+    left: units($theme-site-margins-mobile-width);
     position: absolute;
     top: units($theme-alert-padding-y) * 0.75;
     @include at-media($theme-site-margins-breakpoint) {
-      left: calc(
-        units($theme-site-margins-width) - units($theme-alert-bar-width)
-      );
+      left: $alert-content-left-spacing;
     }
   }
 }
@@ -136,12 +144,16 @@
     &:before {
       display: none;
     }
+  }
+}
 
-    padding-left: units(
-      $theme-site-margins-mobile-width - $theme-alert-bar-width
-    );
+@mixin alert-styles-no-icon-content {
+  .usa-alert__text,
+  .usa-alert__heading {
+    margin-left: units($theme-site-margins-mobile-width);
+
     @include at-media($theme-site-margins-breakpoint) {
-      padding-left: 2 * $alert-icon-optical-padding;
+      margin-left: $alert-content-left-spacing;
     }
   }
 }
@@ -156,6 +168,10 @@
     @supports (mask: url("")) {
       mask-size: $alert-slim-icon-size;
     }
+
+    @include at-media($theme-site-margins-breakpoint) {
+      left: $alert-content-left-spacing;
+    }
   }
 }
 
@@ -163,11 +179,14 @@
   .usa-alert__body {
     @include u-padding-y(1);
     @include add-slim-alert-icon;
+  }
 
-    padding-left: $alert-slim-icon-size + $alert-icon-optical-padding;
+  .usa-alert__heading,
+  .usa-alert__text {
+    margin-left: calc(units($theme-site-margins-mobile-width) + $alert-slim-icon-size + $alert-icon-text-gap);
     @include at-media($theme-site-margins-breakpoint) {
-      padding-left: calc(
-        units($theme-site-margins-width) + $alert-slim-icon-size
+      margin-left: calc(
+        $alert-content-left-spacing + $alert-slim-icon-size + $alert-icon-text-gap
       );
     }
   }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -56,10 +56,14 @@ $alert-icon-text-gap: units(1);
 
   .usa-alert__heading,
   .usa-alert__text {
-    margin-left: calc(units($theme-site-margins-mobile-width) + units($theme-alert-icon-size) + $alert-icon-text-gap);
+    margin-left: calc(
+      units($theme-site-margins-mobile-width) + units($theme-alert-icon-size) +
+        $alert-icon-text-gap
+    );
     @include at-media($theme-site-margins-breakpoint) {
       margin-left: calc(
-        $alert-content-left-spacing + units($theme-alert-icon-size) + $alert-icon-text-gap
+        $alert-content-left-spacing + units($theme-alert-icon-size) +
+          $alert-icon-text-gap
       );
     }
   }
@@ -183,10 +187,14 @@ $alert-icon-text-gap: units(1);
 
   .usa-alert__heading,
   .usa-alert__text {
-    margin-left: calc(units($theme-site-margins-mobile-width) + $alert-slim-icon-size + $alert-icon-text-gap);
+    margin-left: calc(
+      units($theme-site-margins-mobile-width) + $alert-slim-icon-size +
+        $alert-icon-text-gap
+    );
     @include at-media($theme-site-margins-breakpoint) {
       margin-left: calc(
-        $alert-content-left-spacing + $alert-slim-icon-size + $alert-icon-text-gap
+        $alert-content-left-spacing + $alert-slim-icon-size +
+          $alert-icon-text-gap
       );
     }
   }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -90,7 +90,8 @@
 
   padding-left: units($theme-alert-icon-size) + ($alert-icon-optical-padding);
   @include at-media($theme-site-margins-breakpoint) {
-    @include u-padding-x($theme-site-margins-width * 2);
+    padding-left: units($theme-site-margins-width) * 2;
+    padding-right: units($theme-site-margins-width) * 2;
   }
 
   .usa-link {
@@ -122,7 +123,9 @@
     position: absolute;
     top: units($theme-alert-padding-y) * 0.75;
     @include at-media($theme-site-margins-breakpoint) {
-      left: units($theme-site-margins-width) - units($theme-alert-bar-width);
+      left: calc(
+        units($theme-site-margins-width) - units($theme-alert-bar-width)
+      );
     }
   }
 }
@@ -163,7 +166,9 @@
 
     padding-left: $alert-slim-icon-size + $alert-icon-optical-padding;
     @include at-media($theme-site-margins-breakpoint) {
-      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size;
+      padding-left: calc(
+        units($theme-site-margins-width) + $alert-slim-icon-size
+      );
     }
   }
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -13,7 +13,7 @@
 
 // For left content alignment at desktop widths,
 // remove half of the width of the alert bar from the site margin
-$alert-content-left-spacing: calc(
+$alert-content-margin-width: calc(
   units($theme-site-margins-width) - (units($theme-alert-bar-width) / 2)
 );
 $alert-icon-text-gap: units(1);
@@ -62,7 +62,7 @@ $alert-icon-text-gap: units(1);
     );
     @include at-media($theme-site-margins-breakpoint) {
       margin-left: calc(
-        $alert-content-left-spacing + units($theme-alert-icon-size) +
+        $alert-content-margin-width + units($theme-alert-icon-size) +
           $alert-icon-text-gap
       );
     }
@@ -137,7 +137,7 @@ $alert-icon-text-gap: units(1);
     position: absolute;
     top: units($theme-alert-padding-y) * 0.75;
     @include at-media($theme-site-margins-breakpoint) {
-      left: $alert-content-left-spacing;
+      left: $alert-content-margin-width;
     }
   }
 }
@@ -157,7 +157,7 @@ $alert-icon-text-gap: units(1);
     margin-left: units($theme-site-margins-mobile-width);
 
     @include at-media($theme-site-margins-breakpoint) {
-      margin-left: $alert-content-left-spacing;
+      margin-left: $alert-content-margin-width;
     }
   }
 }
@@ -174,7 +174,7 @@ $alert-icon-text-gap: units(1);
     }
 
     @include at-media($theme-site-margins-breakpoint) {
-      left: $alert-content-left-spacing;
+      left: $alert-content-margin-width;
     }
   }
 }
@@ -193,7 +193,7 @@ $alert-icon-text-gap: units(1);
     );
     @include at-media($theme-site-margins-breakpoint) {
       margin-left: calc(
-        $alert-content-left-spacing + $alert-slim-icon-size +
+        $alert-content-margin-width + $alert-slim-icon-size +
           $alert-icon-text-gap
       );
     }


### PR DESCRIPTION
# Summary

**Fixed the alignment calculations for the alert components.**

## Breaking change

This is not a breaking change.

## Related issue
Closes #5583 

## Related pull requests

Changelog PR

## Preview link

- [Alert comparison story](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-theme-site-margins-width-fix/?path=/story/components-alert--alert-comparison)

## Problem statement


## Solution


## Testing and review
- Open the [alert comparison story](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-theme-site-margins-width-fix/?path=/story/components-alert--alert-comparison) and confirm no visual regressions

In a local build:
1. Check out this branch 
2. Customize the value of `$theme-site-margins-width` to any of the following values: 1px, 2px, 05, 1, 105, 2, 205, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0. 
    1. Confirm that the Sass compiles without error
    2. Open the [alert comparison story](http://localhost:6006/?path=/story/components-alert--alert-comparison)
    3. Confirm the visual presentation adjusts as expected.
    4. Confirm that the alert component aligns with the left margin of the banner and footer content 

