### PR TITLE
USWDS - Pages: Avoid reordering content in Documentation example

### DIFF
--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -1,7 +1,7 @@
 <div class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="usa-layout-docs__sidenav desktop:grid-col-3">
+      <div class="usa-layout-docs__sidenav display-none desktop:display-block desktop:grid-col-3">
         <nav aria-label="Secondary navigation">
           <ul class="usa-sidenav">
             <li class="usa-sidenav__item">
@@ -46,10 +46,9 @@
             </li>
           </ul>
         </nav>
-
       </div>
 
-      <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+      <main class="desktop:grid-col-9 usa-prose" id="main-content">
         <h1>Page heading (h1)</h1>
         <p class="usa-intro">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
         <h2 id="section-heading-h2">Section heading (h2)</h2>
@@ -62,5 +61,53 @@
         <p>Read the full documentation on our side navigation on the component page.</p>
       </main>
     </div>
+      
+    <div class="usa-layout-docs__sidenav desktop:display-none">
+      <nav aria-label="Secondary navigation">
+        <ul class="usa-sidenav">
+          <li class="usa-sidenav__item">
+            <a href="">Parent link</a>
+          </li>
+          <li class="usa-sidenav__item">
+            <a href="" class="usa-current">Current page</a>
+            <ul class="usa-sidenav__sublist">
+              <li class="usa-sidenav__item">
+                <a href="">Child link</a>
+              </li>
+              <li class="usa-sidenav__item">
+                <a href="" class="usa-current">Child link</a>
+                <ul class="usa-sidenav__sublist">
+                  <li class="usa-sidenav__item">
+                    <a href="">Grandchild link</a>
+                  </li>
+                  <li class="usa-sidenav__item">
+                    <a href="">Grandchild link</a>
+                  </li>
+                  <li class="usa-sidenav__item">
+                    <a href="" class="usa-current">Grandchild link</a>
+                  </li>
+                  <li class="usa-sidenav__item">
+                    <a href="">Grandchild link</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-sidenav__item">
+                <a href="">Child link</a>
+              </li>
+              <li class="usa-sidenav__item">
+                <a href="">Child link</a>
+              </li>
+              <li class="usa-sidenav__item">
+                <a href="">Child link</a>
+              </li>
+            </ul>
+          </li>
+          <li class="usa-sidenav__item">
+            <a href="">Parent link</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
   </div>
 </div>
+

--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -1,51 +1,49 @@
+{% set settings = {
+  "aria_label": "Side navigation",
+  "items": [
+    {
+      "label": "Parent link",
+      "current": false
+    },
+    {
+      "label": "Current page",
+      "current": true,
+      "subnav": [
+        {
+          "label": "Child link"
+        },
+        {
+          "label": "Child link",
+          "subnav": [
+            {
+              "label": "Grandchild link"
+            },
+            {
+              "label": "Grandchild link",
+              "current": true
+            },
+            {
+              "label": "Grandchild link"
+            }
+          ]
+        },
+        {
+          "label": "Child link"
+        }
+      ]
+    },
+    {
+      "label": "Parent link",
+      "current": false
+    }
+  ]
+}%}
+
 <div class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="usa-layout-docs__sidenav display-none desktop:display-block desktop:grid-col-3">
-        <nav aria-label="Secondary navigation">
-          <ul class="usa-sidenav">
-            <li class="usa-sidenav__item">
-              <a href="">Parent link</a>
-            </li>
-            <li class="usa-sidenav__item">
-              <a href="" class="usa-current">Current page</a>
-              <ul class="usa-sidenav__sublist">
-                <li class="usa-sidenav__item">
-                  <a href="">Child link</a>
-                </li>
-                <li class="usa-sidenav__item">
-                  <a href="" class="usa-current">Child link</a>
-                  <ul class="usa-sidenav__sublist">
-                    <li class="usa-sidenav__item">
-                      <a href="">Grandchild link</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                      <a href="">Grandchild link</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                      <a href="" class="usa-current">Grandchild link</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                      <a href="">Grandchild link</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-sidenav__item">
-                  <a href="">Child link</a>
-                </li>
-                <li class="usa-sidenav__item">
-                  <a href="">Child link</a>
-                </li>
-                <li class="usa-sidenav__item">
-                  <a href="">Child link</a>
-                </li>
-              </ul>
-            </li>
-            <li class="usa-sidenav__item">
-              <a href="">Parent link</a>
-            </li>
-          </ul>
-        </nav>
+        {% include "@components/usa-sidenav/src/usa-sidenav.twig" with settings %}  
       </div>
 
       <main class="desktop:grid-col-9 usa-prose" id="main-content">
@@ -63,50 +61,7 @@
     </div>
       
     <div class="usa-layout-docs__sidenav desktop:display-none">
