### PR TITLE
USWDS - Forms: Enhance form group error border in desktop widths

### DIFF
--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -11,7 +11,13 @@
 
 // Block input elements
 .usa-form-group--error {
-  @include u-border-left(0.5, "error-dark");
-  padding-left: units(2);
   position: relative;
+
+  &::before {
+    @include u-border-left(0.5, "error-dark");
+    content: "";
+    height: 100%;
+    left: units("neg-105");
+    position: absolute;
+  }
 }

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -1,10 +1,9 @@
 @use "uswds-core" as *;
 
-$form-error-border-width: 2px; 
+$form-error-border-width: 2px;
 $form-error-border-padding: units(1);
-$form-error-negative-margin: -( 
-  $form-error-border-width + rem-to-px($form-error-border-padding)
-);
+$form-error-negative-margin: -($form-error-border-width +
+      rem-to-px($form-error-border-padding));
 
 .usa-form-group {
   margin-top: units(3);

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -11,13 +11,11 @@
 
 // Block input elements
 .usa-form-group--error {
+  @include u-border-left(2px, "error-dark");
+  padding-left: units(1);
   position: relative;
 
-  &::before {
-    @include u-border-left(0.5, "error-dark");
-    content: "";
-    height: 100%;
-    left: units("neg-105");
-    position: absolute;
+  @include at-media("desktop") {
+    margin-left: units("neg-2px");
   }
 }

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -1,5 +1,11 @@
 @use "uswds-core" as *;
 
+$form-error-border-width: 2px; 
+$form-error-border-padding: units(1);
+$form-error-negative-margin: -( 
+  $form-error-border-width + rem-to-px($form-error-border-padding)
+);
+
 .usa-form-group {
   margin-top: units(3);
 
@@ -11,11 +17,11 @@
 
 // Block input elements
 .usa-form-group--error {
-  @include u-border-left(2px, "error-dark");
-  padding-left: units(1);
+  @include u-border-left($form-error-border-width, "error-dark");
+  padding-left: $form-error-border-padding;
   position: relative;
 
   @include at-media("desktop") {
-    margin-left: -10px;
+    margin-left: $form-error-negative-margin;
   }
 }

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -14,8 +14,4 @@
   @include u-border-left(0.5, "error-dark");
   padding-left: units(2);
   position: relative;
-
-  @include at-media("desktop") {
-    margin-left: units(-2.5);
-  }
 }

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -16,6 +16,6 @@
   position: relative;
 
   @include at-media("desktop") {
-    margin-left: units(-1);
+    margin-left: -10px;
   }
 }

--- a/packages/usa-form-group/src/styles/_usa-form-group.scss
+++ b/packages/usa-form-group/src/styles/_usa-form-group.scss
@@ -16,6 +16,6 @@
   position: relative;
 
   @include at-media("desktop") {
-    margin-left: units("neg-2px");
+    margin-left: units(-1);
   }
 }


### PR DESCRIPTION
# Summary

**Improved form group error syles.** Form group error border width and relevant spacing have been reduced.

As discussed in [dev sync](https://docs.google.com/document/d/172TU5BVS9kGZQDuPcAhGoZjaTd2ngzcTayq4WRRTBUs/edit#heading=h.3exjgbcdn2d4) (🔒) and this [internal slack thread](https://gsa-tts.slack.com/archives/C050HRGN7/p1722263917352969) (🔒)

## Breaking change

This is not a breaking change.

## Related issue

Closes #5998 

## Related pull requests

[Changelog →](https://github.com/uswds/uswds-site/pull/2773)

## Preview link

[Form group error preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-error-border-margin/iframe.html?args=&id=patterns-forms--test-error-form-elements)

[Sandbox demo page →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/cm-test-5999/pages/prose/)

## Problem statement

In desktop widths, the form group error border uses negative margin and is pushed out of the parent container.

## Solution

After discussion, we opted to keep the original breakpoint to reduce content shift in desktop views, and reduce the size of the border, the padding between the border and the content, as well as the negative margin that pushes it left.

## Major changes

- Form group error styles are now viewable in storybook previews in desktop widths
- Form group error border width is halved
- Padding between border and content is reduced

**Note:** Desktop content does not shift when form group error style are added, mobile content does. This matches the current behavior of develop.

## Testing and review

1. Visit the form group error storybook preview.
2. Resize the window and confirm the left side error border is viewable in all widths.
3. In desktop view, toggle error state control and confirm content does not shift.
4. Confirm visual change is an enhancement and not a regression.

### Screenshots

Screenshots showing the placement of content and border relative to div and margin

| | Before | After |
|--------|--------|--------|
| Desktop | ![Develop-desktop](https://github.com/user-attachments/assets/134762a3-6154-49b4-88d8-35c6a0a1cc8e) | ![Fix-desktop](https://github.com/user-attachments/assets/cd1b6d04-a837-4aa1-a270-3da244b0cb64) |
| Mobile | ![Develop-mobile](https://github.com/user-attachments/assets/a674824b-e26b-4488-be05-369972278e08) | ![Fix-mobile](https://github.com/user-attachments/assets/1b8fc814-b3fd-4b0c-bae8-0dd4bf3d8931) | 
| Demo page (Content has `2rem` of margin from `grid-layout`) | ![Develop-demo-desktop](https://github.com/user-attachments/assets/07954cf1-597f-481b-b67f-5b01a5b3b7c9) | ![Fix-demo-desktop](https://github.com/user-attachments/assets/1d3e06e5-d286-40ef-8ec2-84b86c039734) |

