### PR TITLE
USWDS - Step indicator: Remove aria-label from wrapper

### DIFF
--- a/packages/usa-step-indicator/src/usa-step-indicator.twig
+++ b/packages/usa-step-indicator/src/usa-step-indicator.twig
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator {{ modifier }}" aria-label="progress">
+<div class="usa-step-indicator {{ modifier }}">
   <ol class="usa-step-indicator__segments"{% if noLabels %} aria-hidden="true"{% endif %}>
     {% for step in steps %}
       <li class="usa-step-indicator__segment{% if step.status == "complete" %} usa-step-indicator__segment--complete{% endif %}{% if step.status == "current" %} usa-step-indicator__segment--current{% endif %}"{% if step.status == "current" and showLabels %} aria-current="true"{% endif %}>


### PR DESCRIPTION
# Summary

**Removed the aria-label from the wrapper of the step indicator component.** This resolves an automated testing error related to having an invalid attribute on a `div` element. 

## Markup change
To remove automated testing errors, users must update the markup to remove the `aria-label` on the `usa-step-indicator` element:
```diff 
- <div class="usa-step-indicator" aria-label="progress">
+ <div class="usa-step-indicator">

```

## Breaking change

This is not a breaking change.


## Related issue

Closes #6113 

## Related pull requests

[Changelog PR](https://github.com/uswds/uswds-site/pull/2892)

## Preview link

[Step indicator component](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/al-step-indicator-label/?path=/story/components-step-indicator--default)

## Problem statement

The step indicator component fails SiteImprove accessibility tests because it has an invalid `aria-label` attribute on a `<div>` element.

## Solution

This PR removes the `aria-label` from the `.usa-step-indicator` div element. This was done for the following reasons:
- The `aria-label` attribute is not valid on a `<div>` element. In some cases this means the label is not read out, and in others, it causes accessibility scan failures.
- This `aria-label` was determined to be an unnecessary addition. The accessibility team reported that user interviews suggested the label did not provide necessary context.
    - Note: JAWS does not currently read out the aria-label, but VoiceOver does

## Testing and review

1. If available, confirm that this issue is now resolved in SiteImprove scans
2. Confirm that the `aria-label` has been successfully removed
3. Confirm that removing the `aria-label` is appropriate
4. Confirm no regressions