### PR TITLE
USWDS - File input: Enhance screen reader error callout

### DIFF
--- a/packages/usa-file-input/src/content/usa-file-input.json
+++ b/packages/usa-file-input/src/content/usa-file-input.json
@@ -3,7 +3,7 @@
   "label": "Input accepts a single file",
   "hint": "",
   "error": false,
-  "error_message": "",
+  "error_hint_text": "",
   "accept": "",
   "multiple": false
 }

--- a/packages/usa-file-input/src/content/usa-file-input~error.json
+++ b/packages/usa-file-input/src/content/usa-file-input~error.json
@@ -3,7 +3,7 @@
   "label": "Input has an error",
   "hint": "Select any valid file",
   "error": true,
-  "error_message": "Display a helpful error message",
+  "error_hint_text": "Display a helpful error message",
   "accept": "",
   "multiple": ""
 }

--- a/packages/usa-file-input/src/content/usa-file-input~multiple.json
+++ b/packages/usa-file-input/src/content/usa-file-input~multiple.json
@@ -3,7 +3,7 @@
   "label": "Input accepts multiple files",
   "hint": "Select one or more files",
   "error": false,
-  "error_message": "",
+  "error_hint_text": "",
   "accept": "",
   "multiple": true
 }

--- a/packages/usa-file-input/src/content/usa-file-input~specific.json
+++ b/packages/usa-file-input/src/content/usa-file-input~specific.json
@@ -3,7 +3,7 @@
   "label": "Input accepts only specific file types",
   "hint": "Select PDF or TXT files",
   "error": false,
-  "error_message": "",
+  "error_hint_text": "",
   "accept": ".pdf,.txt",
   "multiple": true
 }

--- a/packages/usa-file-input/src/content/usa-file-input~wildcard.json
+++ b/packages/usa-file-input/src/content/usa-file-input~wildcard.json
@@ -3,7 +3,7 @@
   "label": "Input accepts any kind of image",
   "hint": "Select any type of image format",
   "error": false,
-  "error_message": "",
+  "error_hint_text": "",
   "accept": "image/*",
   "multiple": true
 }

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -507,17 +507,16 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
-      const defaultErrorMsg = "Error: This is not a valid file type.";
+      const errorMessageText = fileInputEl.dataset.errormessage || "Error: This is not a valid file type.";
 
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
-      errorMessage.textContent =
-        fileInputEl.dataset.errormessage || defaultErrorMsg;
+      errorMessage.textContent = errorMessageText
 
       fileInputEl.setAttribute(
         "aria-label",
-        `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}`,
+        `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`,
       );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -515,7 +515,10 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       errorMessage.textContent =
         fileInputEl.dataset.errormessage || defaultErrorMsg;
 
