### PR TITLE
USWDS - Breadcrumb: Add keyboard navigation for current page's link

### DIFF
--- a/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
+++ b/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
@@ -186,22 +186,21 @@ $breadcrumb-back-icon-aspect: (
 }
 
 .usa-breadcrumb__link--no-style {
-  text-decoration: none; 
-  color: inherit; 
+  text-decoration: none;
+  color: inherit;
 
   &:visited {
-    color: inherit; 
+    color: inherit;
   }
-  
+
   &:hover {
-    color: inherit; 
+    color: inherit;
   }
 
   span {
-    text-decoration: none; 
+    text-decoration: none;
   }
 }
-
 
 // ---------------------------------
 // Variations

--- a/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
+++ b/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
@@ -185,6 +185,24 @@ $breadcrumb-back-icon-aspect: (
   }
 }
 
+.usa-breadcrumb__link--no-style {
+  text-decoration: none; 
+  color: inherit; 
+
+  &:visited {
+    color: inherit; 
+  }
+  
+  &:hover {
+    color: inherit; 
+  }
+
+  span {
+    text-decoration: none; 
+  }
+}
+
+
 // ---------------------------------
 // Variations
 // ---------------------------------

--- a/packages/usa-breadcrumb/src/usa-breadcrumb.twig
+++ b/packages/usa-breadcrumb/src/usa-breadcrumb.twig
@@ -16,7 +16,9 @@
       </a>
     </li>
     <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-      <span>Economically disadvantaged women-owned small business federal contracting program</span>
+      <a href="#" class="usa-breadcrumb__link usa-breadcrumb__link--no-style">
+        <span>Economically disadvantaged women-owned small business federal contracting program</span>
+      </a>
     </li>
   </ol>
 </nav>


### PR DESCRIPTION

# Summary

This pull request enhances the accessibility of the breadcrumb component by ensuring that keyboard and screen reader users can interact with the current page link. This improvement aims to create a more inclusive navigation experience for all users.

## Breaking change

This is not a breaking change.


## Related issue

Closes #6054 

## Problem statement

The breadcrumb component was not fully interactive for keyboard users and screen reader users. Specifically, the last link, which represents the current page, was not reachable or identifiable through keyboard navigation, making it difficult for these users to understand their current location within the site.

## Solution

To resolve this issue, we made the following changes:

  1. Changed the Last Breadcrumb Item: The last breadcrumb link was modified to use an anchor (<a>) tag instead of a span. This allows it to be focusable and interactable via keyboard navigation.
  
  2. Added Accessibility Attributes: We included aria-current="page" to the last breadcrumb item, ensuring screen readers announce it as the current page.
   
  3. Styled the Link: We introduced a new class (.usa-breadcrumb__link--no-style) that removes any underlines and prevents the link from changing color when clicked, maintaining visual consistency.

These adjustments ensure that the breadcrumb component is fully accessible, allowing all users to navigate and understand their position within the site effectively.

