### PR TITLE
USWDS - Enhancement: Create label styles mixin for labels and legends

### DIFF
--- a/packages/usa-label/src/styles/_usa-label.scss
+++ b/packages/usa-label/src/styles/_usa-label.scss
@@ -1,15 +1,7 @@
 @use "uswds-core" as *;
 
 .usa-label {
-  @include typeset(
-    $theme-form-font-family,
-    $theme-body-font-size,
-    $theme-input-line-height
-  );
-  display: block;
-  font-weight: font-weight("normal");
-  margin-top: units(3);
-  max-width: units($theme-input-max-width);
+  @include add-label-styles;
 }
 
 .usa-label--error {

--- a/packages/usa-legend/src/styles/_usa-legend.scss
+++ b/packages/usa-legend/src/styles/_usa-legend.scss
@@ -1,15 +1,7 @@
 @use "uswds-core" as *;
 
 .usa-legend {
-  @include typeset(
-    $theme-form-font-family,
-    $theme-body-font-size,
-    $theme-input-line-height
-  );
-  display: block;
-  font-weight: font-weight("normal");
-  margin-top: units(3);
-  max-width: units($theme-input-max-width);
+  @include add-label-styles;
 }
 
 .usa-legend--large {

--- a/packages/uswds-core/src/styles/mixins/helpers/_index.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/_index.scss
@@ -1,3 +1,4 @@
+@forward "add-label-styles";
 @forward "add-link-styles";
 @forward "alert-status-styles";
 @forward "at-media";

--- a/packages/uswds-core/src/styles/mixins/helpers/add-label-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/add-label-styles.scss
@@ -3,16 +3,15 @@
 @use "../../functions/utilities/etc" as *;
 @use "../../functions/units/units" as *;
 
-
 /// Applies consistent styles to form label and legend elements.
 @mixin add-label-styles() {
-  @include typeset( 
-    $theme-form-font-family, 
-    $theme-body-font-size, 
-    $theme-input-line-height 
-  ); 
-  display: block; 
-  font-weight: font-weight("normal"); 
-  margin-top: units(3); 
-  max-width: units($theme-input-max-width); 
+  @include typeset(
+    $theme-form-font-family,
+    $theme-body-font-size,
+    $theme-input-line-height
+  );
+  display: block;
+  font-weight: font-weight("normal");
+  margin-top: units(3);
+  max-width: units($theme-input-max-width);
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/add-label-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/add-label-styles.scss
@@ -1,0 +1,18 @@
+@use "../../settings" as *;
+@use "../../mixins/typography/typeset" as *;
+@use "../../functions/utilities/etc" as *;
+@use "../../functions/units/units" as *;
+
+
+/// Applies consistent styles to form label and legend elements.
+@mixin add-label-styles() {
+  @include typeset( 
+    $theme-form-font-family, 
+    $theme-body-font-size, 
+    $theme-input-line-height 
+  ); 
+  display: block; 
+  font-weight: font-weight("normal"); 
+  margin-top: units(3); 
+  max-width: units($theme-input-max-width); 
+}


### PR DESCRIPTION
# Summary

Created the `add-label-styles` mixin to reduce duplicate code between `usa-label` and `usa-legend` elements. Now duplicate styles can be maintained in one location.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5894

## Preview link

| Develop | Preview |
| --- | --- |
| [Create Account page (legend example)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/iframe.html?args=&id=pages-create-account--create-account-page) | [Create Account page (legend example)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-legend-label-styles/iframe.html?args=&id=pages-create-account--create-account-page&viewMode=story) |
| [Sign in page (label example)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/iframe.html?args=&id=pages-sign-in--sign-in-page) | [Sign in page (label example)](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-legend-label-styles/iframe.html?args=&id=pages-sign-in--sign-in-page) |

## Problem statement

`usa-label` and `usa-legend` share styles to maintain a similar appearance. This requires styles to be maintained in two locations.

## Solution

Create a helper mixin to maintain styles in one location.

## Testing and review

1. Inspect `usa-label` and `usa-legend` styles
2. Compare to develop previews
3. Confirm there are no missing styles
4. Confirm there are no visual regressions
5. Confirm there are no build errors