### PR TITLE
USWDS: Sass 2.0.0: Color function deprecations #6213

### DIFF
--- a/packages/uswds-core/src/styles/functions/color/is-color-dark.scss
+++ b/packages/uswds-core/src/styles/functions/color/is-color-dark.scss
@@ -13,7 +13,7 @@
   $token-from-bg: get-color-token-from-bg($color);
 
   // If returned color is white, then the background must be dark.
-  @return if(color.lightness(color($token-from-bg)) > 50%, true, false);
+  @return if(color.channel(color($token-from-bg), "lightness", $space: hsl) > 50%, true, false);
 }
 
 // @debug is-color-dark("yellow-20v");

--- a/packages/uswds-core/src/styles/functions/color/is-color-dark.scss
+++ b/packages/uswds-core/src/styles/functions/color/is-color-dark.scss
@@ -13,7 +13,11 @@
   $token-from-bg: get-color-token-from-bg($color);
 
   // If returned color is white, then the background must be dark.
-  @return if(color.channel(color($token-from-bg), "lightness", $space: hsl) > 50%, true, false);
+  @return if(
+    color.channel(color($token-from-bg), "lightness", $space: hsl) > 50%,
+    true,
+    false
+  );
 }
 
 // @debug is-color-dark("yellow-20v");

--- a/packages/uswds-core/src/styles/functions/color/luminance.scss
+++ b/packages/uswds-core/src/styles/functions/color/luminance.scss
@@ -17,10 +17,23 @@
 
 @function luminance($color) {
   $lum: (
-      list.nth($luminance-color-component-values, color.channel($color, "red", $space: rgb) + 1) * 0.2126
+      list.nth(
+          $luminance-color-component-values,
+          color.channel($color, "red", $space: rgb) + 1
+        ) * 0.2126
     ) +
-    (list.nth($luminance-color-component-values, color.channel($color, "green", $space: rgb) + 1) * 0.7152) +
-    (list.nth($luminance-color-component-values, color.channel($color, "blue", $space: rgb) + 1) * 0.0722);
+    (
+      list.nth(
+          $luminance-color-component-values,
+          color.channel($color, "green", $space: rgb) + 1
+        ) * 0.7152
+    ) +
+    (
+      list.nth(
+          $luminance-color-component-values,
+          color.channel($color, "blue", $space: rgb) + 1
+        ) * 0.0722
+    );
 
   @return math.div(math.round($lum * 1000), 1000);
 }

--- a/packages/uswds-core/src/styles/functions/color/luminance.scss
+++ b/packages/uswds-core/src/styles/functions/color/luminance.scss
@@ -17,10 +17,10 @@
 
 @function luminance($color) {
   $lum: (
-      list.nth($luminance-color-component-values, red($color) + 1) * 0.2126
+      list.nth($luminance-color-component-values, color.channel($color, "red", $space: rgb) + 1) * 0.2126
     ) +
-    (list.nth($luminance-color-component-values, green($color) + 1) * 0.7152) +
-    (list.nth($luminance-color-component-values, blue($color) + 1) * 0.0722);
+    (list.nth($luminance-color-component-values, color.channel($color, "green", $space: rgb) + 1) * 0.7152) +
+    (list.nth($luminance-color-component-values, color.channel($color, "blue", $space: rgb) + 1) * 0.0722);
 
   @return math.div(math.round($lum * 1000), 1000);
 }

--- a/packages/uswds-core/src/styles/functions/color/luminance.scss
+++ b/packages/uswds-core/src/styles/functions/color/luminance.scss
@@ -20,19 +20,22 @@
       list.nth(
           $luminance-color-component-values,
           color.channel($color, "red", $space: rgb) + 1
-        ) * 0.2126
+        ) *
+        0.2126
     ) +
     (
       list.nth(
           $luminance-color-component-values,
           color.channel($color, "green", $space: rgb) + 1
-        ) * 0.7152
+        ) *
+        0.7152
     ) +
     (
       list.nth(
           $luminance-color-component-values,
           color.channel($color, "blue", $space: rgb) + 1
-        ) * 0.0722
+        ) *
+        0.0722
     );
 
   @return math.div(math.round($lum * 1000), 1000);

--- a/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors.scss
@@ -65,7 +65,7 @@
   $tile-box-shadow--disabled: 0 0 0 units($theme-input-select-border-width)
     color($input-text-color-disabled);
   $input-darkmode: if(
-    color.lightness(color($input-bg-color)) < 50%,
+    color.channel(color($input-bg-color), "lightness", $space: hsl) < 50%,
     true,
     false
   );


### PR DESCRIPTION
# Summary

**Updated color functions in Sass to resolve deprecation warnings.** This change ensures compatibility with Dart Sass 2.0.0 and eliminates the use of deprecated color functions.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6213

## Preview link

[Preview link](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/ml-sass-color-deprecations/)

## Problem statement

The Sass color functions such as color.lightness() are deprecated starting from Sass >= 1.79.0. These deprecated functions will be removed in Dart Sass 2.0.0. The current implementation raises deprecation warnings during compilation, potentially breaking future builds.

## Solution

Replaced deprecated `color()` functions with the recommended `color.channel()` function. This change ensures future compatibility with Dart Sass 2.0.0 and resolves existing deprecation warnings. The new syntax follows the updated pattern for accessing individual color components like lightness, saturation, and hue.

## Major changes

Replaced deprecated `color()` functions with `color.channel()`.
Updated any relevant Sass files to follow the new `color.channel($color, "component", $space: hsl)` syntax.

## Testing and review

1. Pull branch
2. Run `npm run test:sass`
3. Confirm no _color_ related deprecations are triggered

Warning examples:

```
Deprecation Warning: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions
```

```sh
Deprecation Warning: color.lightness() is deprecated. Suggestion:

color.channel($color, "lightness", $space: hsl)

More info: https://sass-lang.com/d/color-functions
```

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
