### PR TITLE
[Test] Create usa-link with Stencil

### DIFF
--- a/packages/usa-link/src/usa-link.stories.js
+++ b/packages/usa-link/src/usa-link.stories.js
@@ -7,3 +7,12 @@ export default {
 const Template = (args) => Component(args);
 
 export const Link = Template.bind({});
+
+const WCTemplate = (args) => `<usa-link text="${args.text}"></usa-link>`;
+
+export const WCLink = WCTemplate.bind({});
+WCLink.args = {
+  text: "This is some link text 🤙",
+  link: "http://designsystem.digital.gov"
+};
+

--- a/packages/usa-link/src/usa-link.stories.js
+++ b/packages/usa-link/src/usa-link.stories.js
@@ -8,11 +8,11 @@ const Template = (args) => Component(args);
 
 export const Link = Template.bind({});
 
-const WCTemplate = (args) => `<usa-link text="${args.text}" url="${args.url}"></usa-link>`;
+const WCTemplate = (args) => `<usa-link text="${args.text}" href="${args.href}"></usa-link>`;
 
 export const WCLink = WCTemplate.bind({});
 WCLink.args = {
   text: "This is some link text 🤙",
-  url: "http://designsystem.digital.gov"
+  href: "http://designsystem.digital.gov"
 };
 

--- a/packages/usa-link/src/usa-link.stories.js
+++ b/packages/usa-link/src/usa-link.stories.js
@@ -8,11 +8,11 @@ const Template = (args) => Component(args);
 
 export const Link = Template.bind({});
 
-const WCTemplate = (args) => `<usa-link text="${args.text}"></usa-link>`;
+const WCTemplate = (args) => `<usa-link text="${args.text}" url="${args.url}"></usa-link>`;
 
 export const WCLink = WCTemplate.bind({});
 WCLink.args = {
   text: "This is some link text 🤙",
-  link: "http://designsystem.digital.gov"
+  url: "http://designsystem.digital.gov"
 };
 

--- a/web-components/src/components.d.ts
+++ b/web-components/src/components.d.ts
@@ -13,11 +13,11 @@ export namespace Components {
         "text": string;
     }
     interface UsaLink {
+        "href": string;
         /**
           * The link text.
          */
         "text": string;
-        "url": string;
     }
 }
 declare global {
@@ -46,11 +46,11 @@ declare namespace LocalJSX {
         "text"?: string;
     }
     interface UsaLink {
+        "href"?: string;
         /**
           * The link text.
          */
         "text"?: string;
-        "url"?: string;
     }
     interface IntrinsicElements {
         "usa-button": UsaButton;

--- a/web-components/src/components.d.ts
+++ b/web-components/src/components.d.ts
@@ -13,11 +13,11 @@ export namespace Components {
         "text": string;
     }
     interface UsaLink {
-        "link": string;
         /**
           * The link text.
          */
         "text": string;
+        "url": string;
     }
 }
 declare global {
@@ -46,11 +46,11 @@ declare namespace LocalJSX {
         "text"?: string;
     }
     interface UsaLink {
-        "link"?: string;
         /**
           * The link text.
          */
         "text"?: string;
+        "url"?: string;
     }
     interface IntrinsicElements {
         "usa-button": UsaButton;

--- a/web-components/src/components.d.ts
+++ b/web-components/src/components.d.ts
@@ -6,77 +6,63 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
-    interface MyComponent {
-        /**
-          * The first name
-         */
-        "first": string;
-        /**
-          * The last name
-         */
-        "last": string;
-        /**
-          * The middle name
-         */
-        "middle": string;
-    }
     interface UsaButton {
         /**
           * The button text.
          */
         "text": string;
     }
+    interface UsaLink {
+        "link": string;
+        /**
+          * The link text.
+         */
+        "text": string;
+    }
 }
 declare global {
-    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-    }
-    var HTMLMyComponentElement: {
-        prototype: HTMLMyComponentElement;
-        new (): HTMLMyComponentElement;
-    };
     interface HTMLUsaButtonElement extends Components.UsaButton, HTMLStencilElement {
     }
     var HTMLUsaButtonElement: {
         prototype: HTMLUsaButtonElement;
         new (): HTMLUsaButtonElement;
     };
+    interface HTMLUsaLinkElement extends Components.UsaLink, HTMLStencilElement {
+    }
+    var HTMLUsaLinkElement: {
+        prototype: HTMLUsaLinkElement;
+        new (): HTMLUsaLinkElement;
+    };
     interface HTMLElementTagNameMap {
-        "my-component": HTMLMyComponentElement;
         "usa-button": HTMLUsaButtonElement;
+        "usa-link": HTMLUsaLinkElement;
     }
 }
 declare namespace LocalJSX {
-    interface MyComponent {
-        /**
-          * The first name
-         */
-        "first"?: string;
-        /**
-          * The last name
-         */
-        "last"?: string;
-        /**
-          * The middle name
-         */
-        "middle"?: string;
-    }
     interface UsaButton {
         /**
           * The button text.
          */
         "text"?: string;
     }
+    interface UsaLink {
+        "link"?: string;
+        /**
+          * The link text.
+         */
+        "text"?: string;
+    }
     interface IntrinsicElements {
-        "my-component": MyComponent;
         "usa-button": UsaButton;
+        "usa-link": UsaLink;
     }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
-            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             "usa-button": LocalJSX.UsaButton & JSXBase.HTMLAttributes<HTMLUsaButtonElement>;
+            "usa-link": LocalJSX.UsaLink & JSXBase.HTMLAttributes<HTMLUsaLinkElement>;
         }
     }
 }

