### PR TITLE
USWDS - Header: Alignment fixes

### DIFF
--- a/packages/usa-header/src/styles/_usa-header.scss
+++ b/packages/usa-header/src/styles/_usa-header.scss
@@ -284,6 +284,7 @@ $z-index-overlay: 400;
     @include at-media($theme-header-min-width) {
       left: 0;
       padding-left: units($theme-site-margins-width);
+      padding-right: units($theme-site-margins-width);
     }
   }
 }

--- a/packages/usa-header/src/styles/_usa-megamenu.scss
+++ b/packages/usa-header/src/styles/_usa-megamenu.scss
@@ -42,6 +42,14 @@
     @include at-media($theme-header-min-width) {
       // needs this round() to avoid a compile bug
       @include u-flex(math.round(math.div(12, $theme-megamenu-columns)));
+
+      // Remove padding from first and last columns on desktop view.
+      &:first-child .usa-nav__submenu-item a {
+        padding-left: 0;
+      }
+      &:last-child .usa-nav__submenu-item a {
+        padding-right: 0;
+      }
     }
   }
 }

--- a/packages/usa-header/src/styles/_usa-megamenu.scss
+++ b/packages/usa-header/src/styles/_usa-megamenu.scss
@@ -43,6 +43,10 @@
       // needs this round() to avoid a compile bug
       @include u-flex(math.round(math.div(12, $theme-megamenu-columns)));
 
+      .usa-nav__submenu-item a {
+        @include u-padding-x(1);
+      }
+
       // Remove padding from first and last columns on desktop view.
       &:first-child .usa-nav__submenu-item a {
         padding-left: 0;

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -384,6 +384,7 @@ $expand-less-icon: map-merge(
 
   @include at-media($theme-header-min-width) {
     @include add-list-reset;
+    @include u-padding-y(1);
     background-color: color("primary-darker");
     width: units("card-lg");
     position: absolute;
@@ -397,10 +398,10 @@ $expand-less-icon: map-merge(
   .usa-nav__submenu-item {
     @include at-media($theme-header-min-width) {
       a {
+        @include u-padding-x(2);
         color: color("white");
         line-height: line-height($theme-navigation-font-family, 3);
         display: block;
-        padding: units(1);
 
         &:focus {
           outline-offset: units("neg-05");


### PR DESCRIPTION
# Summary
Updated the padding on `.usa-nav__submenu` elements so that they align with other header elements.

## Breaking change

This is not a breaking change.
However, we recommend that users confirm that the header elements in their project align as expected. 

## Related issue

Closes #5417
Closes #5604 

## Related pull requests

This PR is a combination of PRs #5418 and #5630.

Changelog PR

## Preview link

- [Header component - default](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--default)
- [Header component - extended](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--extended)
- [Header component - megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--megamenu)
- [Header component - extended megamenu ](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--extended-megamenu)

## Problem statement

Header navigation links do **not** align with other header elements. Standard variants align too far to the left and megamenu variants align too far to the right. 

From PR #5418:
> USWDS 2 had some padding in nav submenus so that the submenu items were visually aligned with the nav menu button itself (see https://github.com/uswds/uswds/blob/v2.13.3/src/stylesheets/components/_navigation.scss#L374). This padding was removed in USWDS 3, and the nav submenus look off. 

- **[Develop - default](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-header--default)**
    
    ![image](https://github.com/uswds/uswds/assets/93996430/4948c7f7-0efe-4e1d-a76e-77f0de007aad)
- **[Develop - extended](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-header--extended)**
    
    ![image](https://github.com/uswds/uswds/assets/93996430/fa27ae3d-7871-4375-b166-a5f6dc61e574)

- **[Develop - megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-header--megamenu)**
    
    ![image](https://github.com/uswds/uswds/assets/93996430/027722b0-0b1a-46b7-8951-c617b58fbdf9)
- **[Develop - extended megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-header--extended-megamenu)**

    ![image](https://github.com/uswds/uswds/assets/93996430/d11a3423-d53e-46ae-b765-5e3ac09847e9)

## Solution

- [Header component - default](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--default)

    ![image](https://github.com/uswds/uswds/assets/93996430/71989199-4802-4b28-823b-aa1e652879fb)

- [Header component - extended](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--extended)
   
    ![image](https://github.com/uswds/uswds/assets/93996430/1767c6b3-d172-4e19-b0f0-f52b10db3031)

- [Header component - megamenu](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--megamenu)
    
    ![image](https://github.com/uswds/uswds/assets/93996430/87072f2f-6dd6-44c7-904e-d99559a73e57)

- [Header component - extended megamenu ](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/header-nav-link-alignment/?path=/story/components-header--extended-megamenu)
    - Some changes in overall submenu width to create right alignment
    
    ![image](https://github.com/uswds/uswds/assets/93996430/8f6e61df-9db6-49d9-8926-945b8d1465a2)

## Testing and review

- Open each variant of the header component and confirm:
    - All navigation links align to the left of the other header elements.
    - Megamenu link elements also align to the right of other header elements.
    - Mobile presentation is not affected. 
    - No visual regressions


