### PR TITLE
USWDS - Core: Remove twig-html-loader dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "style-loader": "3.3.3",
         "stylelint": "16.9.0",
         "svgo": "3.3.2",
-        "twig-html-loader": "0.1.9",
         "twigjs-loader": "1.0.3",
         "typescript": "5.6.2",
         "vinyl-buffer": "1.0.1",
@@ -16532,7 +16531,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "6.5.3",
@@ -20807,6 +20807,7 @@
       "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.32.tgz",
       "integrity": "sha512-fr7OCpbE4xeefhHqfh6hM2/l9ZB3XvClHgtgFnQNImrM/nqL950o6FO98vmUH8GysfQRCcyBYtZ4C8GcY52Edw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10",
         "yarn": ">= 1"
@@ -29309,6 +29310,7 @@
       "resolved": "https://registry.npmjs.org/twig/-/twig-1.17.1.tgz",
       "integrity": "sha512-atxccyr/BHtb1gPMA7Lvki0OuU17XBqHsNH9lzDHt9Rr1293EVZOosSZabEXz/DPVikIW8ZDqSkEddwyJnQN2w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "locutus": "^2.0.11",
@@ -29322,47 +29324,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/twig-html-loader": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/twig-html-loader/-/twig-html-loader-0.1.9.tgz",
-      "integrity": "sha512-fW5TMgYJZdpjDUwcrEWKS4YMs/tLsdq6HCPT+Cbj4RECwP84oSJdzY7tmrdhX4jeojVDBUj3hgOEBivyUGGX2g==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "twig": "^1.15.4"
-      }
-    },
-    "node_modules/twig-html-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/twig-html-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/twig/node_modules/minimatch": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -30474,6 +30441,7 @@
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
       "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "foreachasync": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "style-loader": "3.3.3",
     "stylelint": "16.9.0",
     "svgo": "3.3.2",
-    "twig-html-loader": "0.1.9",
     "twigjs-loader": "1.0.3",
     "typescript": "5.6.2",
     "vinyl-buffer": "1.0.1",


### PR DESCRIPTION
# Summary

**Removed unused webpack dependency.** We're not using the `twig-html-loader` dependency in `uswds` or `uswds-site`. It's been removed to reduce the number of dependencies.

Originated in #5832. Thanks again to @aduth for this contribution.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6082.


## Related pull requests

This is an internal change.

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-remove-deps-6082/?path=/story/design-tokens-fonts--fonts). There shouldn't be any regressions.

## Problem statement

We wanted to confirm there were no regressions here or on `uswds-site` before removing the dependency. We build twig templates in this repo as part of our CI to ensure there aren't breaking changes to our component previews on site.

## Solution

This specific dependency isn't needed and removed to have one less to worry about.

## Testing and review

1. Run `npm run build:html`
2. Templates should still work as expected
3. **On `uswds-site`**; checkout branch [remove-deps-uswds-6082](https://github.com/uswds/uswds-site/tree/remove-deps-uswds-6082)
4. Confirm you can install and run locally `npm install && npm start`
5. Visit component previews (code included) and confirm there aren't regressions


## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| `twig-html-loader` |  0.1.9        |     --      |

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
