### PR TITLE
USWDS - Nav: Fix compilation error when max header width is set to "none"

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -479,15 +479,17 @@ $expand-less-icon: map-merge(
 //
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-$safari-header-bug-min-width: calc(
-  units($theme-header-max-width) - px-to-rem(15px)
-);
-
-@media (min-width: $safari-header-bug-min-width) {
-  .usa-js-mobile-nav--active.is-safari {
-    overflow-y: scroll;
-    position: fixed;
-    // --scrolltop set with JS with zero as fallback.
-    top: var(--scrolltop, 0);
-  }
+@if $theme-header-max-width != "none" {
+  $safari-header-bug-min-width: calc(
+    units($theme-header-max-width) - px-to-rem(15px)
+  );
+    
+  @media (min-width: $safari-header-bug-min-width) {
+    .usa-js-mobile-nav--active.is-safari {
+      overflow-y: scroll;
+      position: fixed;
+      // --scrolltop set with JS with zero as fallback.
+      top: var(--scrolltop, 0);
+    }
+  } 
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -483,7 +483,7 @@ $expand-less-icon: map-merge(
   $safari-header-bug-min-width: calc(
     units($theme-header-max-width) - px-to-rem(15px)
   );
-    
+
   @media (min-width: $safari-header-bug-min-width) {
     .usa-js-mobile-nav--active.is-safari {
       overflow-y: scroll;
@@ -491,5 +491,5 @@ $expand-less-icon: map-merge(
       // --scrolltop set with JS with zero as fallback.
       top: var(--scrolltop, 0);
     }
-  } 
+  }
 }

--- a/packages/uswds-core/src/styles/settings/_settings-components.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-components.scss
@@ -94,7 +94,7 @@ $theme-input-tile-border-width: 2px !default;
 // Header
 $theme-header-font-family: "ui" !default;
 $theme-header-logo-text-width: 33% !default;
-$theme-header-max-width: "none" !default;
+$theme-header-max-width: "desktop" !default;
 $theme-header-min-width: "desktop" !default;
 
 // Hero

--- a/packages/uswds-core/src/styles/settings/_settings-components.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-components.scss
@@ -94,7 +94,7 @@ $theme-input-tile-border-width: 2px !default;
 // Header
 $theme-header-font-family: "ui" !default;
 $theme-header-logo-text-width: 33% !default;
-$theme-header-max-width: "desktop" !default;
+$theme-header-max-width: "none" !default;
 $theme-header-min-width: "desktop" !default;
 
 // Hero


### PR DESCRIPTION
# Summary

Resolved a compilation error when `$theme-max-header-width` was set to `none`. 

## Breaking change

This is not a breaking change

## Related issue

Closes #5579

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2356)

[USWDS: Header: Add fix for Safari-only header bug #5443](https://github.com/uswds/uswds/pull/5443#top)

## Preview link

[Header →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-max-width-none-fix/?path=/story/components-header--default)

[Documentation page →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-max-width-none-fix/?path=/story/pages-documentation-page--documentation-page)

## Problem statement

A compilation error occurs when setting `$theme-max-header-width` to `none`.

This is a regression which stems from our Safari header navigation bug fix #5543. The `calc()` method cannot take a value of `none` so it breaks the calculation.

## Solution

Use sass `@if` at-rule to check if `$theme-max-header-width` value is `none` before enabling the Safari bug fix logic.

- Since there is no max width, the Safari header bug does not occur
- Therefore, we can bypass the additional logic when max-width is set to `none`

## Testing and review

### Test compilation error

1. Set `$theme-header-max-width` to `"none"`
2. Ensure there are no compilation errors

### Safari header bug

Follow Amy’s testing steps from #5543 to ensure there are no regressions:

Use Storybook to test that the mobile menu opens in Safari:

1. Open the Documentation page in Safari
2. Resize the window to somewhere between 1009px-1024px
3. Click the "Menu" button to open the mobile navigation panel
4. Confirm that the mobile header successfully opens as expected

Use Storybook to test that this does not affect other browsers:

1. Open the Documentation page in other browsers
2. Resize the window to somewhere between 1009px-1024px
3. Click the "Menu" button to open the mobile navigation panel
4. Confirm that the main page content is not scrollable

### Testing checklist

- [ ] Confirm there are no compilation errors when `$theme-header-max-width` is set to `"none"`.
- [ ] Confirm use of `@if` is appropriate in this situation.
- [ ] Confirm there are no regressions with header in Safari after this change.