### PR TITLE
USWDS - Footer: Fix link styles for accessibility

### DIFF
--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -87,10 +87,6 @@ $-chevron-expand-more: map-merge(
     @include u-padding-x(0);
   }
 
-  &:hover {
-    text-decoration: underline;
-  }
-
   // Disclosure button functionality happens at mobile widths
   &--button {
     @include place-icon($-chevron-expand-more, "before", 0.5);

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -77,19 +77,10 @@ $-chevron-expand-more: map-merge(
   line-height: line-height($theme-footer-font-family, 2);
 }
 
-.usa-footer__primary-link a,
-.usa-footer__secondary-link a {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 .usa-footer__primary-link {
   @include u-padding-x($theme-site-margins-mobile-width);
   @include u-padding-y(2);
-  @include u-text("ink", "no-underline", "bold");
+  @include u-text("ink", "bold");
   display: block;
 
   @include at-media("mobile-lg") {
@@ -166,11 +157,7 @@ $-chevron-expand-more: map-merge(
   line-height: line-height($theme-footer-font-family, 2);
 
   a {
-    @include u-text("ink", "no-underline");
-
-    &:hover {
-      text-decoration: underline;
-    }
+    @include u-text("ink");
   }
 
   @include at-media("mobile-lg") {


### PR DESCRIPTION
# Summary

**Restores underlines to footer links in default states.** Now, footer links meet WCAG 2.0 AA requirements.

## Breaking change

This is ***not*** a breaking change

## Related issue

Closes #5557

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2328)

## Preview link

[Default footer →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-update-footer-link-styles/?path=/story/components-footer--default)

[Big footer →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-update-footer-link-styles/?path=/story/components-footer--big-footer)

[Slim footer →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-update-footer-link-styles/?path=/story/components-footer--slim-footer)

## Problem statement

Currently, footer links do ***not*** meet WCAG 2.0 AA accessibility requirements.

> The link text must have a 3:1 contrast ratio from the surrounding non-link text.
>
> The link must present a "non-color designator" (typically the introduction of the underline) on both mouse hover and keyboard focus.
>
> WCAG recognizes that meeting these contrast requirements “is not the preferred technique to differentiate link text”. Of course the easy solution to this is to simply underline links in their default state. Interestingly, underlined links can be the exact same color as their surrounding text, though this is far from optimal. [1](https://github.com/orgs/uswds/projects/8/views/14?pane=issue&itemId=41393394#user-content-fn-1-2ae4cabc70c409bf888cd73b48e3cd6b)

[^1]: https://webaim.org/blog/wcag-2-0-and-link-colors/

## Solution

Restore underlines to links in default states.

### Alternative solution

We could alternatively increase the color contrast of links to have at least a `3:1` contrast ratio to surrounding texts. 

This solution seems a bit more opinionated and relies on users to have not modified the colors of their footer text and/or links to ensure compliance. 

<details><summary>Screenshots</summary>
<p>

**************Develop**************

![image](https://github.com/uswds/uswds/assets/25211650/b22c70c7-7c08-4557-847c-93ba11e38abb)

**********After fix**********

![image](https://github.com/uswds/uswds/assets/25211650/204277e6-99ba-443d-b723-03d32b805116)

</p>
</details> 








## Testing and review

1. Inspect each footer variant in mobile, tablet, and desktop.
2. Confirm that links to external pages each have underlines.
3. Confirm this meets accessibility criteria.

### Testing checklist

- [ ]  All footer links meet accessibility criteria in all states/viewports.
- [ ]  Alternatives are considered and decided that this is the best route.
- [ ]  Confirm accordion button links on links the mobile Big Footer variant do not need underlines.
- [ ]  Prettier, linting, and automatic tests pass without error or changes.