### PR TITLE
USWDS - Nav: Set width of primary button to 100%

### DIFF
--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -199,6 +199,7 @@ $expand-less-icon: map-merge(
     line-height: line-height($theme-navigation-font-family, 2);
     padding: units(1.5) units(2);
     text-decoration: none;
+    width: 100%;
 
     @include at-media($theme-header-min-width) {
       @include primary-nav-link;


### PR DESCRIPTION
# Summary

Set the width of `.usa-nav__primary button` to 100%. This overrides the `auto` width added in #5631.

## Breaking change

This is not a breaking change.


## Related issue

N/A

## Related pull requests

N/A

## Preview link

[Header component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-set-nav-button-width/?path=/story/components-header--default)

## Problem statement

After merging in #5631, we discovered that it had an unexpected impact on buttons in the mobile navigation menu:
![image](https://github.com/user-attachments/assets/ae30a2a1-9897-4f37-8455-f7cd5219c3b3)


## Solution

![image](https://github.com/user-attachments/assets/de2f2524-0178-4bb5-8e32-5eddb6eba475)


## Testing and review

- Confirm that this update fixes the display issue in mobile menus
- Confirm no regressions in header at desktop
- Confirm that the changes in #5631 did not affect [other components that use the `unstyled-button` mixin](https://github.com/search?q=repo%3Auswds%2Fuswds%20%40include%20button-unstyled%3B&type=code):
    - Breadcrumb
    - "Show password" in forms
    - Sortable tables
    - Menu button in header
    - Close button in header
    - Banner
    - Accordion