### PR TITLE
USWDS - Banner: Remove redundant banner icon role attribute

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -27,14 +27,14 @@
     <div class="usa-banner__content usa-accordion__content" id="{{ banner.id }}">
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="./img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+          <img class="usa-banner__icon usa-media-block__img" src="./img/icon-dot-gov.svg" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             {# Will cause error without trim because it doesn't know what to do with new lines #}
             <p><strong>{{ domain.heading }}</strong><br/>{{ domain.text | trim | raw }}</p>
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
-          <img class="usa-banner__icon usa-media-block__img" src="./img/icon-https.svg" role="img" alt="" aria-hidden="true">
+          <img class="usa-banner__icon usa-media-block__img" src="./img/icon-https.svg" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             <p><strong>{{ https.heading }}</strong><br/>{{ https.pretext | trim | raw }} ({{ lock }}) {{ https.posttext | trim | raw }}</p>
           </div>


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

**Removed unnecessary role attributes from banner icon images.** A minor accessibility improvement to HTML markup that prevents screen readers from announcing the role of an image that has no content to relay to users.

## Breaking change

:warning: This is a breaking change.

Please update the banner component HTML template in your project to remove the `role="img"` attributes for the image elements with the class `usa-banner__icon`.

## Related issue
Closes [#_5619_](https://github.com/uswds/uswds/issues/5619)
<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here:
https://github.com/uswds/uswds/issues/new/choose.
-->

## Related pull requests

No related pull requests.

## Preview link

No preview link generated.

## Problem statement

We should avoid confusing screenreader systems by announcing the role of an element that doesn't have any information to announce. This is confusing and is a minor annoyance for screenreader users. 

This problem is minor as it likely doesn't affect many screenreader systems, which are generally smart enough to handle invalid HTML / odd attribute pairings. However, as the banner is used consistently across all US government sites, it would be good to fix regardless.

## Solution

Remove the extra unneeded role attributes.

## Major changes

No major changes made.

## Testing and review

Please test using https://validator.w3.org/nu/. If you don't have a live webpage to test against, you can also test using [the manual text input box](https://validator.w3.org/nu/?#textarea) by copying and pasting the HTML source code there. 

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
