### PR TITLE
USWDS - README: Add note about incorrect package link to download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
-   **Note:** Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is [intentional](https://github.com/npm/npm/issues/20439#issuecomment-385121133). This default date is set by npm on all its packages to ensure builds will be identical.
+    <p class="site-note">
+      <strong>Note:</strong> Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is <a href="https://github.com/npm/npm/issues/20439#issuecomment-385121133">intentional</a>. This default date is set by npm on all its packages to ensure builds will be identical.
+    </p>
 
 ## Using USWDS CSS and JavaScript in your project
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
-   **Note:** The file date defaults to October 26, 1985, when you download and install this package. This is intentional. NPM sets a default date to ensure reproducible builds for npm packages.
+   **Note:** Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is [intentional](https://github.com/npm/npm/issues/20439#issuecomment-385121133). This default date is set by npm on all its packages to ensure builds will be identical.
 
 ## Using USWDS CSS and JavaScript in your project
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,7 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
-    <p class="site-note">
-      <strong>Note:</strong> Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is <a href="https://github.com/npm/npm/issues/20439#issuecomment-385121133">intentional</a>. This default date is set by npm on all its packages to ensure builds will be identical.
-    </p>
+    **Note:** Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is [intentional](https://github.com/npm/npm/issues/20439#issuecomment-385121133). This default date is set by npm on all its packages to ensure builds will be identical.
 
 ## Using USWDS CSS and JavaScript in your project
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
+    <!-- 
+      This note also exists on the USWDS Site download page, which is maintained in the USWDS-Site repo. 
+      If any changes are made, make sure to update there as well. 
+    -->
     **Note:** Files in the downloadable USWDS package will show a "last modified" date of October 26, 1985. This is [intentional](https://github.com/npm/npm/issues/20439#issuecomment-385121133). This default date is set by npm on all its packages to ensure builds will be identical.
 
 ## Using USWDS CSS and JavaScript in your project

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    **Note:** The file date defaults to October 26, 1985, when you download and install this package. This is intentional. NPM sets a default date to ensure reproducible builds for npm packages.
 
-
 ## Using USWDS CSS and JavaScript in your project
 
 The three files critical to any USWDS project are the **stylesheet**, the **JavaScript**, and the **initializer**. Most projects require all of these to function properly.

--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
-   {:.site-note}
-   **Note:**: The file date defaults to October 26, 1985, when you download and install this package. This is intentional. NPM sets a default date to ensure reproducible builds for npm packages.
+   **Note:** The file date defaults to October 26, 1985, when you download and install this package. This is intentional. NPM sets a default date to ensure reproducible builds for npm packages.
 
 
 ## Using USWDS CSS and JavaScript in your project

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ If you’re using a framework or package manager that doesn’t support npm, you
 
    You'll notice in our example above that we also outline a `stylesheets`, `images` and `javascript` folder in your `assets` folder. These folders are to help organize any assets that are unique to your project and separate from the design system assets.
 
+   {:.site-note}
+   **Note:**: The file date defaults to October 26, 1985, when you download and install this package. This is intentional. NPM sets a default date to ensure reproducible builds for npm packages.
+
 
 ## Using USWDS CSS and JavaScript in your project
 

--- a/packages/usa-form/src/usa-form.stories.js
+++ b/packages/usa-form/src/usa-form.stories.js
@@ -54,3 +54,4 @@ DisabledFormElements.argTypes = {
     table: { disable: false },
   },
 };
+DisabledFormElements.title = "TESTING";


### PR DESCRIPTION
# Summary

Added note to the USWDS README. This will also update the Documentation page on site.

> [!NOTE]
> ~I used HTML instead of standard markdown here in order to utilize the `site-note` class for the website rendered version of this information:~
>
> <img width="472" alt="image" src="https://github.com/uswds/uswds/assets/25211650/c3965446-b0ce-4dac-8c63-4eb8f8d9cebf">

_This change was reverted to avoid using HTML within markup_

Note now displays on site without the note styles

![image](https://github.com/uswds/uswds/assets/25211650/e747e72a-0c0b-40bd-99d4-bae9fd87060b)


## Breaking change

This is not a breaking change.

## Related issue

Closes #5872

## Related pull requests

uswds/uswds-site#2621

## Preview link

[Rich content README →](https://github.com/uswds/uswds/blob/cm-site-note-incorrect-dates/README.md#Install-the-package-directly-from-GitHub)

[Demo site with documentation preview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-demo-uswds-5871/documentation/developers/#install-the-package-directly-from-github-2)

> [!TIP]
The demo repo pulls in the readme data of this branch in the site _config.yml [INSERT LINK] file.
I was required to run `rm -rf .jekyll_get_cache` to clear the jekyll cache and get the documentation page to update.
> 

## Problem statement

NPM purposefully sets package dates to 10/26/1985 to ensure hash-identical tarballs no matter when or on what device the `npm pack` is ran. This can confuse users who inspect the package and see the incorrect files for the date.

## Solution

Add note to site to specify this is intended behavior from NPM.

## Testing and review

1. Confirm [README](https://github.com/uswds/uswds/tree/cm-site-note-incorrect-dates?tab=readme-ov-file#install-the-package-directly-from-github) has been updated.
2. Confirm the markup is rendered without HTML tags
3. Visit the [Documentation page of the demo repo](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-demo-uswds-5871/documentation/developers/#install-the-package-directly-from-github-2) and confirm the site note is showing up appropriately
    - I was unable to add the `site-note` class without it appearing incorrectly in the readme. Opted to match other notes on that page by bolding the `Note:` span.
4. Confirm there are no spelling or grammatical errors
5. Confirm that there is value by linking to the `npm` decision dates.

### Additional context

I added a link to the npm decision on dates that is captured in a GitHub issue. This appears to be the best source of truth for this information. I was unable to find any documentation on their website addressing this concern.