### PR TITLE
USWDS - Banner: Support simplified icon markup using SVG mask

### DIFF
--- a/packages/usa-banner/src/styles/_usa-banner.scss
+++ b/packages/usa-banner/src/styles/_usa-banner.scss
@@ -113,19 +113,18 @@ $banner-icon-close: (
 }
 
 .usa-banner__lock-image {
+  @include u-display("inline-block");
   $lock-h: 64; // unitless height of svg
   $lock-w: 52; // unitless width of svg
   $lock-aspect: math.div($lock-w, $lock-h);
   $icon-height: 1.5ex; // height of the lock icon; use ex for resilience
-
   height: $icon-height;
   width: $icon-height * $lock-aspect;
-  path {
-    fill: currentColor;
-
-    @media (forced-colors: active) {
-      fill: CanvasText;
-    }
+  mask-image: url("#{$theme-image-path}/lock.svg");
+  mask-size: 100%;
+  background-color: currentColor;
+  @media (forced-colors: active) {
+    background-color: CanvasText;
   }
 }
 

--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -1,11 +1,5 @@
 {% set lock %}
-  <span class="icon-lock">
-    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false">
-      <title id="banner-lock-title">Lock</title>
-      <desc id="banner-lock-description">Locked padlock icon</desc>
-      <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/>
-    </svg>
-  </span>
+  <span class="usa-banner__lock-image" role="img" aria-label="Locked padlock icon"></span>
 {% endset %}
 
 <section class="usa-banner" aria-label="{{ banner.aria_label }}">


### PR DESCRIPTION
# Summary

**The Banner component markup has been simplified.** The banner component no longer includes an embedded icon image, which is instead rendered as part of banner styles.

## Breaking change

This is not a breaking change.

While this does change how the existing element is styled, this has been tested and confirmed support for a site which chooses to update to the newest styles while keeping the same HTML markup, and there is no observed visual regression.

## Preview link

Preview link: http://localhost:6006/?path=/story/components-banner--default

## Problem statement

Ideally, USWDS provides code snippets which are concise and easy to implement, do not needlessly duplicate existing resources, and are not at risk of falling out of sync with said resources.

## Solution

Reference the existing [`lock.svg` image](https://github.com/uswds/uswds/blob/develop/packages/usa-banner/src/img/lock.svg) [CSS background mask](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image), similar to what's done elsewhere in the banner with the "Here's how you know" expanding caret.

Benefits:

- Simpler markup
- More efficient page loads, since image will be referenced externally and loaded on-demand
- Avoids use of non-BEM-standard `icon-lock` wrapping element
- Backwards-compatible for sites which don't opt to change their existing markup

## Testing and review

Review at preview link: http://localhost:6006/?path=/story/components-banner--default

To confirm backwards-compatibility, reset markup of `.twig` file to `develop` branch and observe no visual regressions even with updated styling:

```
git checkout develop -- packages/usa-banner/src/usa-banner.twig
```