### PR TITLE
USWDS - README: Fix broken node.js download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use the npm package manager for Node-based projects. USWDS maintains the [`@uswd
 
 1. Install `Node/npm`. Below is a link to find the install method that coincides with your operating system:
 
-   - Node v12.13.2 (current LTS), [Installation guides](https://nodejs.org/en/download)
+   - Node (see [.nvmrc](https://github.com/uswds/uswds/blob/develop/.nvmrc) for version number), [Installation guides](https://nodejs.org/en/download)
 
    **Note for Windows users:** If you are using Windows and are unfamiliar with Node or npm, we recommend following [Team Treehouse's tutorial](http://blog.teamtreehouse.com/install-node-js-npm-windows) for more information.
 


### PR DESCRIPTION
# Summary

Fixed a 404 link to the node.js download page in the README. 

> [!note]
> This PR blocks https://github.com/uswds/uswds-site/pull/2975 from passing CircleCI checks.

## Breaking change

This is not a breaking change.

## Related issue

N/A

## Related pull requests
This PR blocks https://github.com/uswds/uswds-site/pull/2975. 

## Preview link

[README](https://github.com/uswds/uswds/blob/al-fix-broken-node-link/README.md)

## Testing and review

- Confirm the updated link successfully points to the node.js download page

