### PR TITLE
USWDS - Documentation page: Improve backwards compatibility with sidenav order

### DIFF
--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -42,10 +42,14 @@
 
 {% set desktop_sidenav_classes = "display-none desktop:display-block desktop:grid-col-3" %}
 
+{% if sidenav_reorder %}
+  {% set desktop_sidenav_classes = "" %}
+{% endif %}
+
 <div class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="usa-layout-docs__sidenav {{ sidenav_reorder ? "" : desktop_sidenav_classes }}">
+      <div class="usa-layout-docs__sidenav {{ desktop_sidenav_classes }}">
         {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}
       </div>
 
@@ -57,7 +61,7 @@
             }
           </style>
 
-          To test changes set <code>$theme-sidenav-reorder: true</code> in theme settings & in StorybookJS. The sidenav will be placed <em>after</em> main content and a compile warning should display.
+          Ensure <code>$theme-sidenav-reorder: true</code> in theme settings & in StorybookJS. The sidenav will be placed <em>after</em> main content and a compile warning should display.
         {% endif %}
 
         <h1>Page heading (h1)</h1>

--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -40,14 +40,26 @@
   ]
 }%}
 
+{% set desktop_sidenav_classes = "display-none desktop:display-block desktop:grid-col-3" %}
+
 <div class="usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
-      <div class="usa-layout-docs__sidenav display-none desktop:display-block desktop:grid-col-3">
-        {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}  
+      <div class="usa-layout-docs__sidenav {{ sidenav_reorder ? "" : desktop_sidenav_classes }}">
+        {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}
       </div>
 
       <main class="desktop:grid-col-9 usa-prose" id="main-content">
+        {% if sidenav_reorder %}
+          <style>
+            .usa-layout-docs__sidenav {
+              outline: 1px dashed orange;
+            }
+          </style>
+
+          To test changes set <code>$theme-sidenav-reorder: true</code> in theme settings & in StorybookJS. The sidenav will be placed <em>after</em> main content and a compile warning should display.
+        {% endif %}
+
         <h1>Page heading (h1)</h1>
         <p class="usa-intro">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
         <h2 id="section-heading-h2">Section heading (h2)</h2>
@@ -60,10 +72,12 @@
         <p>Read the full documentation on our side navigation on the component page.</p>
       </main>
     </div>
