### PR TITLE
USWDS - usa-icon-list: Add appropriate alt text to non-decorative icons

### DIFF
--- a/packages/usa-icon-list/src/content/usa-icon-list.json
+++ b/packages/usa-icon-list/src/content/usa-icon-list.json
@@ -4,7 +4,7 @@
       "icon": {
         "name": "check_circle",
         "color": "green",
-        "alt_text": "Yes"
+        "title": "Yes"
       },
       "content": "Wash your hands for 20 seconds with soap"
     },
@@ -12,7 +12,7 @@
       "icon": {
         "name": "check_circle",
         "color": "green",
-        "alt_text": "Yes"
+        "title": "Yes"
       },
       "content": "Stay six feet away from others"
     },
@@ -20,7 +20,7 @@
       "icon": {
         "name": "cancel",
         "color": "red",
-        "alt_text": "No"
+        "title": "No"
       },
       "content": "Avoid large gatherings"
     }

--- a/packages/usa-icon-list/src/content/usa-icon-list.json
+++ b/packages/usa-icon-list/src/content/usa-icon-list.json
@@ -3,21 +3,24 @@
     {
       "icon": {
         "name": "check_circle",
-        "color": "green"
+        "color": "green",
+        "alt_text": "Yes"
       },
       "content": "Wash your hands for 20 seconds with soap"
     },
     {
       "icon": {
         "name": "check_circle",
-        "color": "green"
+        "color": "green",
+        "alt_text": "Yes"
       },
       "content": "Stay six feet away from others"
     },
     {
       "icon": {
         "name": "cancel",
-        "color": "red"
+        "color": "red",
+        "alt_text": "No"
       },
       "content": "Avoid large gatherings"
     }

--- a/packages/usa-icon-list/src/usa-icon-list.twig
+++ b/packages/usa-icon-list/src/usa-icon-list.twig
@@ -8,7 +8,7 @@
   {% for item in items %}
   <li class="usa-icon-list__item">
     <div class="usa-icon-list__icon {% if item.icon.color %} text-{{ item.icon.color }}{% endif %}">
-      <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}" aria-hidden="true" role="img">
+      <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}" aria-hidden="true" role="img" {% if item.icon.alt_text %} aria-label={{ item.icon.alt_text }}{% endif %} >
         <use xlink:href="{{ img_path }}/sprite.svg#{{ item.icon.name }}"></use>
       </svg>
     </div>

--- a/packages/usa-icon-list/src/usa-icon-list.twig
+++ b/packages/usa-icon-list/src/usa-icon-list.twig
@@ -5,16 +5,18 @@
 ] %}
 
 <ul class="{{ list_classes | join(' ') | trim }}">
-  {% for item in items %}
-  <li class="usa-icon-list__item">
-    <div class="usa-icon-list__icon {% if item.icon.color %} text-{{ item.icon.color }}{% endif %}">
-      <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}" aria-hidden="true" role="img" {% if item.icon.alt_text %} aria-label={{ item.icon.alt_text }}{% endif %} >
+  {% for key, item in items %}
+    <li class="usa-icon-list__item">
+      <div class="usa-icon-list__icon {% if item.icon.color %} text-{{ item.icon.color }}{% endif %}">
+        <svg class="usa-icon{% if item.icon.utilities %} {{ item.icon.utilities }}{% endif %}"{% if item.icon.title %} aria-labelledby="usa-icon__title_{{ key }}"{% endif %} aria-hidden="{% if item.icon.title %}false{% else %}true{% endif %}" role="img">
+        {% if item.icon.title %}<title id="usa-icon__title_{{ key }}">{{ item.icon.title }}</title>{% endif %}
+        
         <use xlink:href="{{ img_path }}/sprite.svg#{{ item.icon.name }}"></use>
-      </svg>
-    </div>
-    <div class="usa-icon-list__content">
-      {{ item.content }}
-    </div>
-  </li>
+        </svg>
+      </div>
+      <div class="usa-icon-list__content">
+        {{ item.content }}
+      </div>
+    </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
# Summary
**Updates title text and aria-label of non-descriptive icons in icons list.** The icons that convey meaning in the icon list (indicating "yes" or "no") have appropriate title text and aria-labelledby attribute.

## Breaking change
This is not a breaking change.

## Related issue

Closes [#6118](https://github.com/uswds/uswds/issues/6118)

## Problem statement
One of the lists with icons have icons that are marked as decorative when they are conveying meaning (yes/no or do/don't). The ideal state is they have appropriate "alt text" to indicate meaning. This is only an issue on the list with green/red icons.

## Solution
By adding title tags inside the SVG icons with a unique id that matches the aria-labelledby attribute on the SVG element, screen readers gain accessibility to a description of what they mean.

Some additional info on this strategy and others that were also options: https://accessibilityinsights.io/info-examples/web/svg-img-alt/

## Testing and review
1. Go to https://designsystem.digital.gov/components/icon-list/
2. Using JAWS, VO, or NVDA listen to the icon description.
3. Confirm description is read for the non-decorative icons only.
4. Can also inspect the element to confirm these labels are available for non-decorative icons only.

## Preview
https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/ml-icon-list-alt-txt/?path=/story/components-icon-list--default

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
