### PR TITLE
USWDS: Add instructions to provide a reproducible example to the bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,8 +13,8 @@ body:
   - type: textarea
     id: reproduce
     attributes:
-      label: Instructions for reproducing the bug
-      description: Provide a link to a public repo or code preview that demonstrates this issue. Alternatively, describe how to reproduce this issue.
+      label: Steps to reproduce the bug
+      description: Describe how to reproduce this issue. If the issue is found only in your project, provide a link to a public repo or code preview that demonstrates this issue.
       placeholder: |
         1. Go to '...'
         2. Click on '....'

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,8 +13,8 @@ body:
   - type: textarea
     id: reproduce
     attributes:
-      label: Steps to reproduce the bug
-      description: Describe how to reproduce this issue.
+      label: Instructions for reproducing the bug
+      description: Provide a link to a public repo or code preview that demonstrates this issue. Alternatively, describe how to reproduce this issue.
       placeholder: |
         1. Go to '...'
         2. Click on '....'


### PR DESCRIPTION
# Summary

Added instructions to provide a reproducible example to the bug issue template


## Breaking change

This is not a breaking change.

## Related issue

Closes #6040 

## Related pull requests
N/A 

## Preview

**Before:** 

![image](https://github.com/user-attachments/assets/08d9a051-d628-4996-abb0-e8c128d1e221)

**After:**

![image](https://github.com/user-attachments/assets/4accedf3-8c99-4293-ba47-6f7a01566164)

## Testing and review

- Confirm that the updated instructions are appropriate and make sense
- Confirm no spelling or grammatical errors