### PR TITLE
USWDS - Radio and checkbox: Update label width to fit content

### DIFF
--- a/packages/usa-checkbox/src/styles/_usa-checkbox.scss
+++ b/packages/usa-checkbox/src/styles/_usa-checkbox.scss
@@ -21,6 +21,7 @@
       border-radius: radius($theme-input-tile-border-radius);
       margin-top: units(1);
       padding: units(1.5) units(2) units(1.5) units(5);
+      display: inherit;
 
       &::before {
         left: units(5) - units($input-select-margin-right) - units(
@@ -53,7 +54,7 @@
 .usa-checkbox__label {
   @extend %block-input-general;
   cursor: pointer;
-  display: inherit;
+  display: inline-block;
   font-weight: font-weight("normal");
   margin-top: units(1.5);
   padding-left: units($input-select-margin-right) +

--- a/packages/usa-radio/src/styles/_usa-radio.scss
+++ b/packages/usa-radio/src/styles/_usa-radio.scss
@@ -21,7 +21,7 @@
       border-radius: radius($theme-input-tile-border-radius);
       margin-top: units(1);
       padding: units(1.5) units(2) units(1.5) units(5);
-      display:inherit;
+      display: inherit;
 
       &::before {
         left: units(5) - units($input-select-margin-right) - units(

--- a/packages/usa-radio/src/styles/_usa-radio.scss
+++ b/packages/usa-radio/src/styles/_usa-radio.scss
@@ -21,6 +21,7 @@
       border-radius: radius($theme-input-tile-border-radius);
       margin-top: units(1);
       padding: units(1.5) units(2) units(1.5) units(5);
+      display:inherit;
 
       &::before {
         left: units(5) - units($input-select-margin-right) - units(

--- a/packages/usa-radio/src/styles/_usa-radio.scss
+++ b/packages/usa-radio/src/styles/_usa-radio.scss
@@ -47,7 +47,7 @@
 .usa-radio__label {
   @extend %block-input-general;
   cursor: pointer;
-  display: inherit;
+  display: inline-block;
   font-weight: font-weight("normal");
   margin-top: units(1.5);
   padding-left: units($input-select-margin-right) +


### PR DESCRIPTION
# Summary

Changed display for radio buttons and checkbox to inline-block so that label fits its content. Added inherit to display for tile variant.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6111 

## Related pull requests

[Changelog](https://github.com/uswds/uswds-site/pull/2961)

## Preview link

[Preview link radios:](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cb-tighten-selectable-whitespace-in-radios/?path=/story/components-form-inputs-radio--default)

[Preview link checkboxes:](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cb-tighten-selectable-whitespace-in-radios/?path=/story/components-form-inputs-checkbox--default)

## Problem statement

The selectable area adjacent to radio buttons and checkboxes was full width. This resulted in being able to select the button from an area far away from the component. This fix tightens the selectable area around these components.

### NOTE

This issue also impacts checkbox. The same solution should apply to both components.

## Solution

With display: block, the radio button's label occupies the full width of its parent container. With display: inline-block, the label will only occupy the space needed to fit its content.

## Testing and review

1. Open the federalist link for radios.
2. Verify that each radio button item under form inputs is only actionable directly over the button.
3. Open the federalist link for checkboxes.
4. Verify that each checkbox item under form inputs is only actionable directly over the button.
5. Check for regressions, especially that in tiled variant the right margin is not ragged.

Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
