### PR TITLE
USWDS - Validation: Add screen reader summary on init

### DIFF
--- a/packages/usa-validation/src/index.js
+++ b/packages/usa-validation/src/index.js
@@ -1,5 +1,6 @@
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const validate = require("../../uswds-core/src/js/utils/validate-input");
+const debounce = require("../../uswds-core/src/js/utils/debounce");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 
@@ -7,8 +8,10 @@ const VALIDATE_INPUT =
   "input[data-validation-element],textarea[data-validation-element]";
 const CHECKLIST_ITEM = `.${PREFIX}-checklist__item`;
 
-// Trigger validation on input change
-const handleChange = (el) => validate(el);
+// Trigger validation on input change, after a delay
+const handleChange = debounce((el) => {
+  validate(el);
+}, 1000);
 
 // Create container to hold aria readout
 const createStatusElement = (input) => {
@@ -49,6 +52,7 @@ const createInitialStatus = (input) => {
 const enhanceValidation = (input) => {
   createStatusElement(input);
   createInitialStatus(input);
+  validate(input);
 };
 
 const validator = behavior(

--- a/packages/uswds-core/src/js/utils/validate-input.js
+++ b/packages/uswds-core/src/js/utils/validate-input.js
@@ -1,4 +1,3 @@
-const debounce = require("./debounce");
 const { prefix: PREFIX } = require("../config");
 
 const CHECKED_CLASS = `${PREFIX}-checklist__item--checked`;
@@ -51,12 +50,12 @@ module.exports = function validate(el) {
       // Create a summary of status for all checklist items
       statusSummary += `${checkboxContent}. `;
 
-      // Add summary to screen reader summary container, after a delay
-      const srUpdateStatus = debounce(() => {
+      // Add summary to screen reader summary container
+      const createSrStatus = () =>{
         statusSummaryContainer.textContent = statusSummary;
-      }, 1000);
+      }
 
-      srUpdateStatus();
+      createSrStatus();
     }
   });
 };


### PR DESCRIPTION
# Summary

**Added a screen reader summary of input requirements to the validation component on initialization.** Previously, the component only provided this summary when the user added content to the input. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #5841

## Related pull requests

[Changelog PR ](https://github.com/uswds/uswds-site/pull/2639)

## Preview link

[Validation component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-validation-init-sr-msg/?path=/story/components-validation--input-validation)

## Problem statement

If a screen reader user navigates via the tab key, they will arrive on the validation component input without being made aware of the validation requirements.

## Solution

Ran the `validate()` function on init. Previously, the function was designed to be called only on update. This required the following changes:
1. Removed the debounce from the `validate()` function. This debounce should only be added on update. 
2. Added the validate function to init
3. Added debounce to `handleChange()`

## Testing and review

1. Confirm that the status summary appears in the `#code-sr-summary` element on component initialization
1. Confirm that the status summary appears in the `#code-sr-summary` element when you update the input 
1. Confirm that code meets standards


