### PR TITLE
USWDS - Text input: Demo aria-disabled + readonly behaviors

### DIFF
--- a/packages/usa-input/src/test/test-patterns/test-readonly-input.twig
+++ b/packages/usa-input/src/test/test-patterns/test-readonly-input.twig
@@ -1,0 +1,19 @@
+<div class="padding-2">
+  <h3>Disabled</h3>
+  <textarea class="usa-textarea" disabled>I am unable to be copied from keyboard only interaction</textarea>
+</div>
+<div class="padding-2">
+  <h3>Aria-disabled</h3>
+  <textarea class="usa-textarea" aria-disabled="true"></textarea>
+</div>
+<div class="padding-2">
+  <h3>Aria-disabled + read only</h3>
+  <textarea class="usa-textarea" aria-disabled="true"
+  {% if readonly == true %}readonly{%- endif%}></textarea>
+</div>
+<div class="padding-2">
+  <h3>Aria-disabled + read only</h3>
+  <p>Added some text content to show that it is still able to be selected and copied.
+  <textarea class="usa-textarea" aria-disabled="true"
+  {% if readonly == true %}readonly{%- endif%}>Try selecting and copying me by focusing this text area, hitting cmd/ctrl + a, and cmd/ctrl + v!</textarea>
+</div>

--- a/packages/usa-input/src/usa-input.stories.js
+++ b/packages/usa-input/src/usa-input.stories.js
@@ -1,5 +1,6 @@
 import Component from "./usa-input.twig";
 import Showcase from "./usa-input--showcase.twig";
+import ReadonlyTest from "./test/test-patterns/test-readonly-input.twig"
 
 export default {
   title: "Components/Form Inputs/Text Input",
@@ -22,6 +23,7 @@ export default {
 
 const Template = (args) => Component(args);
 const ShowcaseTemplate = (args) => Showcase(args);
+const ReadonlyTestTemplate = (args) => ReadonlyTest(args);
 
 export const Input = Template.bind({});
 Input.args = {
@@ -44,3 +46,15 @@ StateShowcase.argTypes = {
     table: { disable: true },
   },
 };
+
+export const TestReadonly = ReadonlyTestTemplate.bind({});
+TestReadonly.argTypes = {
+  state: {
+    table: { disable: true },
+  },
+  readonly: {
+    name: "Readonly",
+    control: "boolean",
+    defaultValue: true
+  }
+}


### PR DESCRIPTION
# Summary

Create text story for text area with `aria-disabled="true"` and `readonly` attributes to demonstrate behaviors

## Preview link

[Text input readonly test story →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-text-input-readonly/?path=/story/components-form-inputs-text-input--test-readonly)

<!--
## Breaking change

This is not a breaking change.

## Related issue

Closes #_[issue_no]_

## Related pull requests



## Problem statement


## Solution


## Major changes



## Testing and review


-->
