### PR TITLE
[Test] Header padding fix

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -233,8 +233,6 @@ $expand-less-icon: map-merge(
 
     &[aria-expanded] {
       span {
-        display: inline-block;
-
         &::after {
           position: absolute;
           top: 50%;

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -162,13 +162,21 @@ $expand-less-icon: map-merge(
     > a {
       @include at-media($theme-header-min-width) {
         @include primary-nav-link;
+        align-items: center;
         color: color($nav-link-color);
-        display: block;
+        display: flex;
         font-weight: font-weight("bold");
 
         &:hover {
           color: color("primary");
         }
+      }
+    }
+
+    > button,
+    > a {
+      @include at-media($theme-header-min-width) {
+        height: 100%;
       }
     }
   }
@@ -194,7 +202,6 @@ $expand-less-icon: map-merge(
       @include primary-nav-link;
       font-size: font-size($theme-navigation-font-family, "2xs");
       font-weight: font-weight("bold");
-      height: 100%;
     }
 
     @media (forced-colors: active) {
@@ -307,6 +314,7 @@ $expand-less-icon: map-merge(
   .usa-accordion__button {
     span {
       @include at-media($theme-header-min-width) {
+        display: inline-block;
         margin-right: 0;
         padding-right: units(2);
       }


### PR DESCRIPTION
## Preview link
[Preview link](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-vertical-center-nav-padding-fix/?path=/story/components-header--default)

## Notes
This branch pulled in the most recent updates from `develop`, so unfortunately the files changed might be confusing, but these should be the relevant updates:
![image](https://github.com/uswds/uswds/assets/93996430/b2ecf3a5-c1c5-4dd0-a2c6-de9f781f777e)

![image](https://github.com/uswds/uswds/assets/93996430/5cd70d15-7367-4f1f-a7ee-adee7b527222)

## Screenshots
Single line (Vertically aligned in both)
![image](https://github.com/uswds/uswds/assets/93996430/327f30e3-0282-4595-b13e-b8588800d315)

Mismatched heights/multiple lines (develop does not have vertical center alignment)
![image](https://github.com/uswds/uswds/assets/93996430/06471393-e0f3-47c8-907e-4e79732d81af)
