### PR TITLE
USWDS - In-page navigation: Update reference to data-heading-elements sttribute

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -65,7 +65,7 @@ const createSectionHeadingsArray = (
   selectedHeadingTypesArray.forEach((headingType) => {
     if (!IN_PAGE_NAV_VALID_HEADINGS.includes(headingType)) {
       throw new Error(
-        `In-page navigation: data-header-selector attribute defined with an invalid heading type: "${headingType}".
+        `In-page navigation: data-heading-elements attribute defined with an invalid heading type: "${headingType}".
         Define the attribute with one or more of the following: "${IN_PAGE_NAV_VALID_HEADINGS}".
         Do not use commas or other punctuation in the attribute definition.`
       );


### PR DESCRIPTION
# Summary

**Updated an outdated reference to the `data-header-selector` attribute in an in-page navigation JavaScript error message.** The error message now correctly references the `data-heading-elements` attribute.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5836 

## Related pull requests

N/A

## Preview link

N/A

## Problem statement


## Testing and review

- Confirm that the attribute references match the current USWDS attribute names