-      fileInputEl.setAttribute("aria-label", `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}` );
+      fileInputEl.setAttribute(
+        "aria-label",
+        `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}`,
+      );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -507,12 +507,14 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
-      const errorMessageText = fileInputEl.dataset.errormessage || "Error: This is not a valid file type.";
+      const errorMessageText =
+        fileInputEl.dataset.errormessage ||
+        "Error: This is not a valid file type.";
 
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
-      errorMessage.textContent = errorMessageText
+      errorMessage.textContent = errorMessageText;
 
       fileInputEl.setAttribute(
         "aria-label",

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -513,8 +513,8 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
     if (!allFilesAllowed) {
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
-      dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent = errorMessageText;
+      dropTarget.insertBefore(errorMessage, fileInputEl);
 
       const ariaLabelText = `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`;
 

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -28,6 +28,7 @@ const EXCEL_PREVIEW_CLASS = `${GENERIC_PREVIEW_CLASS_NAME}--excel`;
 const SR_ONLY_CLASS = `${PREFIX}-sr-only`;
 const SPACER_GIF =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+const DEFAULT_ERROR_LABEL_TEXT = "Error: This is not a valid file type.";
 
 let TYPE_IS_VALID = Boolean(true); // logic gate for change listener
 let DEFAULT_ARIA_LABEL_TEXT = "";
@@ -484,6 +485,9 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
   if (acceptedFilesAttr) {
     const acceptedFiles = acceptedFilesAttr.split(",");
     const errorMessage = document.createElement("div");
+    const userErrorText = fileInputEl.dataset.errormessage;
+    const errorMessageText = userErrorText || DEFAULT_ERROR_LABEL_TEXT;
+
     errorMessage.setAttribute("aria-hidden", true);
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
@@ -507,10 +511,6 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
-      const errorMessageText =
-        fileInputEl.dataset.errormessage ||
-        "Error: This is not a valid file type.";
-
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -484,6 +484,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
   if (acceptedFilesAttr) {
     const acceptedFiles = acceptedFilesAttr.split(",");
     const errorMessage = document.createElement("div");
+    errorMessage.setAttribute("aria-hidden", true);
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
     let allFilesAllowed = true;
@@ -506,11 +507,15 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
+      const defaultErrorMsg = "Error: This is not a valid file type.";
+
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent =
-        fileInputEl.dataset.errormessage || `This is not a valid file type.`;
+        fileInputEl.dataset.errormessage || defaultErrorMsg;
+
+      fileInputEl.setAttribute("aria-label", `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}` );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -516,10 +516,9 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent = errorMessageText;
 
-      fileInputEl.setAttribute(
-        "aria-label",
-        `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`,
-      );
+      const ariaLabelText = `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`;
+
+      fileInputEl.setAttribute("aria-label", ariaLabelText);
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -81,7 +81,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         inputEl.files = fileList;
         const e = new Event("change");
         inputEl.dispatchEvent(e);
-      }
+      };
 
       beforeEach(() => {
         body.innerHTML = TEMPLATE;
@@ -153,7 +153,10 @@ tests.forEach(({ name, selector: containerSelector }) => {
         );
         ariaLabel = inputEl.getAttribute("aria-label");
 
-        assert.strictEqual(visibleErrorMessage.textContent, defaultErrorMessage);
+        assert.strictEqual(
+          visibleErrorMessage.textContent,
+          defaultErrorMessage,
+        );
         assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
       });
 

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -143,7 +143,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         );
       });
 
-      it("should display an error message", () => {
+      it("should provide a default error state", () => {
         // add to our elements FileList
         addFiles();
 

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -66,7 +66,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       const mock = new MockFile();
       const file = mock.create("pic.jpg", size, "image/jpeg");
       const fileList = makeFileList(file);
-      const defaultErrorMessage = "Error: This is not a valid file type."
+      const defaultErrorMessage = "Error: This is not a valid file type.";
       const customErrorMessage = "Please upload a valid file";
 
       let dropZone;
@@ -146,13 +146,14 @@ tests.forEach(({ name, selector: containerSelector }) => {
         inputEl.dispatchEvent(e);
 
         // Error message appended to DOM after change event.
-        errorMessage = body.querySelector(".usa-file-input__accepted-files-message");
+        errorMessage = body.querySelector(
+          ".usa-file-input__accepted-files-message",
+        );
         ariaLabel = inputEl.getAttribute("aria-label");
 
         assert.strictEqual(errorMessage.textContent, defaultErrorMessage);
         assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
       });
-      
 
       it("should use custom error message", () => {
         inputEl.dataset.errormessage = customErrorMessage;
@@ -161,12 +162,14 @@ tests.forEach(({ name, selector: containerSelector }) => {
         inputEl.dispatchEvent(e);
 
         // Error message appended to DOM after change event.
-        errorMessage = body.querySelector(".usa-file-input__accepted-files-message");
+        errorMessage = body.querySelector(
+          ".usa-file-input__accepted-files-message",
+        );
         ariaLabel = inputEl.getAttribute("aria-label");
-        
+
         assert.strictEqual(errorMessage.textContent, customErrorMessage);
         assert.strictEqual(ariaLabel.startsWith(customErrorMessage), true);
-      })
+      });
     });
   });
 });

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -66,6 +66,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       const mock = new MockFile();
       const file = mock.create("pic.jpg", size, "image/jpeg");
       const fileList = makeFileList(file);
+      const defaultErrorMessage = "Error: This is not a valid file type."
       const customErrorMessage = "Please upload a valid file";
 
       let dropZone;
@@ -137,6 +138,21 @@ tests.forEach(({ name, selector: containerSelector }) => {
           true,
         );
       });
+
+      it("should display an error message", () => {
+        // add to our elements FileList
+        inputEl.files = fileList;
+        const e = new Event("change");
+        inputEl.dispatchEvent(e);
+
+        // Error message appended to DOM after change event.
+        errorMessage = body.querySelector(".usa-file-input__accepted-files-message");
+        ariaLabel = inputEl.getAttribute("aria-label");
+
+        assert.strictEqual(errorMessage.textContent, defaultErrorMessage);
+        assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
+      });
+      
 
       it("should use custom error message", () => {
         inputEl.dataset.errormessage = customErrorMessage;

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -157,7 +157,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
       });
 
