### PR TITLE
USWDS - Core: Replace receptor library "once" with once option for event listeners

### DIFF
--- a/packages/usa-in-page-navigation/src/index.js
+++ b/packages/usa-in-page-navigation/src/index.js
@@ -1,4 +1,3 @@
-const once = require("receptor/once");
 const keymap = require("receptor/keymap");
 const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
@@ -332,9 +331,10 @@ const handleEnterFromLink = (event) => {
     target.focus();
     target.addEventListener(
       "blur",
-      once(() => {
+      () => {
         target.setAttribute("tabindex", -1);
-      }),
+      },
+      { once: true },
     );
   } else {
     // throw an error?

--- a/packages/usa-skipnav/src/index.js
+++ b/packages/usa-skipnav/src/index.js
@@ -1,4 +1,3 @@
-const once = require("receptor/once");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const { CLICK } = require("../../uswds-core/src/js/events");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
@@ -18,12 +17,9 @@ function setTabindex() {
     target.style.outline = "0";
     target.setAttribute("tabindex", 0);
     target.focus();
-    target.addEventListener(
-      "blur",
-      once(() => {
-        target.setAttribute("tabindex", -1);
-      }),
-    );
+    target.addEventListener("blur", () => target.setAttribute("tabindex", -1), {
+      once: true,
+    });
   } else {
     // throw an error?
   }


### PR DESCRIPTION
# Summary

Reduced the JavaScript bundle size. By optimizing the implementation of core component code, overall JavaScript sizes are reduced.

## Breaking change

This is not a breaking change.

## Related pull requests

Split from #5793, to simplify review.

## Preview link

N/A

## Problem statement

See #5793

## Solution

Replace use of `receptor/once` with `addEventListener`'s `once` option ([see documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)).

The intended purpose is the same.

[`receptor.once`](https://github.com/shawnbot/receptor?tab=readme-ov-file#once):

>Returns a wrapped function that removes itself as an event listener as soon as it's called, then calls the callback function with the same arugments.

[`addEventListener` `once`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once)

>A boolean value indicating that the listener should be invoked at most once after being added. If true, the listener would be automatically removed when invoked.

## Testing and review

Verify that skipnav removes `tabindex` from body after activating and then moving focus away from the body.

Verify that in-page navigation removes `tabindex` from the target heading after activating and then moving focus away from the heading.