### PR TITLE
USWDS - Utilities: Add "full-percent" palettes to top, left, right

### DIFF
--- a/packages/uswds-core/src/styles/_properties.scss
+++ b/packages/uswds-core/src/styles/_properties.scss
@@ -326,7 +326,8 @@ $system-properties: (
         map.get($system-spacing, "smaller-negative"),
         map.get($system-spacing, "small-negative"),
         map.get($partial-values, "zero-zero"),
-        map.get($partial-values, "auto")
+        map.get($partial-values, "auto"),
+        map.get($partial-values, "full-percent")
       ),
     extended: (),
   ),
@@ -610,7 +611,8 @@ $system-properties: (
         map.get($system-spacing, "smaller-negative"),
         map.get($system-spacing, "small-negative"),
         map.get($partial-values, "zero-zero"),
-        map.get($partial-values, "auto")
+        map.get($partial-values, "auto"),
+        map.get($partial-values, "full-percent")
       ),
     extended: (),
   ),
@@ -674,7 +676,8 @@ $system-properties: (
         map.get($system-spacing, "smaller-negative"),
         map.get($system-spacing, "small-negative"),
         map.get($partial-values, "zero-zero"),
-        map.get($partial-values, "auto")
+        map.get($partial-values, "auto"),
+        map.get($partial-values, "full-percent")
       ),
     extended: (),
   ),


### PR DESCRIPTION
# Summary

Fixed a bug that prevented the CSS from generating `.left-full`, `.right-full`, and `.top-full` utility classes.


## Breaking change

This is not a breaking change.

## Related issue

Closes #5632

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2367)

## Problem statement

Our [documentation](https://designsystem.digital.gov/utilities/display/#relative-position) for `.left-`, `.right-`, and `.top-` utility classes state that USWDS offers `.left-full`, `.right-full`, and `.top-full` classes. However, these do not appear in the default USWDS CSS. USWDS CSS _does_ currently provide a `.bottom-full` class. 

## Solution
Added "full-percent" palettes to `.top-`, `.left-`, `.right-` utility classes.

## Testing and review

- Confirm that USWDS should include `.left-full`, `.right-full`, and `.top-full` classes.
- Confirm that the generated CSS now includes `.left-full`, `.right-full`, and `.top-full` classes.
- Confirm that the new classes generate the expected property values
