### PR TITLE
USWDS - Storybook: Create form error story

### DIFF
--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -7,12 +7,12 @@
 *#}
 <form class="usa-form">
   <div class="usa-character-count">
-    <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-      <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="with-hint-input">Character count</label>
+    <div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
+      <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="with-hint-input">Character count</label>
       <span id="with-hint-input-hint" class="usa-hint">This is an input with a character counter.</span>
-      {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+      {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
       <input
-        class="usa-input usa-character-count__field {% if error_state %}usa-input--error{% endif %}"
+        class="usa-input usa-character-count__field {% if error_state == true %}usa-input--error{% endif %}"
         id="with-hint-input"
         maxlength="25"
         name="with-hint-input"
@@ -29,10 +29,10 @@
 * usa-legend and usa-label output the same base styles. Because of this, we can add the 
 * usa-label--error class without any additional changes or unexpected style conflicts.
 *#}
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox</legend>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <legend class="usa-legend {% if error_state == true %}usa-label--error{% endif %}">Checkbox</legend>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-checkbox">
       <input
         class="usa-checkbox__input usa-input--error"
@@ -68,10 +68,10 @@
 * In order for the red border to highlight the form input with an error, the elements must be 
 * nested within a div with the usa-form-group and usa-form-group--error classes.
 *#}
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-  <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Radio</legend>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  <legend class="usa-legend {% if error_state == true %}usa-label--error{% endif %}">Radio</legend>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-radio">
       <input
         class="usa-radio__input"
@@ -108,12 +108,12 @@
 ! its dynamically placed input element. The class remains on the hidden select element. This is true for time picker's 
 ! combo box element as well.
 !#}
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Combo box</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="fruit">Combo box</label>
+  {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
-      class="usa-select {% if error_state %}usa-input--error{% endif %}"
+      class="usa-select {% if error_state == true %}usa-input--error{% endif %}"
       name="fruit"
       id="fruit"
       {% if disabled_state == 'disabled' %} disabled
@@ -125,15 +125,15 @@
   </div>
 </div>
 
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-date-label" for="appointment-date"
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" id="appointment-date-label" for="appointment-date"
     >Date picker</label
   >
   <div class="usa-hint" id="appointment-date-hint">mm/dd/yyyy</div>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-date-picker">
     <input
-      class="usa-input {% if error_state %}usa-input--error{% endif %}"
+      class="usa-input {% if error_state == true %}usa-input--error{% endif %}"
       id="appointment-date"
       name="appointment-date"
       aria-labelledby="appointment-date-label"
@@ -144,11 +144,11 @@
   </div>
 </div>
 
-<div class="usa-form-group {% if error_state %} usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="file-input-single"
+<div class="usa-form-group {% if error_state == true %} usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="file-input-single"
     >File input</label
   >
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     id="file-input-single"
     class="usa-file-input"
@@ -167,22 +167,22 @@
 ! picker to properly initialize.
 !#}
 <form class="usa-form">
-  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask</label>
+  {% if error_state == true %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="ssn">Input mask</label>
     <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <input
       id="ssn"
       inputmode="numeric"
       name="ssn"
       placeholder="___ __ ____"
       pattern="^(?!(000|666|9))\d{3} (?!00)\d{2} (?!0000)\d{4}$"
-      class="usa-input usa-masked {% if error_state %}usa-input--error{% endif %}"
+      class="usa-input usa-masked {% if error_state == true %}usa-input--error{% endif %}"
       aria-describedby="ssnHint"
       {% if disabled_state == 'disabled' %} disabled
       {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
     />
-  {% if error_state %}</div>{% endif %}
+  {% if error_state == true %}</div>{% endif %}
 </form>
 
 {# * 
@@ -191,10 +191,10 @@
 * the styles to display as expected
 *#}
 <form class="usa-form">
-  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix</label>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-    <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
+  {% if error_state == true %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix</label>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-input-group {% if error_state == true %}usa-input--error{% endif %}">
       <div class="usa-input-prefix" aria-hidden="true">
         <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
           <use xlink:href="./img/sprite.svg#credit_card"></use>
@@ -209,14 +209,14 @@
         {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
       />
     </div>
-  {% if error_state %}</div>{% endif %}
+  {% if error_state == true %}</div>{% endif %}
 </form>
 
 <form class="usa-form">
-  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix</label>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-    <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
+  {% if error_state == true %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix</label>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-input-group usa-input-group--sm {% if error_state == true %}usa-input--error{% endif %}">
       <input
         id="example-input-suffix"
         class="usa-input"
@@ -227,19 +227,19 @@
       />
       <div class="usa-input-suffix" aria-hidden="true">lbs.</div>
     </div>
-  {% if error_state %}</div>{% endif %}
+  {% if error_state == true %}</div>{% endif %}
 </form>
 
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset">
-    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Memorable date</legend>
+    <legend class="usa-legend {% if error_state == true %}usa-label--error{% endif %}">Memorable date</legend>
     <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-memorable-date">
       <div class="usa-form-group usa-form-group--month usa-form-group--select">
         <label class="usa-label" for="date_of_birth_month">Month</label>
         <select
-          class="usa-select {% if error_state %}usa-input--error{% endif %}"
+          class="usa-select {% if error_state == true %}usa-input--error{% endif %}"
           id="date_of_birth_month"
           name="date_of_birth_month"
           aria-describedby="mdHint"
@@ -264,7 +264,7 @@
       <div class="usa-form-group usa-form-group--day">
         <label class="usa-label" for="date_of_birth_day">Day</label>
         <input
-          class="usa-input {% if error_state %}usa-input--error{% endif %}"
+          class="usa-input {% if error_state == true %}usa-input--error{% endif %}"
           aria-describedby="mdHint"
           id="date_of_birth_day"
           name="date_of_birth_day"
@@ -279,7 +279,7 @@
       <div class="usa-form-group usa-form-group--year">
         <label class="usa-label" for="date_of_birth_year">Year</label>
         <input
-          class="usa-input {% if error_state %}usa-input--error{% endif %}"
+          class="usa-input {% if error_state == true %}usa-input--error{% endif %}"
           aria-describedby="mdHint"
           id="date_of_birth_year"
           name="date_of_birth_year"
@@ -297,9 +297,9 @@
 </div>
 
 <form class="usa-form">
-  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider</label>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  {% if error_state == true %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="usa-range">Range slider</label>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <input
       id="usa-range"
       class="usa-range"
@@ -315,15 +315,15 @@
       {% if disabled_state == 'disabled' %} disabled
       {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
     />
-  {% if error_state %}</div>{% endif %}
+  {% if error_state == true %}</div>{% endif %}
 </form>
 
 <form class="usa-form">
-  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select</label>
-    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  {% if error_state == true %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="options">Select</label>
+    {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <select
-      class="usa-select {% if error_state %}usa-input--error{% endif %}"
+      class="usa-select {% if error_state == true %}usa-input--error{% endif %}"
       name="options"
       id="options"
       {% if disabled_state == 'disabled' %} disabled
@@ -334,14 +334,14 @@
       <option value="value2">Option B</option>
       <option value="value3">Option C</option>
     </select>
-  {% if error_state %}</div>{% endif %}
+  {% if error_state == true %}</div>{% endif %}
 </form>
 
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="input-type-text">Text input</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" for="input-type-text">Text input</label>
+  {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
-    class="usa-input {% if error_state %}usa-input--error{% endif %}"
+    class="usa-input {% if error_state == true %}usa-input--error{% endif %}"
     id="input-type-text"
     name="input-type-text"
     type="text"
@@ -354,15 +354,15 @@
 ! Due to Combo box's dynamic input element not receiving the same classes as it's select placeholder, 
 ! the error input classes are not set on initialization
 !#}
-<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
+<div class="usa-form-group {% if error_state == true %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state == true %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
     >Time picker</label
   >
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-time-picker">
     <input
-      class="usa-input {% if error_state %}usa-input--error{% endif %}"
+      class="usa-input {% if error_state == true %}usa-input--error{% endif %}"
       id="appointment-time"
       name="appointment-time"
       aria-describedby="appointment-time-label appointment-time-hint"

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -93,7 +93,7 @@
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
-      class="usa-select"
+      class="usa-select usa-input--error"
       name="fruit"
       id="fruit"
       {% if disabled_state == 'disabled' %} disabled

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -18,7 +18,7 @@
 </form>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <fieldset class="usa-fieldset margin-top-2">
+  <fieldset class="usa-fieldset {% if error_state %}usa-form-group--error{% endif %} margin-top-2">
     <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox{% if error_state %} has an error{% endif %}</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-checkbox">
@@ -280,6 +280,7 @@
 
 <form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select{% if error_state %} has an error{% endif %}</label>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <select
     class="usa-select {% if error_state %}usa-input--error{% endif %}"
     name="options"

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -1,7 +1,7 @@
 <form class="usa-form">
   <div class="usa-character-count">
     <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-      <label class="usa-label" for="with-hint-input">Character count</label>
+      <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="with-hint-input">Character count{% if error_state %} has an error{% endif %}</label>
       <span id="with-hint-input-hint" class="usa-hint">This is an input with a character counter.</span>
       {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
       <input
@@ -17,9 +17,9 @@
   </div>
 </form>
 
-<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-    <legend class="usa-legend">Checkbox</legend usa-label>
+    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox{% if error_state %} has an error{% endif %}</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-checkbox">
       <input
@@ -53,9 +53,9 @@
 </div>
 
 
-<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-  <legend class="usa-legend">Radio</legend>
+  <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Radio{% if error_state %} has an error{% endif %}</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-radio">
       <input
@@ -88,8 +88,8 @@
   </fieldset>
 </div>
 
-<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="fruit">Combo box</label>
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Input{% if error_state %} has an error{% endif %}</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
@@ -106,7 +106,7 @@
 </div>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" id="appointment-date-label" for="appointment-date"
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-date-label" for="appointment-date"
     >Date picker</label
   >
   <div class="usa-hint" id="appointment-date-hint">mm/dd/yyyy</div>
@@ -125,8 +125,8 @@
 </div>
 
 <div class="usa-form-group {% if error_state %} usa-form-group--error{% endif %}">
-  <label class="usa-label" for="file-input-single"
-    >File input</label
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="file-input-single"
+    >File input{% if error_state %} has an error{% endif %}</label
   >
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
@@ -139,8 +139,8 @@
   />
 </div>
 
-<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="ssn">Input mask</label>
+<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask{% if error_state %} has an error{% endif %}</label>
   <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
@@ -156,8 +156,8 @@
   />
 </form>
 
-<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="example-input-prefix">Input prefix</label>
+<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix{% if error_state %} has an error{% endif %}</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
     <div class="usa-input-prefix" aria-hidden="true">
@@ -176,8 +176,8 @@
   </div>
 </form>
 
-<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="example-input-suffix">Input suffix</label>
+<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix{% if error_state %} has an error{% endif %}</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
     <input
@@ -194,7 +194,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset">
-    <legend class="usa-legend">Memorable date</legend>
+    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Memorable date{% if error_state %} has an error{% endif %}</legend>
     <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-memorable-date">
@@ -258,8 +258,8 @@
   </fieldset>
 </div>
 
-<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="usa-range">Range slider</label>
+<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider{% if error_state %} has an error{% endif %}</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     id="usa-range"
@@ -278,8 +278,8 @@
   />
 </form>
 
-<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" for="options">Select</label>
+<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select{% if error_state %} has an error{% endif %}</label>
   <select
     class="usa-select {% if error_state %}usa-input--error{% endif %}"
     name="options"
@@ -294,19 +294,22 @@
   </select>
 </form>
 
-<label class="usa-label" for="input-type-text">Text input</label>
-{% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-<input
-  class="usa-input {% if error_state %}usa-input--error{% endif %}"
-  id="input-type-text"
-  name="input-type-text"
-  type="text"
-  {% if disabled_state == 'disabled' %} disabled
-  {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-  >
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="input-type-text">Text input{% if error_state %} has an error{% endif %}</label>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  <input
+    class="usa-input {% if error_state %}usa-input--error{% endif %}"
+    id="input-type-text"
+    name="input-type-text"
+    type="text"
+    {% if disabled_state == 'disabled' %} disabled
+    {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+    >
+</div>
+
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label" id="appointment-time-label" for="appointment-time"
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
     >Time picker</label
   >
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -113,7 +113,7 @@
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
-      class="usa-select usa-input--error"
+      class="usa-select {% if error_state %}usa-input--error{% endif %}"
       name="fruit"
       id="fruit"
       {% if disabled_state == 'disabled' %} disabled

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -1,3 +1,10 @@
+{# *
+* While we could add the usa-form-group--error class to <form class="usa-form"> elements, we should 
+* avoid doing this and only add it to usa-form-group elements.
+*
+* Setting the error on the form element would add the error class to the entire form and not just 
+* the form question that holds the error.
+*#}
 <form class="usa-form">
   <div class="usa-character-count">
     <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
@@ -17,6 +24,11 @@
   </div>
 </form>
 
+
+{# *
+* usa-legend and usa-label output the same base styles. Because of this, we can add the 
+* usa-label--error class without any additional changes or unexpected style conflicts.
+*#}
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
     <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox</legend>
@@ -52,7 +64,10 @@
   </fieldset>
 </div>
 
-
+{# *
+* In order for the red border to highlight the form input with an error, the elements must be 
+* nested within a div with the usa-form-group and usa-form-group--error classes.
+*#}
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
   <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Radio</legend>
@@ -88,6 +103,11 @@
   </fieldset>
 </div>
 
+{# ! 
+! Adding the usa-input--error class to the combo box nested select element does not carry the class over to 
+! its dynamically placed input element. The class remains on the hidden select element. This is true for time picker's 
+! combo box element as well.
+!#}
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Combo box</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
@@ -139,6 +159,13 @@
   />
 </div>
 
+{# ! 
+! Input mask breaks due to DOM structure changing. Related to: #5517.
+!
+! This initialization error also causes subsequent JS files to not initialize properly. 
+! On this page, time picker does not initialize. Removing input-mask or the error states will allow time 
+! picker to properly initialize.
+!#}
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
     <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask</label>
@@ -158,6 +185,11 @@
   {% if error_state %}</div>{% endif %}
 </form>
 
+{# * 
+* Input prefix/suffix input group
+* For input prefix/suffix, the usa-input--error class must be put on the usa-input-group element in order for 
+* the styles to display as expected
+*#}
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
     <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix</label>
@@ -318,7 +350,10 @@
   >
 </div>
 
-
+{# !
+! Due to Combo box's dynamic input element not receiving the same classes as it's select placeholder, 
+! the error input classes are not set on initialization
+!#}
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
     >Time picker</label

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -1,10 +1,11 @@
 <form class="usa-form">
   <div class="usa-character-count">
-    <div class="usa-form-group">
+    <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
       <label class="usa-label" for="with-hint-input">Character count</label>
       <span id="with-hint-input-hint" class="usa-hint">This is an input with a character counter.</span>
+      {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
       <input
-        class="usa-input usa-character-count__field"
+        class="usa-input usa-character-count__field {% if error_state %}usa-input--error{% endif %}"
         id="with-hint-input"
         maxlength="25"
         name="with-hint-input"
@@ -16,94 +17,103 @@
   </div>
 </form>
 
-<fieldset class="usa-fieldset margin-top-2">
-  <legend class="usa-legend">Checkbox</legend usa-label>
-
-  <div class="usa-checkbox">
-    <input
-      class="usa-checkbox__input"
-      id="check-historical-washington"
-      type="checkbox"
-      name="historical-figures"
-      value="booker-t-washington"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-    <label class="usa-checkbox__label" for="check-historical-washington"
-      >Booker T. Washington</label
-    >
-  </div>
-  <div class="usa-checkbox">
-    <input
-      class="usa-checkbox__input"
-      id="check-historical-carver"
-      type="checkbox"
-      name="historical-figures"
-      value="george-washington-carver"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-    <label class="usa-checkbox__label" for="check-historical-carver"
-      >George Washington Carver</label
-    >
-  </div>
-</fieldset>
-
-
-<fieldset class="usa-fieldset margin-top-2">
-  <legend class="usa-legend">Radio</legend>
-  <div class="usa-radio">
-    <input
-      class="usa-radio__input"
-      id="historical-washington"
-      type="radio"
-      name="historical-figures"
-      value="booker-t-washington"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-    <label class="usa-radio__label" for="historical-washington"
-      >Booker T. Washington</label
-    >
-  </div>
-  <div class="usa-radio">
-    <input
-      class="usa-radio__input"
-      id="historical-carver"
-      type="radio"
-      name="historical-figures"
-      value="george-washington-carver"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-    <label class="usa-radio__label" for="historical-carver"
-      >George Washington Carver</label
-    >
-  </div>
-</fieldset>
-
-<label class="usa-label" for="fruit">Combo box</label>
-<div class="usa-combo-box">
-  <select
-    class="usa-select"
-    name="fruit"
-    id="fruit"
-    {% if disabled_state == 'disabled' %} disabled
-    {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}>
-    <option value>Select a fruit</option>
-    <option value="apple">Apple</option>
-    <option value="apricot">Apricot</option>
-  </select>
+<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
+  <fieldset class="usa-fieldset margin-top-2">
+    <legend class="usa-legend">Checkbox</legend usa-label>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-checkbox">
+      <input
+        class="usa-checkbox__input usa-input--error"
+        id="check-historical-washington"
+        type="checkbox"
+        name="historical-figures"
+        value="booker-t-washington"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
+      <label class="usa-checkbox__label" for="check-historical-washington"
+        >Booker T. Washington</label
+      >
+    </div>
+    <div class="usa-checkbox">
+      <input
+        class="usa-checkbox__input"
+        id="check-historical-carver"
+        type="checkbox"
+        name="historical-figures"
+        value="george-washington-carver"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
+      <label class="usa-checkbox__label" for="check-historical-carver"
+        >George Washington Carver</label
+      >
+    </div>
+  </fieldset>
 </div>
 
-<div class="usa-form-group">
+
+<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
+  <fieldset class="usa-fieldset margin-top-2">
+  <legend class="usa-legend">Radio</legend>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-radio">
+      <input
+        class="usa-radio__input"
+        id="historical-washington"
+        type="radio"
+        name="historical-figures"
+        value="booker-t-washington"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
+      <label class="usa-radio__label" for="historical-washington"
+        >Booker T. Washington</label
+      >
+    </div>
+    <div class="usa-radio">
+      <input
+        class="usa-radio__input"
+        id="historical-carver"
+        type="radio"
+        name="historical-figures"
+        value="george-washington-carver"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
+      <label class="usa-radio__label" for="historical-carver"
+        >George Washington Carver</label
+      >
+    </div>
+  </fieldset>
+</div>
+
+<div class="usa-form--group {% if error_state %}usa-form-group--error{% endif %}">
+  <label class="usa-label" for="fruit">Combo box</label>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  <div class="usa-combo-box">
+    <select
+      class="usa-select"
+      name="fruit"
+      id="fruit"
+      {% if disabled_state == 'disabled' %} disabled
+      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}>
+      <option value>Select a fruit</option>
+      <option value="apple">Apple</option>
+      <option value="apricot">Apricot</option>
+    </select>
+  </div>
+</div>
+
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" id="appointment-date-label" for="appointment-date"
     >Date picker</label
   >
   <div class="usa-hint" id="appointment-date-hint">mm/dd/yyyy</div>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-date-picker">
     <input
-      class="usa-input"
+      class="usa-input {% if error_state %}usa-input--error{% endif %}"
       id="appointment-date"
       name="appointment-date"
       aria-labelledby="appointment-date-label"
@@ -114,10 +124,11 @@
   </div>
 </div>
 
-<div class="usa-form-group">
+<div class="usa-form-group {% if error_state %} usa-form-group--error{% endif %}">
   <label class="usa-label" for="file-input-single"
     >File input</label
   >
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     id="file-input-single"
     class="usa-file-input"
@@ -128,25 +139,27 @@
   />
 </div>
 
-<form class="usa-form">
+<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" for="ssn">Input mask</label>
   <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     id="ssn"
     inputmode="numeric"
     name="ssn"
     placeholder="___ __ ____"
     pattern="^(?!(000|666|9))\d{3} (?!00)\d{2} (?!0000)\d{4}$"
-    class="usa-input usa-masked"
+    class="usa-input usa-masked {% if error_state %}usa-input--error{% endif %}"
     aria-describedby="ssnHint"
     {% if disabled_state == 'disabled' %} disabled
     {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
   />
 </form>
 
-<form class="usa-form">
+<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" for="example-input-prefix">Input prefix</label>
-  <div class="usa-input-group">
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
     <div class="usa-input-prefix" aria-hidden="true">
       <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
         <use xlink:href="./img/sprite.svg#credit_card"></use>
@@ -163,9 +176,10 @@
   </div>
 </form>
 
-<form class="usa-form">
+<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" for="example-input-suffix">Input suffix</label>
-  <div class="usa-input-group usa-input-group--sm">
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+  <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
     <input
       id="example-input-suffix"
       class="usa-input"
@@ -178,71 +192,75 @@
   </div>
 </form>
 
-<fieldset class="usa-fieldset">
-  <legend class="usa-legend">Memorable date</legend>
-  <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
-  <div class="usa-memorable-date">
-    <div class="usa-form-group usa-form-group--month usa-form-group--select">
-      <label class="usa-label" for="date_of_birth_month">Month</label>
-      <select
-        class="usa-select"
-        id="date_of_birth_month"
-        name="date_of_birth_month"
-        aria-describedby="mdHint"
-        {% if disabled_state == 'disabled' %} disabled
-        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-      >
-        <option value>- Select -</option>
-        <option value="1">01 - January</option>
-        <option value="2">02 - February</option>
-        <option value="3">03 - March</option>
-        <option value="4">04 - April</option>
-        <option value="5">05 - May</option>
-        <option value="6">06 - June</option>
-        <option value="7">07 - July</option>
-        <option value="8">08 - August</option>
-        <option value="9">09 - September</option>
-        <option value="10">10 - October</option>
-        <option value="11">11 - November</option>
-        <option value="12">12 - December</option>
-      </select>
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend">Memorable date</legend>
+    <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-memorable-date">
+      <div class="usa-form-group usa-form-group--month usa-form-group--select">
+        <label class="usa-label" for="date_of_birth_month">Month</label>
+        <select
+          class="usa-select {% if error_state %}usa-input--error{% endif %}"
+          id="date_of_birth_month"
+          name="date_of_birth_month"
+          aria-describedby="mdHint"
+          {% if disabled_state == 'disabled' %} disabled
+          {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+        >
+          <option value>- Select -</option>
+          <option value="1">01 - January</option>
+          <option value="2">02 - February</option>
+          <option value="3">03 - March</option>
+          <option value="4">04 - April</option>
+          <option value="5">05 - May</option>
+          <option value="6">06 - June</option>
+          <option value="7">07 - July</option>
+          <option value="8">08 - August</option>
+          <option value="9">09 - September</option>
+          <option value="10">10 - October</option>
+          <option value="11">11 - November</option>
+          <option value="12">12 - December</option>
+        </select>
+      </div>
+      <div class="usa-form-group usa-form-group--day">
+        <label class="usa-label" for="date_of_birth_day">Day</label>
+        <input
+          class="usa-input {% if error_state %}usa-input--error{% endif %}"
+          aria-describedby="mdHint"
+          id="date_of_birth_day"
+          name="date_of_birth_day"
+          maxlength="2"
+          pattern="[0-9]*"
+          inputmode="numeric"
+          value=""
+          {% if disabled_state == 'disabled' %} disabled
+          {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+        />
+      </div>
+      <div class="usa-form-group usa-form-group--year">
+        <label class="usa-label" for="date_of_birth_year">Year</label>
+        <input
+          class="usa-input {% if error_state %}usa-input--error{% endif %}"
+          aria-describedby="mdHint"
+          id="date_of_birth_year"
+          name="date_of_birth_year"
+          minlength="4"
+          maxlength="4"
+          pattern="[0-9]*"
+          inputmode="numeric"
+          value=""
+          {% if disabled_state == 'disabled' %} disabled
+          {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+        />
+      </div>
     </div>
-    <div class="usa-form-group usa-form-group--day">
-      <label class="usa-label" for="date_of_birth_day">Day</label>
-      <input
-        class="usa-input"
-        aria-describedby="mdHint"
-        id="date_of_birth_day"
-        name="date_of_birth_day"
-        maxlength="2"
-        pattern="[0-9]*"
-        inputmode="numeric"
-        value=""
-        {% if disabled_state == 'disabled' %} disabled
-        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-      />
-    </div>
-    <div class="usa-form-group usa-form-group--year">
-      <label class="usa-label" for="date_of_birth_year">Year</label>
-      <input
-        class="usa-input"
-        aria-describedby="mdHint"
-        id="date_of_birth_year"
-        name="date_of_birth_year"
-        minlength="4"
-        maxlength="4"
-        pattern="[0-9]*"
-        inputmode="numeric"
-        value=""
-        {% if disabled_state == 'disabled' %} disabled
-        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-      />
-    </div>
-  </div>
-</fieldset>
+  </fieldset>
+</div>
 
-<form class="usa-form">
+<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" for="usa-range">Range slider</label>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     id="usa-range"
     class="usa-range"
@@ -260,10 +278,10 @@
   />
 </form>
 
-<form class="usa-form">
+<form class="usa-form {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" for="options">Select</label>
   <select
-    class="usa-select"
+    class="usa-select {% if error_state %}usa-input--error{% endif %}"
     name="options"
     id="options"
     {% if disabled_state == 'disabled' %} disabled
@@ -277,8 +295,9 @@
 </form>
 
 <label class="usa-label" for="input-type-text">Text input</label>
+{% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
 <input
-  class="usa-input"
+  class="usa-input {% if error_state %}usa-input--error{% endif %}"
   id="input-type-text"
   name="input-type-text"
   type="text"
@@ -286,14 +305,15 @@
   {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
   >
 
-<div class="usa-form-group">
+<div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label" id="appointment-time-label" for="appointment-time"
     >Time picker</label
   >
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
+  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-time-picker">
     <input
-      class="usa-input"
+      class="usa-input {% if error_state %}usa-input--error{% endif %}"
       id="appointment-time"
       name="appointment-time"
       aria-describedby="appointment-time-label appointment-time-hint"

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -89,7 +89,7 @@
 </div>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Input{% if error_state %} has an error{% endif %}</label>
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Combo box{% if error_state %} has an error{% endif %}</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
@@ -182,6 +182,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix{% if error_state %} has an error{% endif %}</label>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
       <input
@@ -320,7 +321,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
-    >Time picker</label
+    >Time picker{% if error_state %} has an error{% endif %}</label
   >
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -18,7 +18,7 @@
 </form>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <fieldset class="usa-fieldset {% if error_state %}usa-form-group--error{% endif %} margin-top-2">
+  <fieldset class="usa-fieldset margin-top-2">
     <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox{% if error_state %} has an error{% endif %}</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-checkbox">
@@ -139,57 +139,62 @@
   />
 </div>
 
-<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask{% if error_state %} has an error{% endif %}</label>
-  <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-  <input
-    id="ssn"
-    inputmode="numeric"
-    name="ssn"
-    placeholder="___ __ ____"
-    pattern="^(?!(000|666|9))\d{3} (?!00)\d{2} (?!0000)\d{4}$"
-    class="usa-input usa-masked {% if error_state %}usa-input--error{% endif %}"
-    aria-describedby="ssnHint"
-    {% if disabled_state == 'disabled' %} disabled
-    {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-  />
+<form class="usa-form">
+  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask{% if error_state %} has an error{% endif %}</label>
+    <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <input
+      id="ssn"
+      inputmode="numeric"
+      name="ssn"
+      placeholder="___ __ ____"
+      pattern="^(?!(000|666|9))\d{3} (?!00)\d{2} (?!0000)\d{4}$"
+      class="usa-input usa-masked {% if error_state %}usa-input--error{% endif %}"
+      aria-describedby="ssnHint"
+      {% if disabled_state == 'disabled' %} disabled
+      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+    />
+  {% if error_state %}</div>{% endif %}
 </form>
 
-<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix{% if error_state %} has an error{% endif %}</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-  <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
-    <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
-        <use xlink:href="./img/sprite.svg#credit_card"></use>
-      </svg>
+<form class="usa-form">
+  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix{% if error_state %} has an error{% endif %}</label>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
+      <div class="usa-input-prefix" aria-hidden="true">
+        <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+          <use xlink:href="./img/sprite.svg#credit_card"></use>
+        </svg>
+      </div>
+      <input
+        id="example-input-prefix"
+        class="usa-input"
+        pattern="[0-9]*"
+        inputmode="numeric"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
     </div>
-    <input
-      id="example-input-prefix"
-      class="usa-input"
-      pattern="[0-9]*"
-      inputmode="numeric"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-  </div>
+  {% if error_state %}</div>{% endif %}
 </form>
 
-<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix{% if error_state %} has an error{% endif %}</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-  <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
-    <input
-      id="example-input-suffix"
-      class="usa-input"
-      pattern="[0-9]*"
-      inputmode="numeric"
-      {% if disabled_state == 'disabled' %} disabled
-      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    />
-    <div class="usa-input-suffix" aria-hidden="true">lbs.</div>
-  </div>
+<form class="usa-form">
+  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
+      <input
+        id="example-input-suffix"
+        class="usa-input"
+        pattern="[0-9]*"
+        inputmode="numeric"
+        {% if disabled_state == 'disabled' %} disabled
+        {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      />
+      <div class="usa-input-suffix" aria-hidden="true">lbs.</div>
+    </div>
+  {% if error_state %}</div>{% endif %}
 </form>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
@@ -258,41 +263,45 @@
   </fieldset>
 </div>
 
-<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider{% if error_state %} has an error{% endif %}</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-  <input
-    id="usa-range"
-    class="usa-range"
-    type="range"
-    min="0"
-    max="100"
-    step="10"
-    value="20"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="20"
-    role="slider"
-    {% if disabled_state == 'disabled' %} disabled
-    {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-  />
+<form class="usa-form">
+  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider{% if error_state %} has an error{% endif %}</label>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <input
+      id="usa-range"
+      class="usa-range"
+      type="range"
+      min="0"
+      max="100"
+      step="10"
+      value="20"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow="20"
+      role="slider"
+      {% if disabled_state == 'disabled' %} disabled
+      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+    />
+  {% if error_state %}</div>{% endif %}
 </form>
 
-<form class="usa-form usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select{% if error_state %} has an error{% endif %}</label>
-  {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
-  <select
-    class="usa-select {% if error_state %}usa-input--error{% endif %}"
-    name="options"
-    id="options"
-    {% if disabled_state == 'disabled' %} disabled
-    {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    >
-    <option value>- Select -</option>
-    <option value="value1">Option A</option>
-    <option value="value2">Option B</option>
-    <option value="value3">Option C</option>
-  </select>
+<form class="usa-form">
+  {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select{% if error_state %} has an error{% endif %}</label>
+    {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
+    <select
+      class="usa-select {% if error_state %}usa-input--error{% endif %}"
+      name="options"
+      id="options"
+      {% if disabled_state == 'disabled' %} disabled
+      {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
+      >
+      <option value>- Select -</option>
+      <option value="value1">Option A</option>
+      <option value="value2">Option B</option>
+      <option value="value3">Option C</option>
+    </select>
+  {% if error_state %}</div>{% endif %}
 </form>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
@@ -305,7 +314,7 @@
     type="text"
     {% if disabled_state == 'disabled' %} disabled
     {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
-    >
+  >
 </div>
 
 

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -1,7 +1,7 @@
 <form class="usa-form">
   <div class="usa-character-count">
     <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-      <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="with-hint-input">Character count{% if error_state %} has an error{% endif %}</label>
+      <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="with-hint-input">Character count</label>
       <span id="with-hint-input-hint" class="usa-hint">This is an input with a character counter.</span>
       {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
       <input
@@ -19,7 +19,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox{% if error_state %} has an error{% endif %}</legend>
+    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Checkbox</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-checkbox">
       <input
@@ -55,7 +55,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset margin-top-2">
-  <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Radio{% if error_state %} has an error{% endif %}</legend>
+  <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Radio</legend>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-radio">
       <input
@@ -89,7 +89,7 @@
 </div>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Combo box{% if error_state %} has an error{% endif %}</label>
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="fruit">Combo box</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <div class="usa-combo-box">
     <select
@@ -126,7 +126,7 @@
 
 <div class="usa-form-group {% if error_state %} usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="file-input-single"
-    >File input{% if error_state %} has an error{% endif %}</label
+    >File input</label
   >
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
@@ -141,7 +141,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask{% if error_state %} has an error{% endif %}</label>
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="ssn">Input mask</label>
     <div class="usa-hint" id="ssnHint">For example, 123 45 6789</div>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <input
@@ -160,7 +160,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix{% if error_state %} has an error{% endif %}</label>
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-prefix">Input prefix</label>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-input-group {% if error_state %}usa-input--error{% endif %}">
       <div class="usa-input-prefix" aria-hidden="true">
@@ -182,7 +182,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix{% if error_state %} has an error{% endif %}</label>
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="example-input-suffix">Input suffix</label>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-input-group usa-input-group--sm {% if error_state %}usa-input--error{% endif %}">
       <input
@@ -200,7 +200,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <fieldset class="usa-fieldset">
-    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Memorable date{% if error_state %} has an error{% endif %}</legend>
+    <legend class="usa-legend {% if error_state %}usa-label--error{% endif %}">Memorable date</legend>
     <span class="usa-hint" id="mdHint">For example: January 19 2000</span>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-memorable-date">
@@ -266,7 +266,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider{% if error_state %} has an error{% endif %}</label>
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="usa-range">Range slider</label>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <input
       id="usa-range"
@@ -288,7 +288,7 @@
 
 <form class="usa-form">
   {% if error_state %}<div class="usa-form-group usa-form-group--error">{% endif %}
-    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select{% if error_state %} has an error{% endif %}</label>
+    <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="options">Select</label>
     {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <select
       class="usa-select {% if error_state %}usa-input--error{% endif %}"
@@ -306,7 +306,7 @@
 </form>
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
-  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="input-type-text">Text input{% if error_state %} has an error{% endif %}</label>
+  <label class="usa-label {% if error_state %}usa-label--error{% endif %}" for="input-type-text">Text input</label>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
   <input
     class="usa-input {% if error_state %}usa-input--error{% endif %}"
@@ -321,7 +321,7 @@
 
 <div class="usa-form-group {% if error_state %}usa-form-group--error{% endif %}">
   <label class="usa-label {% if error_state %}usa-label--error{% endif %}" id="appointment-time-label" for="appointment-time"
-    >Time picker{% if error_state %} has an error{% endif %}</label
+    >Time picker</label
   >
   <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
   {% if error_state %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}

--- a/packages/usa-form/src/usa-form.stories.js
+++ b/packages/usa-form/src/usa-form.stories.js
@@ -17,7 +17,11 @@ export default {
       name: "Disabled state",
       control: { type: "radio" },
       options: ["none", "disabled", "aria-disabled"],
-      defaultValue: "disabled",
+      table: { disable: true },
+    },
+    error_state: {
+      name: "Error state",
+      control: { type: "boolean" },
       table: { disable: true },
     },
   },
@@ -51,6 +55,15 @@ SignInMultipleSpanish.args = EsMultipleContent;
 export const DisabledFormElements = CollectionTemplate.bind({});
 DisabledFormElements.argTypes = {
   disabled_state: {
+    defaultValue: "disabled",
+    table: { disable: false },
+  },
+};
+
+export const ErrorFormElements = CollectionTemplate.bind({});
+ErrorFormElements.argTypes = {
+  error_state: {
+    defaultValue: true,
     table: { disable: false },
   },
 };

--- a/packages/usa-form/src/usa-form.stories.js
+++ b/packages/usa-form/src/usa-form.stories.js
@@ -60,8 +60,8 @@ DisabledFormElements.argTypes = {
   },
 };
 
-export const ErrorFormElements = CollectionTemplate.bind({});
-ErrorFormElements.argTypes = {
+export const TestErrorFormElements = CollectionTemplate.bind({});
+TestErrorFormElements.argTypes = {
   error_state: {
     defaultValue: true,
     table: { disable: false },


### PR DESCRIPTION
# Summary

Added form input error state showcase and controls to forms pattern. This is a general display for development testing and reference. 

There are a few issues we might want to address if we want to normalize form input error states across the design system. I've created #5884 to track the issues.

> [!NOTE]
> I've also created this [draft PR](https://github.com/uswds/uswds/pull/5882) that includes this work and brings error state stories to each individual component story page.
>
> Note that this work might be slightly out of date with the final error showcase PR found in this PR.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5839

## Preview link

[Error Form Elements →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-create-error-stories/?path=/story/patterns-forms--test-error-form-elements)

## Problem statement

Currently, there is no preview or testing environment for form input error states.

## Solution

Create a story to showcase form elements in error states. This new story has a boolean `error_state` control that developers can use to toggle the error state on and off.

When in error state, the twig file conditionally adds:

- `usa-form-group` & `usa-form-group--error` classes where needed
  - In some cases, a new div is created to wrap form content
- `usa-label—error` and “…has an error” labels
- `usa-error-message` spans to showcase helpful error messages
- `usa-input--error` to form elements with eligible input elements

## Major changes

New Form pattern: Error Form Element

## Testing and review

1. Visit Form error state pattern story
1. Confirm all forms have an error state
    - Note that some components such as combo box does not have error styles on their inputs due to initialization bug
1. Confirm error state elements have the red left border when view is lower than desktop widths
1. Confirm error state control works and is named appropriately
1. Inspect component markup and logic based DOM structure

> [!IMPORTANT]
> Due to initialization bugs, Combo box, input mask, and Time Picker are broken with the error state. Additional information is available in comments in [this thread.](https://github.com/uswds/uswds/pull/5879#pullrequestreview-2020825664)