### PR TITLE
USWDS - Pagination: Updated text-decoration value to better show pagination links

### DIFF
--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -119,7 +119,7 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 
 .usa-pagination__button {
   align-items: center;
-  border-color: color.adjust(color($pagination-current-color), $alpha: -0.1);
+  border-color: color.adjust(color($pagination-current-color), $alpha: -0.8);
   border-radius: radius($theme-pagination-button-border-radius);
   border-style: solid;
   border-width: units($theme-pagination-button-border-width);
@@ -127,7 +127,7 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
   display: inline-flex;
   justify-content: center;
   padding: units($pagination-margin-padding);
-  text-decoration: none;
+  text-decoration: underline;
   width: 100%;
 
   &:hover,

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -98,7 +98,6 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
   align-items: center;
   color: color($pagination-link-token);
   display: inline-flex;
-  text-decoration: none;
 
   &[disabled] {
     opacity: 0.4 !important;
@@ -127,7 +126,6 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
   display: inline-flex;
   justify-content: center;
   padding: units($pagination-margin-padding);
-  text-decoration: underline;
   width: 100%;
 
   &:hover,

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -119,7 +119,7 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 
 .usa-pagination__button {
   align-items: center;
-  border-color: color.adjust(color($pagination-current-color), $alpha: 0.6);
+  border-color: color.adjust(color($pagination-current-color), $alpha: -0.1);
   border-radius: radius($theme-pagination-button-border-radius);
   border-style: solid;
   border-width: units($theme-pagination-button-border-width);

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -108,7 +108,6 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
   &:focus,
   &:active {
     color: color($pagination-hover-token);
-    text-decoration: underline;
   }
 
   &:visited {
@@ -160,7 +159,6 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
   &:active {
     background-color: color($pagination-current-color);
     color: color($text-color);
-    text-decoration: none;
 
     @media (forced-colors: active) {
       color: buttontext;

--- a/packages/usa-pagination/src/styles/_usa-pagination.scss
+++ b/packages/usa-pagination/src/styles/_usa-pagination.scss
@@ -119,7 +119,7 @@ $pagination-hover-token: list.nth($pagination-link-tokens, 2);
 
 .usa-pagination__button {
   align-items: center;
-  border-color: color.adjust(color($pagination-current-color), $alpha: -0.8);
+  border-color: color.adjust(color($pagination-current-color), $alpha: 0.6);
   border-radius: radius($theme-pagination-button-border-radius);
   border-style: solid;
   border-width: units($theme-pagination-button-border-width);


### PR DESCRIPTION
# Summary

**Added text underline styles to pagination links.** Pagination links now have the same visual indicators as other USWDS text links. This should improve accessibility for the component.


## Breaking change

This is not a breaking change.

## Related issue

Closes #5939 

## Related pull requests
[Changelog: Text-Decoration Style Fix for Pagination Component Accessibility #2793](https://github.com/uswds/uswds-site/pull/2793)


## Preview link

[Pagination Component Page](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/rc-update-pagination-border-color/?path=/story/components-pagination--default)

## Problem statement

Pagination links do not provide accessible link styles. Pagination borders around the page number have poor color contrast. The light gray ( #d1d1d1 ) on the white background in the example has a color contrast ratio of 1.5:1. We should provide a clear visual indication that the pagination list items are links.

## Solution

Removed `text-decoration: none` so that the "buttons" are more clearly formatted as links.


## Testing and review

Follow these steps:
1. Visit pagination preview page
2. Ensure pagination "buttons" are showing up as links

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [X] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [X] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [X] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.