### PR TITLE
USWDS: Add autocomplete attribute to email inputs

### DIFF
--- a/packages/templates/usa-create-account/_usa-create-account-inner.twig
+++ b/packages/templates/usa-create-account/_usa-create-account-inner.twig
@@ -22,7 +22,7 @@
                   {{ form.email.label }}
                   {{ requiredLabel | trim | raw }}
                 </label>
-                <input class="usa-input" id="email" name="email" type="email" autocapitalize="off" autocorrect="off" required>
+                <input class="usa-input" id="email" name="email" type="email" autocapitalize="off" autocorrect="off" required autocomplete="email">
                 <label class="usa-label" for="password-create-account">
                   {{ form.password.label }}
                 </label>

--- a/packages/usa-footer/src/_includes/usa-signup.twig
+++ b/packages/usa-footer/src/_includes/usa-signup.twig
@@ -2,7 +2,7 @@
   <h3 class="usa-sign-up__heading">Sign up</h3>
   <form class="usa-form">
     <label class="usa-label" for="email" id="">Your email address</label>
-    <input class="usa-input" id="email" name="email" type="email" />
+    <input class="usa-input" id="email" name="email" type="email" autocomplete="email"/>
     <button class="usa-button" type="submit">Sign up</button>
   </form>
 </div>

--- a/packages/usa-footer/src/test/template.html
+++ b/packages/usa-footer/src/test/template.html
@@ -92,7 +92,7 @@
             <h3 class="usa-sign-up__heading">Sign up</h3>
             <form class="usa-form">
               <label class="usa-label" for="email">Your email address</label>
-              <input class="usa-input" id="email" name="email" type="email" />
+              <input class="usa-input" id="email" name="email" type="email" autocomplete="email"/>
               <button class="usa-button" type="submit">Sign up</button>
             </form>
           </div>


### PR DESCRIPTION
# Summary

**Added the `autocomplete="email"` attribute to the email input element in both the big footer and the "Create an account" template.** This attribute allows the components to meet the standards outlined in [WCAG 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html). 

## Breaking change

This is not a breaking change.
This _is_ a markup change.

## Related issue

Closes #6001 

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2765)

## Preview link

- [Footer component - big variant](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-footer-autocomplete/?path=/story/components-footer--big-footer)
- [Create account template](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-footer-autocomplete/?path=/story/pages-create-account--create-account-page)

## Problem statement

The email input in the big footer variant needs the [autocomplete="email"](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute in order to meet [WCAG criteria 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).

## Solution

Added the `autocomplete` attribute to the inputs with an `email` type. 

## Testing and review

- Confirm all instances of inputs with `type="email"` have the `autocomplete="email"` attribute
- Confirm that adding this attribute does not cause harm to the user experience
