### PR TITLE
USWDS - Core: Remove duplicate version tag

### DIFF
--- a/src/stylesheets/uswds.scss
+++ b/src/stylesheets/uswds.scss
@@ -1,3 +1,1 @@
-/*! uswds @version */
-
 @forward "../../packages/uswds";


### PR DESCRIPTION
# Summary

Remove duplicate USWDS version number that's appearing in compiled CSS. 

The version number is already included in the imported USWDS package, so removed redundant one.


## Breaking change

This is not a breaking change.

## Related issue

Closes #5904.


## Related pull requests

n/a. This is an internal change.

## Preview link

This isn't a style change.

## Problem statement

The compiled CSS was showing the USWDS version twice. 

## Solution

Removed the extra USWDS version tag from `src/stylesheets/uswds.scss` because the package imported **already** includes it.


## Testing and review

1. Confirm that the version number is showing twice in `dist/css/uswds.css`.
2. Checkout feature branch.
3. Run `npx gulp compileSass`
4. Open `dist/css/uswds.css` and `dist/css/uswds.min.css`.
5. Confirm that version number only appears once.


<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