--- a/web-components/src/components/usa-link/readme.md
+++ b/web-components/src/components/usa-link/readme.md
@@ -1,0 +1,18 @@
+# usa-link
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description    | Type     | Default     |
+| -------- | --------- | -------------- | -------- | ----------- |
+| `link`   | `link`    |                | `string` | `undefined` |
+| `text`   | `text`    | The link text. | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/web-components/src/components/usa-link/readme.md
+++ b/web-components/src/components/usa-link/readme.md
@@ -9,8 +9,8 @@
 
 | Property | Attribute | Description    | Type     | Default     |
 | -------- | --------- | -------------- | -------- | ----------- |
-| `link`   | `link`    |                | `string` | `undefined` |
 | `text`   | `text`    | The link text. | `string` | `undefined` |
+| `url`    | `url`     |                | `string` | `undefined` |
 
 
 ----------------------------------------------

--- a/web-components/src/components/usa-link/readme.md
+++ b/web-components/src/components/usa-link/readme.md
@@ -9,8 +9,8 @@
 
 | Property | Attribute | Description    | Type     | Default     |
 | -------- | --------- | -------------- | -------- | ----------- |
+| `href`   | `href`    |                | `string` | `undefined` |
 | `text`   | `text`    | The link text. | `string` | `undefined` |
-| `url`    | `url`     |                | `string` | `undefined` |
 
 
 ----------------------------------------------

--- a/web-components/src/components/usa-link/test/usa-link.e2e.ts
+++ b/web-components/src/components/usa-link/test/usa-link.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('usa-link', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<usa-link></usa-link>');
+
+    const element = await page.find('usa-link');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/web-components/src/components/usa-link/test/usa-link.spec.tsx
+++ b/web-components/src/components/usa-link/test/usa-link.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { UsaLink } from '../usa-link';
+
+describe('usa-link', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [UsaLink],
+      html: `<usa-link></usa-link>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <usa-link>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </usa-link>
+    `);
+  });
+});

--- a/web-components/src/components/usa-link/usa-link.scss
+++ b/web-components/src/components/usa-link/usa-link.scss
@@ -1,0 +1,1 @@
+@forward 'usa-link';

