### PR TITLE
USWDS: Add notifications for 3.11.0

### DIFF
--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -192,6 +192,20 @@ $uswds-notifications:
 + "\A   WCAG 3.3.2."
 + "\A   ✏️ Teams should replace the words `hh:mm` in the time picker hint text with "
 + "\A     `Select a time from the dropdown. Type into the input to filter options.`"
++ "\A "
++ "\A --------------------------------------------------------------------"
++ "\A 3.11.0"
++ "\A Release notes: github.com/uswds/uswds/releases/tag/v3.11.0"
++ "\A "
++ "\A - Assets, Markup: [usa-button, usa-collection, usa-icon-list, usa-file-input, "
++ "\A   usa-icon, usa-input-prefix-suffix, usa-modal, usa-pagination]"
++ "\A   Replaced deprecated `xlink:href` references with `href`."
++ "\A   ✏️ Teams should replace `xlink:href` references with `href` "
++ "\A     in their components and pull in the updated `loader.svg` file."
++ "\A - Accessibility: [usa-file-input] Fixed a bug that prevented screen readers "
++ "\A   from announcing the invalid file type error message."
++ "\A - Accessibility: [usa-footer] Removed `overflow: hidden` from `usa-footer` "
++ "\A   to allow the full focus outline to show."
 + "\A ";
 
 /* prettier-ignore */


### PR DESCRIPTION
# Summary

Added Sass notifications for 3.11.0

## Related issue

N/A

## Related pull requests
N/A

## Preview link
![image](https://github.com/user-attachments/assets/531fb73d-b16b-43d7-852c-389d9c1e092c)


## Testing and review
Run `npx gulp buildSass` and view the release notifications
- Confirm the relevant items from 3.11.0 are included in the notifications
- Confirm the notifications are formatted as expected