### PR TITLE
USWDS - Pages: Avoid reordering content in Documentation example

### DIFF
--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -49,7 +49,7 @@
 
       </div>
 
-      <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+      <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose" id="main-content">
         <h1>Page heading (h1)</h1>
         <p class="usa-intro">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
         <h2 id="section-heading-h2">Section heading (h2)</h2>

--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -49,7 +49,7 @@
 
       </div>
 
-      <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose" id="main-content">
+      <main class="desktop:grid-col-9 usa-prose" id="main-content">
         <h1>Page heading (h1)</h1>
         <p class="usa-intro">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
         <h2 id="section-heading-h2">Section heading (h2)</h2>

--- a/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
+++ b/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
@@ -2,16 +2,9 @@
 
 // Flexbox positioning to move sidenav below main content on small screens
 .usa-layout-docs__sidenav {
-  order: 2;
-  padding-top: units(4);
+  padding-bottom: units(4);
 
   @include at-media("desktop") {
-    padding-top: 0;
-  }
-}
-
-.usa-layout-docs__main {
-  @include at-media("desktop") {
-    order: 2;
+    padding-bottom: 0;
   }
 }

--- a/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
+++ b/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
@@ -1,6 +1,5 @@
 @use "uswds-core" as *;
 
-// Flexbox positioning to move sidenav below main content on small screens
 .usa-layout-docs__sidenav {
   padding-bottom: units(4);
 


### PR DESCRIPTION
# Summary

**Documentation page structure follows logical order.** Sidenav on page template now follows logical HTML order on mobile. Previously, the sidenav was shifted _after_ the content, which did not follow the HTML order.

## Breaking change

This is a potentially breaking change. 
**Removed template classes**
- `usa-layout-docs__main`: This is the class that had the styles that reordered element.
- `usa-layout-docs`: This selector unused in current styles.

> [!CAUTION]
> Users who rely on or extended the classes listed above would be negatively affected. See https://github.com/uswds/uswds/pull/5681#discussion_r1442055975.

## Related issue

Closes #4594.

## Related pull requests

Changelog entry: uswds/uswds-site#2495.

## Preview link

Preview links; _test all screen sizes_:

| Current (`develop`) | Feature branch |
|:--------|:--------|
| [Default] | [Preview] |

Sidenav now comes before content on small screens. Previously, it was reordered after content.

[Default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/pages-documentation-page--documentation-page&p=all

[Preview]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-doc-layout-order/?path=/story/pages-documentation-page--documentation-page

## Problem statement

In mobile, tab order doesn't match visual order in the documentation page example.

## Solution

Removed styling that re-ordered the layout.


## Testing and review

- Sidenav should come before content in small screens (currently after)
- Sidenav should be on left on larger screens.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
