### PR TITLE
USWDS - Core: Replace receptor library "behavior" with custom implementation

### DIFF
--- a/packages/uswds-core/src/js/utils/behavior.js
+++ b/packages/uswds-core/src/js/utils/behavior.js
@@ -1,12 +1,19 @@
 /**
+ * Callback handler for component setup and teardown events.
+ *
  * @typedef {(target?: HTMLElement) => any} BehaviorLifecycle
  */
 
 /**
+ * Options object for initializing a component's behavior and including additional properties in
+ * the public interface of each initialized component.
+ *
  * @typedef {Record<string, any> & { init?: BehaviorLifecycle, teardown?: BehaviorLifecycle }} BehaviorProps
  */
 
 /**
+ * Component initializer.
+ *
  * @typedef {BehaviorProps & {
  *   on: BehaviorLifecycle,
  *   off: BehaviorLifecycle,
@@ -16,47 +23,74 @@
  */
 
 /**
+ * Event callback handler.
+ *
  * @typedef {(
  *   this: HTMLElement,
  *   event: K extends keyof HTMLElementEventMap ? HTMLElementEventMap[K] : Event
  * ) => any} EventHandler
- * @template {string} K
+ * @template {string} K Event name(s)
  */
 
 /**
- * @typedef {EventHandler<K> | Record<string, EventHandler<K>>} EventHandlerOrSelectorMap
- * @template {string} K
- */
-
-/**
- * @typedef {Record<K, EventHandlerOrSelectorMap<K>>} Events
- * @template {string} K
- */
-
-/**
- * @param {Events<K>} events
- * @param {Partial<BehaviorProps>} props
- * @template {string} K
+ * Callback or object of selector-scoped callbacks.
  *
- * @return {Behavior}
+ * @typedef {EventHandler<K> | Record<string, EventHandler<K>>} EventHandlerOrSelectorMap
+ * @template {string} K Event name(s)
+ */
+
+/**
+ * Object of component event handlers, where each event handler may be a callback function or an
+ * object of selector-scoped callbacks.
+ *
+ * @typedef {Record<K, EventHandlerOrSelectorMap<K>>} Events
+ * @template {string} K Event name(s)
+ */
+
+/**
+ * @param {Events<K>} events Object of component event handlers, where each event handler may be a
+ * callback function or an object of selector-scoped callbacks.
+ * @param {Partial<BehaviorProps>} props Additional properties to include in public interface of
+ * each initialized component.
+ * @template {string} K Event name(s)
+ *
+ * @return {Behavior} Component initializer.
  */
 module.exports = (events, props) => {
+  // Normalize event handlers to to an array of arguments to be passed to either `addEventListener`
+  // or `removeEventListener` during component initialization.
   const listeners = Object.entries(events).flatMap(([eventTypes, handlers]) =>
+    // Each event handler can be defined for one or more space-separated event names.
     eventTypes.split(" ").map(
       (eventType) =>
+        // Generate arguments of `[add/remove]EventListener` as [eventType, callback]
         /** @type {[keyof HTMLElementEventMap, EventHandler<any>]} */ ([
           eventType,
+          // Event handlers can be defined as a callback or object of selector-scoped callbacks. To
+          // normalize as a function, create a function from a given object to perform the scoping
+          // logic.
           typeof handlers === "function"
             ? handlers
             : (event) =>
+                // When a handler is defined as an object, event handling should terminate if any of
+                // the scoped callbacks return `false`. This is accomplished by iterating over the
+                // object's values as an array and using `Array#some` to abort at the first `false`
+                // return value.
                 Object.entries(handlers).some(([selector, handler]) => {
+                  // Since this event is attached at an ancestor and is handled using event
+                  // delegation, ensure that the actual event target is within the scoped selector.
                   const target = event.target && event.target.closest(selector);
                   return target && handler.call(target, event) === false;
                 }),
-        ])
-    )
+        ]),
+    ),
   );
 
