### PR TITLE
USWDS: Remove JavaScript destructuring example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Importing a modular component.
 
 ```js
 import accordion from "@uswds/uswds/js/usa-accordion";
+import characterCount from "@uswds/uswds/js/usa-character-count";
 ```
 
 ⚠️Requires webpack 5+

--- a/README.md
+++ b/README.md
@@ -355,10 +355,6 @@ Some components have additional methods based on that component's functionality.
 Importing a modular component.
 
 ```js
-import USWDS from "@uswds/uswds/js";
-const { characterCount, accordion } = USWDS; // deconstruct your components here
-
-// Alternatively
 import accordion from "@uswds/uswds/js/usa-accordion";
 ```
 


### PR DESCRIPTION
# Summary

**Improve documentation for JavaScript customization.** Updated code snippets to ensure optimal build size.

## Breaking change

This is not a breaking change.

## Related issue

Tangentially related to #4515 . #4515 could enable optimized top-level imports using a syntax similar to the code being removed here, if combined with [`package.json` `sideEffects` tree-shaking](https://webpack.js.org/guides/tree-shaking/).

Related Slack discussion in USWDS public Slack: https://gsa-tts.slack.com/archives/C3F14AHSQ/p1715273540567929

## Problem statement

As a developer interested in reducing the size of the JavaScript produced by USWDS, I expect that [USWDS's documentation for customizing JavaScript](https://github.com/uswds/uswds?tab=readme-ov-file#js-customization) will produce code with the intended effect of reducing of my JavaScript, so that I'm not misled into thinking my code is optimal when it's not, or confused that the JavaScript size remains the same. 

## Solution

The "Importing a modular component" provides two example syntaxes, but only one of them has the intended effect of reducing the size of the JavaScript bundle. The changes here remove the other example code.

## Testing and review

Testing with [ESBuild](https://esbuild.github.io/) bundler:

```
echo "import USWDS from '@uswds/uswds/js';" | esbuild --bundle --minify | wc -c
   73851
```

```
echo "import accordion from '@uswds/uswds/js/usa-accordion';" | esbuild --bundle --minify | wc -c      
    5035
```

**Before:** 73.8kb
**After:** 5.0kb
**Diff:** -68.8kb (-93.2%)