### PR TITLE
USWDS - In-Page Navigation: Fix scrolling to nested headers

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -189,12 +189,22 @@ const getSectionId = (value) => {
 };
 
 /**
- * Recursively calculate a heading element's offset from the top of the page.
+ * Calculates the total offset of an element from the top of the page.
  *
- * @param {HTMLElement} el A heading element
+ * @param {HTMLElement} el A heading element to calculate the offset for.
+ * @returns {number} The total element offset from the top of its parent.
  */
-const getTotalElementOffset = (el) =>
-  el.offsetTop + (el.offsetParent && getTotalElementOffset(el.offsetParent));
+const getTotalElementOffset = (el) => {
+  const calculateOffset = (currentEl) => {
+    if (!currentEl.offsetParent) {
+      return currentEl.offsetTop;
+    }
+
+    return currentEl.offsetTop + calculateOffset(currentEl.offsetParent);
+  };
+
+  return calculateOffset(el);
+};
 
 /**
  * Scroll smoothly to a section based on the passed in element

--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -189,19 +189,28 @@ const getSectionId = (value) => {
 };
 
 /**
+ * Recursively calculate a heading element's offset from the top of the page.
+ *
+ * @param {HTMLElement} el A heading element
+ */
+const getTotalElementOffset = (el) =>
+  el.offsetTop + (el.offsetParent && getTotalElementOffset(el.offsetParent));
+
+/**
  * Scroll smoothly to a section based on the passed in element
  *
- * @param {HTMLElement} - Id value with the number sign removed
+ * @param {HTMLElement} el A heading element
  */
 const handleScrollToSection = (el) => {
   const inPageNavEl = document.querySelector(`.${IN_PAGE_NAV_CLASS}`);
   const inPageNavScrollOffset =
     inPageNavEl.dataset.scrollOffset || IN_PAGE_NAV_SCROLL_OFFSET;
 
+  const offsetTop = getTotalElementOffset(el);
+
   window.scroll({
     behavior: "smooth",
-    top: el.offsetTop - inPageNavScrollOffset,
-    block: "start",
+    top: offsetTop - inPageNavScrollOffset,
   });
 
   if (window.location.hash.slice(1) !== el.id) {

--- a/packages/usa-in-page-navigation/src/test/test-patterns/test-nested-headers.twig
+++ b/packages/usa-in-page-navigation/src/test/test-patterns/test-nested-headers.twig
@@ -1,0 +1,138 @@
+<div class="usa-prose measure-5 padding-2 border-1px border-gray-20 margin-bottom-4">
+  <p class="font-body-lg text-bold margin-top-0">Test if the in-page nav can scroll to headers nested within other USWDS components, such as cards and summary boxes.</p>
+  <p>The in-page nav link list should show the following six headers:</p>
+  <ul>
+    <li>H2 heading</li>
+    <li>Card heading</li>
+    <li>Card heading</li>
+    <li>H3 heading</li>
+    <li>Summary box heading</li>
+    <li>H2 heading</li>
+  </ul>
+</div>
+
+<div class="usa-in-page-nav-container">
+  <aside class="usa-in-page-nav">
+  </aside>
+  <main>
+    <div class="usa-prose">
+      <h2>H2 heading</h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+    </div>
+    <ul class="usa-card-group margin-top-4">
+      <li class="usa-card tablet:grid-col-4">
+        <div class="usa-card__container ">
+          <div class="usa-card__header">
+            <h2 class="usa-card__heading">Card heading</h2>
+          </div>
+          <div class="usa-card__body ">
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Facilis earum tenetur quo cupiditate, eaque qui officia recusandae.</p>
+          </div>
+          <div class="usa-card__footer">
+            <a href="#" class="usa-button">Visit Florida Keys</a>
+          </div>
+        </div>
+      </li>
+      <li class="usa-card tablet:grid-col-4">
+        <div class="usa-card__container ">
+          <div class="usa-card__header">
+            <h2 class="usa-card__heading">Card heading</h2>
+          </div>
+          <div class="usa-card__media ">
+            <div class="usa-card__img ">
+              <img src="https://designsystem.digital.gov/img/introducing-uswds-2-0/built-to-grow--alt.jpg" alt="A placeholder image">
+            </div>
+          </div>
+          <div class="usa-card__body ">
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Facilis earum tenetur quo cupiditate, eaque qui officia recusandae.</p>
+          </div>
+          <div class="usa-card__footer">
+            <a href="#" class="usa-button">Visit Florida Keys</a>
+          </div>
+        </div>
+      </li>
+    </ul>
+    <div class="usa-prose">
+      <h3>H3 heading</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+    </div>
+    <div class="usa-summary-box margin-bottom-4" role="region" aria-labelledby="summary-box-key-information">
+      <div class="usa-summary-box__body">
+        <h3 class="usa-summary-box__heading" id="summary-box-key-information">
+          Summary box heading
+        </h3>
+        <div class="usa-summary-box__text">
+          <ul class="usa-list">
+            <li>If you are under a winter storm warning, <a class="usa-summary-box__link" href="">find shelter</a> right away.</li>
+            <li>Sign up for <a class="usa-summary-box__link" href="">your community’s warning system</a>.</li>
+            <li>Learn the signs of, and basic treatments for, <a class="usa-summary-box__link" href="">frostbite</a> and <a class="usa-summary-box__link" href="">hypothermia</a>.</li>
+            <li>Gather emergency supplies for your <a class="usa-summary-box__link" href="">home</a> and your <a class="usa-summary-box__link" href="">car</a>.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="usa-prose">
+      <h2>H2 heading</h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo,
+        ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio
+        lorem non turpis.
+      </p>
+    </div>
+  </main>
+</div>

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.stories.js
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.stories.js
@@ -3,6 +3,7 @@ import TestCustomContentComponent from "./test/test-patterns/test-custom-content
 import TestCustomHeaderComponent from "./test/test-patterns/test-custom-header-selector.twig";
 import TestHiddenHeaderComponent from "./test/test-patterns/test-hidden-headers.twig";
 import TestMinimumHeaderComponent from "./test/test-patterns/test-minimum-header.twig";
+import TestNestedHeaderComponent from "./test/test-patterns/test-nested-headers.twig";
 import Content from "./usa-in-page-navigation.json";
 
 export default {
@@ -14,6 +15,7 @@ const TestCustomContentTemplate = (args) => TestCustomContentComponent(args);
 const TestCustomHeaderTemplate = (args) => TestCustomHeaderComponent(args);
 const TestHiddenHeaderTemplate = (args) => TestHiddenHeaderComponent(args);
 const TestMinimumHeaderTemplate = (args) => TestMinimumHeaderComponent(args);
+const TestNestedHeaderTemplate = (args) => TestNestedHeaderComponent(args);
 
 export const Default = Template.bind({});
 Default.args = Content;
@@ -60,3 +62,4 @@ TestMinimumHeaders.argTypes = {
     control: { type: "select" },
   },
 };
+export const TestNestedHeaders = TestNestedHeaderTemplate.bind();


### PR DESCRIPTION
<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

**Fixed issue with in-page navigation being unable to scroll to nested headings.** The in-page navigation can now smooth scroll to headings within the summary box and card components.

> [!important]
> There is currently a build error related to prettier. This should be resolved by PR #6319.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5255

## Related pull requests

_N/A_

## Preview link

[Preview link](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jh-fix-in-page-navigation-scroll-bug/?path=/story/components-in-page-navigation--default)

## Problem statement

The in-page navigation should navigate the user to the section of the page with the indicated heading when the heading link is clicked. 

Currently, clicking on links that refer to nested headings, within the summary box or card components (or any other custom, non-standard USWDS component) causes the page to reset its scroll. 

This poor user experience hinders users from accessing content they are seeking quickly and may mislead users to thinking desired content doesn't exist on the page. Erroneous behaviour reduces users trust in the site and USWDS branded sites as a whole. 

## Solution

The existing code uses the `offsetTop` value of the element to identify how much to scroll down the page. This value is relative to the parent container. To correctly scroll to the location of the element, the `offsetTop` must be added to the `parentOffset` of all the elements parent components. This MR adds a function to calculate the elements true offset in this manner.

An alternative solution would be to refactor the code to use `scrollIntoView` instead. This would involve refactoring the approach we use to test this component, which is being supported using a mocked offsetTop value and watching the `window.scroll` function with `sinon`. 

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Major changes

No major changes to component implementation / testing approach made.

## Testing and review

A new Storybook story in the in-page navigation component has been created for testing. If running storybook locally, go to http://localhost:6006/iframe.html?args=&id=components-in-page-navigation--test-nested-headers&viewMode=story and click on each link in the in-page navigation. The page should correctly scroll to each heading in turn.

Any feedback on the solution would be helpful. I would like to add a test case to cover this fix, but I'm not sure how I'd go about mocking offsetParent only for certain elements. It also feels like if I was to mock this for specific contexts, the test would be verifying a very specific scenario instead of being representative. Using a testing framework such as Playwright instead of Jest would be helpful here. 

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass - _invalid synk key? other tests pass as expected_
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
