### PR TITLE
USWDS - File input: Add role="alert" to error message [TEST]

### DIFF
--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -488,6 +488,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
   if (acceptedFilesAttr) {
     const acceptedFiles = acceptedFilesAttr.split(",");
     const errorMessage = document.createElement("div");
+    errorMessage.setAttribute("role", "alert");
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
     let allFilesAllowed = true;
@@ -512,9 +513,9 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
     if (!allFilesAllowed) {
       removeOldPreviews(dropTarget, instructions);
       fileInputEl.value = ""; // eslint-disable-line no-param-reassign
-      dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.textContent =
-        fileInputEl.dataset.errormessage || `This is not a valid file type.`;
+      fileInputEl.dataset.errormessage || `This is not a valid file type.`;
+      dropTarget.insertBefore(errorMessage, fileInputEl);
       errorMessage.classList.add(ACCEPTED_FILE_MESSAGE_CLASS);
       dropTarget.classList.add(INVALID_FILE_CLASS);
       TYPE_IS_VALID = false;


### PR DESCRIPTION
# Summary

Alternative approach for #6168.

This approach adds `role="alert"` attribute to the file input error message. While testing, I heard the alert exactly one time the first time I tested this approach. After refreshing, it does not call out the alert again

## Preview link

[File input: Specific →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-file-input-sr-only-error/iframe.html?args=&id=components-form-inputs-file-input--specific&viewMode=story)

