### PR TITLE
USWDS - Core: Fix missing import to `add-link-styles` mixin

### DIFF
--- a/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
@@ -4,7 +4,6 @@
 
 /// Adds link default and state (visited, hover, active) styles.
 ///
-///
 /// @param {List} $color - A list of colors for default, hover, and active.
 /// @param {String} $hover [null] - The link's hover color.
 /// @param {String} $active [null] - The link's active color.

--- a/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/add-link-styles.scss
@@ -1,6 +1,35 @@
 @use "sass:meta";
 @use "sass:list";
+@use "../../functions/utilities/color" as *;
 
+/// Adds link default and state (visited, hover, active) styles.
+///
+///
+/// @param {List} $color - A list of colors for default, hover, and active.
+/// @param {String} $hover [null] - The link's hover color.
+/// @param {String} $active [null] - The link's active color.
+///
+/// @example
+/// @include add-link-styles(
+///   $theme-text-color,
+///   $hover: "primary",
+///   $active: "primary-darker"
+/// );
+///
+/// @output
+/// &:link{
+///   color:#1b1b1b;
+/// }
+/// &:visited{
+///   color:#1b1b1b;
+/// }
+/// &:hover{
+///   color:#005ea2;
+/// }
+/// &:active{
+///   color:#162e51;
+/// }
+///
 @mixin add-link-styles($color, $hover: null, $active: null) {
   @if meta.type-of($color) == "list" {
     $active: list.nth($color, 3);

--- a/packages/uswds-core/src/test/tests.scss
+++ b/packages/uswds-core/src/test/tests.scss
@@ -685,4 +685,50 @@ $this-function: "is-color-dark()";
   }
 }
 
+@include describe("[mixin] add-link-styles()") {
+  @include it("Adds link styles from a SASS list of color tokens") {
+    @include assert {
+      @include output {
+        $link-colors: ("primary", "primary-vivid", "primary-darker");
+        @include add-link-styles($link-colors);
+      }
+      @include expect {
+        &:link {
+          color: #005ea2;
+        }
+        &:visited {
+          color: #005ea2;
+        }
+        &:hover {
+          color: #0050d8;
+        }
+        &:active {
+          color: #162e51;
+        }
+      }
+    }
+  }
+  @include it("Adds link styles from color tokens") {
+    @include assert {
+      @include output {
+        @include add-link-styles("ink", "primary", "primary-darker");
+      }
+      @include expect {
+        &:link {
+          color: #1b1b1b;
+        }
+        &:visited {
+          color: #1b1b1b;
+        }
+        &:hover {
+          color: #005ea2;
+        }
+        &:active {
+          color: #162e51;
+        }
+      }
+    }
+  }
+}
+
 // Debug


### PR DESCRIPTION
# Summary

Adds missing color utility to `add-link-styles` mixin. This is an internal change.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6160. 

## Related pull requests

There's no guidance for this mixin.

## Preview link

n/a 

## Problem statement

Mixin expects a color token, but outputs the color function as a string instead of a value. 

**Example**

| Expected CSS | Actual |
| :----- | :---- |
|  `color: #005ea2;`  |  `color: color("primary");`   |


## Solution

- Included color utility
- Added SASSDoc comments
- Added unit test

## Testing and review

- [ ] Unit tests pass [`npm run test:sass`]
- [ ] Matches code standards and style
- [ ] You can pass a color token to the mixin

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
