### PR TITLE
Update `caniuse-lite` and drop unused browserslist IE string

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,4 @@
 # Supported browsers
 > 2%
 last 2 versions
-IE 11
 not dead

--- a/package-lock.json
+++ b/package-lock.json
@@ -12544,9 +12544,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
       "dev": true,
       "funding": [
         {
@@ -12561,7 +12561,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Moved from https://github.com/uswds/uswds/pull/5889

# Summary

- This updates the `caniuse-lite` database, which was last updated 4 months ago (updated via `npx update-browserslist-db@latest`).
- This removes the `IE 11` string from the `.browserslistrc` config file. You can see via running `npx browserslist` that the `IE 11` string does not make a difference, because IE 11 is included in the `dead` browsers set, and this project's browserslist config specifies `not dead` (see https://github.com/browserslist/browserslist?tab=readme-ov-file#full-list). 

## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| caniuse-lite  |     1.0.30001570     |   1.0.30001669   |
