### PR TITLE
USWDS - Button: Nest button variant styles underneath usa-button class

### DIFF
--- a/packages/usa-button/src/styles/_usa-button.scss
+++ b/packages/usa-button/src/styles/_usa-button.scss
@@ -231,6 +231,7 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
     @include button-unstyled;
   }
 
+  // Disabled styles must come after variants to avoid regression due to specificity.
   &:disabled,
   &[aria-disabled="true"] {
     @include button-disabled;

--- a/packages/usa-button/src/styles/_usa-button.scss
+++ b/packages/usa-button/src/styles/_usa-button.scss
@@ -59,104 +59,104 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
       border: $border-high-contrast;
     }
   }
-  
+
   &.usa-button--accent-cool {
     @include set-text-and-bg("accent-cool", $context: $button-context);
-  
+
     &:visited {
       @include set-text-and-bg("accent-cool", $context: $button-context);
     }
-  
+
     &:hover,
     &.usa-button--hover {
       @include set-text-and-bg("accent-cool-dark", $context: $button-context);
     }
-  
+
     &:active,
     &.usa-button--active {
       @include set-text-and-bg("accent-cool-darker", $context: $button-context);
     }
   }
-  
+
   &.usa-button--accent-warm {
     @include set-text-and-bg("accent-warm", $context: $button-context);
-  
+
     &:visited {
       @include set-text-and-bg("accent-warm", $context: $button-context);
     }
-  
+
     &:hover,
     &.usa-button--hover {
       @include set-text-and-bg("accent-warm-dark", $context: $button-context);
     }
-  
+
     &:active,
     &.usa-button--active {
       @include set-text-and-bg("accent-warm-darker", $context: $button-context);
     }
   }
-  
+
   &.usa-button--outline {
     background-color: color("transparent");
     box-shadow: $button-stroke color("primary");
     color: color("primary");
-  
+
     &:visited {
       color: color("primary");
     }
-  
+
     &:hover,
     &.usa-button--hover {
       background-color: color("transparent");
       box-shadow: $button-stroke color("primary-dark");
       color: color("primary-dark");
     }
-  
+
     &:active,
     &.usa-button--active {
       background-color: color("transparent");
       box-shadow: $button-stroke color("primary-darker");
       color: color("primary-darker");
     }
-  
+
     &.usa-button--inverse {
       $button-inverse-color: $theme-link-reverse-color;
       $button-inverse-hover-color: $theme-link-reverse-hover-color;
       $button-inverse-active-color: $theme-link-reverse-active-color;
-  
+
       box-shadow: $button-stroke color("base-lighter");
       color: color($button-inverse-color);
-  
+
       &:visited {
         color: color($button-inverse-color);
       }
-  
+
       &:hover,
       &.usa-button--hover {
         box-shadow: $button-stroke color($button-inverse-hover-color);
         color: color($button-inverse-hover-color);
       }
-  
+
       &:active,
       &.usa-button--active {
         background-color: transparent;
         box-shadow: $button-stroke color($button-inverse-active-color);
         color: color($button-inverse-active-color);
       }
-  
+
       &.usa-button--unstyled {
         @include button-unstyled;
         color: color($button-inverse-color);
-  
+
         &:visited {
           color: color($button-inverse-color);
         }
-  
+
         &:hover,
         &.usa-button--hover {
           color: color($button-inverse-hover-color);
         }
-  
+
         &:active,
         &.usa-button--active {
           color: color($button-inverse-active-color);
@@ -164,41 +164,41 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
       }
     }
   }
-  
+
   &.usa-button--base {
     @include set-text-and-bg("base", $context: $button-context);
-  
+
     &:hover,
     &.usa-button--hover {
       @include set-text-and-bg("base-dark", $context: $button-context);
     }
-  
+
     &:active,
     &.usa-button--active {
       @include set-text-and-bg("base-darker", $context: $button-context);
     }
   }
-  
+
   &.usa-button--secondary {
     @include set-text-and-bg("secondary", $context: $button-context);
-  
+
     &:hover,
     &.usa-button--hover {
       @include set-text-and-bg("secondary-dark", $context: $button-context);
     }
-  
+
     &:active,
     &.usa-button--active {
       @include set-text-and-bg("secondary-darker", $context: $button-context);
     }
   }
-  
+
   &.usa-button--big {
     border-radius: radius($theme-button-border-radius);
     font-size: font-size($theme-button-font-family, "lg");
     padding: units(2) units(3);
   }
-  
+
   // Cannot use disabled mixin due to transparent causing build errors with color grade check.
   &.usa-button--outline:disabled,
   &.usa-button--outline[aria-disabled="true"],
@@ -212,21 +212,21 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
       color: color("disabled");
     }
   }
