### PR TITLE
USWDS - Header: Use $theme-header-min-width for safari fix calc

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -479,15 +479,18 @@ $expand-less-icon: map-merge(
 //
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-$safari-header-bug-min-width: calc(
-  units($theme-header-min-width) - px-to-rem(15px)
-);
 
-@media (min-width: $safari-header-bug-min-width) {
-  .usa-js-mobile-nav--active.is-safari {
-    overflow-y: scroll;
-    position: fixed;
-    // --scrolltop set with JS with zero as fallback.
-    top: var(--scrolltop, 0);
+@if $theme-header-min-width != "none" {
+  $safari-header-bug-min-width: calc(
+    units($theme-header-min-width) - px-to-rem(15px)
+  );
+
+  @media (min-width: $safari-header-bug-min-width) {
+    .usa-js-mobile-nav--active.is-safari {
+      overflow-y: scroll;
+      position: fixed;
+      // --scrolltop set with JS with zero as fallback.
+      top: var(--scrolltop, 0);
+    }
   }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -479,7 +479,8 @@ $expand-less-icon: map-merge(
 //
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-@if $theme-header-min-width != "none" {
+@if $theme-header-min-width != "none" and not $theme-header-min-width == "auto"
+{
   $safari-header-bug-min-width: calc(
     units($theme-header-min-width) - px-to-rem(15px)
   );

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -475,12 +475,12 @@ $expand-less-icon: map-merge(
 }
 
 // Safari-only fix that forces a vertical scrollbar when mobile menu is open.
-// Only needed in the 15px immediately preceding $theme-header-max-width.
+// Only needed in the 15px immediately preceding $theme-header-min-width.
 //
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
 $safari-header-bug-min-width: calc(
-  units($theme-header-max-width) - px-to-rem(15px)
+  units($theme-header-min-width) - px-to-rem(15px)
 );
 
 @media (min-width: $safari-header-bug-min-width) {

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "uswds-core" as *;
 
 // Navigation helpers
@@ -478,20 +479,23 @@ $expand-less-icon: map-merge(
 // Only needed in the 15px immediately preceding $theme-header-min-width.
 //
 // Note: 15px is the current width of the Safari scrollbar.
-// More details in https://github.com/uswds/uswds/pull/5443
-@if $theme-header-min-width != "none" and $theme-header-min-width != "auto" {
+// Note: This fix only applies when $theme-header-min-width is defined with a system breakpoint
+//   because the header visually breaks with other values.
+//   This bypass prevents compilation errors with values like "none" or 1px.
+
+$our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
+
+@if map-has-key($our-breakpoints, $theme-header-min-width) {
   $safari-header-bug-min-width: calc(
     units($theme-header-min-width) - px-to-rem(15px)
   );
 
-  @if $safari-header-bug-min-width > 0 {
-    @media (min-width: $safari-header-bug-min-width) {
-      .usa-js-mobile-nav--active.is-safari {
-        overflow-y: scroll;
-        position: fixed;
-        // --scrolltop set with JS with zero as fallback.
-        top: var(--scrolltop, 0);
-      }
+  @media (min-width: $safari-header-bug-min-width) {
+    .usa-js-mobile-nav--active.is-safari {
+      overflow-y: scroll;
+      position: fixed;
+      // --scrolltop set with JS with zero as fallback.
+      top: var(--scrolltop, 0);
     }
   }
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -477,26 +477,21 @@ $expand-less-icon: map-merge(
 // Safari-only fix that forces a vertical scrollbar when mobile menu is open.
 // Only needed in the 15px immediately preceding $theme-header-min-width.
 //
-// Note: To prevent error, this fix is currently scoped to only work
-//  when $theme-header-min-width receives expected values. The setting is used
-//  primarily in at-media(), which only accepts breakpoints from $system-properties.
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-$our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
-
-@if map-has-key($our-breakpoints, $theme-header-min-width) {
+@if $theme-header-min-width != "none" {
   $safari-header-bug-min-width: calc(
     units($theme-header-min-width) - px-to-rem(15px)
   );
 
-  @media (min-width: $safari-header-bug-min-width) {
-    .usa-js-mobile-nav--active.is-safari {
-      overflow-y: scroll;
-      position: fixed;
-      // --scrolltop set with JS with zero as fallback.
-      top: var(--scrolltop, 0);
+  @if $safari-header-bug-min-width > 0 {
+    @media (min-width: $safari-header-bug-min-width) {
+      .usa-js-mobile-nav--active.is-safari {
+        overflow-y: scroll;
+        position: fixed;
+        // --scrolltop set with JS with zero as fallback.
+        top: var(--scrolltop, 0);
+      }
     }
   }
-} @else {
-  @warn '`#{$theme-header-min-width}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}';
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -477,10 +477,14 @@ $expand-less-icon: map-merge(
 // Safari-only fix that forces a vertical scrollbar when mobile menu is open.
 // Only needed in the 15px immediately preceding $theme-header-min-width.
 //
+// Note: To prevent error, this fix is currently scoped to only work
+//  when $theme-header-min-width receives expected values. The setting is used
+//  primarily in at-media(), which only accepts breakpoints from $system-properties.
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
+$our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
 
-@if $theme-header-min-width != "none" {
+@if map-has-key($our-breakpoints, $theme-header-min-width) {
   $safari-header-bug-min-width: calc(
     units($theme-header-min-width) - px-to-rem(15px)
   );
@@ -493,4 +497,6 @@ $expand-less-icon: map-merge(
       top: var(--scrolltop, 0);
     }
   }
+} @else {
+  @warn '`#{$theme-header-min-width}` is not a valid USWDS project breakpoint. Valid values: #{map-keys($our-breakpoints)}';
 }

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -479,8 +479,7 @@ $expand-less-icon: map-merge(
 //
 // Note: 15px is the current width of the Safari scrollbar.
 // More details in https://github.com/uswds/uswds/pull/5443
-@if $theme-header-min-width != "none" and not $theme-header-min-width == "auto"
-{
+@if $theme-header-min-width != "none" and $theme-header-min-width != "auto" {
   $safari-header-bug-min-width: calc(
     units($theme-header-min-width) - px-to-rem(15px)
   );


### PR DESCRIPTION
# Summary

Fixed a bug that prevented `$theme-max-header-width` from accepting a value of "none".

## Breaking change

This is not a breaking change.

## Related issue

Closes #5579 

## Related pull requests

This PR replaces the fix proposed in https://github.com/uswds/uswds/pull/5617.

[Changelog PR](https://github.com/uswds/uswds-site/pull/2356)

## Preview link

Preview link: [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-bug-fix-regression/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story)

## Problem statement

A compilation error occurs when setting `$theme-max-header-width` to `"none"`.

This is a regression which stems from our Safari header navigation bug fix in  https://github.com/uswds/uswds/pull/5543. The calc() method cannot take a value of none so it breaks the calculation.

## Solution

The calculation mistakenly used `$theme-header-max-width` instead of `$theme-header-min-width`. The settings have two distinct purposes:

- `$theme-header-min-width` is the setting that determines where the mobile nav should change to the desktop nav.
- `$theme-header-max-width`  is the setting that determines the maximum width of the desktop navigation. 

For the Safari fix to work as expected, the fix needs to be triggered within 15px of the mobile/desktop breakpoint, which is `$theme-header-min-width`.

By removing `$theme-header-max-width` from the calculation, there should no longer be errors when the setting's value is set to "none". 

## Testing and review

- Confirm that there is no compilation error when you set `$theme-header-max-width` to "none" 
- Confirm that the Safari bug fix from https://github.com/uswds/uswds/pull/5617 still works by checking if the mobile menu opens as expected in Safari:
  1. Open the [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-bug-fix-regression/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in Safari
  1. Resize the window to somewhere between 1009px-1024px
  1. Click the "Menu" button to open the mobile navigation panel
  1. Confirm that the mobile header successfully opens as expected
- Confirm that the mobile menu opens as expected in other browsers:
   1. Open the [Documentation page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-safari-header-bug/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in other browsers
   1. Resize the window to somewhere between 1009px-1024px
   1. Click the "Menu" button to open the mobile navigation panel
   1. Confirm that the main page content is not scrollable
- Confirm that the bug fix works with different values for `$theme-header-min-width`
  1. In a local build, change the value of `$theme-header-min-width` to expected values like "widescreen" or "tablet"
  1. Open the [documentation page](http://localhost:6006/iframe.html?args=&id=pages-documentation-page--documentation-page&viewMode=story) in Safari
  1. Resize the window to within 15px of the value set for `$theme-header-min-width`
  1. Confirm that the menu
- Confirm that we don't need to account for any special values for `$theme-header-min-width` that could cause an error (like "none")