-      it("should use custom error message", () => {
+      it("should allow a custom error message", () => {
         inputEl.dataset.errormessage = customErrorMessage;
         addFiles();
 

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -143,7 +143,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         );
       });
 
-      it("should provide a default error state", () => {
+      it("should provide a default error message for invalid file type", () => {
         // add to our elements FileList
         addFiles();
 
@@ -160,7 +160,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
         assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
       });
 
-      it("should allow a custom error message", () => {
+      it("should allow a custom error message for invalid file type", () => {
         inputEl.dataset.errormessage = customErrorMessage;
         addFiles();
 

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -74,7 +74,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       let inputEl;
       let dragText;
       let box;
-      let errorMessage;
+      let visibleErrorMessage;
       let ariaLabel;
 
       const addFiles = () => {
@@ -148,12 +148,12 @@ tests.forEach(({ name, selector: containerSelector }) => {
         addFiles();
 
         // Error message appended to DOM after change event.
-        errorMessage = body.querySelector(
+        visibleErrorMessage = body.querySelector(
           ".usa-file-input__accepted-files-message",
         );
         ariaLabel = inputEl.getAttribute("aria-label");
 
-        assert.strictEqual(errorMessage.textContent, defaultErrorMessage);
+        assert.strictEqual(visibleErrorMessage.textContent, defaultErrorMessage);
         assert.strictEqual(ariaLabel.startsWith(defaultErrorMessage), true);
       });
 
@@ -162,12 +162,12 @@ tests.forEach(({ name, selector: containerSelector }) => {
         addFiles();
 
         // Error message appended to DOM after change event.
-        errorMessage = body.querySelector(
+        visibleErrorMessage = body.querySelector(
           ".usa-file-input__accepted-files-message",
         );
         ariaLabel = inputEl.getAttribute("aria-label");
 
-        assert.strictEqual(errorMessage.textContent, customErrorMessage);
+        assert.strictEqual(visibleErrorMessage.textContent, customErrorMessage);
         assert.strictEqual(ariaLabel.startsWith(customErrorMessage), true);
       });
     });

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -77,6 +77,12 @@ tests.forEach(({ name, selector: containerSelector }) => {
       let errorMessage;
       let ariaLabel;
 
+      const addFiles = () => {
+        inputEl.files = fileList;
+        const e = new Event("change");
+        inputEl.dispatchEvent(e);
+      }
+
       beforeEach(() => {
         body.innerHTML = TEMPLATE;
         fileInput.on(containerSelector());
@@ -130,9 +136,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("mock file should not be allowed", () => {
         // add to our elements FileList
-        inputEl.files = fileList;
-        const e = new Event("change");
-        inputEl.dispatchEvent(e);
+        addFiles();
         assert.strictEqual(
           dropZone.classList.contains(INVALID_FILE_CLASS),
           true,
@@ -141,9 +145,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should display an error message", () => {
         // add to our elements FileList
-        inputEl.files = fileList;
-        const e = new Event("change");
-        inputEl.dispatchEvent(e);
+        addFiles();
 
         // Error message appended to DOM after change event.
         errorMessage = body.querySelector(
@@ -157,9 +159,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
       it("should use custom error message", () => {
         inputEl.dataset.errormessage = customErrorMessage;
-        inputEl.files = fileList;
-        const e = new Event("change");
-        inputEl.dispatchEvent(e);
+        addFiles();
 
         // Error message appended to DOM after change event.
         errorMessage = body.querySelector(

--- a/packages/usa-file-input/src/test/file-input-accepts.spec.js
+++ b/packages/usa-file-input/src/test/file-input-accepts.spec.js
@@ -66,12 +66,15 @@ tests.forEach(({ name, selector: containerSelector }) => {
       const mock = new MockFile();
       const file = mock.create("pic.jpg", size, "image/jpeg");
       const fileList = makeFileList(file);
+      const customErrorMessage = "Please upload a valid file";
 
       let dropZone;
       let instructions;
       let inputEl;
       let dragText;
       let box;
+      let errorMessage;
+      let ariaLabel;
 
       beforeEach(() => {
         body.innerHTML = TEMPLATE;
@@ -134,6 +137,20 @@ tests.forEach(({ name, selector: containerSelector }) => {
           true,
         );
       });
+
+      it("should use custom error message", () => {
+        inputEl.dataset.errormessage = customErrorMessage;
+        inputEl.files = fileList;
+        const e = new Event("change");
+        inputEl.dispatchEvent(e);
+
+        // Error message appended to DOM after change event.
+        errorMessage = body.querySelector(".usa-file-input__accepted-files-message");
+        ariaLabel = inputEl.getAttribute("aria-label");
+        
+        assert.strictEqual(errorMessage.textContent, customErrorMessage);
+        assert.strictEqual(ariaLabel.startsWith(customErrorMessage), true);
+      })
     });
   });
 });

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -16,6 +16,10 @@ export default {
       control: { type: "radio" },
       options: ["none", "disabled", "aria-disabled"],
     },
+    error_message: {
+      name: "Error message",
+      control: { type: "text" },
+    }
   },
 };
 

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -19,13 +19,13 @@ export default {
     error_message: {
       name: "Error message",
       control: { type: "text" },
-      defaultValue: ""
+      defaultValue: "",
     },
     accepted_files_message: {
       name: "Accepted files message",
       control: { type: "text" },
-      defaultValue: ""
-    }
+      defaultValue: "",
+    },
   },
 };
 

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -16,13 +16,13 @@ export default {
       control: { type: "radio" },
       options: ["none", "disabled", "aria-disabled"],
     },
-    error_message: {
-      name: "Error message",
+    error_hint_text: {
+      name: "Error message - hint",
       control: { type: "text" },
       defaultValue: "",
     },
-    accepted_files_message: {
-      name: "Accepted files message",
+    invalid_file_text: {
+      name: "Error text - Invalid file type (data-errorMessage)",
       control: { type: "text" },
       defaultValue: "",
     },

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -19,6 +19,12 @@ export default {
     error_message: {
       name: "Error message",
       control: { type: "text" },
+      defaultValue: ""
+    },
+    accepted_files_message: {
+      name: "Accepted files message",
+      control: { type: "text" },
+      defaultValue: ""
     }
   },
 };

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -22,11 +22,11 @@
     class="usa-file-input"
     type="file"
     name="{{ id }}"
-    {% if hint %} aria-describedby="{{ aria_hint }}"{% endif %}
-    {% if accept %} accept="{{ accept }}"{% endif %}
-    {% if multiple %} multiple{% endif %}
-    {% if disabled_state == 'disabled' %} disabled{% endif %}
-    {% if disabled_state == "aria-disabled" %} aria-disabled="true"{% endif %}
-    {% if accepted_files_message %} data-errorMessage="{{ accepted_files_message }}"{% endif %}
+    {% if hint %}aria-describedby="{{ aria_hint }}"{% endif %}
+    {% if accept %}accept="{{ accept }}"{% endif %}
+    {% if multiple %}multiple{% endif %}
+    {% if disabled_state == 'disabled' %}disabled{% endif %}
+    {% if disabled_state == "aria-disabled" %}aria-disabled="true"{% endif %}
+    {% if accepted_files_message %}data-errorMessage="{{ accepted_files_message }}"{% endif %}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -28,6 +28,7 @@
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled_state == 'disabled' %} disabled{%- endif %}
     {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
+    {% if error_message -%}data-errorMessage="{{ error_message }}"{%- endif -%}
     {% endif %}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -22,11 +22,11 @@
     class="usa-file-input"
     type="file"
     name="{{ id }}"
-    {% if hint -%} aria-describedby="{{ aria_hint }}"{%- endif -%}
-    {% if accept -%} accept="{{ accept }}"{%- endif -%}
-    {% if multiple -%} multiple{%- endif -%}
-    {% if disabled_state == 'disabled' %} disabled{%- endif %}
-    {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
-    {% if accepted_files_message -%} data-errorMessage="{{ accepted_files_message }}"{%- endif -%}
+    {% if hint %} aria-describedby="{{ aria_hint }}"{% endif %}
+    {% if accept %} accept="{{ accept }}"{% endif %}
+    {% if multiple %} multiple{% endif %}
+    {% if disabled_state == 'disabled' %} disabled{% endif %}
+    {% if disabled_state == "aria-disabled" %} aria-disabled="true"{% endif %}
+    {% if accepted_files_message %} data-errorMessage="{{ accepted_files_message }}"{% endif %}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -22,13 +22,11 @@
     class="usa-file-input"
     type="file"
     name="{{ id }}"
-    {% if hint or accept or multiple or disabled_state -%}
     {% if hint -%}aria-describedby="{{ aria_hint }}"{%- endif -%}
     {% if accept -%}accept="{{ accept }}"{%- endif -%}
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled_state == 'disabled' %} disabled{%- endif %}
     {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
     {% if accepted_files_message -%}data-errorMessage="{{ accepted_files_message }}"{%- endif -%}
-    {% endif %}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -22,11 +22,11 @@
     class="usa-file-input"
     type="file"
     name="{{ id }}"
-    {% if hint -%}aria-describedby="{{ aria_hint }}"{%- endif -%}
-    {% if accept -%}accept="{{ accept }}"{%- endif -%}
+    {% if hint -%} aria-describedby="{{ aria_hint }}"{%- endif -%}
+    {% if accept -%} accept="{{ accept }}"{%- endif -%}
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled_state == 'disabled' %} disabled{%- endif %}
     {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
-    {% if accepted_files_message -%}data-errorMessage="{{ accepted_files_message }}"{%- endif -%}
+    {% if accepted_files_message -%} data-errorMessage="{{ accepted_files_message }}"{%- endif -%}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -28,7 +28,7 @@
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled_state == 'disabled' %} disabled{%- endif %}
     {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
-    {% if error_message -%}data-errorMessage="{{ error_message }}"{%- endif -%}
+    {% if accepted_files_message -%}data-errorMessage="{{ accepted_files_message }}"{%- endif -%}
     {% endif %}
   />
 </div>

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -14,7 +14,7 @@
   {%- endif -%}
   {%- if error %}
     <span class="usa-error-message" id="{{ aria_error }}">
-      {{ error_message }}
+      {{ error_hint_text }}
     </span>
   {%- endif %}
   <input
@@ -27,6 +27,6 @@
     {% if multiple %}multiple{% endif %}
     {% if disabled_state == 'disabled' %}disabled{% endif %}
     {% if disabled_state == "aria-disabled" %}aria-disabled="true"{% endif %}
-    {% if accepted_files_message %}data-errorMessage="{{ accepted_files_message }}"{% endif %}
+    {% if invalid_file_text %}data-errorMessage="{{ invalid_file_text }}"{% endif %}
   />
 </div>


### PR DESCRIPTION
# Summary

Fixed a bug that prevented screen readers from announcing the invalid file type error message. Now, screen readers will consistently read out the invalid file state.

## Breaking change

This is not a breaking change

## Related issue

Closes #6157 

## Related pull requests

[Change log →](https://github.com/uswds/uswds-site/pull/2933)

## Preview link

[File input specific variant →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-file-input-sr-error/?path=/story/components-form-inputs-file-input--specific)

## Problem statement

When entering an incorrect format in the file input, there's no indication to the screen reader that there's an error. Text present, but isn't not announced. This fails criteria [4.1.3, status message](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html).

## Solution

Bring error message into the `aria-label` to match SR instructions. This allows consistent callouts whenever the error message is present. It also avoids an issue where the focus doesn’t return to the browser if an SR user drags and drops a file, causing the error message alert to be skipped.

### Alternative solution considered

I attempted Mandy’s recommendation of adding `role="alert"` to the error message. It seemed to have worked at first but then continued to be ignored by screen readers.

## Major changes

- Error messages are now added to `aria-label`
- Visual error messages are now `aria-hidden` to avoid duplicate callouts
- Default error message now contains `Error:`
- Created `data-errorMessage` control in storybook preview

## Testing and review

1. Visit the [file input specific variant](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-file-input-sr-error/iframe.html?args=&id=components-form-inputs-file-input--specific) page
2. Activate screen reader
3. Using your keyboard, navigate to the file input button
4. Activate the button and select a file to upload that is not a `.txt` or `.pdf` file.
5. Listen for error state to be read alongside instructions
6. Drag and drop another incorrect file into the input
7. Return focus to the component and confirm error state is read.
8. Activate file input once more
9. Use storybook controls to set a custom error message (`error_message` string control)
10. Confirm correct error message is displayed and ready by screen reader
11. Close out of the file browser without uploading a file
12. Confirm the error message has cleared.

> [!TIP]
It’s my understanding that screen reader users generally navigate via keyboard, so it’s important to test keyboard only navigation with this work.
> 

### Testing checklist

- [ ]  Error state is consistently read by screen readers
- [ ]  `aria-label` approach is logical and follows USWDS patterns
- [ ]  Code matches USWDS standards
- [ ] Accepted file message storybook control works as expected