### PR TITLE
USWDS - Hotfix: Remove classlist-polyfill dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.8.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -13633,11 +13632,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/clean-css": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   },
   "homepage": "https://github.com/uswds/uswds#readme",
   "dependencies": {
-    "classlist-polyfill": "1.2.0",
     "object-assign": "4.1.1",
     "receptor": "1.0.0",
     "resolve-id-refs": "0.1.0"

--- a/packages/uswds-core/src/js/polyfills/index.js
+++ b/packages/uswds-core/src/js/polyfills/index.js
@@ -1,5 +1,3 @@
-// polyfills HTMLElement.prototype.classList and DOMTokenList
-require("classlist-polyfill");
 // polyfills HTMLElement.prototype.hidden
 require("./element-hidden");
 // polyfills Number.isNaN()


### PR DESCRIPTION
# Summary

Removed the IE11 `classlist-polyfill` dependency that caused a DoS Vulnerability

## Breaking change

This is a _potentially_ breaking change.

This polyfill added support for the classList property in IE11, which now has [_partial_ support](https://caniuse.com/classlist).


## Related issue

Closes #6008 

## Related pull requests

The remaining IE11 polyfills are removed in #4692 

## Preview link

[Storybook preview →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-remove-classlist-polyfill/)

## Problem statement

The `classlist-polyfill` dependency was causing a DoS vulnerability affecting downstream projects.

## Solution

Remove the polyfill now that IE11 is no longer officially supported.

## Testing and review

1. Run `npm install` and confirm there are no issues
2. Run `npm run start` and confirm there are no build errors
3. Use JS components and confirm there are no visual or functional regressions across browsers
4. Confirm there are no additional references to the removed dependency that also need to be removed

## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| classlist-polyfill |     `1.2.0`      |   -   |
