### PR TITLE
USWDS - README: Update capitalization of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are two ways to install the design system on a project:
 **We recommend using npm to make it as straightforward as possible to install the design system and update it as we release new versions.**
 
 ### Install using Node and npm
-npm is a package manager for Node-based projects. USWDS maintains the [`@uswds/uswds` package](https://www.npmjs.com/package/uswds) that includes both the pre-compiled and compiled files. npm packages make it easy to update and install the design system from the command line.
+Use the npm package manager for Node-based projects. USWDS maintains the [`@uswds/uswds` package](https://www.npmjs.com/package/uswds) that includes both the pre-compiled and compiled files. We rely on npm packages to easily update and install the design system from the command line.
 
 1. Install `Node/npm`. Below is a link to find the install method that coincides with your operating system:
 


### PR DESCRIPTION
# Summary

Updated `npm` references to improve lowercase consistency.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5876

## Preview link

[README preview →](https://github.com/uswds/uswds/blob/7ac8dc377afa57d61322adf08b564ef70af909b6/README.md)

[Site preview →](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.sites.pages.cloud.gov/preview/uswds/uswds-site/cm-demo-uswds-5915/documentation/developers/#install-using-node-and-npm-2)

## Problem statement

Where possible, avoid beginning sentences with words like "npm" that conventionally begin with a lowercase letter. When it appears at the beginning of a sentence, capitalize the N in npm.

## Solution

Update references in README to follow the recommended presentation of `npm`

## Testing and review

1. Review content change to ensure clarity
2. Review README and site previews and confirm the change looks appropriate
3. Confirm there are no other capitalized references to `npm` in any user facing files.