### PR TITLE
USWDS - Combo box search results

### DIFF
--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -343,6 +343,9 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
   const escapeRegExp = (text) =>
     text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 
+  // Ensure query is escaped and anchored at the start
+  const escapedQuery = escapeRegExp(query);
+  
   let find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
     const key = $1.trim();
     const queryFilter = extras[key];
@@ -356,13 +359,15 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
 
       return "";
     }
-    return escapeRegExp(query);
-  });
 
-  find = `^(?:${find})$`;
+    // Use the query here and enforce a start of string match
+    return `^${escapedQuery}`; 
+  });
 
   return new RegExp(find, "i");
 };
+
+
 
 /**
  * Display the option list of a combo box component.

--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -346,7 +346,7 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
   // Ensure query is escaped and anchored at the start
   const escapedQuery = escapeRegExp(query);
   
-  let find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
+  const find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
     const key = $1.trim();
     const queryFilter = extras[key];
     if (key !== "query" && queryFilter) {

--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -345,7 +345,7 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
 
   // Ensure query is escaped and anchored at the start
   const escapedQuery = escapeRegExp(query);
-  
+
   const find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
     const key = $1.trim();
     const queryFilter = extras[key];
@@ -361,13 +361,11 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
     }
 
     // Use the query here and enforce a start of string match
-    return `^${escapedQuery}`; 
+    return `^${escapedQuery}`;
   });
 
   return new RegExp(find, "i");
 };
-
-
 
 /**
  * Display the option list of a combo box component.

--- a/packages/usa-combo-box/src/test/combo-box-change-event.spec.js
+++ b/packages/usa-combo-box/src/test/combo-box-change-event.spec.js
@@ -165,7 +165,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should emit change events when selecting the focused list item in the list when pressing enter on a focused item", () => {
         select.value = "grapefruit";
-        input.value = "emo";
+        input.value = "Lemo";
 
         EVENTS.input(input);
         EVENTS.keydownArrowDown(input);
@@ -199,7 +199,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should emit change events when pressing escape from a focused item", () => {
         select.value = "grapefruit";
-        input.value = "dew";
+        input.value = "Honeydew";
 
         EVENTS.input(input);
         assert.ok(

--- a/packages/usa-combo-box/src/test/combo-box-disable-filtering.spec.js
+++ b/packages/usa-combo-box/src/test/combo-box-disable-filtering.spec.js
@@ -41,7 +41,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       });
 
       it("should display the full list and focus the first found item", () => {
-        input.value = "oo";
+        input.value = "blo";
 
         EVENTS.input(input);
 

--- a/packages/usa-combo-box/src/test/combo-box.spec.js
+++ b/packages/usa-combo-box/src/test/combo-box.spec.js
@@ -215,7 +215,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         assert.ok(!list.hidden, "should display the option list");
         assert.strictEqual(
           list.children.length,
-          44,
+          4,
           "should filter the item by the string being present in the option",
         );
       });
@@ -384,7 +384,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should select the focused list item in the list when pressing enter on a focused item", () => {
         select.value = "pineapple";
-        input.value = "berry";
+        input.value = "black";
         EVENTS.input(input);
         EVENTS.keydownArrowDown(input);
         const focusedOption = document.activeElement;
@@ -410,7 +410,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should select the focused list item in the list when pressing space on a focused item", () => {
         select.value = "cantaloupe";
-        input.value = "berry";
+        input.value = "black";
         EVENTS.input(input);
         EVENTS.keydownArrowDown(input);
         const focusedOption = document.activeElement;
@@ -435,7 +435,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       });
 
       it("should not select the focused list item in the list when blurring component from a focused item", () => {
-        input.value = "la";
+        input.value = "Bla";
         EVENTS.input(input);
         EVENTS.keydownArrowDown(input);
         const focusedOption = document.activeElement;
@@ -456,13 +456,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
       });
 
       it("should focus the last item in the list when pressing down many times from the input", () => {
-        input.value = "la";
+        input.value = "Pla";
 
         EVENTS.input(input);
         assert.ok(!list.hidden, "should display the option list");
         assert.strictEqual(
           list.children.length,
-          2,
+          1,
           "should filter the item by the string being present in the option",
         );
         EVENTS.keydownArrowDown(input);
@@ -485,7 +485,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should not select the focused item in the list when pressing escape from the focused item", () => {
         select.value = "pineapple";
-        input.value = "la";
+        input.value = "Bla";
 
         EVENTS.input(input);
         assert.ok(
@@ -515,13 +515,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
       });
 
       it("should focus the input and hide the list when pressing up from the first item in the list", () => {
-        input.value = "la";
+        input.value = "Bla";
 
         EVENTS.input(input);
         assert.ok(!list.hidden, "should display the option list");
         assert.strictEqual(
           list.children.length,
-          2,
+          1,
           "should filter the item by the string being present in the option",
         );
         EVENTS.keydownArrowDown(input);

--- a/packages/usa-combo-box/src/test/generateDynamicRegExp.spec.js
+++ b/packages/usa-combo-box/src/test/generateDynamicRegExp.spec.js
@@ -1,37 +1,63 @@
 const assert = require("assert");
 const { generateDynamicRegExp } = require("../index");
 
-describe("generateDynamicRegExp function", () => {
-  it("allows for static string", () => {
-    const regex = generateDynamicRegExp("something", "");
-    assert.ok(regex.test("something"));
-    assert.strictEqual(regex.test("something else"), false);
+describe('generateDynamicRegExp', () => {
+  const extras = {
+    key1: 'someRegex',
+    key2: 'anotherRegex',
+    query: 'searchTerm',
+  };
+
+  it('should return a RegExp that matches the query', () => {
+    const filter = '{{query}}';
+    const query = 'apple';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test('apple'), true);
+    assert.strictEqual(regex.test('banana'), false);
   });
 
-  it("allows for string replacement", () => {
-    const regex = generateDynamicRegExp("something{{ query }}", " else");
-    assert.ok(regex.test("something else"));
-    assert.strictEqual(regex.test("something"), false);
+  it('should escape special characters in the query', () => {
+    const filter = '{{query}}';
+    const query = 'hello.*';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test('hello.*'), true);
+    assert.strictEqual(regex.test('hello'), false);
   });
 
-  it("allows for string replacement with filter", () => {
-    const regex = generateDynamicRegExp("something{{ filter }}", " Else", {
-      filter: "([LS]+)",
-    });
-    assert.ok(regex.test("somethingLS"));
-    assert.strictEqual(regex.test("something"), false);
-    assert.strictEqual(regex.test("something Else"), false);
+  it('should return an anchored regex for the query when no extras match', () => {
+    const filter = '{{nonExistentKey}}';
+    const query = 'xyz';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test('xyz'), true);
+    assert.strictEqual(regex.test('abcxyz'), false);
   });
 
-  it("allows for escaped string", () => {
-    const regex = generateDynamicRegExp("something\\{\\{else\\}\\}", " else");
-    assert.ok(regex.test("something{{else}}"));
-    assert.strictEqual(regex.test("something else"), false);
+  it('should handle an empty query gracefully', () => {
+    const filter = '{{query}}';
+    const query = '';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test('anything'), true); // Empty query should match everything
   });
 
-  it("escapes regular expression inputs", () => {
-    const regex = generateDynamicRegExp("something {{query}}", ".* else");
-    assert.ok(regex.test("something .* else"));
-    assert.strictEqual(regex.test("something ?? else"), false);
+  it('should return a case-insensitive regex', () => {
+    const filter = '{{query}}';
+    const query = 'apple';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test('APPLE'), true);
+  });
+
+  it('should match empty string in filter correctly', () => {
+    const filter = '{{query}}';
+    const query = ' ';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(regex.test(' '), true);
+    assert.strictEqual(regex.test('a'), false);
+  });
+
+  it('should not modify the original filter string', () => {
+    const filter = '{{query}}';
+    const query = 'test';
+    const regex = generateDynamicRegExp(filter, query, extras);
+    assert.strictEqual(filter, '{{query}}'); // Ensure original filter remains unchanged
   });
 });

--- a/packages/usa-combo-box/src/test/generateDynamicRegExp.spec.js
+++ b/packages/usa-combo-box/src/test/generateDynamicRegExp.spec.js
@@ -1,63 +1,63 @@
 const assert = require("assert");
 const { generateDynamicRegExp } = require("../index");
 
-describe('generateDynamicRegExp', () => {
+describe("generateDynamicRegExp", () => {
   const extras = {
-    key1: 'someRegex',
-    key2: 'anotherRegex',
-    query: 'searchTerm',
+    key1: "someRegex",
+    key2: "anotherRegex",
+    query: "searchTerm",
   };
 
-  it('should return a RegExp that matches the query', () => {
-    const filter = '{{query}}';
-    const query = 'apple';
+  it("should return a RegExp that matches the query", () => {
+    const filter = "{{query}}";
+    const query = "apple";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test('apple'), true);
-    assert.strictEqual(regex.test('banana'), false);
+    assert.strictEqual(regex.test("apple"), true);
+    assert.strictEqual(regex.test("banana"), false);
   });
 
-  it('should escape special characters in the query', () => {
-    const filter = '{{query}}';
-    const query = 'hello.*';
+  it("should escape special characters in the query", () => {
+    const filter = "{{query}}";
+    const query = "hello.*";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test('hello.*'), true);
-    assert.strictEqual(regex.test('hello'), false);
+    assert.strictEqual(regex.test("hello.*"), true);
+    assert.strictEqual(regex.test("hello"), false);
   });
 
-  it('should return an anchored regex for the query when no extras match', () => {
-    const filter = '{{nonExistentKey}}';
-    const query = 'xyz';
+  it("should return an anchored regex for the query when no extras match", () => {
+    const filter = "{{nonExistentKey}}";
+    const query = "xyz";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test('xyz'), true);
-    assert.strictEqual(regex.test('abcxyz'), false);
+    assert.strictEqual(regex.test("xyz"), true);
+    assert.strictEqual(regex.test("abcxyz"), false);
   });
 
-  it('should handle an empty query gracefully', () => {
-    const filter = '{{query}}';
-    const query = '';
+  it("should handle an empty query gracefully", () => {
+    const filter = "{{query}}";
+    const query = "";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test('anything'), true); // Empty query should match everything
+    assert.strictEqual(regex.test("anything"), true); // Empty query should match everything
   });
 
-  it('should return a case-insensitive regex', () => {
-    const filter = '{{query}}';
-    const query = 'apple';
+  it("should return a case-insensitive regex", () => {
+    const filter = "{{query}}";
+    const query = "apple";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test('APPLE'), true);
+    assert.strictEqual(regex.test("APPLE"), true);
   });
 
-  it('should match empty string in filter correctly', () => {
-    const filter = '{{query}}';
-    const query = ' ';
+  it("should match empty string in filter correctly", () => {
+    const filter = "{{query}}";
+    const query = " ";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(regex.test(' '), true);
-    assert.strictEqual(regex.test('a'), false);
+    assert.strictEqual(regex.test(" "), true);
+    assert.strictEqual(regex.test("a"), false);
   });
 
-  it('should not modify the original filter string', () => {
-    const filter = '{{query}}';
-    const query = 'test';
+  it("should not modify the original filter string", () => {
+    const filter = "{{query}}";
+    const query = "test";
     const regex = generateDynamicRegExp(filter, query, extras);
-    assert.strictEqual(filter, '{{query}}'); // Ensure original filter remains unchanged
+    assert.strictEqual(filter, "{{query}}"); // Ensure original filter remains unchanged
   });
 });

--- a/packages/usa-time-picker/src/test/time-picker-regex.spec.js
+++ b/packages/usa-time-picker/src/test/time-picker-regex.spec.js
@@ -1,11 +1,10 @@
 const assert = require("assert");
 const { FILTER_DATASET } = require("../index");
 
-
 const generateDynamicRegExp = (filter, query = "", extras = {}) => {
   const escapeRegExp = (text) =>
     text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-  
+
   let find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
     const key = $1.trim();
     const queryFilter = extras[key];
@@ -19,16 +18,14 @@ const generateDynamicRegExp = (filter, query = "", extras = {}) => {
 
       return "";
     }
-      
+
     return escapeRegExp(query);
   });
 
-    find = `^(?:${find})$`;
+  find = `^(?:${find})$`;
 
   return new RegExp(find, "i");
 };
-
-
 
 describe("time picker regex", () => {
   const { filter, ...dataset } = FILTER_DATASET;

--- a/packages/usa-time-picker/src/test/time-picker-regex.spec.js
+++ b/packages/usa-time-picker/src/test/time-picker-regex.spec.js
@@ -1,6 +1,34 @@
 const assert = require("assert");
-const { generateDynamicRegExp } = require("../../../usa-combo-box/src/index");
 const { FILTER_DATASET } = require("../index");
+
+
+const generateDynamicRegExp = (filter, query = "", extras = {}) => {
+  const escapeRegExp = (text) =>
+    text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+  
+  let find = filter.replace(/{{(.*?)}}/g, (m, $1) => {
+    const key = $1.trim();
+    const queryFilter = extras[key];
+    if (key !== "query" && queryFilter) {
+      const matcher = new RegExp(queryFilter, "i");
+      const matches = query.match(matcher);
+
+      if (matches) {
+        return escapeRegExp(matches[1]);
+      }
+
+      return "";
+    }
+      
+    return escapeRegExp(query);
+  });
+
+    find = `^(?:${find})$`;
+
+  return new RegExp(find, "i");
+};
+
+
 
 describe("time picker regex", () => {
   const { filter, ...dataset } = FILTER_DATASET;

--- a/packages/usa-time-picker/src/usa-time-picker.twig
+++ b/packages/usa-time-picker/src/usa-time-picker.twig
@@ -1,6 +1,6 @@
 <div class="usa-form-group">
   <label class="usa-label" id="appointment-time-label" for="appointment-time">Appointment time</label>
-  <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
+  <div class="usa-hint" id="appointment-time-hint">Start typing or select a time (AM/PM) in 30-minute intervals</div>
   <div class="usa-time-picker">
     <input
       class="usa-input"

--- a/packages/usa-time-picker/src/usa-time-picker.twig
+++ b/packages/usa-time-picker/src/usa-time-picker.twig
@@ -1,6 +1,6 @@
 <div class="usa-form-group">
   <label class="usa-label" id="appointment-time-label" for="appointment-time">Appointment time</label>
-  <div class="usa-hint" id="appointment-time-hint">Start typing or select a time (AM/PM) in 30-minute intervals</div>
+  <div class="usa-hint" id="appointment-time-hint">hh:mm</div>
   <div class="usa-time-picker">
     <input
       class="usa-input"


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary
Implement First Letter Navigation for Combo Box Filtering

## Breaking change
No breaking change

## Related issue

Closes #5647 



## Problem statement
Users interacting with the combo box for selecting states or countries expect intuitive behavior where typing the first letter of an option narrows down the results to only those that begin with that letter. Currently, the combo box shows all results containing the typed letter, leading to confusion, as options like "Connecticut" appear when users type "T." This does not align with user expectations and can hinder the overall usability of the component.

## Solution
The solution implements first letter navigation in the combo box's filtering logic. By modifying the generateDynamicRegExp function, we ensure that only the options starting with the typed letter are displayed, providing a more accurate and user-friendly experience.

## Major changes

1. Modification of `generateDynamicRegExp` Function:

    -  Updated the regex generation to anchor matches to the start of the string, ensuring that only options beginning with the input character(s) are returned.
    - Adjusted the logic to prioritize first-letter matches over partial matches.

2. Testing Enhancements:

    - Added new test cases to validate the updated behavior, ensuring that typing a letter displays only options starting with that letter.
    - Ensured backward compatibility by retaining existing functionalities while focusing on first-letter navigation.