-      <nav aria-label="Secondary navigation">
-        <ul class="usa-sidenav">
-          <li class="usa-sidenav__item">
-            <a href="">Parent link</a>
-          </li>
-          <li class="usa-sidenav__item">
-            <a href="" class="usa-current">Current page</a>
-            <ul class="usa-sidenav__sublist">
-              <li class="usa-sidenav__item">
-                <a href="">Child link</a>
-              </li>
-              <li class="usa-sidenav__item">
-                <a href="" class="usa-current">Child link</a>
-                <ul class="usa-sidenav__sublist">
-                  <li class="usa-sidenav__item">
-                    <a href="">Grandchild link</a>
-                  </li>
-                  <li class="usa-sidenav__item">
-                    <a href="">Grandchild link</a>
-                  </li>
-                  <li class="usa-sidenav__item">
-                    <a href="" class="usa-current">Grandchild link</a>
-                  </li>
-                  <li class="usa-sidenav__item">
-                    <a href="">Grandchild link</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-sidenav__item">
-                <a href="">Child link</a>
-              </li>
-              <li class="usa-sidenav__item">
-                <a href="">Child link</a>
-              </li>
-              <li class="usa-sidenav__item">
-                <a href="">Child link</a>
-              </li>
-            </ul>
-          </li>
-          <li class="usa-sidenav__item">
-            <a href="">Parent link</a>
-          </li>
-        </ul>
-      </nav>
+      {% include "@components/usa-sidenav/src/usa-sidenav.twig" with settings %}  
     </div>
   </div>
 </div>

--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -1,4 +1,4 @@
-{% set settings = {
+{% set sidenav_settings = {
   "aria_label": "Secondary navigation",
   "items": [
     {
@@ -44,7 +44,7 @@
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="usa-layout-docs__sidenav display-none desktop:display-block desktop:grid-col-3">
-        {% include "@components/usa-sidenav/src/usa-sidenav.twig" with settings %}  
+        {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}  
       </div>
 
       <main class="desktop:grid-col-9 usa-prose" id="main-content">
@@ -62,7 +62,7 @@
     </div>
       
     <div class="usa-layout-docs__sidenav desktop:display-none">
-      {% include "@components/usa-sidenav/src/usa-sidenav.twig" with settings %}  
+      {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}  
     </div>
   </div>
 </div>

--- a/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
+++ b/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
@@ -1,17 +1,9 @@
 @use "uswds-core" as *;
 
-// Flexbox positioning to move sidenav below main content on small screens
 .usa-layout-docs__sidenav {
-  order: 2;
   padding-top: units(4);
 
   @include at-media("desktop") {
     padding-top: 0;
-  }
-}
-
-.usa-layout-docs__main {
-  @include at-media("desktop") {
-    order: 2;
   }
 }


### PR DESCRIPTION
# Summary

**Added mobile sidenav to the Documentation page template.** Sidenavs will now always follow logical HTML order on mobile and desktop views. Both navs use utility classes to change display settings based on viewport width.

## Breaking change

:warning: This is potentially breaking change.

### **Changed HTML**

This solution effectively duplicates the nav HTML and displays only the correctly placed in-page nav.

While this doesn’t affect the in-page nav component, we do offer this page as a [template](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-demo-5794/templates/documentation-page/) and the component code is changed as a result of this PR. _// Need to verify this causes a change_

### **Removed template classes:**

- `usa-layout-docs__main`: This is the class that had the styles that reordered element.
- `usa-layout-docs`: This selector unused in current styles.

## Related issue

Closes #4594

## Related pull requests

Alternate approach as discussed in #5681
[Changelog →](https://github.com/uswds/uswds-site/pull/2495) (Taken from #5681)

## Preview link

| Current (`develop`) | Feature branch |
|:-----|:-----|
| [Default] | [Preview] |
| [Template] (Site) | [Feature branch template] |

[Default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/pages-documentation-page--documentation-page&p=all

[Preview]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-feature-doc-layout-order/?path=/story/pages-documentation-page--documentation-page

[Template]: https://designsystem.digital.gov/templates/documentation-page/

[Feature branch template]: https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-demo-5794/templates/documentation-page/

## Problem statement

In mobile, tab order doesn't match visual order in the documentation page example.

## Solution

Create a second, mobile only in-page nav. Use utility classes to dictate which is displayed.

## Testing and review

Visit [Documentation page →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-feature-doc-layout-order/?path=/story/pages-documentation-page--documentation-page)

### In desktop widths

1. Tab through navigation
2. Confirm tab order is correct
3. Confirm screen readers read nav before main content
4. Confirm second nav is hidden and not tabbed to or read by screen readers

### In mobile widths

1. Confirm nav is still at the bottom of the page
2. Confirm tab order is correct
3. Confirm screen readers read main content before nav
4. Confirm original nav is hidden and not tabbed to or read by screen readers

### Testing checklist

- [ ]  No visual regressions
- [ ]  Hidden navs are not targetted by tabbing
- [ ]  Hidden navs are not read by screen readers
- [ ] Screen readers read content in visual order
- [ ]  Tab order follows matches expectation.