+  /**
+   * Initialize components within the given target, defaulting to the document body.
+   *
+   * @param {Element} target Ancestor element in which to initialized components.
+   */
   const on = (target = document.body) => {
     if (props && props.init) {
       props.init(target);
@@ -65,6 +99,11 @@ module.exports = (events, props) => {
     listeners.forEach((args) => target.addEventListener(...args));
   };
 
+  /**
+   * Remove component behaviors within the given target, defaulting to the document body.
+   *
+   * @param {Element} target Ancestor element in which to remove component behaviors.
+   */
   const off = (target = document.body) => {
     if (props && props.teardown) {
       props.teardown(target);

--- a/packages/uswds-core/src/js/utils/test/behavior.spec.js
+++ b/packages/uswds-core/src/js/utils/test/behavior.spec.js
@@ -8,10 +8,117 @@ describe("behavior", () => {
     assert(component && typeof component === "object");
   });
 
-  it("has on() and off() methods", () => {
+  it("has on(), off(), add(), remove() functions", () => {
     const component = behavior({});
     assert.strictEqual(typeof component.on, "function");
     assert.strictEqual(typeof component.off, "function");
+    assert.strictEqual(typeof component.add, "function");
+    assert.strictEqual(typeof component.remove, "function");
+  });
+
+  it("includes additional properties from given arguments", () => {
+    const component = behavior({}, { extra: true });
+
+    assert.strictEqual(component.extra, true);
+  });
+
+  it("calls event handlers as function", () => {
+    const click = sinon.stub();
+    const component = behavior({ click });
+    component.on();
+    const event = new Event("click", { bubbles: true });
+    document.body.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, document.body);
+  });
+
+  it("scopes event handling by the given target", () => {
+    const click = sinon.stub();
+    const component = behavior({ click });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on(div);
+    document.body.dispatchEvent(event);
+
+    assert(click.notCalled);
+    div.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, div);
+  });
+
+  it("calls event handlers as object for matched selector", () => {
+    const divClick = sinon.stub();
+    const spanClick = sinon.stub();
+    const component = behavior({ click: { div: divClick, span: spanClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    const span = document.createElement("span");
+    document.body.appendChild(div);
+    document.body.appendChild(span);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(spanClick.notCalled);
+  });
+
+  it("calls event handlers as object for matched ancestor selector", () => {
+    const bodyClick = sinon.stub();
+    const component = behavior({ click: { body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(bodyClick.calledOnceWithExactly(event));
+    assert.strictEqual(bodyClick.getCall(0).thisValue, document.body);
+  });
+
+  it("calls event handlers as object for multiple matches", () => {
+    const bodyClick = sinon.stub();
+    const divClick = sinon.stub();
+    const component = behavior({ click: { div: divClick, body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(bodyClick.calledOnceWithExactly(event));
+    assert.strictEqual(bodyClick.getCall(0).thisValue, document.body);
+  });
+
+  it("skips other event handlers once one returns false", () => {
+    const bodyClick = sinon.stub();
+    const divClick = sinon.stub().returns(false);
+    const component = behavior({ click: { div: divClick, body: bodyClick } });
+    const event = new Event("click", { bubbles: true });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    component.on();
+    div.dispatchEvent(event);
+
+    assert(divClick.calledOnceWithExactly(event));
+    assert.strictEqual(divClick.getCall(0).thisValue, div);
+    assert(bodyClick.notCalled);
+  });
+
+  it("calls event handlers with space separated event names", () => {
+    const click = sinon.stub();
+    const component = behavior({ "keydown click": click });
+    component.on();
+    const event = new Event("click", { bubbles: true });
+    document.body.dispatchEvent(event);
+
+    assert(click.calledOnceWithExactly(event));
+    assert.strictEqual(click.getCall(0).thisValue, document.body);
   });
 
   describe("behavior.on()", () => {
@@ -33,6 +140,17 @@ describe("behavior", () => {
       behavior({}, { init }).on(el);
       assert(init.calledWithExactly(el));
     });
+
+    it("binds events", () => {
+      const sandbox = sinon.createSandbox();
+      sandbox.spy(document.body, "addEventListener");
+      const component = behavior({ click() {} });
+      component.on();
+
+      assert(document.body.addEventListener.calledOnceWith("click"));
+
+      sandbox.restore();
+    });
   });
 
   describe("behavior.off()", () => {
@@ -53,6 +171,18 @@ describe("behavior", () => {
       const el = document.createElement("div");
       behavior({}, { teardown }).off(el);
       assert(teardown.calledWithExactly(el));
+    });
+
+    it("removes event bindings", () => {
+      const sandbox = sinon.createSandbox();
+      sandbox.spy(document.body, "removeEventListener");
+      const component = behavior({ click() {} });
+      component.on();
+      component.off();
+
+      assert(document.body.removeEventListener.calledOnceWith("click"));
+
+      sandbox.restore();
     });
   });
 });

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -9,7 +9,11 @@ const mochaConfig = {
 module.exports = {
   // run unit test.
   unitTests() {
-    return src("packages/usa-*/**/*.spec.js").pipe(mocha(mochaConfig));
+    return src([
+      "packages/usa-*/**/*.spec.js",
+      "packages/uswds-*/**/*.spec.js",
+      "!packages/uswds-core/src/test/sass.spec.js"
+    ]).pipe(mocha(mochaConfig));
   },
 
   sassTests() {


### PR DESCRIPTION
# Summary

**Reduced the JavaScript bundle size.** By optimizing the implementation of core component code, overall JavaScript sizes are reduced.

## Breaking change

This is not a breaking change (see #5793 for edge-cases).

## Related pull requests

Split from #5793, to simplify review.

Includes additional inline code comments based on review feedback from that pull request (see abdbea1ae05d85e9c80e336b1b533758e058c91f).

## Preview link

N/A

## Problem statement

See #5793

## Solution

Replace use of `receptor/behavior` with equivalent custom implementation.

Refer to #5793 for full details of expected performance impact following complete removal of `receptor`.

## Testing and review

Verify all unit tests pass:

```
npm exec gulp unitTests
```

Review experience for individual components within the Storybook preview at http://localhost:6006
