### PR TITLE
USWDS - Button: Collapse unstyled button width at small viewport sizes

### DIFF
--- a/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
+++ b/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
@@ -14,6 +14,7 @@
   text-align: left;
   margin: 0;
   padding: 0;
+  width: auto;
 
   &:hover,
   &.usa-button--hover,


### PR DESCRIPTION
# Summary

**Unstyled buttons no longer appear as full width at narrow viewport sizes.** This brings the button into alignment with expectation of it being used in plain text contexts.

## Breaking change

This may be considered a breaking change if someone had come to rely on the previous behavior. However, I'd argue that this behavior should have never been considered expected, and therefore fits the definition of a bug fix.

## Related PR
[Changelog PR](https://github.com/uswds/uswds-site/pull/2795)

## Preview link

Preview link: http://localhost:6006/?path=/story/components-button--unstyled

Before|After
---|---
![Screenshot 2023-11-21 at 9 04 46 AM](https://github.com/uswds/uswds/assets/1779930/c10c1415-d913-4398-8d7f-3a6aca551a6b)|![Screenshot 2023-11-21 at 9 05 20 AM](https://github.com/uswds/uswds/assets/1779930/22fcca97-f195-4bf5-ab50-0348e026269f)

## Problem statement

We often use unstyled buttons as visually equivalent to a link. Therefore, we've encountered issues where the unstyled button occupies full width at mobile viewport sizes, causing line breaks in content.

See screenshots at https://github.com/18F/identity-idp/pull/9632 for example effect.

## Solution

The solution proposed here resets the `width: 100%` applied to buttons by default at mobile viewport sizes, specifically for the unstyled button.