### PR TITLE
USWDS - Validation: Remove ability to focus checklist items

### DIFF
--- a/packages/usa-validation/src/index.js
+++ b/packages/usa-validation/src/index.js
@@ -41,7 +41,6 @@ const createInitialStatus = (input) => {
       currentStatus = input.getAttribute("data-validation-incomplete");
     }
     const itemStatus = `${listItem.textContent} ${currentStatus} `;
-    listItem.setAttribute("tabindex", "0");
     listItem.setAttribute("aria-label", itemStatus);
   });
 };


### PR DESCRIPTION
# Summary

Fixed a bug which caused non-interactive checklist items to receive focus on tab. Now, only the interactive input will receive focus.

Created #5841 as a follow up to enhance screen reader callouts for the validation input element.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5760

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2555)

## Preview link

[Validation component →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-validation-remove-tabindex/iframe.html?args=&id=components-validation--input-validation)

## Problem statement

`tabindex="0"` was added to checklist items in https://github.com/uswds/uswds/pull/4914 to make the validation checklist items easier to navigate via tab. 

This could prove confusing to keyboard users because text typically isn’t focusable in the DOM unless it’s interactive. [^1]

[^1]: [Comment from Amy C.](https://github.com/uswds/uswds/issues/5760#issuecomment-1989482332)

## Solution

Remove `tabindex` from checklist items. 

- Items are no longer focused via tab
- Items are still read as expected when using a screen reader

## Testing and review

1. Visit the validation component page
2. Use tab to select the text input. Checklist item should *not* be focused at any point during tabbing.
3. Test component with screen reader and confirm that interactions are unaffected
    1. Checklist items should be accessible using arrow keys
    2. Checklist items should also be read after input change

### Testing checklist

- [ ]  Checklist items are not focusable
- [ ]  Screen readers behaviors are unaffected
- [ ]  No additional regression caused due to removing `tabindex`