-  
+
   &.usa-button--outline:disabled,
   &.usa-button--outline[aria-disabled="true"] {
     box-shadow: $button-stroke color("disabled-lighter");
-  
+
     &.usa-button--inverse {
       box-shadow: $button-stroke color("disabled-light");
       color: color("disabled-light");
-  
+
       @media (forced-colors: active) {
         color: color(GrayText);
       }
     }
   }
-  
+
   &.usa-button--unstyled {
     @include button-unstyled;
   }

--- a/packages/usa-button/src/styles/_usa-button.scss
+++ b/packages/usa-button/src/styles/_usa-button.scss
@@ -50,11 +50,6 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
     outline-offset: units(0.5);
   }
 
-  &:disabled,
-  &[aria-disabled="true"] {
-    @include button-disabled;
-  }
-
   .usa-icon {
     flex-shrink: 0; // Avoid shrinking on small screens.
   }
@@ -64,175 +59,180 @@ $button-stroke: inset 0 0 0 units($theme-button-stroke-width);
       border: $border-high-contrast;
     }
   }
-}
-
-.usa-button--accent-cool {
-  @include set-text-and-bg("accent-cool", $context: $button-context);
-
-  &:visited {
+  
+  &.usa-button--accent-cool {
     @include set-text-and-bg("accent-cool", $context: $button-context);
-  }
-
-  &:hover,
-  &.usa-button--hover {
-    @include set-text-and-bg("accent-cool-dark", $context: $button-context);
-  }
-
-  &:active,
-  &.usa-button--active {
-    @include set-text-and-bg("accent-cool-darker", $context: $button-context);
-  }
-}
-
-.usa-button--accent-warm {
-  @include set-text-and-bg("accent-warm", $context: $button-context);
-
-  &:visited {
-    @include set-text-and-bg("accent-warm", $context: $button-context);
-  }
-
-  &:hover,
-  &.usa-button--hover {
-    @include set-text-and-bg("accent-warm-dark", $context: $button-context);
-  }
-
-  &:active,
-  &.usa-button--active {
-    @include set-text-and-bg("accent-warm-darker", $context: $button-context);
-  }
-}
-
-.usa-button--outline {
-  background-color: color("transparent");
-  box-shadow: $button-stroke color("primary");
-  color: color("primary");
-
-  &:visited {
-    color: color("primary");
-  }
-
-  &:hover,
-  &.usa-button--hover {
-    background-color: color("transparent");
-    box-shadow: $button-stroke color("primary-dark");
-    color: color("primary-dark");
-  }
-
-  &:active,
-  &.usa-button--active {
-    background-color: color("transparent");
-    box-shadow: $button-stroke color("primary-darker");
-    color: color("primary-darker");
-  }
-
-  &.usa-button--inverse {
-    $button-inverse-color: $theme-link-reverse-color;
-    $button-inverse-hover-color: $theme-link-reverse-hover-color;
-    $button-inverse-active-color: $theme-link-reverse-active-color;
-
-    box-shadow: $button-stroke color("base-lighter");
-    color: color($button-inverse-color);
-
+  
     &:visited {
-      color: color($button-inverse-color);
+      @include set-text-and-bg("accent-cool", $context: $button-context);
     }
-
+  
     &:hover,
     &.usa-button--hover {
-      box-shadow: $button-stroke color($button-inverse-hover-color);
-      color: color($button-inverse-hover-color);
+      @include set-text-and-bg("accent-cool-dark", $context: $button-context);
     }
-
+  
     &:active,
     &.usa-button--active {
-      background-color: transparent;
-      box-shadow: $button-stroke color($button-inverse-active-color);
-      color: color($button-inverse-active-color);
+      @include set-text-and-bg("accent-cool-darker", $context: $button-context);
     }
-
-    &.usa-button--unstyled {
-      @include button-unstyled;
+  }
+  
+  &.usa-button--accent-warm {
+    @include set-text-and-bg("accent-warm", $context: $button-context);
+  
+    &:visited {
+      @include set-text-and-bg("accent-warm", $context: $button-context);
+    }
+  
+    &:hover,
+    &.usa-button--hover {
+      @include set-text-and-bg("accent-warm-dark", $context: $button-context);
+    }
+  
+    &:active,
+    &.usa-button--active {
+      @include set-text-and-bg("accent-warm-darker", $context: $button-context);
+    }
+  }
+  
+  &.usa-button--outline {
+    background-color: color("transparent");
+    box-shadow: $button-stroke color("primary");
+    color: color("primary");
+  
+    &:visited {
+      color: color("primary");
+    }
+  
+    &:hover,
+    &.usa-button--hover {
+      background-color: color("transparent");
+      box-shadow: $button-stroke color("primary-dark");
+      color: color("primary-dark");
+    }
+  
+    &:active,
+    &.usa-button--active {
+      background-color: color("transparent");
+      box-shadow: $button-stroke color("primary-darker");
+      color: color("primary-darker");
+    }
+  
+    &.usa-button--inverse {
+      $button-inverse-color: $theme-link-reverse-color;
+      $button-inverse-hover-color: $theme-link-reverse-hover-color;
+      $button-inverse-active-color: $theme-link-reverse-active-color;
+  
+      box-shadow: $button-stroke color("base-lighter");
       color: color($button-inverse-color);
-
+  
       &:visited {
         color: color($button-inverse-color);
       }
-
+  
       &:hover,
       &.usa-button--hover {
+        box-shadow: $button-stroke color($button-inverse-hover-color);
         color: color($button-inverse-hover-color);
       }
-
+  
       &:active,
       &.usa-button--active {
+        background-color: transparent;
+        box-shadow: $button-stroke color($button-inverse-active-color);
         color: color($button-inverse-active-color);
+      }
+  
+      &.usa-button--unstyled {
+        @include button-unstyled;
+        color: color($button-inverse-color);
+  
+        &:visited {
+          color: color($button-inverse-color);
+        }
+  
+        &:hover,
+        &.usa-button--hover {
+          color: color($button-inverse-hover-color);
+        }
+  
+        &:active,
+        &.usa-button--active {
+          color: color($button-inverse-active-color);
+        }
       }
     }
   }
-}
-
-.usa-button--base {
-  @include set-text-and-bg("base", $context: $button-context);
-
-  &:hover,
-  &.usa-button--hover {
-    @include set-text-and-bg("base-dark", $context: $button-context);
-  }
-
-  &:active,
-  &.usa-button--active {
-    @include set-text-and-bg("base-darker", $context: $button-context);
-  }
-}
-
-.usa-button--secondary {
-  @include set-text-and-bg("secondary", $context: $button-context);
-
-  &:hover,
-  &.usa-button--hover {
-    @include set-text-and-bg("secondary-dark", $context: $button-context);
-  }
-
-  &:active,
-  &.usa-button--active {
-    @include set-text-and-bg("secondary-darker", $context: $button-context);
-  }
-}
-
-.usa-button--big {
-  border-radius: radius($theme-button-border-radius);
-  font-size: font-size($theme-button-font-family, "lg");
-  padding: units(2) units(3);
-}
-
-// Cannot use disabled mixin due to transparent causing build errors with color grade check.
-.usa-button--outline:disabled,
-.usa-button--outline[aria-disabled="true"],
-.usa-button--outline-inverse:disabled,
-.usa-button--outline-inverse[aria-disabled="true"] {
-  &,
-  &:hover,
-  &:active,
-  &:focus {
-    background-color: transparent;
-    color: color("disabled");
-  }
-}
-
-.usa-button--outline:disabled,
-.usa-button--outline[aria-disabled="true"] {
-  box-shadow: $button-stroke color("disabled-lighter");
-
-  &.usa-button--inverse {
-    box-shadow: $button-stroke color("disabled-light");
-    color: color("disabled-light");
-
-    @media (forced-colors: active) {
-      color: color(GrayText);
+  
+  &.usa-button--base {
+    @include set-text-and-bg("base", $context: $button-context);
+  
+    &:hover,
+    &.usa-button--hover {
+      @include set-text-and-bg("base-dark", $context: $button-context);
+    }
+  
+    &:active,
+    &.usa-button--active {
+      @include set-text-and-bg("base-darker", $context: $button-context);
     }
   }
-}
+  
+  &.usa-button--secondary {
+    @include set-text-and-bg("secondary", $context: $button-context);
+  
+    &:hover,
+    &.usa-button--hover {
+      @include set-text-and-bg("secondary-dark", $context: $button-context);
+    }
+  
+    &:active,
+    &.usa-button--active {
+      @include set-text-and-bg("secondary-darker", $context: $button-context);
+    }
+  }
+  
+  &.usa-button--big {
+    border-radius: radius($theme-button-border-radius);
+    font-size: font-size($theme-button-font-family, "lg");
+    padding: units(2) units(3);
+  }
+  
+  // Cannot use disabled mixin due to transparent causing build errors with color grade check.
+  &.usa-button--outline:disabled,
+  &.usa-button--outline[aria-disabled="true"],
+  &.usa-button--outline-inverse:disabled,
+  &.usa-button--outline-inverse[aria-disabled="true"] {
+    &,
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: transparent;
+      color: color("disabled");
+    }
+  }
+  
+  &.usa-button--outline:disabled,
+  &.usa-button--outline[aria-disabled="true"] {
+    box-shadow: $button-stroke color("disabled-lighter");
+  
+    &.usa-button--inverse {
+      box-shadow: $button-stroke color("disabled-light");
+      color: color("disabled-light");
+  
+      @media (forced-colors: active) {
+        color: color(GrayText);
+      }
+    }
+  }
+  
+  &.usa-button--unstyled {
+    @include button-unstyled;
+  }
 
-.usa-button--unstyled {
-  @include button-unstyled;
+  &:disabled,
+  &[aria-disabled="true"] {
+    @include button-disabled;
+  }
 }


### PR DESCRIPTION
# Summary

> [!NOTE]
This is a test PR to explore combining variant styles and it’s outcome.
> 

Combined button variant classes with the `usa-button` standard class. Now, variant classes have increased specificity so `usa-button` style changes do not affect button variants.

Additionally, I had to move the `disabled` styles beneath the other variants to avoid specificity issues.

| CSS Output (develop) | CSS output (change) |
| --- | --- |
| .usa-button--accent-cool | .usa-button.usa-button--accent-cool |

## Breaking change

:warning: This is potentially a breaking change.

We'll want to consider any possible regressions users might face. So far, I haven't observed any after installing this branch on site or sandbox.

## Related issue

Closes #5776.

## Related pull requests

Changelog → 

## Preview link

[Button storybook preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-refactor-button-styles/?path=/story/components-button--default)

[Sandbox demo PR →](https://github.com/uswds/uswds-sandbox/pull/131)

[Sandbox demo preview →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/cm-demo-uswds-5849/)

## Problem statement

Some users want to be able to customize `usa-button` colors without the use of sass or need to recompile. If users attempt to change the background color of the `usa-button` class, it updates the background color of all button variants.

## Solution

Nest variant button styles and use the parent selector (`&`) to combine classes.

## Major changes

- Button variant classes are now output combined with the standard `usa-button` class
- [Output css comparison on Diffchecker →](https://www.diffchecker.com/i7BMzQBZ/)

## Testing and review

1. Visit button previews
2. Confirm buttons are styled appropriately
3. Pull down [test repo](https://github.com/uswds/uswds-sandbox/pull/131) and start local build
4. Confirm updated button background color defined in `_uswds-theme-custom-styles.scss` is only set on the standard `usa-button` variant.
    1. Additionally, if you want to see the bug in action you can install the latest version of USWDS `npm install @uswds/uswds@latest --save`.
    2. Recompile and you’ll see that all variants take the `usa-button` background color.
5. Review updated CSS and consider changes.
6. Review output CSS and consider changes.
7. Confirm there are no unintended changes or regressions.

## Additional considerations

Should we expect users to customize components this way? Or should we provide guidance on alternatives approaches?

I created uswds/uswds-site#2562 to address adding customization instruction to match the newly added part two of the [uswds-tutorial](https://github.com/uswds/uswds-site).