### PR TITLE
USWDS - Modal: Use classname constants for all variable references in JavaScript file.

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -66,10 +66,10 @@ function toggleModal(event) {
   const safeActive = !isActive();
   const modalId = clickedElement
     ? clickedElement.getAttribute("aria-controls")
-    : document.querySelector(".usa-modal-wrapper.is-visible");
+    : document.querySelector(`.${WRAPPER_CLASSNAME}.${VISIBLE_CLASS}`);
   const targetModal = safeActive
     ? document.getElementById(modalId)
-    : document.querySelector(".usa-modal-wrapper.is-visible");
+    : document.querySelector(`.${WRAPPER_CLASSNAME}.${VISIBLE_CLASS}`);
 
   // if there is no modal we return early
   if (!targetModal) {
@@ -78,7 +78,7 @@ function toggleModal(event) {
 
   const openFocusEl = targetModal.querySelector(INITIAL_FOCUS)
     ? targetModal.querySelector(INITIAL_FOCUS)
-    : targetModal.querySelector(".usa-modal");
+    : targetModal.querySelector(`.${MODAL_CLASSNAME}`);
   const returnFocus = document.getElementById(
     targetModal.getAttribute("data-opener"),
   );


### PR DESCRIPTION
# Summary

**Fixed a bug in the usa-modal component whereby the class name was hard-coded in JavaScript.** Using the PREFIX variable consistently allows users to bundle the modal package with a prefix other than usa-. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #6027 

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2842)

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

Users may choose to use a different prefix in the modal component. Currently, not all of the variables use the PREFIX variable for all styles. Update the styles to allow users to bundle the modal package with a prefix other than usa-.

## Solution

By replacing hardcoded variables like (".usa-modal") with available constants such as (`.${MODAL_CLASSNAME}`) users that choose to customize the prefix with the modal component can do so.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
