### PR TITLE
USWDS - Core: Avoid usa-prose override styles when usa-prose not loaded

### DIFF
--- a/packages/uswds-core/src/styles/mixins/helpers/override-prose.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/override-prose.scss
@@ -1,6 +1,11 @@
+@use "sass:meta";
+
 @mixin override-prose {
   @content;
-  .usa-prose {
-    @content;
+
+  @if meta.mixin-exists("prose-test") {
+    .usa-prose {
+      @content;
+    }
   }
 }


### PR DESCRIPTION
# Summary

**Reduced output size for projects optimized using component packages that do not include `usa-prose`.**

## Problem statement

As a developer, I expect that if I choose to [optimize my installation to use only packages for components I'm using](https://designsystem.digital.gov/documentation/migration/#6-optimize-your-installation), the compiled output will not include styles for unused components, so that the compiled output is as optimized as possible.

## Solution

The general idea is that we only want to include the `.usa-prose`-wrapped content if `usa-prose` is actually loaded. After referencing [`sass:meta` documentation](https://sass-lang.com/documentation/modules/meta/) and what's [defined in the `usa-prose` styles themselves](https://github.com/uswds/uswds/blob/develop/packages/usa-prose/src/styles/_usa-prose.scss), I landed at `meta.mixin-exists("prose-test")`. Another option might be to define a new mixin or variable explicitly for this check.

### Results:

Results will vary depending on which packages someone chooses to include. The example below uses `usa-process-list`, which includes a [non-insignificant amount of prose-overriding styles](https://github.com/uswds/uswds/blob/48bfdf2960d7cbd043dac5bf71a9616ec1defa65/packages/usa-process-list/src/styles/_usa-process-list.scss#L14-L39).

Test file:

```scss
@use "uswds-core" with ($theme-show-notifications: false);
@forward "usa-process-list";
```

Sass-compressed, raw:

```
sass --load-path=packages --style=compressed example.scss | wc -c
```

**Before:** 5612 bytes
**After:** 5004 bytes
**Diff:** -608 bytes (-10.8%)

Sass-compressed, [Brotli compression](https://en.wikipedia.org/wiki/Brotli) (using [brotli-size-cli](https://www.npmjs.com/package/brotli-size-cli)):

```
sass --load-path=packages --style=compressed example.scss | brotli-size
```

**Before:** 759 bytes
**After:** 735 bytes
**Diff:** -24 bytes (-3.2%)