### PR TITLE
USWDS - Banner: Remove invalid baseline styling from banner button

### DIFF
--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -230,7 +230,7 @@ $banner-icon-close: (
   @include button-unstyled;
   @include u-pin("left");
   @include u-pin("y");
-  @include u-text("primary", underline, baseline);
+  @include u-text("primary", underline);
   @include set-link-from-bg(
     $theme-banner-background-color,
     $theme-banner-link-color,


### PR DESCRIPTION
# Summary

**Removes invalid styles from the banner component.** These styles had no effect and were safely removed.

## Problem statement

As a developer, I expect that USWDS ships valid CSS, so that (a) it is correct, (b) my CSS bundles are optimized only to include what has a meaningful effect on styles, and (c) my code will not be flagged by automated validation tools.

The application of `vertical-align: baseline` is invalid here because the component is also styled as `display: block`

https://github.com/uswds/uswds/blob/48bfdf2960d7cbd043dac5bf71a9616ec1defa65/packages/usa-banner/src/styles/_usa-banner.scss#L239

References:

>Note that vertical-align only applies to inline, inline-block and table-cell elements: you can't use it to vertically align [block-level elements](https://developer.mozilla.org/en-US/docs/Glossary/Block-level_content).

Source: https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align

>Applies to: | inline-level and `table-cell` elements

Source: https://drafts.csswg.org/css2/#propdef-vertical-align

Validation warning via VSCode:

![Screenshot 2023-10-30 at 8 56 32 AM](https://github.com/uswds/uswds/assets/1779930/21142d34-b36b-4ebf-ac2d-3f4986ce5c66)

## Solution

Removes the `vertical-align: baseline` styles.