### PR TITLE
USWDS - Tooltip: Create a mixin for the tooltip spacer

### DIFF
--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -1,5 +1,36 @@
 @use "uswds-core" as *;
 
+/// Create a spacer to increase target area for tooltip triangle.
+///
+/// @param {String} $direction - The direction of the tooltip; can be top, bottom, left, right.
+/// @param {Length} $triangle-size [5px] - The size of the triangle.
+///
+/// @example
+/// @include tooltip-spacer("top");
+///
+/// @output
+/// .usa-tooltip__body--top::before {
+///    top: 100%;
+///    height: 5px;
+///    left: 0;
+///    right: 0;
+///  }
+@mixin tooltip-spacer($direction) {
+  &::before {
+    #{$direction}: 100%;
+
+    @if ($direction == "left") or ($direction == "right") {
+      bottom: 0;
+      top: 0;
+      width: $triangle-size;
+    } @else {
+      height: $triangle-size;
+      left: 0;
+      right: 0;
+    }
+  }
+}
+
 // Variables
 $triangle-size: 5px;
 
@@ -74,15 +105,12 @@ $triangle-size: 5px;
 }
 
 .usa-tooltip__body--top {
-  &::before {
-    height: $triangle-size;
-    left: 0;
-    right: 0;
-    top: 100%;
-  }
+  @include tooltip-spacer("top");
 }
 
 .usa-tooltip__body--bottom {
+  @include tooltip-spacer("bottom");
+
   &::after {
     border-left: $triangle-size solid transparent;
     border-right: $triangle-size solid transparent;
@@ -91,16 +119,11 @@ $triangle-size: 5px;
     bottom: auto;
     top: -$triangle-size;
   }
-
-  &::before {
-    height: $triangle-size;
-    bottom: 100%;
-    left: 0;
-    right: 0;
-  }
 }
 
 .usa-tooltip__body--right {
+  @include tooltip-spacer("right");
+
   &::after {
     border-top: $triangle-size solid transparent;
     border-bottom: $triangle-size solid transparent;
@@ -112,16 +135,11 @@ $triangle-size: 5px;
     left: -$triangle-size;
     margin: -$triangle-size 0 0 0;
   }
-
-  &::before {
-    bottom: 0;
-    right: 100%;
-    top: 0;
-    width: $triangle-size;
-  }
 }
 
 .usa-tooltip__body--left {
+  @include tooltip-spacer("left");
+
   &::after {
     border-top: $triangle-size solid transparent;
     border-bottom: $triangle-size solid transparent;
@@ -132,12 +150,5 @@ $triangle-size: 5px;
     bottom: 0;
     left: auto;
     margin: -$triangle-size 0 0 0;
-  }
-
-  &::before {
-    bottom: 0;
-    left: 100%;
-    top: 0;
-    width: $triangle-size;
   }
 }

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -6,7 +6,6 @@ $triangle-size: 5px;
 /// Create a spacer to increase target area for tooltip triangle.
 ///
 /// @param {String} $direction - The direction of the tooltip; can be top, bottom, left, right.
-/// @param {Length} $triangle-size [5px] - The size of the triangle.
 ///
 /// @example
 /// @include tooltip-spacer("top");

--- a/packages/usa-tooltip/src/styles/_usa-tooltip.scss
+++ b/packages/usa-tooltip/src/styles/_usa-tooltip.scss
@@ -1,5 +1,8 @@
 @use "uswds-core" as *;
 
+// Variables
+$triangle-size: 5px;
+
 /// Create a spacer to increase target area for tooltip triangle.
 ///
 /// @param {String} $direction - The direction of the tooltip; can be top, bottom, left, right.
@@ -30,9 +33,6 @@
     }
   }
 }
-
-// Variables
-$triangle-size: 5px;
 
 /* Tooltips */
 .usa-tooltip {


### PR DESCRIPTION
# Summary

Created mixin for tooltip spacer to avoid duplicate code.

## Breaking change

This is not a breaking change.

## Related issue

#5918

## Related pull requests

Related to #5919.

## Preview link

Preview link: [Tooltip →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-tooltip-hoverable/?path=/story/components-tooltip--tooltip) 

## Problem statement

The CSS for creating the tooltip spacer was repetitive.

## Solution

Created a mixin to manage this in one place.


## Testing and review

Tooltips should create a spacer element between trigger and body that keeps the content visible.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
