### PR TITLE
USWDS - Date Picker: Add high contrast focus styling to calendar button

### DIFF
--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -141,7 +141,6 @@ $navigate_far_next: map-merge(
     position: relative;
 
     &:not([disabled]) {
-
       &:focus,
       &:hover {
         background-color: Highlight;

--- a/packages/usa-date-picker/src/styles/_usa-date-picker.scss
+++ b/packages/usa-date-picker/src/styles/_usa-date-picker.scss
@@ -141,6 +141,8 @@ $navigate_far_next: map-merge(
     position: relative;
 
     &:not([disabled]) {
+
+      &:focus,
       &:hover {
         background-color: Highlight;
       }


### PR DESCRIPTION
# Summary

Adds focus styles to calendar button in high contrast mode. Now, the calendar icon changes to the `highlight` high contrast token.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5535

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2483)

## Preview link

[Date Picker →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-date-picker-hc-focus/iframe.html?args=&id=components-form-inputs-date-picker--default&viewMode=story)

## Problem statement

In high contrast mode, the date picker calendar button does not have a visible focus indicator when focused. It is still functional via keyboard but lacks context that it is focused.

_Indicator is missing focus because the button is empty and relies on mask technique to set icon._

High contrast icons throughout the design system are mostly set as a mask using the`add-color-icon()` mixin. We use this method to color the icon using high contrast tokens and ensure visibility throughout high contrast light/dark themes.

Because the mask covers the entire element, the focus indicator is covered by the mask as well.

## Solution

Change the icon color to `highlight` on focus.

### Possible downfalls

The default light-theme colors aren’t great and still make it hard to see that the color is focused. We *****could***** try another high contrast token but it feels beneficial to use `highlight`. Some users customize their high contrast theme and it’s important they recognize the color.

Alternatively, we could investigate other ways to place the icon and ensure visibility in high-contrast.

## Major changes

Calendar icon changes color on focus in high contrast modes.

## Testing and review

1. Visit the [date picker](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-date-picker-hc-focus/iframe.html?args=&id=components-form-inputs-date-picker--default&viewMode=story).
2. Activate high contrast mode.
    - Chrome instructions. _(creating doc)_
3. Use the tab key to focus the date picker button.
4. Confirm icon changes color.
    - Color should match the focus border on the date input.