### PR TITLE
USWDS - Styles: Remove `.scss` extension causing linting issue

### DIFF
--- a/packages/uswds-core/src/styles/functions/units/units.scss
+++ b/packages/uswds-core/src/styles/functions/units/units.scss
@@ -10,7 +10,7 @@ the desired final units (currently rem)
 @use "sass:map";
 @use "sass:meta";
 @use "sass:string";
-@use "../../functions/general/error-not-token.scss";
+@use "../../functions/general/error-not-token";
 @use "../../functions/output/number-to-token" as *;
 @use "../../variables/project-spacing" as vars;
 


### PR DESCRIPTION
# Summary

Quick fix to remove `.scss` extension from SCSS `@use` which was causing a sass linting error

## Breaking change

This is not a breaking change.

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-unit-scss-lint/)

## Problem statement

`.scss` extension was causing a listing error

## Solution

Remove `.scss` extension


## Testing and review

1. In branch, update a `units()` function paramater to a non token value.
    1. Search for any `units()` function
    2. Replace value with something like "hello"
3. Compile
4. Confirm the `error-not-token` error displays correctly in the terminal / storybook preview
