### PR TITLE
USWDS - Input: Add error state story

### DIFF
--- a/packages/usa-input/src/usa-input.stories.js
+++ b/packages/usa-input/src/usa-input.stories.js
@@ -38,6 +38,11 @@ AriaDisabled.args = {
   state: "aria-disabled",
 };
 
+export const Error = Template.bind({});
+Error.args = {
+  state: "error",
+};
+
 export const StateShowcase = ShowcaseTemplate.bind({});
 StateShowcase.argTypes = {
   state: {

--- a/packages/usa-input/src/usa-input.twig
+++ b/packages/usa-input/src/usa-input.twig
@@ -1,20 +1,24 @@
-<label class="usa-label" for="input-type-text">Text input label</label>
-{% if state == "error" %} <span class="usa-error-message" id="input-error-message" role="alert">Helpful error message</span>{%- endif %}
-<input class="usa-input
-  {% if state == "focus" %} usa-focus{%- endif%}
-  {% if state == "error" %} usa-input--error{%- endif%}
-  {% if state == "success" %} usa-input--success{%- endif%}"
-  {% if state == "disabled" %} disabled{%- endif%}
-  {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}
-  id="input-type-text" name="input-type-text" type="text">
-<label class="usa-label" for="input-type-textarea">Text area label</label>
-{% if state == "error" %}
-  <span class="usa-error-message" id="textarea-error-message" role="alert">Helpful error message</span>
-{%- endif %}
-<textarea class="usa-textarea
-  {% if state == "focus" %} usa-focus{%- endif%}
-  {% if state == "error" %} usa-input--error{%- endif%}
-  {% if state == "success" %} usa-input--success{%- endif%}"
-  {% if state == "disabled" %} disabled{%- endif%}
-  {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}
-  id="input-type-textarea" name="input-type-textarea"></textarea>
+{% if state == "error" %}<div class="usa-form-group usa-form-group--error">{%- endif %}
+  <label class="usa-label{% if state == "error" %} usa-label--error{%- endif %}" for="input-type-text">Text input label</label>
+  {% if state == "error" %} <span class="usa-error-message" id="input-error-message" role="alert">Helpful error message</span>{%- endif %}
+  <input class="usa-input
+    {% if state == "focus" %} usa-focus{%- endif%}
+    {% if state == "error" %} usa-input--error{%- endif%}
+    {% if state == "success" %} usa-input--success{%- endif%}"
+    {% if state == "disabled" %} disabled{%- endif%}
+    {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}
+    id="input-type-text" name="input-type-text" type="text">
+{% if state == "error" %}</div>{%- endif %}
+{% if state == "error" %}<div class="usa-form-group usa-form-group--error">{%- endif %}
+  <label class="usa-label{% if state == "error" %} usa-label--error{%- endif %}" for="input-type-textarea">Text area label</label>
+  {% if state == "error" %}
+    <span class="usa-error-message" id="textarea-error-message" role="alert">Helpful error message</span>
+  {%- endif %}
+  <textarea class="usa-textarea
+    {% if state == "focus" %} usa-focus{%- endif%}
+    {% if state == "error" %} usa-input--error{%- endif%}
+    {% if state == "success" %} usa-input--success{%- endif%}"
+    {% if state == "disabled" %} disabled{%- endif%}
+    {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}
+    id="input-type-textarea" name="input-type-textarea"></textarea>
+{% if state == "error" %}</div>{%- endif %}

--- a/packages/usa-input/src/usa-input.twig
+++ b/packages/usa-input/src/usa-input.twig
@@ -3,20 +3,20 @@
   {% if state == "error" %} <span class="usa-error-message" id="input-error-message" role="alert">Helpful error message</span>{%- endif %}
   <input class="usa-input
     {% if state == "focus" %} usa-focus{%- endif%}
-    {% if state == "error" %} usa-input--error{%- endif%}
+    {% if state == "error" %} usa-input--error" aria-describedby="input-error-message{%- endif%}
     {% if state == "success" %} usa-input--success{%- endif%}"
     {% if state == "disabled" %} disabled{%- endif%}
     {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}
     id="input-type-text" name="input-type-text" type="text">
-{% if state == "error" %}</div>{%- endif %}
-{% if state == "error" %}<div class="usa-form-group usa-form-group--error">{%- endif %}
+{% if state == "error" %}</div>
+<div class="usa-form-group usa-form-group--error">{%- endif %}
   <label class="usa-label{% if state == "error" %} usa-label--error{%- endif %}" for="input-type-textarea">Text area label</label>
   {% if state == "error" %}
     <span class="usa-error-message" id="textarea-error-message" role="alert">Helpful error message</span>
   {%- endif %}
   <textarea class="usa-textarea
     {% if state == "focus" %} usa-focus{%- endif%}
-    {% if state == "error" %} usa-input--error{%- endif%}
+    {% if state == "error" %} usa-input--error" aria-describedby="textarea-error-message{%- endif%}
     {% if state == "success" %} usa-input--success{%- endif%}"
     {% if state == "disabled" %} disabled{%- endif%}
     {% if state == "aria-disabled" %} aria-disabled="true"{%- endif%}


### PR DESCRIPTION
# Summary

Created error state Storybook controls and preview to showcase error styles.

## Breaking change

This is _not_ a breaking change

## Related issue

Closes #5991

## Related pull requests

_No changelog created. Not a user-facing change._

## Preview link

[Text input error story →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-input-error-story/?path=/story/components-form-inputs-text-input--error)

## Problem statement

We need stories to showcase error states on the design system website.

## Solution

Create an error state storybook preview for text input to match existing controls.

## Major changes

- New option for state control for text input component
- New error state input story
- Conditional logic wraps each text input and it's relevant labels in `usa-form-group usa-form-group--error` divs.

## Testing and review

1. Visit text input story
2. Confirm controls work as expected
3. Confirm the error input has expected markup
4. Confirm error state is displaying correctly
5. Confirm there are no regressions in other states
6. Confirm pattern matches existing variants / components
