### PR TITLE
USWDS - Tooltip: Announce tooltip before it's content

### DIFF
--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -317,6 +317,7 @@ const setUpAttributes = (tooltipTrigger) => {
   const tooltipContent = tooltipTrigger.getAttribute("title");
   const wrapper = document.createElement("span");
   const tooltipBody = document.createElement("span");
+  const ariaSpan = document.createElement("span");
   const additionalClasses = tooltipTrigger.getAttribute("data-classes");
   let position = tooltipTrigger.getAttribute("data-position");
 
@@ -355,6 +356,10 @@ const setUpAttributes = (tooltipTrigger) => {
 
   // place the text in the tooltip
   tooltipBody.textContent = tooltipContent;
+
+  // insert aria span before text content to be read first
+  ariaSpan.setAttribute("aria-label", "Tooltip :");
+  tooltipBody.insertBefore(ariaSpan, tooltipBody.firstChild);
 
   return { tooltipBody, position, tooltipContent, wrapper };
 };

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -318,6 +318,7 @@ const setUpAttributes = (tooltipTrigger) => {
   const wrapper = document.createElement("span");
   const tooltipBody = document.createElement("span");
   const ariaSpan = document.createElement("span");
+  const contentSpan = document.createElement("span");
   const additionalClasses = tooltipTrigger.getAttribute("data-classes");
   let position = tooltipTrigger.getAttribute("data-position");
 
@@ -354,11 +355,12 @@ const setUpAttributes = (tooltipTrigger) => {
   tooltipBody.setAttribute("role", "tooltip");
   tooltipBody.setAttribute("aria-hidden", "true");
 
-  // place the text in the tooltip
-  tooltipBody.textContent = tooltipContent;
+  // place the text span in the tooltip
+  contentSpan.textContent = tooltipContent;
+  tooltipBody.appendChild(contentSpan);
 
   // insert aria span before text content to be read first
-  ariaSpan.setAttribute("aria-label", "Tooltip :");
+  ariaSpan.setAttribute("aria-label", "Tooltip");
   tooltipBody.insertBefore(ariaSpan, tooltipBody.firstChild);
 
   return { tooltipBody, position, tooltipContent, wrapper };

--- a/packages/usa-tooltip/src/index.js
+++ b/packages/usa-tooltip/src/index.js
@@ -318,7 +318,6 @@ const setUpAttributes = (tooltipTrigger) => {
   const wrapper = document.createElement("span");
   const tooltipBody = document.createElement("span");
   const ariaSpan = document.createElement("span");
-  const contentSpan = document.createElement("span");
   const additionalClasses = tooltipTrigger.getAttribute("data-classes");
   let position = tooltipTrigger.getAttribute("data-position");
 
@@ -355,12 +354,11 @@ const setUpAttributes = (tooltipTrigger) => {
   tooltipBody.setAttribute("role", "tooltip");
   tooltipBody.setAttribute("aria-hidden", "true");
 
-  // place the text span in the tooltip
-  contentSpan.textContent = tooltipContent;
-  tooltipBody.appendChild(contentSpan);
+  // place the text in the tooltip
+  tooltipBody.textContent = tooltipContent;
 
   // insert aria span before text content to be read first
-  ariaSpan.setAttribute("aria-label", "Tooltip");
+  ariaSpan.setAttribute("aria-label", "Tooltip.");
   tooltipBody.insertBefore(ariaSpan, tooltipBody.firstChild);
 
   return { tooltipBody, position, tooltipContent, wrapper };


### PR DESCRIPTION
# Summary
**Use an accessible aria label span to announce tooltip before it's content is read** An added span with aria-label "Tooltip :" is read by the screen reader before reading the contents of the tooltip. 

Tooltip elements must have discernible text that clearly describes the destination, purpose, function, or action for screen reader users. The previous combination of only `aria-labeledby` on the container paired `with role="tooltip"` on the tooltip was not satisfying that requirement.

## Breaking change
This is not a breaking change.

## Related issue
Closes #5891 

<!--
## Related pull requests
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Preview link
[Preview link: tooltip](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/ml-tooltip/?path=/story/components-tooltip--tooltip)

## Problem Statement
The [tooltip component](https://designsystem.digital.gov/components/tooltip/) does not announce the word "tooltip" as a label, even when using a combination of `aria-labelledby` on the container element and `role="tooltip"` on the tooltip element. As a result, screen reader users cannot discern the purpose of elements with `role="tooltip"` that lack an accessible name. 

### Solution
To address this, we need to add an empty `<span>` with an accessible `aria-label` to ensure the tooltip is announced to screen reader users before the tooltip contents are read.

## Testing and review
1. Navigate to tooltip component via preview link or locally
2. Using VO, JAWS, or NVDA trigger the tooltip 
3. Confirm it is announced as "Tooltip, colon" before the tooltip contents are read
4. Confirm no visual regressions

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
