### PR TITLE
USWDS - Update README references to 3.8.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The `@uswds/uswds` module is now installed as a dependency. You can use the comp
 ### Install the package directly from GitHub
 If you’re using a framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the steps outlined in this section.
 
-1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.7.1/uswds-uswds-3.7.1.tgz) directly from the latest USWDS release and uncompress that file.
+1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.8.0/uswds-uswds-3.8.0.tgz) directly from the latest USWDS release and uncompress that file.
 
 2. Copy these files and folders into a relevant place in your project's code base. Here is an example structure for how this might look:
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The `@uswds/uswds` module is now installed as a dependency. You can use the comp
 ### Install the package directly from GitHub
 If you’re using a framework or package manager that doesn’t support npm, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the steps outlined in this section.
 
-1. Download the [USWDS package](https://github.com/uswds/uswds/releases/download/v3.8.0/uswds-uswds-3.8.0.tgz) directly from the latest USWDS release and uncompress that file.
+1. Download the [USWDS package](https://github.com/uswds/uswds/releases) directly from the latest USWDS release and uncompress that file.
 
 2. Copy these files and folders into a relevant place in your project's code base. Here is an example structure for how this might look:
 


### PR DESCRIPTION
Updates the two current version references in the README to `3.8.0`

> [!Note]
> The process is still unclear on this, but it might make sense to bundle Sass notifications with this update. We should update the [release process doc](https://docs.google.com/document/d/1Ux0TJf_wi3Sfikg_lZL0yXQhaY_stTr8-B_eAUY9B1U/edit#heading=h.fa3sv1ray42g) (Google Docs 🔒) with our preferred process.  