### PR TITLE
USWDS - Footer: Grid layout hotfix

### DIFF
--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -22,11 +22,7 @@ $-chevron-expand-more: map-merge(
   )
 );
 
- // Grid styles ported over to remove dependency
- .grid-container {
-  @include grid-container($theme-footer-max-width);
-}
-
+// Grid styles ported over to remove dependency
 .grid-row {
   @include grid-row;
 }
@@ -119,6 +115,10 @@ $-chevron-expand-more: map-merge(
   @include border-box-sizing;
   @include typeset($theme-footer-font-family);
   overflow: hidden;
+
+  > .grid-container {
+    @include grid-container($theme-footer-max-width);
+  }
 }
 .usa-footer__return-to-top {
   @include u-padding-y(2.5);

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -65,8 +65,11 @@ $-chevron-expand-more: map-merge(
     // Columns
     [class*="grid-col"] {
       @include u-position(relative);
-      @include u-width(full);
       box-sizing: border-box;
+    }
+
+    .grid-col {
+      @include u-width(full);
     }
 
     .grid-col-auto {
@@ -76,6 +79,10 @@ $-chevron-expand-more: map-merge(
     // Columns: Mobile Large
     /* stylelint-disable */
     @include at-media("mobile-lg") {
+      .mobile-lg\:grid-col {
+        @include u-width(full);
+      }
+
       .mobile-lg\:grid-col-auto {
         @include grid-col("auto");
       }
@@ -99,6 +106,10 @@ $-chevron-expand-more: map-merge(
 
     // Columns: Tablet
     @include at-media("tablet") {
+      .tablet\:grid-col {
+        @include u-width(full);
+      }
+
       .tablet\:grid-col-4 {
         @include grid-col(4);
       }
@@ -110,6 +121,10 @@ $-chevron-expand-more: map-merge(
 
     // Columns: Desktop
     @include at-media("desktop") {
+      .desktop\:grid-col {
+        @include u-width(full);
+      }
+
       .desktop\:grid-col-auto {
         @include grid-col("auto");
       }

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -26,22 +26,22 @@ $-chevron-expand-more: map-merge(
 .grid-row {
   @include grid-row;
 
-  .grid-gap-1 {
+  &.grid-gap-1 {
     @include grid-gap(1);
   }
 
-  .grid-gap-2 {
+  &.grid-gap-2 {
     @include grid-gap(2);
   }
 
-  .grid-gap-4 {
+  &.grid-gap-4 {
     @include grid-gap(4);
   }
 
   // Gaps: Mobile Large
   /* stylelint-disable */
   @include at-media("mobile-lg") {
-    .mobile-lg\:grid-gap-2 {
+    &.mobile-lg\:grid-gap-2 {
       @include grid-gap(2);
     }
   }

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -25,33 +25,33 @@ $-chevron-expand-more: map-merge(
 // Grid styles ported over to remove dependency
 .grid-row {
   @include grid-row;
+
+  .grid-gap-1 {
+    @include grid-gap(1);
+  }
+
+  .grid-gap-2 {
+    @include grid-gap(2);
+  }
+
+  .grid-gap-4 {
+    @include grid-gap(4);
+  }
+
+  // Gaps: Mobile Large
+  /* stylelint-disable */
+  @include at-media("mobile-lg") {
+    .mobile-lg\:grid-gap-2 {
+      @include grid-gap(2);
+    }
+  }
+  /* stylelint-enable */
 }
 
 // Gaps
 .grid-gap {
   @include grid-gap;
 }
-
-.grid-gap-1 {
-  @include grid-gap(1);
-}
-
-.grid-gap-2 {
-  @include grid-gap(2);
-}
-
-.grid-gap-4 {
-  @include grid-gap(4);
-}
-
-// Gaps: Mobile Large
-/* stylelint-disable */
-@include at-media("mobile-lg") {
-  .mobile-lg\:grid-gap-2 {
-    @include grid-gap(2);
-  }
-}
-/* stylelint-enable */
 
 // Columns
 [class*="grid-col"] {

--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -22,119 +22,103 @@ $-chevron-expand-more: map-merge(
   )
 );
 
+ // Grid styles ported over to remove dependency
+ .grid-container {
+  @include grid-container($theme-footer-max-width);
+}
+
+.grid-row {
+  @include grid-row;
+}
+
+// Gaps
+.grid-gap {
+  @include grid-gap;
+}
+
+.grid-gap-1 {
+  @include grid-gap(1);
+}
+
+.grid-gap-2 {
+  @include grid-gap(2);
+}
+
+.grid-gap-4 {
+  @include grid-gap(4);
+}
+
+// Gaps: Mobile Large
+/* stylelint-disable */
+@include at-media("mobile-lg") {
+  .mobile-lg\:grid-gap-2 {
+    @include grid-gap(2);
+  }
+}
+/* stylelint-enable */
+
+// Columns
+[class*="grid-col"] {
+  @include u-position(relative);
+  @include u-width(full);
+  box-sizing: border-box;
+}
+
+.grid-col-auto {
+  @include grid-col("auto");
+}
+
+// Columns: Mobile Large
+/* stylelint-disable */
+@include at-media("mobile-lg") {
+  .mobile-lg\:grid-col-auto {
+    @include grid-col("auto");
+  }
+
+  .mobile-lg\:grid-col-4 {
+    @include grid-col(4);
+  }
+
+  .mobile-lg\:grid-col-6 {
+    @include grid-col(6);
+  }
+
+  .mobile-lg\:grid-col-8 {
+    @include grid-col(8);
+  }
+
+  .mobile-lg\:grid-col-12 {
+    @include grid-col(12);
+  }
+}
+
+// Columns: Tablet
+@include at-media("tablet") {
+  .tablet\:grid-col-4 {
+    @include grid-col(4);
+  }
+
+  .tablet\:grid-col-8 {
+    @include grid-col(8);
+  }
+}
+
+// Columns: Desktop
+@include at-media("desktop") {
+  .desktop\:grid-col-auto {
+    @include grid-col("auto");
+  }
+
+  .desktop\:grid-col-3 {
+    @include grid-col(3);
+  }
+}
+
 // General footer styles
 .usa-footer {
   @include border-box-sizing;
   @include typeset($theme-footer-font-family);
   overflow: hidden;
-
-  // Grid styles ported over to remove dependency
-  .grid-container {
-    @include grid-container($theme-footer-max-width);
-  }
-
-  .grid-row {
-    @include grid-row;
-
-    // Gaps
-    &.grid-gap {
-      @include grid-gap;
-    }
-
-    &.grid-gap-1 {
-      @include grid-gap(1);
-    }
-
-    &.grid-gap-2 {
-      @include grid-gap(2);
-    }
-
-    &.grid-gap-4 {
-      @include grid-gap(4);
-    }
-
-    // Gaps: Mobile Large
-    /* stylelint-disable */
-    @include at-media("mobile-lg") {
-      &.mobile-lg\:grid-gap-2 {
-        @include grid-gap(2);
-      }
-    }
-    /* stylelint-enable */
-
-    // Columns
-    [class*="grid-col"] {
-      @include u-position(relative);
-      box-sizing: border-box;
-    }
-
-    .grid-col {
-      @include u-width(full);
-    }
-
-    .grid-col-auto {
-      @include grid-col("auto");
-    }
-
-    // Columns: Mobile Large
-    /* stylelint-disable */
-    @include at-media("mobile-lg") {
-      .mobile-lg\:grid-col {
-        @include u-width(full);
-      }
-
-      .mobile-lg\:grid-col-auto {
-        @include grid-col("auto");
-      }
-
-      .mobile-lg\:grid-col-4 {
-        @include grid-col(4);
-      }
-
-      .mobile-lg\:grid-col-6 {
-        @include grid-col(6);
-      }
-
-      .mobile-lg\:grid-col-8 {
-        @include grid-col(8);
-      }
-
-      .mobile-lg\:grid-col-12 {
-        @include grid-col(12);
-      }
-    }
-
-    // Columns: Tablet
-    @include at-media("tablet") {
-      .tablet\:grid-col {
-        @include u-width(full);
-      }
-
-      .tablet\:grid-col-4 {
-        @include grid-col(4);
-      }
-
-      .tablet\:grid-col-8 {
-        @include grid-col(8);
-      }
-    }
-
-    // Columns: Desktop
-    @include at-media("desktop") {
-      .desktop\:grid-col {
-        @include u-width(full);
-      }
-
-      .desktop\:grid-col-auto {
-        @include grid-col("auto");
-      }
-
-      .desktop\:grid-col-3 {
-        @include grid-col(3);
-      }
-    }
-    /* stylelint-enable */
-  }
 }
 .usa-footer__return-to-top {
   @include u-padding-y(2.5);


### PR DESCRIPTION
# Summary

**Resolves style specificity issues between `usa-footer` and `usa-grid-layout`.** This resolves visual regressions potentially caused by #5289.

## Breaking change
This is not a breaking change.

## Related issue

Closes #5676 

## Related pull requests

Changes implemented in #5289

## Preview link

[Footer →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-footer-grid-hotfix/?path=/story/components-footer--default)

[Demo repo →](https://github.com/uswds/uswds-sandbox/tree/cm-testing-footer-layout-grid)

[Demo footer →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/cm-testing-footer-layout-grid/)

## Problem statement

Layout grid styles defined in footer have higher specificity than other layout-grid styles. As a result, updated layout grid utility classes in footer markup do not affect layout as expected.

## Solution

> [!TIP]
> The files changed may look confusing, but it simply moves the styles above the `.footer{}` declaration instead of nesting them.

Move layout grid classes **above** `.footer` class.

**Example**
https://github.com/uswds/uswds/blob/9fe48ce5d022307a792c10e201b4497bff4bfb5d/packages/usa-footer/src/styles/_usa-footer.scss#L25-L45

## Testing and review

The demo repo below showcases how footer-defined grid styles have specificity over standard grid classes when both are imported to a project.

1. Checkout and start this [test repo](https://github.com/uswds/uswds-sandbox/tree/cm-testing-footer-layout-grid) on your local machine
    - By default, this test repo uses `3.7.1`
    - Imports both `footer` and `grid-layout`
2. Inspect markup for both footers
    - Top footer features a mobile utility class which is found in **footer** and a desktop utility class found in **grid-layout**
    - Bottom footer features two utility classes, neither of which are included in footer css
3. In **desktop** width viewports
    - Note that the top footer breaks only one link to second line.
    - The bottom footer has all links in one column.
5. Inspect `<li>` style changes
    - Note that the **footer** defined classes take priority, despite layout-grid being included
6. Install this branch
    - `npm install @uswds/uswds "https://github.com/uswds/uswds/tree/cm-footer-grid-hotfix" --save`
7. Trigger sass rebuild
8. Hard refresh the page
9. Resize window and view changes
   - Note that both footers now break links into two columns with two rows on _desktop_ widths
11. Inspect styles at breakpoints
12. Layout grid classes should now apply as expected

### Testing checklist

- [ ]  Layout grid utility classes work as expected
- [ ]  Footer styles no longer take priority
- [ ]  Confirm there is no issue with non-nested gird classes in `_usa-footer.scss`
- [ ]  `$theme-layout-grid-use-important: true` is not required for desired layout-grid styles

## Further consideration

I considered investigating a `sass:meta` test to check for the inclusion of `grid-layout` and nest the footer grid classes within that but figured this would be enough for a hotfix/mvp.

Alternatively, we could investigate using a theme setting to enable/disable these styles. I opt for a logic test _(if possible)_ so users are not required to take an extra step other than importing `grid-layout`