### PR TITLE
USWDS - Footer: Use `:where()` on all grid layout classes defined component styles

### DIFF
--- a/packages/usa-footer/src/styles/_usa-footer.scss
+++ b/packages/usa-footer/src/styles/_usa-footer.scss
@@ -29,92 +29,92 @@ $-chevron-expand-more: map-merge(
   overflow: hidden;
 
   // Grid styles ported over to remove dependency
-  .grid-container {
+  :where(.grid-container) {
     @include grid-container($theme-footer-max-width);
   }
 
-  .grid-row {
+  :where(.grid-row) {
     @include grid-row;
 
     // Gaps
-    &.grid-gap {
+    :where(&.grid-gap) {
       @include grid-gap;
     }
 
-    &.grid-gap-1 {
+    :where(&.grid-gap-1) {
       @include grid-gap(1);
     }
 
-    &.grid-gap-2 {
+    :where(&.grid-gap-2) {
       @include grid-gap(2);
     }
 
-    &.grid-gap-4 {
+    :where(&.grid-gap-4) {
       @include grid-gap(4);
     }
 
     // Gaps: Mobile Large
     /* stylelint-disable */
     @include at-media("mobile-lg") {
-      &.mobile-lg\:grid-gap-2 {
+      :where(&.mobile-lg\:grid-gap-2) {
         @include grid-gap(2);
       }
     }
     /* stylelint-enable */
 
     // Columns
-    [class*="grid-col"] {
+    :where([class*="grid-col"]) {
       @include u-position(relative);
       @include u-width(full);
       box-sizing: border-box;
     }
 
-    .grid-col-auto {
+    :where(.grid-col-auto) {
       @include grid-col("auto");
     }
 
     // Columns: Mobile Large
     /* stylelint-disable */
     @include at-media("mobile-lg") {
-      .mobile-lg\:grid-col-auto {
+      :where(.mobile-lg\:grid-col-auto) {
         @include grid-col("auto");
       }
 
-      .mobile-lg\:grid-col-4 {
+      :where(.mobile-lg\:grid-col-4) {
         @include grid-col(4);
       }
 
-      .mobile-lg\:grid-col-6 {
+      :where(.mobile-lg\:grid-col-6) {
         @include grid-col(6);
       }
 
-      .mobile-lg\:grid-col-8 {
+      :where(.mobile-lg\:grid-col-8) {
         @include grid-col(8);
       }
 
-      .mobile-lg\:grid-col-12 {
+      :where(.mobile-lg\:grid-col-12) {
         @include grid-col(12);
       }
     }
 
     // Columns: Tablet
     @include at-media("tablet") {
-      .tablet\:grid-col-4 {
+      :where(.tablet\:grid-col-4) {
         @include grid-col(4);
       }
 
-      .tablet\:grid-col-8 {
+      :where(.tablet\:grid-col-8) {
         @include grid-col(8);
       }
     }
 
     // Columns: Desktop
     @include at-media("desktop") {
-      .desktop\:grid-col-auto {
+      :where(.desktop\:grid-col-auto) {
         @include grid-col("auto");
       }
 
-      .desktop\:grid-col-3 {
+      :where(.desktop\:grid-col-3) {
         @include grid-col(3);
       }
     }


### PR DESCRIPTION
# Summary

**Resolves style specificity issues between `usa-footer` and `usa-grid-layout`.** This resolves visual regressions potentially caused by #5289.

## Breaking change
This is not a breaking change.

## Related issue

Closes #5676 
Changelog → _pending_

## Related pull requests

Grid dependency removed in #5289

## Preview link

[Footer →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-footer-grid-where-hotfix/?path=/story/components-footer--default)

[Demo repo →](https://github.com/uswds/uswds-sandbox/tree/cm-testing-footer-layout-grid)

[Demo footer →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/cm-testing-footer-layout-grid/)

>[!WARNING]
By default, the test repo and preview are using `3.7.1`. To see fix in affect, install this branch as USWDS
>
>`npm install @uswds/uswds "https://github.com/uswds/uswds/tree/cm-footer-grid-where-hotfix" --save`



## Problem statement

Layout grid styles defined in footer have higher specificity than other layout-grid styles. As a result, updated layout grid utility classes in footer markup do not affect layout as expected.

## Solution

Use `:where()` to negate specificity in nested grid classes.

## Testing and review

The demo repo below showcases how footer-defined grid styles have specificity over standard grid classes when both are imported to a project and then instructs the user to install this branch to resolve the issue.

1. Checkout and start this [test repo](https://github.com/uswds/uswds-sandbox/tree/cm-testing-footer-layout-grid) on your local machine
    - By default, this test repo uses `3.7.1`
    - Imports both `footer` and `grid-layout`
2. Inspect markup for both footers
    - Top footer features a mobile utility class which is found in **footer** and a desktop utility class found in **grid-layout**
    - Bottom footer features two utility classes, neither of which are included in footer css
3. In **desktop** width viewports
    - Note that the top footer breaks only one link to second line.
    - The bottom footer has all links in one column.
5. Inspect `<li>` style changes
    - Note that the **footer** defined classes take priority, despite layout-grid being included
6. Install this branch
    - `npm install @uswds/uswds "https://github.com/uswds/uswds/tree/cm-footer-grid-where-hotfix" --save`
7. Trigger sass rebuild
8. Hard refresh the page
9. Resize window and view changes
   - Note that both footers now break links into two columns with two rows on _desktop_ widths
11. Inspect styles at breakpoints
12. Layout grid classes should now apply as expected

### Testing checklist

- [ ]  Layout grid utility classes work as expected
- [ ]  Footer styles no longer take priority
- [ ]  Confirm there is no issue with non-nested gird classes in `_usa-footer.scss`
- [ ]  `$theme-layout-grid-use-important: true` is not required for desired layout-grid styles
- [ ] Confirm `:where()` is needed on _each_ grid class

## Further consideration

I tested some of the options offered by [sass:meta](https://sass-lang.com/documentation/modules/meta/) to test for the inclusion of the layout grid package. Since the grid classes are always included in our sass package, I was unable to use the functions to check for the existence of layout grid (They always return true).

We should consider if there are other ways to check for the inclusion of the package on the project level.

From @mejiaj in #5675 

> Long term, I like the idea of a flag to check if layout grid is loaded. We'll have to see what additional components rely heavily on layout grid.