### PR TITLE
USWDS - Breadcrumb: Make current page keyboard focusable

### DIFF
--- a/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
+++ b/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
@@ -185,6 +185,14 @@ $breadcrumb-back-icon-aspect: (
   }
 }
 
+.usa-breadcrumb__link[aria-current="page"] {
+  @include add-link-styles(
+    $theme-text-color,
+    $hover: $theme-text-color,
+    $active: $theme-text-color
+  );
+}
+
 // ---------------------------------
 // Variations
 // ---------------------------------

--- a/packages/usa-breadcrumb/src/usa-breadcrumb.twig
+++ b/packages/usa-breadcrumb/src/usa-breadcrumb.twig
@@ -15,8 +15,10 @@
         <span>Contracting assistance programs</span>
       </a>
     </li>
-    <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-      <span>Economically disadvantaged women-owned small business federal contracting program</span>
+    <li class="usa-breadcrumb__list-item usa-current">
+      <a href="" class="usa-breadcrumb__link" aria-current="page">
+        Economically disadvantaged women-owned small business federal contracting program
+      </a>
     </li>
   </ol>
 </nav>

--- a/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
@@ -1,6 +1,35 @@
 @use "sass:meta";
 @use "sass:list";
+@use "../../functions/utilities/color" as *;
 
+/// Adds link default and state (visited, hover, active) styles.
+///
+///
+/// @param {List} $color - A list of colors for default, hover, and active.
+/// @param {String} $hover [null] - The link's hover color.
+/// @param {String} $active [null] - The link's active color.
+///
+/// @example
+/// @include add-link-styles(
+///   $theme-text-color,
+///   $hover: "primary",
+///   $active: "primary-darker"
+/// );
+///
+/// @output
+/// &:link{
+///   color:#1b1b1b;
+/// }
+/// &:visited{
+///   color:#1b1b1b;
+/// }
+/// &:hover{
+///   color:#005ea2;
+/// }
+/// &:active{
+///   color:#162e51;
+/// }
+///
 @mixin add-link-styles($color, $hover: null, $active: null) {
   @if meta.type-of($color) == "list" {
     $active: list.nth($color, 3);

--- a/packages/uswds-core/src/test/tests.scss
+++ b/packages/uswds-core/src/test/tests.scss
@@ -685,4 +685,50 @@ $this-function: "is-color-dark()";
   }
 }
 
+@include describe("[mixin] add-link-styles()") {
+  @include it("Adds link styles from a SASS list of color tokens") {
+    @include assert {
+      @include output {
+        $link-colors: ("primary", "primary-vivid", "primary-darker");
+        @include add-link-styles($link-colors);
+      }
+      @include expect {
+        &:link {
+          color: #005ea2;
+        }
+        &:visited {
+          color: #005ea2;
+        }
+        &:hover {
+          color: #0050d8;
+        }
+        &:active {
+          color: #162e51;
+        }
+      }
+    }
+  }
+  @include it("Adds link styles from color tokens") {
+    @include assert {
+      @include output {
+        @include add-link-styles("ink", "primary", "primary-darker");
+      }
+      @include expect {
+        &:link {
+          color: #1b1b1b;
+        }
+        &:visited {
+          color: #1b1b1b;
+        }
+        &:hover {
+          color: #005ea2;
+        }
+        &:active {
+          color: #162e51;
+        }
+      }
+    }
+  }
+}
+
 // Debug


### PR DESCRIPTION
# Summary

**Breadcrumb current page is now focusable.** Users can now tab to focus to breadcrumb's current page.

### Markup changes

```diff
<!-- usa-breadcrumb.html -->
- <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-  <span>Economically disadvantaged women-owned small business federal contracting program</span>
+ <li class="usa-breadcrumb__list-item usa-current">
+   <a href="" class="usa-breadcrumb__link" aria-current="page">
       Economically disadvantaged women-owned small business federal contracting program
+   </a> 
</li>
```

Users will need to update to the following markup for the current breadcrumb item:
```html
<!-- project-breadcrumb.html -->
<li class="usa-breadcrumb__list-item usa-current">
  <a href="" class="usa-breadcrumb__link" aria-current="page">
    {{ PROJECT_CURRENT_PAGE_TITLE }}
  </a>
</li>
```

## Breaking change

This is not a breaking change. The [original a11y test](https://designsystem.digital.gov/components/breadcrumb/accessibility-tests/) passes. No failures if users aren't able to update right away.

## Related issue

Closes #6054.

## Related pull requests

Changelog PR: uswds/uswds-site#2918

<!--
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Preview link

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2069625e-58d1-42e5-bdad-aa625670abf0"/>


| Before | After |
| :----- | :---- |
| [Develop] |  [Feature]       |

[Develop]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-breadcrumb--default&p=all
[Feature]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-breadcrumb-current-focusable/?path=/story/components-breadcrumb--default

## Problem statement

Users can't tab to focus on the current breadcrumb link.

## Solution

Follows Also follows recommended markup from W3 [Breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/).


## Major changes

1. **Updated breadcrumb current page markup.** The current breadcrumb page is now a link, instead of a span.
2. **Fixed mixin `add-link-styles`.** This mixin used color util function, but the output was incorrect due to missing import. Added SASSDoc comments and unit tests.
3.  **Current page link appears as normal text.** Instead of using USA link primary colors, this uses the theme text color to make it appear like normal text.
4. **Removed unstyled button colors.** Redundant because we're already setting link styles on `usa-breadcrumb__link`. It's also outputting _a lot_ more CSS than we actually need.


## Testing and review


1. Visit Breadcrumb [default] and [wrap] variant.
2. Confirm current page is keyboard focusable
3. Confirm that current page link looks like normal text.

[default]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-breadcrumb-current-focusable/?path=/story/components-breadcrumb--default
[wrap]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-breadcrumb-current-focusable/?path=/story/components-breadcrumb--wrap

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
