### PR TITLE
USWDS - Layout grid utility: Custom breakpoints 

### DIFF
--- a/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
+++ b/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
@@ -6,6 +6,9 @@
 
 $namespace-grid: ns("grid");
 
+$custom-breakpoints: map-deep-get($system-properties, breakpoints, extended);
+$all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
+
 // basic container
 .#{$namespace-grid}container {
   $props: append-important($grid-global, $theme-grid-container-max-width);
@@ -56,7 +59,7 @@ $namespace-grid: ns("grid");
   }
 
   // responsive column gaps
-  @each $mq-key, $mq-value in $system-breakpoints {
+  @each $mq-key, $mq-value in $all-breakpoints {
     @if map.get($theme-utility-breakpoints-complete, $mq-key) {
       @include at-media($mq-key) {
         @each $gap-key,
@@ -103,7 +106,7 @@ $namespace-grid: ns("grid");
 }
 
 // responsive columns
-@each $mq-key, $mq-value in $system-breakpoints {
+@each $mq-key, $mq-value in $all-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}col {
@@ -142,7 +145,7 @@ $namespace-grid: ns("grid");
 }
 
 // responsive offsets
-@each $mq-key, $mq-value in $system-breakpoints {
+@each $mq-key, $mq-value in $all-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @each $width-key, $width-value in $system-layout-grid-widths {
       @include at-media($mq-key) {

--- a/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
+++ b/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
@@ -16,7 +16,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // container with custom widths
-@each $width-key, $width-value in $system-breakpoints {
+@each $width-key, $width-value in $all-breakpoints {
   .#{$namespace-grid}container-#{$width-key} {
     $props: append-important($grid-global, $width-key);
     @include grid-container($props);
@@ -24,7 +24,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // responsive containers...
-@each $mq-key, $mq-value in $system-breakpoints {
+@each $mq-key, $mq-value in $all-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}container {
@@ -33,7 +33,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
       }
 
       // ...with custom widths
-      @each $width-key, $width-value in $system-breakpoints {
+      @each $width-key, $width-value in $all-breakpoints {
         .#{$mq-key}#{$separator}#{$namespace-grid}container-#{$width-key} {
           $props: append-important($grid-global, $width-key);
           @include grid-container($props);

--- a/packages/uswds-core/src/styles/mixins/layout-grid/_grid-container.scss
+++ b/packages/uswds-core/src/styles/mixins/layout-grid/_grid-container.scss
@@ -1,9 +1,10 @@
 @use "sass:list";
+@use "sass:map";
 @use "../../settings" as *;
 @use "../../functions/general" as *;
 @use "../../mixins/general/add-responsive-site-margins" as *;
 @use "../../mixins/utilities" as *;
-@use "../../mixins/helpers/border-box-sizing.scss" as *;
+@use "../../mixins/helpers" as *;
 
 @mixin grid-container($props...) {
   @if length($props) == 0 {
@@ -13,7 +14,11 @@
     $props: list.nth($props, 1);
     $margin-x: append-important($props, auto);
     @include u-margin-x($margin-x);
-    @include u-maxw($props);
+    @if map.has-key($custom-breakpoints, $props) {
+      max-width: map.get($custom-breakpoints, $props);
+    } @else {
+      @include u-maxw($props);
+    }
   }
 
   @include add-responsive-site-margins;


### PR DESCRIPTION
# Summary

A potential addition to PR #6048

Added support for generating custom breakpoints for layout grid utility classes.



## Breaking change

This is not a breaking change.

## Related issue

Related to #5984

## Related pull requests

Potential addition to  #6048

## Preview link
[Storybook](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-custom-breakpoints/?path=/story/design-tokens-fonts--fonts)

## Problem statement

In PR #6048, we added support to create custom breakpoints with the theme setting `$theme-utility-breakpoints-custom`. However, this setting did not generate custom breakpoints for layout grid. 

## Solution

This PR generates custom responsive variants for `grid-col`, `grid-gap`, `grid-offset`, and `grid-container` classes.
    
> [!note]
> The media queries for grid-container have some pre-existing quirks that should probably be broken out into a separate issue. Here is an example:
> ```
> @media all and (min-width: 30em) and (min-width: 64em){
>   .mobile-lg\:grid-container-card{
>     padding-left:2rem;
>     padding-right:2rem;
>   }
> }
> ```
> These media queries have multiple `min-width` declarations, which are redundant and at times contradictory. This PR does not attempt to address this pre-existing issue.

### Performance impact
Including custom breakpoints for layout grid classes adds 8kb to the compiled CSS file. Here are the details on CSS size:

| Description | CSS size |
|:--------|:--------|
| With default breakpoints | 524kb |
| With 1 new custom breakpoint _without_ layout grid (`cm-custom-breakpoints` branch) | 572kb |
| With 1 new custom breakpoint _with_ layout grid (this branch) | 580kb | 

## Testing and review
- Checkout the [`al-test-custom-breakpoints` branch in uswds-sandbox](https://github.com/uswds/uswds-sandbox/tree/al-test-custom-breakpoints). 
- Use the following code in [`uswds-theme.scss`](https://github.com/uswds/uswds-sandbox/blob/al-test-custom-breakpoints/src/_styles/_uswds-theme.scss):
  ```scss
  @use "uswds-core" with (
    $theme-utility-breakpoints-custom: (
      "new-breakpoint": 800px
    ),
    $theme-utility-breakpoints: (
      widescreen: true,
    )
  );
  ```
- Run `npx gulp buildSass` and navigate to  `_site/assets/css/styles.css`
- In styles.css, search for:
    - `.widescreen\:grid-container` and `.new-breakpoint\:grid-container`. Confirm that the style rules match for the two rules, with the exception of a different media query width. 
    - `.widescreen\:grid-gap` and `.new-breakpoint\:grid-gap`. Confirm that the style rules match for the two rules, with the exception of a different media query width. 
    - `.widescreen\:grid-col` and `.new-breakpoint\:grid-col`. Confirm that the style rules match for the two rules, with the exception of a different media query width. 
    - `.widescreen\:grid-offset` and `.new-breakpoint\:grid-offset`. Confirm that the style rules match for the two rules, with the exception of a different media query width.
