### PR TITLE
use modal and wrapper variables

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -66,10 +66,10 @@ function toggleModal(event) {
   const safeActive = !isActive();
   const modalId = clickedElement
     ? clickedElement.getAttribute("aria-controls")
-    : document.querySelector(".usa-modal-wrapper.is-visible");
+    : document.querySelector(`.${WRAPPER_CLASSNAME}.is-visible`);
   const targetModal = safeActive
     ? document.getElementById(modalId)
-    : document.querySelector(".usa-modal-wrapper.is-visible");
+    : document.querySelector(`.${WRAPPER_CLASSNAME}.is-visible`);
 
   // if there is no modal we return early
   if (!targetModal) {
@@ -78,7 +78,7 @@ function toggleModal(event) {
 
   const openFocusEl = targetModal.querySelector(INITIAL_FOCUS)
     ? targetModal.querySelector(INITIAL_FOCUS)
-    : targetModal.querySelector(".usa-modal");
+    : targetModal.querySelector(MODAL);
   const returnFocus = document.getElementById(
     targetModal.getAttribute("data-opener"),
   );


### PR DESCRIPTION
recently updating 3.8.2 to 3.9.0,
the following changes were made to leverage the existing modal and wrapper variables

https://github.com/GSA/touchpoints/pull/1667/commits/a47009ec902d4ef0ac0d244444b589d7a5f9db5f