--- a/web-components/src/components/usa-link/usa-link.tsx
+++ b/web-components/src/components/usa-link/usa-link.tsx
@@ -10,12 +10,12 @@ export class UsaLink {
    * The link text.
    */
   @Prop() text: string;
-  @Prop() url: string;
+  @Prop() href: string;
 
   render() {
     return (
       <Host>
-        <a class="usa-link" href={this.url}>{ this.text }</a>
+        <a class="usa-link" href={this.href}>{ this.text }</a>
       </Host>
     );
   }

--- a/web-components/src/components/usa-link/usa-link.tsx
+++ b/web-components/src/components/usa-link/usa-link.tsx
@@ -1,0 +1,23 @@
+import { Component,Prop, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'usa-link',
+  styleUrl: 'usa-link.scss',
+  shadow: true,
+})
+export class UsaLink {
+  /**
+   * The link text.
+   */
+  @Prop() text: string;
+  @Prop() link: string;
+
+  render() {
+    return (
+      <Host>
+        <a class="usa-link" href={this.link}>{ this.text }</a>
+      </Host>
+    );
+  }
+
+}

--- a/web-components/src/components/usa-link/usa-link.tsx
+++ b/web-components/src/components/usa-link/usa-link.tsx
@@ -10,12 +10,12 @@ export class UsaLink {
    * The link text.
    */
   @Prop() text: string;
-  @Prop() link: string;
+  @Prop() url: string;
 
   render() {
     return (
       <Host>
-        <a class="usa-link" href={this.link}>{ this.text }</a>
+        <a class="usa-link" href={this.url}>{ this.text }</a>
       </Host>
     );
   }


### PR DESCRIPTION
## Notes about what I did

1. Open uswds repo
2. `git checkout jm-setup-stenciljs`
3. `cd web-components`
4. `npm install`
    1. npm WARN deprecated @types/autoprefixer@10.2.0: This is a stub types definition. autoprefixer provides its own type definitions, so you do not need this installed.
        
        added 366 packages, and audited 367 packages in 18s
        
        42 packages are looking for funding
        run `npm fund` for details
        
        found 0 vulnerabilities
        
5. `npm run build`
6. `cd ..`
7. `npm install`
8. `npm run start`
    1. Success: [[localhost:6006](http://localhost:6006/)](http://localhost:6006) renders as expected
9. `cd web-components`
10. `npm run watch`
    1. Received: build finished, watching for changes…
11. `cd ..`
12. `npm run start`
    1. Error: `ModuleNotFoundError: Module not found: Error: Can't resolve '../dist/esm/polyfills/index.js' in '/Users/amy.leadem/Dev/github/uswds/web-components/loader'`
13. cd web-components
14. `npx stencil generate usa-link`
    1. Received: Which additional files do you want to generate?
        1. Pressed `enter`
        2. Received:
            
            The following files have been generated:
            
            - src/components/usa-link/usa-link.tsx
            - src/components/usa-link/usa-link.css
            - src/components/usa-link/test/usa-link.spec.tsx
            - src/components/usa-link/test/usa-link.e2e.ts
        3. Generated `web-components/src/components/usa-link`
15. Renamed usa-link.css → usa-link.scss
16. Updated `styleUrl` value to: `styleUrl: 'usa-link.scss`
17. Add `@forward 'usa-link';` to `web-components/src/components/usa-link/usa-link.scss`
18. Add “Prop” import to `web-components/src/components/usa-link/usa-link.tsx`
    1. Add references to new props:
        1.   @Prop() text: string;
          @Prop() href: string;
        2. Create render markup
            1. <a class="usa-link" href={this.href}>{ this.text }</a>
19. Open `packages/usa-link/src/usa-link.stories.js
    1. Create new story:
        1. const WCTemplate = (args) => `<usa-link text="${args.text}" href="${args.href}"></usa-link>`;
        
        export const WCLink = WCTemplate.bind({});
        WCLink.args = {
          text: "This is some link text 🤙",
          href: "http://designsystem.digital.gov/"
        };
20. Run `npm run build` in `web-components`
21. Run `npm run start` in root directory
22. View WC story in localhost:6006
23. Run `npm run build` in `web-components` after each change in `web-components`