-      
+
+    {# Hide additional sidenav if we're using pre-3.8.0 behavior.#}
+    {% if not sidenav_reorder %}
     <div class="usa-layout-docs__sidenav desktop:display-none">
-      {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}  
+      {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}
     </div>
+    {% endif %}
   </div>
 </div>
-

--- a/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
+++ b/packages/templates/usa-documentation/includes/_usa-docs-inner.twig
@@ -42,6 +42,7 @@
 
 {% set desktop_sidenav_classes = "display-none desktop:display-block desktop:grid-col-3" %}
 
+{# If true, revert to the old single sidenav behavior. #}
 {% if sidenav_reorder %}
   {% set desktop_sidenav_classes = "" %}
 {% endif %}
@@ -77,7 +78,7 @@
       </main>
     </div>
 
-    {# Hide additional sidenav if we're using pre-3.8.0 behavior.#}
+    {# Hide additional sidenav if we're using pre-3.8.0 behavior. #}
     {% if not sidenav_reorder %}
     <div class="usa-layout-docs__sidenav desktop:display-none">
       {% include "@components/usa-sidenav/src/usa-sidenav.twig" with sidenav_settings %}

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -3,15 +3,18 @@ import Component from "./usa-docs.twig";
 
 export default {
   title: "Pages/Documentation Page",
+  args: DefaultContent
 };
 
 const Template = (args) => Component(args);
 
 export const DocumentationPage = Template.bind({});
-DocumentationPage.args = DefaultContent;
 
 export const TestDocumentationReorder = Template.bind({});
-TestDocumentationReorder.args = {
-  ...DefaultContent,
-  sidenav_reorder: false,
+TestDocumentationReorder.argTypes = {
+  sidenav_reorder: {
+    control: { type: 'boolean' },
+    defaultValue: false,
+    name: "Reorder with CSS",
+  },
 };

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -3,7 +3,7 @@ import Component from "./usa-docs.twig";
 
 export default {
   title: "Pages/Documentation Page",
-  args: DefaultContent
+  args: DefaultContent,
 };
 
 const Template = (args) => Component(args);
@@ -13,7 +13,7 @@ export const DocumentationPage = Template.bind({});
 export const TestDocumentationReorder = Template.bind({});
 TestDocumentationReorder.argTypes = {
   sidenav_reorder: {
-    control: { type: 'boolean' },
+    control: { type: "boolean" },
     defaultValue: false,
     name: "Reorder with CSS",
   },

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -13,5 +13,5 @@ DocumentationPage.args = DefaultContent;
 export const TestDocumentationReorder = Template.bind({});
 TestDocumentationReorder.args = {
   ...DefaultContent,
-  sidenav_reorder: false
+  sidenav_reorder: false,
 };

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -9,3 +9,9 @@ const Template = (args) => Component(args);
 
 export const DocumentationPage = Template.bind({});
 DocumentationPage.args = DefaultContent;
+
+export const TestDocumentationReorder = Template.bind({});
+TestDocumentationReorder.args = {
+  ...DefaultContent,
+  sidenav_reorder: false
+};

--- a/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
+++ b/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss
@@ -1,9 +1,26 @@
 @use "uswds-core" as *;
 
+$sidenav-reorder-warning: "$theme-sidenav-reorder is enabled and has accessibility concerns. This behavior has a negative impact on users of assistive technologies.";
+
 .usa-layout-docs__sidenav {
   padding-top: units(4);
 
   @include at-media("desktop") {
     padding-top: 0;
+  }
+
+  // Revert to >3.8.0 behavior and give a warning.
+  @if $theme-sidenav-reorder {
+    @warn $sidenav-reorder-warning;
+
+    &:first-of-type {
+      @include grid-col(12);
+      order: 2;
+
+      @include at-media("desktop") {
+        @include grid-col(3);
+        order: 0;
+      }
+    }
   }
 }

--- a/packages/uswds-core/src/styles/settings/_settings-components.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-components.scss
@@ -172,6 +172,7 @@ $theme-search-min-width: 27ch !default;
 // Sidenav
 $theme-sidenav-current-border-width: 0.5 !default;
 $theme-sidenav-font-family: "ui" !default;
+$theme-sidenav-reorder: false !default;
 
 // Site Alert
 $theme-site-alert-max-width: "desktop" !default;


### PR DESCRIPTION
# Summary


**Introduced a fallback for Documentation sidenav changes.** A new setting `$theme-sidenav-reorder` allows users to reorder the sidenav to avoid visual regressions.

> [!CAUTION]
> Setting `$theme-sidenav-reorder: true` has a negative impact on users of assistive technologies.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5807.

## Related pull requests

Changelog entry added to uswds/uswds-site#2495.

## Preview link

Preview link: [Test Documentation Reorder ⋅ Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-feature-doc-layout-order-setting/?path=/story/pages-documentation-page--test-documentation-reorder)


## Problem statement

Without a fallback, users who update to `3.8.0` will have to update all their templates to follow new guidance. This new setting allows for incremental adoption towards this new recommendation.

## Solution

This pull request adds a new component them setting for those who are unable to make that change right now. You can do that by setting `$theme-sidenav-reorder: true` in theme settings.

This will give you a warning on compile and suggesting the new recommendation above.

### New recommendation from #5794

#5794 introduced a potentially breaking change that requires a markup update. We recommend including a duplicate sidenav and toggling visibility based on breakpoints.

Include a duplicate sidenav and ensure the utility classes are correct. The example below shows a before/after.

```diff
<div class="grid-container">
  <div class="grid-row grid-gap">
-   <div class="usa-layout-docs__sidenav">
+   <!-- One of two sidenav's only shown in desktop breakpoints. --> 
+   <div class="usa-layout-docs__sidenav display-none desktop:display-block desktop:grid-col-3">
      {{ SIDENAV_MARKUP }}
    </div>
-   <main class="usa-layout-docs__main desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
+   <main class="desktop:grid-col-9 usa-prose usa-layout-docs" id="main-content">
      {{ MAIN_CONTENT }}
    </main>
  </div>
+ <!-- New duplicate section only shown on mobile. -->
+  <div class="usa-layout-docs__sidenav desktop:display-none">
+    {{ SIDENAV_MARKUP }}
+  </div>
</div>
```

### Approach

### Possible limitations

The `desktop` breakpoint in `_usa-layout-docs.scss:20` is fixed and users don't have an easy way of overriding this.

https://github.com/uswds/uswds/blob/17600ba4043b4bde0d0963fa8e0f4b35973819b5/packages/usa-layout-docs/src/styles/_usa-layout-docs.scss#L20-L23

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Major changes

- New component theme setting `$theme-sidenav-reorder: false !default`.
- New test story & storybook control

## Testing and review

There's a new test story that allow you to toggle and compare behaviors. Toggle `Reorder with CSS` to test old behavior.

### Testing checklist

- [ ] Zero regressions in HTML output - `npm run build:html`.
- [ ] Documentation page by default has two sidenavs that toggle display based on breakpoint.
- [ ] Documentation page test can revert to old behavior on `TRUE` via StorybookJS control.
- [ ] New reorder setting in `_settings-components.scss`.
- [ ] New setting is `FALSE` by default.
- [ ] New setting reorders sidenav on `TRUE` and provides a warning on compile.

## Todo

- [ ] Write SASS notification

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
