### PR TITLE
Improve depiction of 🇺🇸 ASCII flag

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -25,5 +25,9 @@ exports.build = series(
   parallel(copyTheme, copyImages, copyFonts, copyIcons, copySass),
   buildSprite,
   compileJS,
-  compileSass
+  compileSass,
+  (done) => {
+    dutil.logPostscript();
+    done();
+  }
 );

--- a/tasks/utils/doc-util.js
+++ b/tasks/utils/doc-util.js
@@ -4,15 +4,46 @@ const pkg = require("../../package.json");
 
 const shellPrefix = "$";
 
-function drawFlag() {
+function drawFlagBW() {
   log(colors.white(""));
-  log(colors.white("* * * * * ========================"));
-  log(colors.white("* * * * * ========================"));
-  log(colors.white("* * * * * ========================"));
-  log(colors.white("* * * * * ========================"));
-  log(colors.white("=================================="));
-  log(colors.white("=================================="));
-  log(colors.white("=================================="));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ █████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★                                    "));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ █████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★                                    "));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ █████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★                                    "));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ █████████████████████████████████"));
+  log(colors.white("                                                        "));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.white("                                                        "));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.white("                                                        "));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.white(""));
+}
+
+function drawFlagColor() {
+  log(colors.white(""));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ ") +
+    colors.red("█████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★   ") +
+    colors.white("█████████████████████████████████"));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ ") +
+    colors.red("█████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★   ") +
+    colors.white("█████████████████████████████████"));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ ") +
+    colors.red("█████████████████████████████████"));
+  log(colors.white("   ★   ★   ★   ★   ★   ") +
+    colors.white("█████████████████████████████████"));
+  log(colors.white(" ★   ★   ★   ★   ★   ★ ") +
+    colors.red("█████████████████████████████████"));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.red("████████████████████████████████████████████████████████"));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.red("████████████████████████████████████████████████████████"));
+  log(colors.white("████████████████████████████████████████████████████████"));
+  log(colors.red("████████████████████████████████████████████████████████"));
   log(colors.white(""));
 }
 
@@ -24,10 +55,16 @@ module.exports = {
 
   dirName: `${pkg.name}-${pkg.version}`,
 
-  logIntroduction(message) {
-    const introMessage = message || "USWDS";
-    log(colors.yellow(`${introMessage} v${pkg.version}`));
-    drawFlag();
+  logIntroduction() {
+    log(colors.white(""));
+    log(colors.yellow(` Building USWDS v${pkg.version}`));
+    drawFlagBW();
+  },
+
+  logPostscript() {
+    log(colors.white(""));
+    log(colors.yellow(` USWDS v${pkg.version} built!`));
+    drawFlagColor();
   },
 
   logCommand(name, message) {


### PR DESCRIPTION
The build system outputs an ASCII flag. The current ASCII flag is missing some stars and stripes! This PR updates the ASCII flag to improve its fidelity. It shows a B/W flag when the build system is started, and a color flag when it has successfully built the USWDS without error. 🇺🇸🇺🇸🇺🇸

To test, run `npm install`

For reference, see general provisions for the flag image on https://uscode.house.gov/view.xhtml?path=/prelim@title4/chapter1&edition=prelim

Before:
<img width="422" alt="Screenshot 2024-04-24 at 5 55 20 PM" src="https://github.com/uswds/uswds/assets/704760/e9f3ed58-6907-4a5e-9cb8-932bb3d8b9d4">

After:
<img width="525" alt="Screenshot 2024-04-24 at 6 44 48 PM" src="https://github.com/uswds/uswds/assets/704760/822a5672-c197-4258-b3c8-4ba354529448">

<img width="522" alt="Screenshot 2024-04-24 at 6 44 55 PM" src="https://github.com/uswds/uswds/assets/704760/c8264b4c-4052-4cf2-8ff3-5026f08d48d8">
