### PR TITLE
USWDS - Memorable Date: Remove numbers from the dropdown list of months

### DIFF
--- a/packages/usa-memorable-date/src/usa-memorable-date.twig
+++ b/packages/usa-memorable-date/src/usa-memorable-date.twig
@@ -9,18 +9,18 @@
         {% elseif disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
       >
         <option value>- Select -</option>
-        <option value="1">01 - January</option>
-        <option value="2">02 - February</option>
-        <option value="3">03 - March</option>
-        <option value="4">04 - April</option>
-        <option value="5">05 - May</option>
-        <option value="6">06 - June</option>
-        <option value="7">07 - July</option>
-        <option value="8">08 - August</option>
-        <option value="9">09 - September</option>
-        <option value="10">10 - October</option>
-        <option value="11">11 - November</option>
-        <option value="12">12 - December</option>
+        <option value="1">January</option>
+        <option value="2">February</option>
+        <option value="3">March</option>
+        <option value="4">April</option>
+        <option value="5">May</option>
+        <option value="6">June</option>
+        <option value="7">July</option>
+        <option value="8">August</option>
+        <option value="9">September</option>
+        <option value="10">October</option>
+        <option value="11">November</option>
+        <option value="12">December</option>
       </select>
     </div>
     <div class="usa-form-group usa-form-group--day">


### PR DESCRIPTION
# Summary

**Removed the leading numbers from the month options in the memorable date component.** Recent usability testing indicated that having both numbers and names to represent months was confusing for screen reader users.

## Breaking change

This is not a breaking change.

## Related issue

Closes https://github.com/uswds/uswds/issues/5910

## Related pull requests

Changelog uswds/uswds-site#2787

## Preview link

Preview link: [Memorable Date preview
](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cb-memorable-date-input-options/?path=/story/components-form-inputs-memorable-date--memorable-date)

## Problem statement

The desired state for the memorable date component is that there is only one option for the values in the months dropdown (either numbers or month names) so that users can search by typing in the month name. The current state is that both the number and the month name are included in the option dropdown, which means users cannot search by the month name. 

## Solution

The solution is to remove the numbers from the memorable date component option dropdown. Another approach was to make both options (numbers AND month names) available, but the risk of this approach did not outweigh the rewards. The team decided that including month names is the best way to resolve this accessibility issue. 

## Testing and review

1. Opened federalist link and inspected source.
2. Verify that the id="date_of_birth_month" options do not include a number.
3. Opened the component in production.
4. Verify that the id="date_of_birth_month" options includes a number.
5. Verify that if you tab to the memorable date month field and hit the first letter of each month on the keyboard the correct month appears.
6. Verify that the correct code appears on uswds-site for this component when the "component code" button is selected. This code should not include numbers.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
