### PR TITLE
USWDS - Time picker: Update usage instructions 

### DIFF
--- a/packages/usa-time-picker/src/usa-time-picker.twig
+++ b/packages/usa-time-picker/src/usa-time-picker.twig
@@ -1,6 +1,6 @@
 <div class="usa-form-group">
   <label class="usa-label" id="appointment-time-label" for="appointment-time">Appointment time</label>
-  <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
+  <div class="usa-hint" id="appointment-time-hint">Start typing or select a time (AM/PM) in 30-minute intervals</div>
   <div class="usa-time-picker">
     <input
       class="usa-input"


### PR DESCRIPTION
# Summary
Updated the usage instructions for the Time Picker component.

## Breaking change
No breaking change.

## Related issue

Closes #6061 


## Problem statement
[Issue link](https://github.com/uswds/uswds/issues/6061). 
The existing visible instructions for time picker aren't sufficient to prevent errors; we need to add clarity to the format and options to prevent users from typing in potentially invalid times.


## Solution
Changed the instructions from`hh:mm` to `Start typing or select a time (AM/PM) in 30-minute intervals`


