### PR TITLE
USWDS - Utilities: Add theme setting for custom breakpoints

### DIFF
--- a/packages/uswds-core/src/styles/_properties.scss
+++ b/packages/uswds-core/src/styles/_properties.scss
@@ -159,7 +159,8 @@ $system-properties: (
       map-collect(
         map.get($system-spacing, "large"),
         map.get($system-spacing, "larger"),
-        map.get($system-spacing, "largest")
+        map.get($system-spacing, "largest"),
+        map.get($system-spacing, "custom"),
       ),
     extended: (),
   ),

--- a/packages/uswds-core/src/styles/_properties.scss
+++ b/packages/uswds-core/src/styles/_properties.scss
@@ -160,7 +160,7 @@ $system-properties: (
         map.get($system-spacing, "large"),
         map.get($system-spacing, "larger"),
         map.get($system-spacing, "largest"),
-        map.get($system-spacing, "custom"),
+        map.get($system-spacing, "custom")
       ),
     extended: (),
   ),

--- a/packages/uswds-core/src/styles/_properties.scss
+++ b/packages/uswds-core/src/styles/_properties.scss
@@ -160,7 +160,7 @@ $system-properties: (
         map.get($system-spacing, "large"),
         map.get($system-spacing, "larger"),
         map.get($system-spacing, "largest"),
-        map.get($system-spacing, "custom")
+        map.get($system-spacing, "custom"),
       ),
     extended: (),
   ),

--- a/packages/uswds-core/src/styles/mixins/_utility-builder.scss
+++ b/packages/uswds-core/src/styles/mixins/_utility-builder.scss
@@ -355,7 +355,11 @@ through all possible variants
 
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
   @each $media-key, $media-value in $our-breakpoints {
-    @if map.get($theme-utility-breakpoints-complete, $media-key) {
+    @if (map.get($theme-utility-breakpoints-complete, $media-key)) {
+      @include at-media($media-key) {
+        @include these-utilities($utilities, $media-key);
+      }
+    } @else if (map-has-key($theme-utility-breakpoints-custom, $media-key)) {
       @include at-media($media-key) {
         @include these-utilities($utilities, $media-key);
       }

--- a/packages/uswds-core/src/styles/settings/_settings-utilities.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-utilities.scss
@@ -55,6 +55,8 @@ $theme-utility-breakpoints-complete: map.merge(
   $theme-utility-breakpoints
 ) !default;
 
+$theme-utility-breakpoints-custom: () !default;
+
 /*
 ----------------------------------------
 Global colors

--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -100,7 +100,7 @@ $system-spacing: (
     // 1400px
   ),
   "custom": (
-    $theme-utility-breakpoints-custom
+    $theme-utility-breakpoints-custom,
   ),
   "special": (
     0: spacing-multiple(0),

--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -1,5 +1,6 @@
 @use "neg-prefix" as *;
 @use "../../functions/units/spacing-multiple" as *;
+@use "../../settings" as *;
 
 $system-spacing: (
   "smaller": (
@@ -97,6 +98,9 @@ $system-spacing: (
     // 1200px
     "widescreen": spacing-multiple(175),
     // 1400px
+  ),
+  "custom": (
+    $theme-utility-breakpoints-custom
   ),
   "special": (
     0: spacing-multiple(0),

--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -99,9 +99,7 @@ $system-spacing: (
     "widescreen": spacing-multiple(175),
     // 1400px
   ),
-  "custom": (
-    $theme-utility-breakpoints-custom
-  ),
+  "custom": $theme-utility-breakpoints-custom,
   "special": (
     0: spacing-multiple(0),
     "auto": auto,

--- a/packages/uswds-core/src/styles/tokens/units/spacing.scss
+++ b/packages/uswds-core/src/styles/tokens/units/spacing.scss
@@ -100,7 +100,7 @@ $system-spacing: (
     // 1400px
   ),
   "custom": (
-    $theme-utility-breakpoints-custom,
+    $theme-utility-breakpoints-custom
   ),
   "special": (
     0: spacing-multiple(0),


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

**Added a theme setting for including custom breakpoints to the utility classes.** 

Being able to add a custom breakpoint to the utilities is useful for integrating USWDS with existing frameworks or other design requirements. Custom breakpoints will generate with the default system breakpoints.

## Breaking change

This is not a breaking change.

<!--
Breaking changes include:
  - Changes to the JavaScript API
  - Changes to markup or content in our components
  - Significant changes to the display of a component
If applicable, explain what actions are required for the user to remediate the break.
-->

## Related issue

Closes https://github.com/uswds/uswds/issues/5984

<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here:
https://github.com/uswds/uswds/issues/new/choose.
-->

<!--
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Problem statement

As a designer or developer on projects that have existing designs, I would like to be able to add existing breakpoints to the generated USWDS utilities. Currently, the only breakpoints generating with the utilities are those that are available in the internal system settings (which are understandably not modifiable). 

The consequence of not being able to add custom breakpoints is the fracturing of site stylesheets causing additional maintenance as well as the possibility of needing to fork parts of the USWDS system in order to handle those custom breakpoints. Being able to programmatically add custom breakpoints also provides a safer approach versus [hacking the `$system-properties` directly](https://github.com/uswds/uswds/issues/4230).

<!--
A successful problem statement conveys:
1. The desired state,
2. The actual state, and
3. Consequences of remaining in the current state
   (who does this affect and to what degree?)
-->

## Solution

This PR will add a new theme setting `$theme-utility-breakpoints-custom` which is a map to pass additional breakpoint keys and values.

This approach does not modify the default breakpoints. Instead, it simply integrates any custom breakpoints with those system properties in order to generate utility classes.

A possible gotcha is that it appears the setting will require that the key value be in `rem` because of the `at-media` mixin. This could be mitigated by adding clear [documentation](https://designsystem.digital.gov/documentation/settings/#utilities-settings) for setting usage though.

The new theme setting can be used alongside the existing breakpoint setting like this:

```scss
@use "uswds-core" with (
  $theme-namespace: (
    'utility': (
      namespace: 'u-',
      output: false,
    ),
  ),
  $theme-utility-breakpoints: (
    "card": false,
    "card-lg": false,
    "mobile": true,
    "mobile-lg": false,
    "tablet": true,
    "tablet-lg": false,
    "desktop": false,
    "desktop-lg": true,
    "widescreen": false
  ),
  $theme-utility-breakpoints-custom: (
    "medium-screen": 48rem,
  )
);
```

Which will generate additional utility breakpoint classes. For example:

```css
@media all and (min-width: 48em) {
  .medium-screen\:vads-u-border-top--10px {
    border-top: 10px solid;
  }
  .medium-screen\:vads-u-border-right--10px {
    border-right: 10px solid;
  }
  .medium-screen\:vads-u-border-bottom--10px {
    border-bottom: 10px solid;
  }
  .medium-screen\:vads-u-border-left--10px {
    border-left: 10px solid;
  }

  ....
}
```

## Testing and review

I tested this locally with the VA design system [CSS-Library utilities generator](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/css-library/src/stylesheets/utilities.scss#L27-L28) and inspecting the generated utility classes.

<!--
1. Describe the tests that you ran to verify your changes,
2. Provide instructions to reproduce these tests, and
3. Clarify the type of feedback you are looking for at this phase.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
