### PR TITLE
USWDS - Core: Replace receptor library "ignore" with Element#contains

### DIFF
--- a/packages/usa-search/src/index.js
+++ b/packages/usa-search/src/index.js
@@ -1,4 +1,3 @@
-const ignore = require("receptor/ignore");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const select = require("../../uswds-core/src/js/utils/select");
 
@@ -39,13 +38,17 @@ const toggleSearch = (button, active) => {
   }
   // when the user clicks _outside_ of the form w/ignore(): hide the
   // search, then remove the listener
-  const listener = ignore(form, () => {
+  const listener = (event) => {
+    if (form.contains(event.target)) {
+      return;
+    }
+
     if (lastButton) {
       hideSearch.call(lastButton); // eslint-disable-line no-use-before-define
     }
 
     document.body.removeEventListener(CLICK, listener);
-  });
+  };
 
   // Normally we would just run this code without a timeout, but
   // IE11 and Edge will actually call the listener *immediately* because


### PR DESCRIPTION
# Summary

Reduced the JavaScript bundle size. By optimizing the implementation of core component code, overall JavaScript sizes are reduced.

## Breaking change

This is not a breaking change.

## Related pull requests

Split from #5793, to simplify review.

## Preview link

N/A

## Problem statement

See #5793

## Solution

Replace use of `receptor/ignore` with equivalent [`Node#contains`](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains) condition.

The intended purpose is the same.

[`receptor.ignore`](https://github.com/shawnbot/receptor?tab=readme-ov-file#ignore):

>Returns a delegated function that only calls the callback if the event's target isn't contained by the provided element. This is useful for creating event handlers that only fire if the user interacts with something outside of a given UI element.

[`Node#contains`](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)

>The contains() method of the [Node](https://developer.mozilla.org/en-US/docs/Web/API/Node) interface returns a boolean value indicating whether a node is a descendant of a given node, that is the node itself, one of its direct children ([childNodes](https://developer.mozilla.org/en-US/docs/Web/API/Node/childNodes)), one of the children's direct children, and so on.

## Testing and review

To be totally honest, I'm not sure what this behavior is meant to control. References to `js-search-button` CSS class do not appear in any relevant Storybook stories or [documentation](https://search.usa.gov/search?utf8=%E2%9C%93&affiliate=uswds&query=js-search-button&commit=).