### PR TITLE
USWDS - File Input: Replace inline javascript to meet content security policy (CSP) standards

### DIFF
--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -350,6 +350,22 @@ const addPreviewHeading = (fileInputEl, fileNames) => {
   fileInputEl.setAttribute("aria-label", changeItemText);
 };
 
+/** Add an error listener to the image preview to set a fallback image
+ * @param {HTMLImageElement} previewImage - The image element
+ * @param {String} fallbackClass - The CSS class of the fallback image
+ */
+const setPreviewFallback = (previewImage, fallbackClass) => {
+  previewImage.addEventListener(
+    "error",
+    () => {
+      const localPreviewImage = previewImage; // to avoid no-param-reassign from ESLint
+      localPreviewImage.src = SPACER_GIF;
+      localPreviewImage.classList.add(fallbackClass);
+    },
+    { once: true },
+  );
+};
+
 /**
  * When new files are applied to file input, this function generates previews
  * and removes old ones.
@@ -393,37 +409,25 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
     // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
       const previewImage = document.getElementById(imageId);
-      if (fileName.indexOf(".pdf") > 0) {
-        previewImage.setAttribute(
-          "onerror",
-          `this.onerror=null;this.src="${SPACER_GIF}"; this.classList.add("${PDF_PREVIEW_CLASS}")`,
-        );
+      const fileExtension = fileName.split(".").pop();
+      if (fileExtension === "pdf") {
+        setPreviewFallback(previewImage, PDF_PREVIEW_CLASS);
       } else if (
-        fileName.indexOf(".doc") > 0 ||
-        fileName.indexOf(".pages") > 0
+        fileExtension === "doc" ||
+        fileExtension === "docx" ||
+        fileExtension === "pages"
       ) {
-        previewImage.setAttribute(
-          "onerror",
-          `this.onerror=null;this.src="${SPACER_GIF}"; this.classList.add("${WORD_PREVIEW_CLASS}")`,
-        );
+        setPreviewFallback(previewImage, WORD_PREVIEW_CLASS);
       } else if (
-        fileName.indexOf(".xls") > 0 ||
-        fileName.indexOf(".numbers") > 0
+        fileExtension === "xls" ||
+        fileExtension === "xlsx" ||
+        fileExtension === "numbers"
       ) {
-        previewImage.setAttribute(
-          "onerror",
-          `this.onerror=null;this.src="${SPACER_GIF}"; this.classList.add("${EXCEL_PREVIEW_CLASS}")`,
-        );
-      } else if (fileName.indexOf(".mov") > 0 || fileName.indexOf(".mp4") > 0) {
-        previewImage.setAttribute(
-          "onerror",
-          `this.onerror=null;this.src="${SPACER_GIF}"; this.classList.add("${VIDEO_PREVIEW_CLASS}")`,
-        );
+        setPreviewFallback(previewImage, EXCEL_PREVIEW_CLASS);
+      } else if (fileExtension === "mov" || fileExtension === "mp4") {
+        setPreviewFallback(previewImage, VIDEO_PREVIEW_CLASS);
       } else {
-        previewImage.setAttribute(
-          "onerror",
-          `this.onerror=null;this.src="${SPACER_GIF}"; this.classList.add("${GENERIC_PREVIEW_CLASS}")`,
-        );
+        setPreviewFallback(previewImage, GENERIC_PREVIEW_CLASS);
       }
 
       // Removes loader and displays preview


### PR DESCRIPTION
# Summary

**Fixed the file input component to meet content security policy standards.** Inline Javascript is forbidden by typical content security policies (CSPs), and this replaces several inline `onerror` handlers in the file input component with addEventListener to avoid that violation.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5990

## Related pull requests

Changelog: https://github.com/uswds/uswds-site/pull/2912

## Preview link

None

## Problem statement

The USWDS library should be compatible with sites that apply a [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP). Currently the file input component uses `onerror` inline event handlers, which are prohibited by CSP ([source](https://web.dev/articles/strict-csp#refactor)), so the component does not work correctly under a CSP.

## Solution

* Replace `onerror` with calls to `addEventListener`.
* Add a helper method `setPreviewFallback` to remove code duplication
* Update file extension parsing logic to parse the file extension at the end of the filename rather than anywhere in the filename

## Major changes

None

## Testing and review

Steps to test:
1. Run `npm start`
2. Open http://localhost:6006/?path=/story/components-form-inputs-file-input--default
3. Create a text file and upload it to the file input component with the following filenames. In each case confirm that the expected preview icon is shown.
   * file.txt (or any extension not in the list below)
   * file.pdf
   * file.doc
   * file.pages
   * file.xls
   * file.numbers
   * file.mov
   * file.mp4

Steps to test with a CSP policy:

>[!TIP]
>To streamline testing, I copied @jeffpw-goog demo repo work in our sandbox repo so we can utilize the preview build!
>
>[CSP Preview link →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/jeffpw-goog-csp-test/)
>
>You can use this link and complete the steps about without reproducing a CSP policy demo via the steps below.
>
> Leaving the steps below which outline how Jeff made the testing repo
> _Added by @mahoneycm_
>

1. Clone uswds-sandbox
2. Update `src/_includes/head.html`:
   * Add `<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-mynonce' 'strict-dynamic' https:" />`
   * Add `nonce="mynonce"` to the `<link rel="preload" ... as="script">` tag
3. Update `src/_layouts/default.html`:
   * Add `nonce="mynonce"` to the `<script>` tag
   * Add a file input component to the body (I copied from https://designsystem.digital.gov/components/file-input/)
4. Run `npm install "https://github.com/jeffpw-goog/uswds/tree/file-input-csp" --save`
5. Run `npm install && npm init && npm start`
6. Load http://localhost:8080 in your browser
7. Repeat the test cases from above