### PR TITLE
USWDS - File input: Update sr-only status with error message [TEST]

### DIFF
--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -507,17 +507,16 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
-      const defaultErrorMsg = "Error: This is not a valid file type.";
+      const errorMessageText = fileInputEl.dataset.errormessage || "Error: This is not a valid file type.";
 
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
-      errorMessage.textContent =
-        fileInputEl.dataset.errormessage || defaultErrorMsg;
+      errorMessage.textContent = errorMessageText
 
       fileInputEl.setAttribute(
         "aria-label",
-        `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}`,
+        `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`,
       );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -458,6 +458,8 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
  * @param {HTMLDivElement} dropTarget - The drag and drop target area.
  */
 const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
+  const inputParent = dropTarget.closest(`.${DROPZONE_CLASS}`);
+  const statusElement = inputParent.querySelector(`.${SR_ONLY_CLASS}`);
   const acceptedFilesAttr = fileInputEl.getAttribute("accept");
   dropTarget.classList.remove(INVALID_FILE_CLASS);
 
@@ -515,11 +517,9 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent = errorMessageText;
+      statusElement.setAttribute("aria-role", "alert");
+      statusElement.textContent = `Screen reader status ${errorMessageText}`;
 
-      fileInputEl.setAttribute(
-        "aria-label",
-        `${errorMessageText} ${DEFAULT_ARIA_LABEL_TEXT}`,
-      );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -515,7 +515,10 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
       errorMessage.textContent =
         fileInputEl.dataset.errormessage || defaultErrorMsg;
 
-      fileInputEl.setAttribute("aria-label", `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}` );
+      fileInputEl.setAttribute(
+        "aria-label",
+        `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}`,
+      );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -507,12 +507,14 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
-      const errorMessageText = fileInputEl.dataset.errormessage || "Error: This is not a valid file type.";
+      const errorMessageText =
+        fileInputEl.dataset.errormessage ||
+        "Error: This is not a valid file type.";
 
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
-      errorMessage.textContent = errorMessageText
+      errorMessage.textContent = errorMessageText;
 
       fileInputEl.setAttribute(
         "aria-label",

--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -484,6 +484,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
   if (acceptedFilesAttr) {
     const acceptedFiles = acceptedFilesAttr.split(",");
     const errorMessage = document.createElement("div");
+    errorMessage.setAttribute("aria-hidden", true);
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
     let allFilesAllowed = true;
@@ -506,11 +507,15 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If dragged files are not accepted, this removes them from the value of the input and creates and error state
     if (!allFilesAllowed) {
+      const defaultErrorMsg = "Error: This is not a valid file type.";
+
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
       dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent =
-        fileInputEl.dataset.errormessage || `This is not a valid file type.`;
+        fileInputEl.dataset.errormessage || defaultErrorMsg;
+
+      fileInputEl.setAttribute("aria-label", `${defaultErrorMsg} ${DEFAULT_ARIA_LABEL_TEXT}` );
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -28,6 +28,7 @@
     {% if multiple -%} multiple{%- endif -%}
     {% if disabled_state == 'disabled' %} disabled{%- endif %}
     {% if disabled_state == "aria-disabled" -%} aria-disabled="true"{%- endif -%}
+    {% if error_message -%}data-errorMessage="{{ error_message }}"{%- endif -%}
     {% endif %}
   />
 </div>


### PR DESCRIPTION
# Summary

Alternative approach for #6168.

This approach updates the SR only span instead of the aria-label. While testing, I'm not getting consistent callouts between browsers using this approach.

## Preview link

[File input: Specific →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-file-input-sr-only-error/iframe.html?id=components-form-inputs-file-input--specific)