### PR TITLE
USWDS - Settings: Fix math errors with $theme-site-margins-width

### DIFF
--- a/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/alert-status-styles.scss
@@ -90,7 +90,8 @@
 
   padding-left: units($theme-alert-icon-size) + ($alert-icon-optical-padding);
   @include at-media($theme-site-margins-breakpoint) {
-    @include u-padding-x($theme-site-margins-width * 2);
+    padding-left: units($theme-site-margins-width) * 2;
+    padding-right: units($theme-site-margins-width) * 2;
   }
 
   .usa-link {
@@ -122,7 +123,9 @@
     position: absolute;
     top: units($theme-alert-padding-y) * 0.75;
     @include at-media($theme-site-margins-breakpoint) {
-      left: units($theme-site-margins-width) - units($theme-alert-bar-width);
+      left: calc(
+        units($theme-site-margins-width) - units($theme-alert-bar-width)
+      );
     }
   }
 }
@@ -163,7 +166,9 @@
 
     padding-left: $alert-slim-icon-size + $alert-icon-optical-padding;
     @include at-media($theme-site-margins-breakpoint) {
-      padding-left: units($theme-site-margins-width) + $alert-slim-icon-size;
+      padding-left: calc(
+        units($theme-site-margins-width) + $alert-slim-icon-size
+      );
     }
   }
 }


### PR DESCRIPTION
# Summary

**Fixed a bug that prevented `$theme-site-margins-width` from accepting expected token values.**

## Breaking change

This is not a breaking change.

## Related issue

Closes #5559

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2313)

## Preview link

[Alert component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-theme-site-margins-fix/?path=/story/components-alert--alert-comparison)

## Problem statement

When setting custom values for `$theme-site-margins-width`, some values that the system says are acceptable cause an error.

For example,`$theme-site-margins-width: 6` results in the following error:
    
```
SassError: "`12` is not a valid `padding` token. You should correct this. Standard `padding` tokens:  1px, 2px, 05, 1, 105, 2, 205, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0"

19 │     padding-left: get-uswds-value("padding", $value...) #{$important};
    
```

This happens because the `u-padding` mixins accept only known padding units. The current calculations perform multiplication on the setting value before running it through the mixin, which means that the mixins are not always receiving acceptable unit values. For example, when `$theme-site-margins-width` is defined with 6, the mixin receives the value of 12, which is not a mapped unit value.

## Solution
1. Defining the padding with the CSS `padding` property rather than the `u-padding` mixin allows the system to successfully do the required calculations. 
1. Wrapping calculations inside `calc()` enables the math to work when there are mixed units (For example,  when `$theme-site-margins-width` is set to `1px`).

> **Warning**
> This PR uncovered that the alert component has some alignment issues when the value for `$theme-site-margins-width` is adjusted. It can cause text to overlap or become misaligned with the other components. I have opened issue #5583  to address this.

## Testing and review
To test the alignment with default value for `$theme-site-margins-width`:
Open the [alert](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-theme-site-margins-width-fix/?path=/story/components-alert--alert-comparison) component and confirm no visual regressions in alignment.

To test custom values for `$theme-site-margins-width`:
1. Check out this branch in a local build
2. Customize the value of `$theme-site-margins-width` to any of the following values: 1px, 2px, 05, 1, 105, 2, 205, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0. 
1. Confirm that the Sass compiles without error
1. Confirm the visual presentation adjusts as expected.
    - :warning: Note that the alert component will not adjust as expected. See the warning above for more details.
