### PR TITLE
USWDS - Card: Enable $theme-card-font-family setting

### DIFF
--- a/packages/usa-card/src/styles/_usa-card.scss
+++ b/packages/usa-card/src/styles/_usa-card.scss
@@ -57,7 +57,7 @@
 .usa-card__container {
   @include border-box-sizing;
   @include set-text-and-bg("white");
-  @include typeset;
+  @include typeset($theme-card-font-family);
   @include u-border($theme-card-border-width, $theme-card-border-color);
   @include u-display("flex");
   @include u-height("full");


### PR DESCRIPTION
# Summary
**Fixed a bug that caused the component to ignore the `$theme-card-font-family` setting.**

## Breaking change
**This is potentially a breaking change.**

Prior to this PR, the card component disregarded the value set in the `$theme-card-font-family` setting. Because the component will now respect the value of that setting, your implementation of the card component might display with an unexpected font family. If it does, update the value of `$theme-card-font-family` in your [USWDS settings configuration](https://designsystem.digital.gov/documentation/settings/#configuring-custom-uswds-settings) with your expected font family. 

## Related issue

Closes #5824

## Related pull requests

Changelog uswds/uswds-site#2805

## Preview link

[Card component preview
](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/component_should_use_theme_setting_font/?path=/story/components-card--default)

This preview won't show any changes until the style itself changes, refer to the screen captures below in the "solution" section to see what happens when this change is included.

## Problem statement

$theme-card-font-family is a value that is set in _settings-components.scss. However, the typeset mixin that is used by the style doesn't currently have this value passed to it, so if the style were to change it would not display.
 
## Solution
Added the value of $theme-card-font-family to the @typeset mixin so that whatever value is set in settings is honored in the component. Now, when the $theme-card-font-family is set the component will show the appropriate font-family.

change `@include typeset;` to `@include typeset($theme-card-font-family);` so that the value of the style is passed to the mixin.

both of these screen captures use `$theme-card-font-family: "mono" !default;`

before:
![Screenshot 2024-07-08 at 4 08 11 PM](https://github.com/uswds/uswds/assets/161740096/26243f69-cba1-4e37-a2df-65ced06770e4)
after:
![Screenshot 2024-07-08 at 4 08 48 PM](https://github.com/uswds/uswds/assets/161740096/bb073aab-f609-408e-b25b-fe57b90d919a)

This approach was chosen because if this style changes it should be available in the component.

## Testing and review

- [ ] For testing, change $theme-card-font-family to some visually obvious font, such as mono.
- [ ] Open preview link and confirm that the style changes for the card component. 

To reproduce:
1. pull the branch  cb-component_should_use_theme_setting_font
2. this issue appears on card component.
3. preview will not immediately show this change. To see it, change $theme-card-font-family to some visually obvious font, such as mono and reload the component.
4. I am just looking for confirmation that it works.

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
