### PR TITLE
USWDS - JS Loading: Add JS loading hidden content component

### DIFF
--- a/packages/usa-accordion/src/usa-accordion.twig
+++ b/packages/usa-accordion/src/usa-accordion.twig
@@ -6,7 +6,7 @@
         {{ item.title }}
       </button>
     </h4>
-    <div id="{{ id_prefix }}{{ item.id }}" class="usa-accordion__content usa-prose">
+    <div id="{{ id_prefix }}{{ item.id }}" class="usa-accordion__content usa-prose {% if item.expanded != true %}usa-js-loading__hidden-content{% endif %}">
       {{ item.content }}
     </div>
   {% endfor %}

--- a/packages/usa-js-loading/_index.scss
+++ b/packages/usa-js-loading/_index.scss
@@ -1,0 +1,4 @@
+// dependencies
+
+// src
+@forward "src/styles";

--- a/packages/usa-js-loading/src/styles/_index.scss
+++ b/packages/usa-js-loading/src/styles/_index.scss
@@ -1,0 +1,4 @@
+// dependencies
+
+// src
+@forward "usa-js-loading";

--- a/packages/usa-js-loading/src/styles/_usa-js-loading.scss
+++ b/packages/usa-js-loading/src/styles/_usa-js-loading.scss
@@ -1,0 +1,3 @@
+.usa-js-loading .usa-js-loading__hidden-content {
+  display: none;
+}

--- a/packages/uswds/_index.scss
+++ b/packages/uswds/_index.scss
@@ -2,6 +2,7 @@
 
 // Global
 // -------------------------------------
+@forward "usa-js-loading";
 @forward "uswds-global";
 
 // Helpers

--- a/src/stylesheets/packages/_usa-js-loading.scss
+++ b/src/stylesheets/packages/_usa-js-loading.scss
@@ -1,0 +1,4 @@
+// dependencies
+
+// src
+@forward "usa-js-loading";

--- a/src/stylesheets/packages/_uswds-global.scss
+++ b/src/stylesheets/packages/_uswds-global.scss
@@ -1,5 +1,6 @@
 // Global
 // -------------------------------------
+@forward "usa-js-loading";
 @forward "uswds-elements/lib/normalize";
 @forward "uswds-core";
 @forward "uswds-elements";


### PR DESCRIPTION
# Summary

**Adds support for hiding content while JavaScript is loading.** This can be used on accordion content to avoid flashing content while JavaScript loads.

## Related issue

Closes #5817

Related to #3092

## Related pull requests

This is an alternative or complementary solution to #5826.

Even if #5826 is merged, this could still provide benefit if there was a use-case to want to hide specific content during the time that JavaScript is loading. That being said, I don't have any specific use-cases in mind, so would be fine to close this if #5826 is the preferred solution.

## Solution

This is the second solution proposed in #5817:

>An alternative solution could be to lean into "usa-js-loading" as a proper component, with a CSS [BEM](https://css-tricks.com/bem-101/) "element" like `usa-js-loading__hidden-content` which could be added to elements expected to be hidden during the time that the main JavaScript bundle is being loaded.

If this were to be accepted...

- ...it could make sense to move `uswds-init.js` source code from `uswds-core` into this component.
- ...it would require some corresponding changes to documentation site for component example markup to use the new class

## Testing and review

1. Go to http://localhost:6006/?path=/story/components-accordion--default
2. Observe hidden content unaffected by changes
3. In local copy of running code, comment out these lines: https://github.com/uswds/uswds/blob/98566ec5dc12807a2b0bc36699a033fe3a711d44/packages/usa-accordion/src/index.js#L86-L89
4. Refresh the page
5. Observe all content is visible
6. Using browser DevTools inspector, add `usa-js-loading` CSS class to some ancestor element of one of the accordions which would be collapsed without the changes implemented in Step 3
7. Observe that the accordion content becomes hidden