### PR TITLE
USWDS - Breadcrumb: Remove button-unstyled mixin

### DIFF
--- a/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
+++ b/packages/usa-breadcrumb/src/styles/_usa-breadcrumb.scss
@@ -96,7 +96,6 @@ $breadcrumb-back-icon-aspect: (
       @include not-sr-only;
 
       .usa-breadcrumb__link {
-        @include button-unstyled;
         @include exdent-icon;
         @include place-icon(
           $icon-breadcrumb-back,
@@ -104,14 +103,6 @@ $breadcrumb-back-icon-aspect: (
           0,
           baseline,
           $theme-breadcrumb-background-color
-        );
-
-        // Override link colors from button-unstyled()
-
-        @include set-link-from-bg(
-          $theme-breadcrumb-background-color,
-          $theme-breadcrumb-link-color,
-          $context: $breadcrumb-context
         );
 
         @include u-display("inline-block");

--- a/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
+++ b/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
@@ -3,6 +3,15 @@
 @use "../../mixins/utilities" as *;
 @use "../typography/typeset" as *;
 
+///
+/// Removes button styles and adds link styles.
+/// Includes hover, active, disabled, and focus states for accessibility.
+///
+/// @example
+/// .my-unstyled-button {
+///   @include button-unstyled;
+/// }
+///
 @mixin button-unstyled {
   @include typeset-link;
   background-color: transparent;


### PR DESCRIPTION
# Summary

> [!TIP]
> This only affects **mobile** view.

Removes redundant unstyled button mixin and overrides that are causing redundant CSS. 

<img width="889" alt="image" src="https://github.com/user-attachments/assets/7bf3e3c1-920f-4128-a06f-1ee4a00a9781">

## Breaking change

This is not a breaking change.

## Related issue

Closes #6153.

## Related pull requests

<!--
_Indicate if there are other pull requests necessary to complete this issue._

Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Preview link

View this change in **Small mobile** breakpoint.

| Before | After |
| :----- | :---- |
| [develop] |  [feature] |

[develop]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-breadcrumb-unstyled-btn-6153/?path=/story/components-breadcrumb--default

[feature]: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/develop/?path=/story/components-breadcrumb--wrap&globals=backgrounds.grid:false&p=all

## Problem statement

Reduces output CSS by 4 KB.

## Solution

1. Removed mixin since we're later setting breadcrumb link styles with `set-link-from-bg`.
2. Removed overrides required for `button-unstyled()`.
3. Add SASSDoc comment to `button-unstyled()`.


## Testing and review

Confirm there aren't regressions in mobile Breadcrumb.

<!--
1. Describe the tests that you ran to verify your changes,
4. Provide instructions to reproduce these tests, and
5. Clarify the type of feedback you are looking for at this phase.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
