### PR TITLE
USWDS - Core: Replace receptor behavior with custom optimized implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
-        "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
       },
       "devDependencies": {
@@ -15614,14 +15613,6 @@
       "integrity": "sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==",
       "dev": true
     },
-    "node_modules/element-closest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/element-resize-detector": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
@@ -21466,11 +21457,6 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
-    "node_modules/keyboardevent-key-polyfill": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha512-NTDqo7XhzL1fqmUzYroiyK2qGua7sOMzLav35BfNA/mPUSCtw8pZghHFMTYR9JdnJ23IQz695FcaM6EE6bpbFQ=="
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -22251,11 +22237,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/matches-selector": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
-      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
@@ -26133,17 +26114,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/receptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/receptor/-/receptor-1.0.0.tgz",
-      "integrity": "sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==",
-      "dependencies": {
-        "element-closest": "^2.0.1",
-        "keyboardevent-key-polyfill": "^1.0.2",
-        "matches-selector": "^1.0.0",
-        "object-assign": "^4.1.0"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   "dependencies": {
     "classlist-polyfill": "1.2.0",
     "object-assign": "4.1.1",
-    "receptor": "1.0.0",
     "resolve-id-refs": "0.1.0"
   },
   "devDependencies": {

--- a/packages/usa-button/src/index.js
+++ b/packages/usa-button/src/index.js
@@ -1,4 +1,4 @@
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 
 const ANCHOR_BUTTON = `a[class*="usa-button"]`;

--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -1,4 +1,4 @@
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const Sanitizer = require("../../uswds-core/src/js/utils/sanitizer");

--- a/packages/usa-date-picker/src/index.js
+++ b/packages/usa-date-picker/src/index.js
@@ -1,4 +1,4 @@
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const select = require("../../uswds-core/src/js/utils/select");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");

--- a/packages/usa-header/src/index.js
+++ b/packages/usa-header/src/index.js
@@ -1,4 +1,4 @@
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const select = require("../../uswds-core/src/js/utils/select");
 const toggle = require("../../uswds-core/src/js/utils/toggle");

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -1,5 +1,5 @@
 const once = require("receptor/once");
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -334,7 +334,7 @@ const handleEnterFromLink = (event) => {
       () => {
         target.setAttribute("tabindex", -1);
       },
-      { once: true }
+      { once: true },
     );
   } else {
     // throw an error?

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -1,4 +1,3 @@
-const once = require("receptor/once");
 const keymap = require("../../uswds-core/src/js/utils/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
@@ -332,9 +331,10 @@ const handleEnterFromLink = (event) => {
     target.focus();
     target.addEventListener(
       "blur",
-      once(() => {
+      () => {
         target.setAttribute("tabindex", -1);
-      }),
+      },
+      { once: true }
     );
   } else {
     // throw an error?

--- a/packages/usa-language-selector/src/index.js
+++ b/packages/usa-language-selector/src/index.js
@@ -1,4 +1,4 @@
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const toggle = require("../../uswds-core/src/js/utils/toggle");
 const FocusTrap = require("../../uswds-core/src/js/utils/focus-trap");

--- a/packages/usa-search/src/index.js
+++ b/packages/usa-search/src/index.js
@@ -1,4 +1,3 @@
-const ignore = require("receptor/ignore");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const select = require("../../uswds-core/src/js/utils/select");
 
@@ -39,13 +38,17 @@ const toggleSearch = (button, active) => {
   }
   // when the user clicks _outside_ of the form w/ignore(): hide the
   // search, then remove the listener
-  const listener = ignore(form, () => {
+  const listener = (event) => {
+    if (form.contains(event.target)) {
+      return;
+    }
+
     if (lastButton) {
       hideSearch.call(lastButton); // eslint-disable-line no-use-before-define
     }
 
     document.body.removeEventListener(CLICK, listener);
-  });
+  };
 
   // Normally we would just run this code without a timeout, but
   // IE11 and Edge will actually call the listener *immediately* because

--- a/packages/usa-skipnav/src/index.js
+++ b/packages/usa-skipnav/src/index.js
@@ -1,4 +1,3 @@
-const once = require("receptor/once");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
@@ -18,12 +17,9 @@ function setTabindex() {
     target.style.outline = "0";
     target.setAttribute("tabindex", 0);
     target.focus();
-    target.addEventListener(
-      "blur",
-      once(() => {
-        target.setAttribute("tabindex", -1);
-      }),
-    );
+    target.addEventListener("blur", () => target.setAttribute("tabindex", -1), {
+      once: true,
+    });
   } else {
     // throw an error?
   }

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -1,5 +1,5 @@
 // Tooltips
-const keymap = require("receptor/keymap");
+const keymap = require("../../uswds-core/src/js/utils/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");

--- a/packages/uswds-core/src/js/utils/behavior.js
+++ b/packages/uswds-core/src/js/utils/behavior.js
@@ -53,8 +53,8 @@ module.exports = (events, props) => {
                   const target = event.target && event.target.closest(selector);
                   return target && handler.call(target, event) === false;
                 }),
-        ])
-    )
+        ]),
+    ),
   );
 
   const on = (target = document.body) => {

--- a/packages/uswds-core/src/js/utils/focus-trap.js
+++ b/packages/uswds-core/src/js/utils/focus-trap.js
@@ -1,5 +1,5 @@
 const assign = require("object-assign");
-const { keymap } = require("receptor");
+const keymap = require("receptor/keymap");
 const behavior = require("./behavior");
 const select = require("./select");
 const activeElement = require("./active-element");

--- a/packages/uswds-core/src/js/utils/focus-trap.js
+++ b/packages/uswds-core/src/js/utils/focus-trap.js
@@ -1,5 +1,5 @@
 const assign = require("object-assign");
-const keymap = require("receptor/keymap");
+const keymap = require("./keymap");
 const behavior = require("./behavior");
 const select = require("./select");
 const activeElement = require("./active-element");

--- a/packages/uswds-core/src/js/utils/keymap.js
+++ b/packages/uswds-core/src/js/utils/keymap.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef {(event: KeyboardEvent) => any} KeyboardEventHandler
+ */
+
+/**
+ * @typedef {Record<string, KeyboardEventHandler>} KeymapConfig
+ */
+
+/**
+ * @param {KeymapConfig} map
+ * @return {KeyboardEventHandler}
+ */
+module.exports = (map) => (event) =>
+  Object.keys(map).forEach((combo) => {
+    const parts = combo.split("+");
+    const key = parts.pop();
+    const isModifierMatch = ["Shift", "Alt", "Ctrl", "Meta"]
+      .filter((mod) => event.getModifierState(mod) || parts.includes(mod))
+      .every((mod) => event.getModifierState(mod) && parts.includes(mod));
+
+    if (key === event.key && isModifierMatch) {
+      map[combo](event);
+    }
+  });

--- a/packages/uswds-core/src/js/utils/test/behavior.spec.js
+++ b/packages/uswds-core/src/js/utils/test/behavior.spec.js
@@ -8,10 +8,117 @@ describe("behavior", () => {
     assert(component && typeof component === "object");
   });
 
-  it("has on() and off() methods", () => {
+  it("has on(), off(), add(), remove() functions", () => {
     const component = behavior({});
     assert.strictEqual(typeof component.on, "function");
     assert.strictEqual(typeof component.off, "function");
+    assert.strictEqual(typeof component.add, "function");
+    assert.strictEqual(typeof component.remove, "function");
+  });
+
+  it("includes additional properties from given arguments", () => {
+    const component = behavior({}, { extra: true });
+
+    assert.strictEqual(component.extra, true);
+  });
+
+  it("calls event handlers as function", () => {
+    const click = sinon.stub();
+    const component = behavior({ click });
+    component.on();
+    const event = new Event("click", { bubbles: true });
+    document.body.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, document.body);
+  });
+
+  it("scopes event handling by the given target", () => {
+    const click = sinon.stub();
+    const component = behavior({ click });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on(div);
+    document.body.dispatchEvent(event);
+
+    assert(click.notCalled);
+    div.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, div);
+  });
+
+  it("calls event handlers as object for matched selector", () => {
+    const divClick = sinon.stub();
+    const spanClick = sinon.stub();
+    const component = behavior({ click: { div: divClick, span: spanClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    const span = document.createElement("span");
+    document.body.appendChild(div);
+    document.body.appendChild(span);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(spanClick.notCalled);
+  });
+
+  it("calls event handlers as object for matched ancestor selector", () => {
+    const bodyClick = sinon.stub();
+    const component = behavior({ click: { body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(bodyClick.calledOnceWithExactly(event));
+    assert.strictEqual(bodyClick.getCall(0).thisValue, document.body);
+  });
+
+  it("calls event handlers as object for multiple matches", () => {
+    const bodyClick = sinon.stub();
+    const divClick = sinon.stub();
+    const component = behavior({ click: { div: divClick, body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(bodyClick.calledOnceWithExactly(event));
+    assert.strictEqual(bodyClick.getCall(0).thisValue, document.body);
+  });
+
+  it("skips other event handlers once one returns false", () => {
+    const bodyClick = sinon.stub();
+    const divClick = sinon.stub().returns(false);
+    const component = behavior({ click: { div: divClick, body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(bodyClick.notCalled);
+  });
+
+  it("calls event handlers with space separated event names", () => {
+    const click = sinon.stub();
+    const component = behavior({ "keydown click": click });
+    component.on();
+    const event = new Event("click", { bubbles: true });
+    document.body.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, document.body);
   });
 
   describe("behavior.on()", () => {
@@ -33,6 +140,17 @@ describe("behavior", () => {
       behavior({}, { init }).on(el);
       assert(init.calledWithExactly(el));
     });
+
+    it("binds events", () => {
+      const sandbox = sinon.createSandbox();
+      sandbox.spy(document.body, "addEventListener");
+      const component = behavior({ click() {} });
+      component.on();
+
+      assert(document.body.addEventListener.calledOnceWith("click"));
+
+      sandbox.restore();
+    });
   });
 
   describe("behavior.off()", () => {
@@ -53,6 +171,18 @@ describe("behavior", () => {
       const el = document.createElement("div");
       behavior({}, { teardown }).off(el);
       assert(teardown.calledWithExactly(el));
+    });
+
+    it("removes event bindings", () => {
+      const sandbox = sinon.createSandbox();
+      sandbox.spy(document.body, "removeEventListener");
+      const component = behavior({ click() {} });
+      component.on();
+      component.off();
+
+      assert(document.body.removeEventListener.calledOnceWith("click"));
+
+      sandbox.restore();
     });
   });
 });

--- a/packages/uswds-core/src/js/utils/test/keymap.spec.js
+++ b/packages/uswds-core/src/js/utils/test/keymap.spec.js
@@ -1,0 +1,65 @@
+const sinon = require("sinon");
+const assert = require("assert");
+const keymap = require("../keymap");
+
+describe("keymap", () => {
+  it("does not call handler if keypress is not for the mapped key", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ Tab: onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.notCalled);
+  });
+
+  it("calls handler if combo does not include modifier and neither does keypress", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ Tab: onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab" });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.calledOnceWithExactly(event));
+  });
+
+  it("does not call handler if combo does not include modifier from keypress", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ Tab: onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.notCalled);
+  });
+
+  it("calls handler if all modifiers in combo are pressed", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ "Shift+Tab": onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.calledOnceWithExactly(event));
+  });
+
+  it("does not call handler if some but not all modifiers in combo are pressed", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ "Shift+Ctrl+Tab": onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.notCalled);
+  });
+
+  it("does not call handler if event has modifiers but combo does not", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ Tab: onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.notCalled);
+  });
+});

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -9,7 +9,11 @@ const mochaConfig = {
 module.exports = {
   // run unit test.
   unitTests() {
-    return src("packages/usa-*/**/*.spec.js").pipe(mocha(mochaConfig));
+    return src([
+      "packages/usa-*/**/*.spec.js",
+      "packages/uswds-*/**/*.spec.js",
+      "!packages/uswds-core/src/test/sass.spec.js"
+    ]).pipe(mocha(mochaConfig));
   },
 
   sassTests() {


### PR DESCRIPTION
# Summary

**Reduced the JavaScript bundle size.** By optimizing the implementation of core component code, overall JavaScript sizes are reduced.

## Breaking change

This _could_ be considered a breaking change in the unlikely circumstance that someone is using USWDS' internal `behavior` module and expecting to leverage behaviors of the underlying [`receptor` library](https://github.com/shawnbot/receptor) that are not implemented here, namely:

1. ["A string in the form `types:delegate(selector)`"](https://github.com/shawnbot/receptor/tree/master?tab=readme-ov-file#-receptorbehaviorlisteners--properties:~:text=A%20string%20in%20the%20form%20types%3Adelegate(selector))
2. Support for [listener options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options), which is only [documented in passing](https://github.com/shawnbot/receptor/tree/master?tab=readme-ov-file#once:~:text=If%20you%20provide%20listener%20options%2C%20those%20will%20also%20be%20passed%20to%20removeEventListener().)

Overall, I'd expect it to be quite unlikely anyone would be using these features, since it would require familiarity with `receptor` such that I'd expect anyone interested in using them would use `receptor` directly rather than through USWDS's `behavior` abstraction.

Backwards-compatibility has been artificially preserved with the return value of `behavior` including additional function aliases `add` (alias for `on`) and `remove` (alias for `off`).

## Problem statement

As a developer interested in optimizing their installation of USWDS, I expect that USWDS will keep overhead of common code to an absolute minimum, so that I can maximize optimization in cases where I'm interested in using one or a few components.

* Example: At Login.gov, we include very few components in our critical-path JavaScript bundle ([source](https://github.com/18F/identity-idp/blob/fab35dc2accf4f34fbe194baf553abea8e3384d4/app/javascript/packs/application.ts#L1-L4))

As a user interacting with a site using USWDS, I expect that pages will load quickly, so that I can access information without delay.

As a USWDS maintainer, I expect that the project minimizes its use of third-party dependencies in cases where such code is already heavily customized, so that I can avoid the maintenance burden associated with keeping those dependencies (including transitive dependencies) up-to-date and free from security vulnerabilities.

## Solution

The changes proposed here reimplement `behavior` and `keymap`, preserving existing functionality while removing underlying use of [the third-party `receptor` library](https://www.npmjs.com/package/receptor).

**Why?**

- Reduces size of behavior by 66%, keymap by 65%, and minimal component import (banner) by 50%
- Narrows scope to features in use
- Avoid baked-in polyfills not necessary for current browser supports ([`Object.assign`](https://github.com/shawnbot/receptor/blob/de712fd134c5fb1f9c48671579245d58d3296bcd/src/behavior.js#L1), [`Element#closest`](https://github.com/shawnbot/receptor/blob/de712fd134c5fb1f9c48671579245d58d3296bcd/src/delegate.js#L2))
- Remove third-party dependencies to reduce maintenance overhead and security vulnerability attack surface area
   - Avoid using dependencies which aren't actively maintained (the last release of `receptor` was 6 years ago)
- Add TypeScript annotations for IDEs supporting code autocompletion (e.g. VS Code)

### Performance Impact

The following examples use [ESBuild](https://github.com/evanw/esbuild) and [brotli-size-cli](https://github.com/andrewiggins/brotli-size-cli) to simulate a real-world scenario of downloading a minified, bundled, and compressed JavaScript.

#### Scenario 1: Importing only `behavior`

```
echo "import './packages/uswds-core/src/js/utils/behavior'" | npx esbuild --bundle --minify | brotli-size
```

Before: 1.43 kB
After: 473 B
Diff: -957 B (-66.9%)

#### Scenario 2: Importing only `keymap`

```
# Before:
echo "import 'receptor/keymap" | npx esbuild --bundle --minify | brotli-size

# After:
echo "import './packages/uswds-core/src/js/utils/keymap'" | npx esbuild --bundle --minify | brotli-size
```

Before: 1.18 kB
After: 413 B
Diff: -767 B (-65%)

#### Scenario 3: Importing a single component ("Best Case")

```
echo "import './packages/usa-banner/src/index.js'" | npx esbuild --bundle --minify | brotli-size
```

Before: 1.84 kB
After: 896 B
Diff: -944 B (-51.3%)

#### Scenario 4: Importing the full JavaScript package ("Worst Case")

```
echo "import './packages/uswds-core/src/js/index.js'" | npx esbuild --bundle --minify | brotli-size
```

Before: 22.2 kB
After: 20.9 kB
Diff: -1.3 kB (-5.9%)

~**Note:** I believe the reason for lack of any difference here is that this pull request doesn't completely remove `receptor` yet, and there are imports referencing the package that may end up pulling in the whole library still ([example](https://github.com/uswds/uswds/blob/b741317537b0053a0c553188de349e35eb16298e/packages/uswds-core/src/js/utils/focus-trap.js#L2)). A follow-up pull request should seek to replace `receptor`'s `keymap` functionality and remove the dependency altogether, which should prove to have an impact on the bundle size for the full package.~

**Edit:** I addressed this in 9924be3 by updating the import semantics, which prevents the full library from being pulled in, a temporary fix until the library can be removed altogether.

**Edit 2:** In additional commits starting from d55ee9c1a, I included the full replacement/removal of the `receptor` library, which further reduces the overall bundle size.

## Testing and review

Verify all unit tests pass:

```
npm exec gulp unitTests
```

If full unit test coverage cannot be guaranteed, it may be wise to review experience for individual components within the Storybook preview at http://localhost:6006
