### PR TITLE
USWDS - Accordions: Add support for hidden until found

### DIFF
--- a/packages/usa-accordion/src/styles/_usa-accordion.scss
+++ b/packages/usa-accordion/src/styles/_usa-accordion.scss
@@ -147,7 +147,7 @@ $accordion-button-open-hc-icon: map-merge(
 }
 
 .usa-accordion--bordered {
-  .usa-accordion__content {
+  .usa-accordion__content:where(:not([hidden])) {
     border-bottom: $accordion-border;
     border-left: $accordion-border;
     border-right: $accordion-border;
@@ -177,8 +177,11 @@ $accordion-button-open-hc-icon: map-merge(
     $context: $accordion-context
   );
   margin-top: 0;
-  overflow: auto;
-  padding: units(2) units(2.5) calc(#{units(2)} - #{units(0.5)}) units(2.5);
+
+  &:where(:not([hidden])) {
+    overflow: auto;
+    padding: units(2) units(2.5) calc(#{units(2)} - #{units(0.5)}) units(2.5);
+  }
 
   > *:first-child {
     margin-top: 0;

--- a/packages/usa-accordion/src/test/test-patterns/test-accordion-icon.twig
+++ b/packages/usa-accordion/src/test/test-patterns/test-accordion-icon.twig
@@ -1,9 +1,0 @@
-<div class="padding-8">
-  {% include '@components/usa-banner/src/usa-banner.twig' %}
-</div>
-<div class="padding-8">
-  {% include '@components/usa-accordion/src/usa-accordion.twig' with DefaultContent %}
-</div>
-<div class="padding-8">
-  {% include '@components/usa-header/src/usa-header.twig' %}
-</div>

--- a/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
+++ b/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
@@ -1,25 +1,24 @@
 <div class="padding-8">
-  <h3>Banner</h3>
-  {% include '@components/usa-banner/src/usa-banner.twig' %}
+  <article class="margin-bottom-6">
+    {% include '@components/usa-banner/src/usa-banner.twig' %}
+  </article>
 
-  <h3>Accordion</h3>
-  {% include '@components/usa-accordion/src/usa-accordion.twig' with DefaultContent %}
+  <article class="margin-bottom-6">
+    {% include '@components/usa-accordion/src/usa-accordion.twig' with DefaultContent %}
+  </article>
 
-
-  <h3>Headers</h3>
-
-  <div class="margin-bottom-6">
+  <article class="margin-bottom-6">
     {% include '@components/usa-header/src/usa-header.twig' with header %}
-  </div>
+  </article>
 
-  <div class="margin-bottom-6">
+  <article class="margin-bottom-6">
     {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerExtended %}
-  </div>
+  </article>
 
 
-  <div class="margin-bottom-6">
+  <article class="margin-bottom-6">
     {% include '@components/usa-header/src/usa-header.twig' with headerMegamenu %}
-  </div>
+  </article>
 
   {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerMegamenuExtended %}
 </div>

--- a/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
+++ b/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
@@ -9,21 +9,17 @@
   <h3>Headers</h3>
 
   <div class="margin-bottom-6">
-    <h4>Default</h4>
     {% include '@components/usa-header/src/usa-header.twig' with header %}
   </div>
 
   <div class="margin-bottom-6">
-    <h4>Extended</h4>
     {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerExtended %}
   </div>
 
 
   <div class="margin-bottom-6">
-    <h4>Megamenu</h4>
     {% include '@components/usa-header/src/usa-header.twig' with headerMegamenu %}
   </div>
 
-  <h4>Megamenu extended</h4>
   {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerMegamenuExtended %}
 </div>

--- a/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
+++ b/packages/usa-accordion/src/test/test-patterns/test-accordions.twig
@@ -1,0 +1,29 @@
+<div class="padding-8">
+  <h3>Banner</h3>
+  {% include '@components/usa-banner/src/usa-banner.twig' %}
+
+  <h3>Accordion</h3>
+  {% include '@components/usa-accordion/src/usa-accordion.twig' with DefaultContent %}
+
+
+  <h3>Headers</h3>
+
+  <div class="margin-bottom-6">
+    <h4>Default</h4>
+    {% include '@components/usa-header/src/usa-header.twig' with header %}
+  </div>
+
+  <div class="margin-bottom-6">
+    <h4>Extended</h4>
+    {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerExtended %}
+  </div>
+
+
+  <div class="margin-bottom-6">
+    <h4>Megamenu</h4>
+    {% include '@components/usa-header/src/usa-header.twig' with headerMegamenu %}
+  </div>
+
+  <h4>Megamenu extended</h4>
+  {% include '@components/usa-header/src/usa-header--extended/usa-header--extended.twig' with headerMegamenuExtended %}
+</div>

--- a/packages/usa-accordion/src/usa-accordion.stories.js
+++ b/packages/usa-accordion/src/usa-accordion.stories.js
@@ -32,8 +32,37 @@ export const Test = TestTemplate.bind({});
 Test.args = {
   ...DefaultContent,
   ...BannerContent,
-  header: HeaderContent,
-  headerExtended: HeaderExtendedContent,
-  headerMegamenu: HeaderMegamenuContent,
-  headerMegamenuExtended: HeaderExtendedMegamenuContent,
+  header: {
+    ...HeaderContent,
+    site_title: "Basic header",
+    nav: {
+      ...HeaderContent.nav,
+      aria_label: "Test navigation",
+    },
+    search: null,
+  },
+  headerExtended: {
+    ...HeaderExtendedContent,
+    site_title: "Extended header",
+    nav: {
+      ...HeaderExtendedContent.nav,
+      aria_label: "Test extended navigation",
+    },
+    search: null,
+    secondaryNav: false,
+  },
+  headerMegamenu: {
+    ...HeaderMegamenuContent,
+    site_title: "Megamenu header",
+    aria_label: "Test megamenu navigation",
+    search: null,
+    secondaryNav: false,
+  },
+  headerMegamenuExtended: {
+    ...HeaderExtendedMegamenuContent,
+    site_title: "Extended megamenu header",
+    aria_label: "Test extended megamenu navigation",
+    search: null,
+    secondaryNav: false,
+  },
 };

--- a/packages/usa-accordion/src/usa-accordion.stories.js
+++ b/packages/usa-accordion/src/usa-accordion.stories.js
@@ -1,16 +1,23 @@
 import Component from "./usa-accordion.twig";
 import { DefaultContent, BorderedContent, MultiContent } from "./content";
 
-import IconTest from "./test/test-patterns/test-accordion-icon.twig";
+import TestAccordionsTemplate from "./test/test-patterns/test-accordions.twig";
+
+// Content imports
 import HeaderContent from "../../usa-header/src/usa-header.json";
+import HeaderExtendedContent from "../../usa-header/src/usa-header--extended/usa-header--extended.json";
+import HeaderExtendedMegamenuContent from "../../usa-header/src/usa-header--extended/usa-header--extended-megamenu.json";
+import HeaderMegamenuContent from "../../usa-header/src/usa-header~megamenu.json";
+
 import BannerContent from "../../usa-banner/src/content/usa-banner.json";
 
+// StorybookJS Setup
 export default {
   title: "Components/Accordion",
 };
 
 const Template = (args) => Component(args);
-const TestTemplate = (args) => IconTest(args);
+const TestTemplate = (args) => TestAccordionsTemplate(args);
 
 export const Default = Template.bind({});
 Default.args = DefaultContent;
@@ -21,9 +28,12 @@ Bordered.args = BorderedContent;
 export const Multiselectable = Template.bind({});
 Multiselectable.args = MultiContent;
 
-export const TestIcons = TestTemplate.bind({});
-TestIcons.args = {
+export const Test = TestTemplate.bind({});
+Test.args = {
   ...DefaultContent,
-  ...HeaderContent,
   ...BannerContent,
+  header: HeaderContent,
+  headerExtended: HeaderExtendedContent,
+  headerMegamenu: HeaderMegamenuContent,
+  headerMegamenuExtended: HeaderExtendedMegamenuContent,
 };

--- a/packages/usa-accordion/src/usa-accordion.stories.js
+++ b/packages/usa-accordion/src/usa-accordion.stories.js
@@ -54,14 +54,20 @@ Test.args = {
   headerMegamenu: {
     ...HeaderMegamenuContent,
     site_title: "Megamenu header",
-    aria_label: "Test megamenu navigation",
+    nav: {
+      ...HeaderMegamenuContent.nav,
+      aria_label: "Test megamenu navigation",
+    },
     search: null,
     secondaryNav: false,
   },
   headerMegamenuExtended: {
     ...HeaderExtendedMegamenuContent,
     site_title: "Extended megamenu header",
-    aria_label: "Test extended megamenu navigation",
+    nav: {
+      ...HeaderExtendedMegamenuContent.nav,
+      aria_label: "Test extended megamenu navigation",
+    },
     search: null,
     secondaryNav: false,
   },

--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -80,18 +80,21 @@ $banner-icon-close: (
 }
 
 .usa-banner__content {
-  @include grid-container($theme-banner-max-width);
-  @include add-responsive-site-margins;
   background-color: color("transparent");
   font-size: font-size($theme-banner-font-family, 4);
   overflow: hidden;
-  padding-bottom: units(2);
-  padding-left: units($theme-site-margins-mobile-width) - units(1);
-  padding-top: units(0.5);
   width: 100%;
 
-  @include at-media("tablet") {
-    @include u-padding-y(3);
+  &:where(:not([hidden])) {
+    @include grid-container($theme-banner-max-width);
+    @include add-responsive-site-margins;
+    padding-bottom: units(2);
+    padding-left: units($theme-site-margins-mobile-width) - units(1);
+    padding-top: units(0.5);
+
+    @include at-media("tablet") {
+      @include u-padding-y(3);
+    }
   }
 
   p {

--- a/packages/usa-header/src/_includes/usa-navbar.twig
+++ b/packages/usa-header/src/_includes/usa-navbar.twig
@@ -1,7 +1,5 @@
 <div class="usa-navbar">
-  {% include "@components/usa-site-title/src/usa-site-title.twig" with {
-    'site_title': '<Project title>'
-    }
+  {% include "@components/usa-site-title/src/usa-site-title.twig" with site_title
   %}
   {% if nav %}
     <button type="button" class="usa-menu-btn">

--- a/packages/usa-header/src/styles/_usa-megamenu.scss
+++ b/packages/usa-header/src/styles/_usa-megamenu.scss
@@ -49,10 +49,14 @@
 .usa-megamenu.usa-nav__submenu {
   @include at-media($theme-header-min-width) {
     @include u-padding-x(0);
-    @include u-padding-y(4);
     left: -$theme-header-logo-text-width;
     right: 0;
     width: auto;
+
+    // Hide megamenu dropdown for `hidden-until-found`.
+    &:where(:not([hidden])) {
+      @include u-padding-y(4);
+    }
   }
 
   &::before {

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended-megamenu.json
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended-megamenu.json
@@ -95,5 +95,19 @@
       }
     ]
   },
-  "img_path": "./img"
+  "img_path": "./img",
+  "secondaryNav": {
+    "search": true,
+    "items": [
+      {
+        "label": "Secondary link",
+        "href": "javascript:void(0);"
+      },
+      {
+        "label": "Another secondary link",
+        "href": "javascript:void(0);",
+        "current": true
+      }
+    ]
+  }
 }

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended.json
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended.json
@@ -47,5 +47,19 @@
       }
     ]
   },
-  "img_path": "./img"
+  "img_path": "./img",
+  "secondaryNav": {
+    "search": true,
+    "items": [
+      {
+        "label": "Secondary link",
+        "href": "javascript:void(0);"
+      },
+      {
+        "label": "Another secondary link",
+        "href": "javascript:void(0);",
+        "current": true
+      }
+    ]
+  }
 }

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended.twig
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended.twig
@@ -4,7 +4,9 @@
   <nav aria-label="{{ nav.aria_label }}" class="usa-nav">
     <div class="usa-nav__inner">
       {% include "@components/usa-nav/src/usa-nav__primary/usa-nav__primary.twig" %}
-      {% include "@components/usa-nav/src/usa-nav__secondary/usa-nav__secondary.twig" with secondaryNav %}
+      {% if secondaryNav %}
+        {% include "@components/usa-nav/src/usa-nav__secondary/usa-nav__secondary.twig" with secondaryNav %}
+      {% endif %}
     </div>
   </nav>
 </header>

--- a/packages/usa-header/src/usa-header--extended/usa-header--extended.twig
+++ b/packages/usa-header/src/usa-header--extended/usa-header--extended.twig
@@ -4,7 +4,7 @@
   <nav aria-label="{{ nav.aria_label }}" class="usa-nav">
     <div class="usa-nav__inner">
       {% include "@components/usa-nav/src/usa-nav__primary/usa-nav__primary.twig" %}
-      {% include "@components/usa-nav/src/usa-nav__secondary/usa-nav__secondary.twig" with navSecondaryContent %}
+      {% include "@components/usa-nav/src/usa-nav__secondary/usa-nav__secondary.twig" with secondaryNav %}
     </div>
   </nav>
 </header>

--- a/packages/usa-header/src/usa-header.stories.js
+++ b/packages/usa-header/src/usa-header.stories.js
@@ -5,7 +5,6 @@ import DefaultContent from "./usa-header.json";
 import MegamenuContent from "./usa-header~megamenu.json";
 import ExtendedContent from "./usa-header--extended/usa-header--extended.json";
 import ExtendedMegamenuContent from "./usa-header--extended/usa-header--extended-megamenu.json";
-import navSecondaryContent from "../../usa-nav/src/usa-nav__secondary/usa-nav__secondary.json";
 import { SmallContent as SmallSearchContent } from "../../usa-search/src/content";
 import TitleContent from "../../usa-site-title/src/usa-site-title.json";
 

--- a/packages/usa-header/src/usa-header.stories.js
+++ b/packages/usa-header/src/usa-header.stories.js
@@ -1,5 +1,6 @@
 import Component from "./usa-header.twig";
 import ComponentExtended from "./usa-header--extended/usa-header--extended.twig";
+
 import DefaultContent from "./usa-header.json";
 import MegamenuContent from "./usa-header~megamenu.json";
 import ExtendedContent from "./usa-header--extended/usa-header--extended.json";
@@ -32,19 +33,7 @@ Megamenu.args = {
 };
 
 export const Extended = ExtendedTemplate.bind({});
-Extended.args = {
-  ...ExtendedContent,
-  navSecondaryContent: {
-    ...navSecondaryContent,
-    search: true,
-  },
-};
+Extended.args = ExtendedContent;
 
 export const ExtendedMegamenu = ExtendedTemplate.bind({});
-ExtendedMegamenu.args = {
-  ...ExtendedMegamenuContent,
-  navSecondaryContent: {
-    ...navSecondaryContent,
-    search: true,
-  },
-};
+ExtendedMegamenu.args = ExtendedMegamenuContent;

--- a/packages/usa-header/src/usa-header.twig
+++ b/packages/usa-header/src/usa-header.twig
@@ -5,7 +5,9 @@
     {% if nav %}
     <nav aria-label="{{ nav.aria_label }}" class="usa-nav">
       {% include "@components/usa-nav/src/usa-nav__primary/usa-nav__primary.twig" %}
-      {% include "@components/usa-search/src/usa-search.twig" with search.settings %}
+      {% if search.settings %}
+        {% include "@components/usa-search/src/usa-search.twig" with search.settings %}
+      {% endif %}
     </nav>
     {% endif %}
   </div>

--- a/packages/usa-search/src/usa-search.twig
+++ b/packages/usa-search/src/usa-search.twig
@@ -1,9 +1,8 @@
 {% set base_label = search_label|default("Search") %}
 {% set id = id|default("search-field") %}
-{% set section_label = section_label|default("Search component") %}
 
 {% if not search_js %}
-  <section aria-label="{{ section_label }}">
+  <section aria-label="{{ section_label | default("Search component") }}">
 {% endif %}
   <form class="usa-search {{ modifier }} {% if search_js %}js-search-form{% endif %}" role="search">
     <label class="usa-sr-only" for="{{ id }}">

--- a/packages/usa-site-title/src/usa-site-title.twig
+++ b/packages/usa-site-title/src/usa-site-title.twig
@@ -1,7 +1,7 @@
 <div class="usa-logo">
   <em class="usa-logo__text">
     <a href="{{ href|default('/') }}" title="{{ site_title|default('Home') }}" >
-      {{ site_title |e|default('Home') }}
+        {{ site_title | escape | default('Home') }}
     </a>
   </em>
 </div>

--- a/packages/usa-site-title/src/usa-site-title.twig
+++ b/packages/usa-site-title/src/usa-site-title.twig
@@ -1,7 +1,9 @@
+{% set title = site_title | default("<Project title>") %}
+
 <div class="usa-logo">
   <em class="usa-logo__text">
-    <a href="{{ href|default('/') }}" title="{{ site_title|default('Home') }}" >
-        {{ site_title | escape | default('Home') }}
+    <a href="{{ href | default('/') }}" title="{{ title | escape }}" >
+        {{ title | escape }}
     </a>
   </em>
 </div>

--- a/packages/uswds-core/src/js/utils/toggle.js
+++ b/packages/uswds-core/src/js/utils/toggle.js
@@ -17,10 +17,15 @@ module.exports = (button, expanded) => {
     throw new Error(`No toggle target found with id: "${id}"`);
   }
 
+  // Return boolean if browser supports "until-found".
+  const testHiddenUntilFound = () => !!("onbeforematch" in document.body);
+
+  const hiddenAttributeValue = testHiddenUntilFound() ? "until-found" : "";
+
   if (safeExpanded) {
     controls.removeAttribute(HIDDEN);
   } else {
-    controls.setAttribute(HIDDEN, "");
+    controls.setAttribute(HIDDEN, hiddenAttributeValue);
   }
 
   return safeExpanded;

--- a/packages/uswds-elements/lib/_normalize.scss
+++ b/packages/uswds-elements/lib/_normalize.scss
@@ -349,3 +349,8 @@ template {
 [hidden] {
   display: none;
 }
+
+[hidden="until-found"] {
+  display: revert;
+  content-visibility: hidden;
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> Breaking change for all accordions in IE11. Due to `:where(:not())` selector.

# Summary

**Accordion content is now discoverable.** As an enhancement, content inside accordions is now discoverable. Browsers must support `hidden="until-found"` attribute[^1]. 

Browsers that **don't** support this attribute will fallback to current `hidden` behavior.

[^1]: [Caniuse.com](https://caniuse.com/mdn-html_global_attributes_hidden_until-found_value)


## Breaking change

This is potentially a breaking change. Users with padding overrides on accordions are affected.

**Broken when custom padding set**
USWDS website examples have padding overrides.

| Before | After |
| :----- | :---- |
| ![image](https://github.com/uswds/uswds/assets/3385219/231bf1c3-4209-4610-9526-775964d8b92e) |  ![image](https://github.com/uswds/uswds/assets/3385219/68c4b3f2-ce92-4e3a-93b2-f9f8e60ca1ce)  | 

**Browsers tested**

| Browser         | Tested version | Latest version |
| --------------- | -------------- | -------------- |
| Chrome          | 112            | 119            |
| Firefox         | 112            | 120            |
| Opera           | 97            |      105       |
| Edge            | 112            | 119            |
| iPhone (Safari) | 12             | 15             |

_Based on https://analytics.usa.gov/ data._

## Related issue

Closes #4799.
Closes uswds/uswds-site#2405.

## Related pull requests

TODO: Need changelog PR.

## Preview link

- [Accordion test preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-accordion--test-icons) 
- [Header preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-header--default)
- [Secondary nav preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-header-partials-secondary--default)


## Problem statement

Accordion content should be discoverable on page search. Currently, content is hidden. Users find it difficult to find content in of accordions. There's also an impact to SEO.

## Solution

Enhanced toggle utility (used in Accordion, Banner, Header, and Language Selector[^2]). This approach is a progressive enhancement on existing accordions. Unsupported browsers like Safari and Firefox will fallback to previous behavior.

[^2]: Language selector is unaffected because it uses `hidden="true"`.

## Major changes

- Remove padding on hidden content  with`:where(:not())` selector.
- Add check to toggle.js for hidden until found, fallback to hidden.
- Normalize supports hidden until found.
- Accordion test includes header variants.
- Header menus include secondaryNav data in JSON (previously as StorybookJS args) fixes uswds/uswds-site#2403.
- Header hides secondary nav & search if not defined.

## Testing and review

**Chrome**

1. Visit [Preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-accordion--test-icons)
2. Banner
    - Search for a term in content (like "_government organization_").
    - Component should expand
3. Accordion
    - Search for a term in content (like "_otherwise infamous_").
    - Fifth amendment should expand


**Firefox or Safari**
These browsers don't support `hidden="until-found"`. There should be no regressions in behavior or display.

**Header changes**
1. Run `npm run build:html`.
2. View compiled HTML file in `html-templates` and confirm secondary nav is showing.
3. Visit StorybookJS preview and ensure there are no regressions in:
    - [Header](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-header--default)
    - [Header megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-header--megamenu)
    - [Secondary nav](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-accordion-hidden-content/?path=/story/components-header-partials-secondary--default)

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm run prettier:sass` to format any Sass updates.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).

- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
