### PR TITLE
USWDS - Combobox: Remove added aria instructions (too verbose).

### DIFF
--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -172,7 +172,6 @@ const enhanceComboBox = (_comboBoxEl) => {
   const selectLabel = document.querySelector(`label[for="${selectId}"]`);
   const listId = `${selectId}--list`;
   const listIdLabel = `${selectId}-label`;
-  const assistiveHintID = `${selectId}--assistiveHint`;
   const additionalAttributes = [];
   const { defaultValue } = comboBoxEl.dataset;
   const { placeholder } = comboBoxEl.dataset;
@@ -226,7 +225,6 @@ const enhanceComboBox = (_comboBoxEl) => {
   input.setAttribute("aria-owns", listId);
   input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
-  input.setAttribute("aria-describedby", assistiveHintID);
   input.setAttribute("aria-expanded", "false");
   input.setAttribute("autocapitalize", "off");
   input.setAttribute("autocomplete", "off");

--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -260,11 +260,7 @@ const enhanceComboBox = (_comboBoxEl) => {
         aria-labelledby="${listIdLabel}"
         hidden>
       </ul>
-      <div class="${STATUS_CLASS} usa-sr-only" role="status"></div>
-      <span id="${assistiveHintID}" class="usa-sr-only">
-        When autocomplete results are available use up and down arrows to review and enter to select.
-        Touch device users, explore by touch or with swipe gestures.
-      </span>`,
+      <div class="${STATUS_CLASS} usa-sr-only" role="status"></div>`,
   );
 
   if (selectedOption) {


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

**Removed the arria instructions from combobox component.** The combobox arria instructions are overly verbose and user testing reveals they are unnecessary. https://github.com/uswds/uswds/issues/5955

## Breaking change

This is not a breaking change.

## Related issue

Closes #5955 



## Related pull requests

Changelog uswds/uswds-site#2786

## Preview link

Preview link:
[Combobox with no arria instructions](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cb-remove-aria-instructions/?path=/story/design-tokens-fonts--fonts)

## Problem statement

1. The arria instructions for the combo box component are verbose, however, adding them to the page would lengthen it significantly. The desired state is to not have the arria instructions on the page at all given that users already understand how to interact with this component.
2. The actual state is that the verbose instructions are included in the arria instructions.
3. If we dont change this the verbose arria instructions remain.

## Solution

Solution: 
1. Remove lines L264-267. Instructions are too general to be helpful.
2. Remove references to assistiveHintID variable, which was removed in 1 above.
Why this approach was chosen: We considered adding instructions visible on the page that reflect the audible ARIA instructions. However, that would lengthen the page unnecessarily. We'd follow this guidance https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions that suggests instructions be equally visible and audible (ie accessible to all users). In order to pass this SC, we recommend removing those additional keyboard instructions so the visible and audible instructions are more analogous.

## Major changes

Removed lines L264-267 in packages/usa-combo-box/src/index.js:

```
    <span id="${assistiveHintID}" class="usa-sr-only">
        When autocomplete results are available use up and down arrows to review and enter to select.
        Touch device users, explore by touch or with swipe gestures.
      </span>
```
Removed line 228
`  input.setAttribute("aria-describedby", assistiveHintID);
`
Removed line 175
`  const assistiveHintID = `${selectId}--assistiveHint`;
`

## Testing and review

1. Opened federalist link and inspected source. 
2. Searched for text "When autocomplete results are available", this text was not found.
3. Searched for text "assistiveHint", this text was not found.
4. Opened link in production and inspected source.
5. Searched for text "When autocomplete results are available", this text was found.
6. Searched for text "assistiveHint", this text was found.

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
