### PR TITLE
Prototype: Initial banner web component 

### DIFF
--- a/packages/usa-banner/src/Banner.js
+++ b/packages/usa-banner/src/Banner.js
@@ -1,0 +1,153 @@
+import * as content from "./content/usa-banner.json";
+
+const templateString = (data) => {
+  // Get the data object and destructure.
+  const { banner, domain, https } = data;
+
+  // Create the template with passed data.
+  /* html */ return `
+  <section
+    class="usa-banner"
+    aria-label="Official website of the United States government"
+  >
+    <div class="usa-accordion">
+      <header class="usa-banner__header">
+        <div class="usa-banner__inner">
+          <img
+            aria-hidden="true"
+            class="usa-banner__header-flag"
+            src="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.3.0/img/us_flag_small.png"
+            alt=""
+          />
+          <p class="usa-banner__header-text">
+            ${banner.text}
+          </p>
+          <button
+          type="button"
+          class="usa-accordion__button usa-banner__button"
+          aria-expanded="false"
+          aria-controls="gov-banner-default"
+          >
+            <span class="usa-banner__button-text">
+              ${banner.action}
+            </span>
+          </button>
+        </div>
+      </header>
+      <div
+        class="usa-banner__content usa-accordion__content"
+        id="gov-banner-default"
+        hidden>
+        <div class="grid-row grid-gap-lg">
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img
+              class="usa-banner__icon usa-media-block__img"
+              src="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.3.0/img/icon-dot-gov.svg"
+              role="img"
+              alt=""
+              aria-hidden="true"
+            />
+            <div class="usa-media-block__body">
+              <p>
+                ${domain.heading}
+                ${domain.text}
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <img
+              class="usa-banner__icon usa-media-block__img"
+              src="https://cdnjs.cloudflare.com/ajax/libs/uswds/3.3.0/img/icon-https.svg"
+              role="img"
+              alt=""
+              aria-hidden="true"
+            />
+            <div class="usa-media-block__body">
+            <p>
+              ${https.heading}
+              ${https.pretext}
+                <span class="icon-lock">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="52"
+                    height="64"
+                    viewBox="0 0 52 64"
+                    class="usa-banner__lock-image"
+                    role="img"
+                    aria-labelledby="banner-lock-description-default"
+                    focusable="false"
+                  >
+                    <title id="banner-lock-title-default">Lock</title>
+                    < id="banner-lock-description-default">Locked padlock icon</  desc>
+                    <path
+                      fill="#000000"
+                      fill-rule="evenodd"
+                      d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0   1-4   4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26   0zm0  8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6. 075-4.  925-11-11-11z"/>
+                  </svg>
+                </span>
+                ${https.posttext}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+`;
+};
+
+class BannerComponent extends HTMLElement {
+  constructor() {
+    super();
+
+    this.template = document.createElement("template");
+    this.template.innerHTML = templateString(content);
+  }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (name === "tld" || name === "locale") {
+      this.render();
+    }
+  }
+
+  connectedCallback() {
+    /**
+     *
+     * ! ShadowDOM experiment
+     * ! Markup still showed up via shadow root and styles were lost.
+     *
+     */
+    // this.attachShadow({ mode: "open" });
+    // const bannerShadowDOM = this.shadowRoot;
+    // this.template.innerHTML = templateString(content);
+    // bannerShadowDOM.appendChild(this.template.content.cloneNode(true));
+
+    this.appendChild(this.template.content.cloneNode(true));
+
+    // const bannerElem = bannerShadowDOM.querySelector(".usa-banner");
+    // const accordionElem = bannerShadowDOM.querySelector(".usa-accordion");
+
+    // banner.on(bannerElem);
+    // accordion.on(bannerElem);
+
+    this.render();
+  }
+
+  render() {
+    // ? Set defaults and/or fallback if attributes aren't set.
+    const locale = this.getAttribute("locale") || "en";
+    const tld = this.getAttribute("tld") || "gov";
+
+    // const content2 = this.template.content.cloneNode(true);
+    // this.innerHTML = "";
+    // this.append(content2);
+
+    // this.append(banner);
+  }
+
+  static get observedAttributes() {
+    return ["locale", "tld"];
+  }
+}
+
+window.customElements.define("usa-banner", BannerComponent);

--- a/packages/usa-banner/src/usa-banner.stories.js
+++ b/packages/usa-banner/src/usa-banner.stories.js
@@ -1,3 +1,5 @@
+import "./Banner";
+
 import component from "./usa-banner.twig";
 import {
   DefaultContent,
@@ -35,3 +37,5 @@ MilSpanish.args = {
   ...defaults,
   ...MilContentLangEs,
 };
+
+export const BannerWCTest = () => `<usa-banner></usa-banner>`;


### PR DESCRIPTION
> [!IMPORTANT]  
> This is native banner created for internal testing and insights.
 
# Summary

Initial native banner test.

## Breaking change

:warning: This is a breaking change.

## Related issue

Closes #5639. 


## Related pull requests

n/a


## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-native-wc-banner/?path=/story/components-banner--banner-wc-test)

## Problem statement

Native web components will allow us to:
1. Work closer to the browser.
2. Reduce the number of dependencies required.
3. Allow users to more easily stay up-to-date with the design system.

## Solution

Solution uses Light DOM. To allow existing USWDS styling and JS methods. This method was chosen to allow maximum re-use of existing code.

**Limitations of this approach**
1. Major changes to build requirements required to improve DX. For example, browser support for importing JSON is not widely supported.
    <img width="600" src="https://github.com/uswds/uswds/assets/3385219/d871b2bb-2598-4540-a207-275abfb4cddd" />
    <img width="600" src="https://github.com/uswds/uswds/assets/3385219/d1d2bbd0-175a-4a79-9012-89e2350e5423" />
    [MDN Source →](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#browser_compatibility)
1. Using light DOM allows us to re-use SASS & JS without major changes. But this puts components in a weird in-between state where we're not able to fully leverage native API's (especially in JS) to improve these components.
1. Additional development required to create methods for bundling and releasing.

An alternative solution is using a lighter framework based on web standards, like [Open Web Components](https://open-wc.org/), Lit, or StencilJS.

## Major changes

HTML moved to component JS. Concerned with how much markup there is for a component with no visual variants. This'll greatly impact maintainability when we start looking at components that have variants that require different markup.


## Testing and review

There shouldn't be any regressions to Banner functionality.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
