### PR TITLE
USWDS - Component lifecycle: Add discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/component-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/component-proposals.yml
@@ -5,11 +5,12 @@ body:
     attributes:
       value: |
         Thanks for sharing your new component suggestion for the U.S. Web Design System (USWDS).
-        </p><p>
+        
         We ask for a lot of detail in this form, but it’s okay to start with basic information. Only the fields marked with an asterisk (*) are required at this time. You can work with the community to add more detail after you start this discussion. It helps if you link to supporting evidence and research wherever you can.
-        </p><p>
-        <a href="https://github.com/uswds/uswds/discussions/5764">Learn more about the component proposal process</a>.
-        <h2>About this component</h2>
+        
+        [Learn more about the component proposal process](https://github.com/uswds/uswds/discussions/5764).
+        
+        ## About this component
   - type: textarea
     id: name
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/component-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/component-proposals.yml
@@ -1,0 +1,93 @@
+title: "Component proposal: [Component name]"
+labels: ["Type: New component proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your new component suggestion for the U.S. Web Design System (USWDS).
+        </p><p>
+        We ask for a lot of detail in this form, but it’s okay to start with basic information. Only the fields marked with an asterisk (*) are required at this time. You can work with the community to add more detail after you start this discussion. It helps if you link to supporting evidence and research wherever you can.
+        </p><p>
+        <a href="https://github.com/uswds/uswds/discussions/5764">Learn more about the component proposal process</a>.
+        <h2>About this component</h2>
+  - type: textarea
+    id: name
+    attributes:
+      label: Component name
+      description: |
+        Share the common name (or names) for this component.
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: 'Component description'
+      description: |
+        Briefly describe the component.
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: need
+    attributes:
+      label: 'Why USWDS needs this component'
+      description: |
+        Include key interactions, current gaps in USWDS, and the problems this component solves. Explain how the component supports federal laws, guidance, or policies.
+      value:
+    validations:
+      required: true
+  - type: textarea
+    id: design
+    attributes:
+      label: 'How the component works'
+      description: |
+        Describe how the component works. Include any interactive states and variants. Diagrams, images, wireframes, and prototypes can help you make your case.
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: implementation
+    attributes:
+      label: 'Real-life examples'
+      description: |
+        Link to examples of other sites — preferably government sites — that use this kind of component.
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: when_to_use
+    attributes:
+      label: When to use this component and when to consider something else
+      description: |
+        What kind of content works best with this component, and what kind of content would work poorly with it? What are common misuses of this type of component?
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: usability
+    attributes:
+      label: Usability considerations
+      description: |
+        Include conditions that would make this component more usable or less usable. Also include common pitfalls or implementation mistakes associated with this component.
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: accessibility
+    attributes:
+      label: Accessibility considerations
+      description: |
+        Include how this component interacts with assistive technologies such as keyboard navigation, screen readers, zoom magnification, and voice command. Are there audiences that might struggle with this component? How might the component become inaccessible?
+      value:
+    validations:
+      required: false
+  - type: textarea
+    id: involved
+    attributes:
+      label: Who’s involved
+      description: |
+        Please tag volunteers who may be willing to help design, develop or test this component. Note agencies that can offer significant support for the component, and tag any stakeholders. Be sure to share a list of those who helped research and prepare this proposal. Include your name and/or GitHub username if you’d like credit as a contributor.
+      value:
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/component-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/component-proposals.yml
@@ -4,9 +4,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing your new component suggestion for the U.S. Web Design System (USWDS).
+        Thank you for suggesting a new component for the U.S. Web Design System (USWDS).
         
-        We ask for a lot of detail in this form, but it’s okay to start with basic information. Only the fields marked with an asterisk (*) are required at this time. You can work with the community to add more detail after you start this discussion. It helps if you link to supporting evidence and research wherever you can.
+        To get the discussion started, you just need to fill out the three fields marked with an asterisk (*). Then collaborate with the community to add supporting evidence and research, and get feedback. The work you do now can help the USWDS team create a formal component proposal.
         
         [Learn more about the component proposal process](https://github.com/uswds/uswds/discussions/5764).
         

--- a/.github/DISCUSSION_TEMPLATE/component-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/component-proposals.yml
@@ -54,7 +54,7 @@ body:
   - type: textarea
     id: implementation
     attributes:
-      label: 'Real-life examples'
+      label: 'Real-world examples'
       description: |
         Link to examples of other sites — preferably government sites — that use this kind of component.
       value:

--- a/.github/DISCUSSION_TEMPLATE/component-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/component-proposals.yml
@@ -10,7 +10,7 @@ body:
         
         [Learn more about the component proposal process](https://github.com/uswds/uswds/discussions/5764).
         
-        ## About this component
+        ## The basics
   - type: textarea
     id: name
     attributes:
@@ -25,7 +25,7 @@ body:
     attributes:
       label: 'Component description'
       description: |
-        Briefly describe the component.
+        Briefly tell us the purpose of this component.
       value:
     validations:
       required: true
@@ -38,6 +38,10 @@ body:
       value:
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Component details
   - type: textarea
     id: design
     attributes:


### PR DESCRIPTION
# Summary

Added a discussion template for the new component proposals discussion board. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5784 

## Related pull requests

N/A

## Preview link

[Discussion template - Demo repo](https://github.com/amyleadem/uswds-proposals/discussions/new?category=component-proposals-friendly-template) 
>[!Important]
> This preview link is not from this PR. Instead, it points to a test repo so that you can get a see what the template will look like. This is because it is not possible to see this template in its final form in the uswds repo until it is merged. I will try to keep the test repo code in sync with this code, but be warned that this preview might not reflect the current code in this PR.

## Problem statement

It should be easy for users to know what information to include when they start a new component discussion. However, the [current discussion form](https://github.com/uswds/uswds/discussions/new?category=component-proposals) has only one generic field with no additional guidance. This can lead the user to wonder what information they should be providing and will also likely result in inconsistent discussions. 

## Solution

Adding a discussion template allows us to create prompts for different types of content. 

Some notes about this PR:
- The copy and sections were mostly pulled from the "What your discussion needs" section in the [pinned post](https://github.com/uswds/uswds/discussions/5764). This was preferred over doing a 1:1 with the [proposal template](https://github.com/uswds/uswds-proposals/blob/main/proposals/_proposal-template.md) because it felt more approachable and appropriate for the venue. 
- Only the first three fields are required. All others are optional. 
- This template will add a "Type: new component proposal" label to each new discussion. 

Resource: [Instructions for creating discussion category forms](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms)

## Testing and review
Overall, we should confirm that adding this template will make starting a new component discussion _easier_ for the user. The goal here is to add clarity and guidance without being overwhelming. 

1. Confirm that the sections listed in the template are helpful, comprehensive and approachable. 
1. Confirm that the sections marked as required are the correct choices
1. Confirm that the code matches the guidance from GitHub for [creating discussion category forms](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms)
    1. Confirm that the file name matches the discussion title slug
    1. Confirm that the value of the `labels` field matches labels that are currently in USWDS, and that the labels listed are the correct ones
    1. Confirm that the code builds as expected in the [test repo](https://github.com/amyleadem/uswds-proposals/discussions/new?category=component-proposals-friendly-template), and that the code structure in this PR matches the [test file](https://github.com/amyleadem/uswds-proposals/blob/main/.github/DISCUSSION_TEMPLATE/component-proposals-friendly-template.yml)
1. Confirm the copy makes sense and is free from error. 
