### PR TITLE
USWDS - Tooltip: Make tooltip dismissible with escape key

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -358,8 +358,10 @@ const setUpAttributes = (tooltipTrigger) => {
 };
 
 const handleEscape = (event) => {
-  const activeTooltips = document.querySelectorAll(".usa-tooltip__body.is-visible");
-  if ( event.key === 'Escape' || event.key === 'Esc') {
+  const activeTooltips = document.querySelectorAll(
+    ".usa-tooltip__body.is-visible"
+  );
+  if (event.key === "Escape" || event.key === "Esc") {
     activeTooltips.forEach((activeTooltip) => {
       hideToolTip(activeTooltip);
     });

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -373,7 +373,7 @@ const handleEscape = (event) => {
     `.${TOOLTIP_BODY_CLASS}.${VISIBLE_CLASS}`
   );
 
-  if (!activeTooltips) {
+  if (activeTooltips.length === 0) {
     return;
   }
 

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -1,9 +1,11 @@
 // Tooltips
+const keymap = require("receptor/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
 const isElementInViewport = require("../../uswds-core/src/js/utils/is-in-viewport");
 
+const BODY = "body";
 const TOOLTIP = `.${PREFIX}-tooltip`;
 const TOOLTIP_TRIGGER = `.${PREFIX}-tooltip__trigger`;
 const TOOLTIP_TRIGGER_CLASS = `${PREFIX}-tooltip__trigger`;
@@ -357,21 +359,27 @@ const setUpAttributes = (tooltipTrigger) => {
   return { tooltipBody, position, tooltipContent, wrapper };
 };
 
-
 /**
  * Hide all active tooltips when escape key is pressed.
  * @param event - Keydown event
  */
 
 const handleEscape = (event) => {
+  if (event.key !== "Escape") {
+    return;
+  }
+
   const activeTooltips = document.querySelectorAll(
     ".usa-tooltip__body.is-visible"
   );
-  if (event.key === "Escape" || event.key === "Esc") {
-    activeTooltips.forEach((activeTooltip) => {
-      hideToolTip(activeTooltip);
-    });
+
+  if (!activeTooltips) {
+    return;
   }
+
+  activeTooltips.forEach((activeTooltip) => {
+    hideToolTip(activeTooltip);
+  });
 };
 
 // Setup our function to run on various events
@@ -391,7 +399,6 @@ const tooltip = behavior(
         const { trigger, body } = getTooltipElements(e.target);
 
         showToolTip(body, trigger, trigger.dataset.position);
-        window.addEventListener("keydown", handleEscape);
       },
     },
     "mouseout focusout": {
@@ -399,8 +406,10 @@ const tooltip = behavior(
         const { body } = getTooltipElements(e.target);
 
         hideToolTip(body);
-        window.removeEventListener("keydown", handleEscape);
       },
+    },
+    keydown: {
+      [BODY]: keymap({ Escape: handleEscape }),
     },
   },
   {

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -361,8 +361,7 @@ const setUpAttributes = (tooltipTrigger) => {
 
 const handleEscape = () => {
   const activeTooltips = document.querySelectorAll(".is-set");
-  if ( event.keyCode === 27 ) {
-    console.log("Pressed escape");
+  if ( event.key === 'Escape' ) {
     activeTooltips.forEach((activeTooltip) => {
       hideToolTip (activeTooltip);
     });

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -366,7 +366,7 @@ const setUpAttributes = (tooltipTrigger) => {
 const handleEscape = () => {
   const activeTooltips = selectOrMatches(`.${TOOLTIP_BODY_CLASS}.${SET_CLASS}`);
 
-  if (!activeTooltips) {
+  if (activeTooltips.length === 0) {
     return;
   }
 

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -357,7 +357,7 @@ const setUpAttributes = (tooltipTrigger) => {
   return { tooltipBody, position, tooltipContent, wrapper };
 };
 
-const handleEscape = () => {
+const handleEscape = (event) => {
   const activeTooltips = document.querySelectorAll(".usa-tooltip__body.is-visible");
   if ( event.key === 'Escape' || event.key === 'Esc') {
     activeTooltips.forEach((activeTooltip) => {

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -370,7 +370,7 @@ const handleEscape = (event) => {
   }
 
   const activeTooltips = document.querySelectorAll(
-    ".usa-tooltip__body.is-visible"
+    `.${TOOLTIP_BODY_CLASS}.${VISIBLE_CLASS}`
   );
 
   if (!activeTooltips) {

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -34,7 +34,6 @@ const getTooltipElements = (trigger) => {
  */
 const showToolTip = (tooltipBody, tooltipTrigger, position) => {
   tooltipBody.setAttribute("aria-hidden", "false");
-  console.log("🏄‍♀️ show tooltip");
 
   // This sets up the tooltip body. The opacity is 0, but
   // we can begin running the calculations below.
@@ -307,8 +306,6 @@ const hideToolTip = (tooltipBody) => {
   tooltipBody.classList.remove(SET_CLASS);
   tooltipBody.classList.remove(ADJUST_WIDTH_CLASS);
   tooltipBody.setAttribute("aria-hidden", "true");
-  console.log("👻 hide tooltip");
-
 };
 
 /**

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -32,6 +32,7 @@ const getTooltipElements = (trigger) => {
  */
 const showToolTip = (tooltipBody, tooltipTrigger, position) => {
   tooltipBody.setAttribute("aria-hidden", "false");
+  attachGlobalListener();
 
   // This sets up the tooltip body. The opacity is 0, but
   // we can begin running the calculations below.
@@ -304,6 +305,7 @@ const hideToolTip = (tooltipBody) => {
   tooltipBody.classList.remove(SET_CLASS);
   tooltipBody.classList.remove(ADJUST_WIDTH_CLASS);
   tooltipBody.setAttribute("aria-hidden", "true");
+  removeGlobalListener();
 };
 
 /**
@@ -356,6 +358,24 @@ const setUpAttributes = (tooltipTrigger) => {
 
   return { tooltipBody, position, tooltipContent, wrapper };
 };
+
+const handleEscape = () => {
+  const activeTooltips = document.querySelectorAll(".is-set");
+  if ( event.keyCode === 27 ) {
+    console.log("Pressed escape");
+    activeTooltips.forEach((activeTooltip) => {
+      hideToolTip (activeTooltip);
+    });
+  }
+};
+
+const attachGlobalListener = () => {
+  document.addEventListener("keydown", handleEscape);
+}
+
+const removeGlobalListener = () => {
+  document.removeEventListener("keydown", handleEscape);
+}
 
 // Setup our function to run on various events
 const tooltip = behavior(

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -361,7 +361,7 @@ const handleEscape = () => {
   const activeTooltips = document.querySelectorAll(".usa-tooltip__body.is-visible");
   if ( event.key === 'Escape' || event.key === 'Esc') {
     activeTooltips.forEach((activeTooltip) => {
-      hideToolTip (activeTooltip);
+      hideToolTip(activeTooltip);
     });
   }
 };

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -357,6 +357,12 @@ const setUpAttributes = (tooltipTrigger) => {
   return { tooltipBody, position, tooltipContent, wrapper };
 };
 
+
+/**
+ * Hide all active tooltips when escape key is pressed.
+ * @param {HTMLElement} event - Keydown event
+ */
+
 const handleEscape = (event) => {
   const activeTooltips = document.querySelectorAll(
     ".usa-tooltip__body.is-visible"

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -34,6 +34,7 @@ const getTooltipElements = (trigger) => {
  */
 const showToolTip = (tooltipBody, tooltipTrigger, position) => {
   tooltipBody.setAttribute("aria-hidden", "false");
+  console.log("🏄‍♀️ show tooltip");
 
   // This sets up the tooltip body. The opacity is 0, but
   // we can begin running the calculations below.
@@ -306,6 +307,8 @@ const hideToolTip = (tooltipBody) => {
   tooltipBody.classList.remove(SET_CLASS);
   tooltipBody.classList.remove(ADJUST_WIDTH_CLASS);
   tooltipBody.setAttribute("aria-hidden", "true");
+  console.log("👻 hide tooltip");
+
 };
 
 /**
@@ -361,19 +364,12 @@ const setUpAttributes = (tooltipTrigger) => {
 
 /**
  * Hide all active tooltips when escape key is pressed.
- * @param event - Keydown event
  */
 
-const handleEscape = (event) => {
-  if (event.key !== "Escape") {
-    return;
-  }
+const handleEscape = () => {
+  const activeTooltips = selectOrMatches(`.${TOOLTIP_BODY_CLASS}.${SET_CLASS}`);
 
-  const activeTooltips = document.querySelectorAll(
-    `.${TOOLTIP_BODY_CLASS}.${VISIBLE_CLASS}`
-  );
-
-  if (activeTooltips.length === 0) {
+  if (!activeTooltips) {
     return;
   }
 

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -366,11 +366,11 @@ const setUpAttributes = (tooltipTrigger) => {
 const handleEscape = () => {
   const activeTooltips = selectOrMatches(`.${TOOLTIP_BODY_CLASS}.${SET_CLASS}`);
 
-  if (activeTooltips) {
-    activeTooltips.forEach((activeTooltip) => {
-      hideToolTip(activeTooltip);
-    });
+  if (!activeTooltips) {
+    return;
   }
+
+  activeTooltips.forEach((activeTooltip) => hideToolTip(activeTooltip));
 };
 
 // Setup our function to run on various events

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -32,7 +32,6 @@ const getTooltipElements = (trigger) => {
  */
 const showToolTip = (tooltipBody, tooltipTrigger, position) => {
   tooltipBody.setAttribute("aria-hidden", "false");
-  attachGlobalListener();
 
   // This sets up the tooltip body. The opacity is 0, but
   // we can begin running the calculations below.
@@ -305,7 +304,6 @@ const hideToolTip = (tooltipBody) => {
   tooltipBody.classList.remove(SET_CLASS);
   tooltipBody.classList.remove(ADJUST_WIDTH_CLASS);
   tooltipBody.setAttribute("aria-hidden", "true");
-  removeGlobalListener();
 };
 
 /**
@@ -360,21 +358,13 @@ const setUpAttributes = (tooltipTrigger) => {
 };
 
 const handleEscape = () => {
-  const activeTooltips = document.querySelectorAll(".is-set");
-  if ( event.key === 'Escape' ) {
+  const activeTooltips = document.querySelectorAll(".usa-tooltip__body.is-visible");
+  if ( event.key === 'Escape' || event.key === 'Esc') {
     activeTooltips.forEach((activeTooltip) => {
       hideToolTip (activeTooltip);
     });
   }
 };
-
-const attachGlobalListener = () => {
-  document.addEventListener("keydown", handleEscape);
-}
-
-const removeGlobalListener = () => {
-  document.removeEventListener("keydown", handleEscape);
-}
 
 // Setup our function to run on various events
 const tooltip = behavior(
@@ -393,6 +383,7 @@ const tooltip = behavior(
         const { trigger, body } = getTooltipElements(e.target);
 
         showToolTip(body, trigger, trigger.dataset.position);
+        window.addEventListener("keydown", handleEscape);
       },
     },
     "mouseout focusout": {
@@ -400,6 +391,7 @@ const tooltip = behavior(
         const { body } = getTooltipElements(e.target);
 
         hideToolTip(body);
+        window.removeEventListener("keydown", handleEscape);
       },
     },
   },

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -360,7 +360,7 @@ const setUpAttributes = (tooltipTrigger) => {
 
 /**
  * Hide all active tooltips when escape key is pressed.
- * @param {HTMLElement} event - Keydown event
+ * @param event - Keydown event
  */
 
 const handleEscape = (event) => {

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -366,13 +366,11 @@ const setUpAttributes = (tooltipTrigger) => {
 const handleEscape = () => {
   const activeTooltips = selectOrMatches(`.${TOOLTIP_BODY_CLASS}.${SET_CLASS}`);
 
-  if (activeTooltips.length === 0) {
-    return;
+  if (activeTooltips) {
+    activeTooltips.forEach((activeTooltip) => {
+      hideToolTip(activeTooltip);
+    });
   }
-
-  activeTooltips.forEach((activeTooltip) => {
-    hideToolTip(activeTooltip);
-  });
 };
 
 // Setup our function to run on various events

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -92,7 +92,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     it("tooltip is hidden on escape keydown", () => {
       tooltipTrigger.focus();
-      EVENTS.escape(body);
+      EVENTS.escape(tooltipTrigger);
       assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
     });
 

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -18,23 +18,7 @@ const EVENTS = {
     });
 
     el.dispatchEvent(escapeKeyEvent);
-  },
-  mouseover(el) {
-    const mouseoverEvent = new Event("mouseover", {
-      bubbles: true,
-      cancelable: true,
-    });
-
-    el.dispatchEvent(mouseoverEvent);
-  },
-  mouseout(el) {
-    const mouseoutEvent = new Event("mouseout", {
-      bubbles: true,
-      cancelable: true,
-    });
-
-    el.dispatchEvent(mouseoutEvent);
-  },
+  }
 };
 
 tests.forEach(({ name, selector: containerSelector }) => {
@@ -77,16 +61,6 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     it("tooltip is hidden on blur", () => {
       tooltipTrigger.blur();
-      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
-    });
-
-    it("tooltip is visible on mouseover", () => {
-      EVENTS.mouseover(tooltipTrigger);
-      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
-    });
-
-    it("tooltip is hidden on mouseout", () => {
-      EVENTS.mouseout(tooltipTrigger);
       assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
     });
 

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -10,6 +10,33 @@ const tests = [
   { name: "tooltip", selector: () => document.querySelector(".usa-tooltip") },
 ];
 
+const EVENTS = {
+  escape(el) {
+    const escapeKeyEvent = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+    });
+
+    el.dispatchEvent(escapeKeyEvent);
+  },
+  mouseover(el) {
+    const mouseoverEvent = new Event("mouseover", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    el.dispatchEvent(mouseoverEvent);
+  },
+  mouseout(el) {
+    const mouseoutEvent = new Event("mouseout", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    el.dispatchEvent(mouseoutEvent);
+  },
+};
+
 tests.forEach(({ name, selector: containerSelector }) => {
   describe(`tooltips initialized at ${name}`, () => {
     const { body } = document;
@@ -50,6 +77,22 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     it("tooltip is hidden on blur", () => {
       tooltipTrigger.blur();
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    });
+
+    it("tooltip is visible on mouseover", () => {
+      EVENTS.mouseover(tooltipTrigger);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), true);
+    });
+
+    it("tooltip is hidden on mouseout", () => {
+      EVENTS.mouseout(tooltipTrigger);
+      assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
+    });
+
+    it("tooltip is hidden on escape keydown", () => {
+      tooltipTrigger.focus();
+      EVENTS.escape(body);
       assert.strictEqual(tooltipBody.classList.contains("is-set"), false);
     });
 

--- a/packages/usa-tooltip/src/test/tooltips.spec.js
+++ b/packages/usa-tooltip/src/test/tooltips.spec.js
@@ -18,7 +18,7 @@ const EVENTS = {
     });
 
     el.dispatchEvent(escapeKeyEvent);
-  }
+  },
 };
 
 tests.forEach(({ name, selector: containerSelector }) => {


### PR DESCRIPTION
# Summary

**Updated tooltip component behavior to close active tooltips when the `escape` key is pressed.** This allows the component to meet the "dismissible" standard outlined in [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html).

> [!Note]
> This issue is slated to be in the same release as #5919, which also edits the tooltip JavaScript. We should confirm there are no conflicts between the two PRs.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5901 

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2660)

## Preview link

[Tooltip component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-tooltip-escape/iframe.html?id=components-tooltip--tooltip&viewMode=story)

> [!important]
> In the [default storybook view](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-tooltip-escape/?path=/story/components-tooltip--tooltip), pressing `escape` will not close a tooltip that is triggered by `mouseover` until one of the trigger buttons receives focus. After that, it should work as expected.  However, this issue does not happen when the Story canvas is [opened in its own tab](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-tooltip-escape/iframe.html?id=components-tooltip--tooltip&viewMode=story). For that reason, I do not consider this to be an issue with the component, but rather Storybook. 

## Problem statement

According to W3C, the tooltip component interaction should be dismissible by hitting the "escape" key. 

## Solution

This PR creates the `handleEscape()` function to hide the tooltip when when the `escape` key is pressed. 

## Testing and review
1. Confirm that active tooltips close when you press `escape`. 
1. Confirm no regressions in behavior.
1. Confirm the code meet standards.