### PR TITLE
USWDS - Test: Fix mixed declaration warnings in accordion

### DIFF
--- a/packages/usa-accordion/src/styles/_usa-accordion.scss
+++ b/packages/usa-accordion/src/styles/_usa-accordion.scss
@@ -37,22 +37,43 @@ $accordion-button-open-hc-icon: map-merge(
 
 // Accordion Styles
 @mixin accordion-list-styles {
+  & {
+    color: color("ink");
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
   @include unstyled-list;
-  color: color("ink");
-  margin: 0;
-  padding: 0;
-  width: 100%;
 }
 
 @mixin accordion-hc-icon-styles {
-  height: 100%;
-  position: absolute;
-  right: units(2.5);
-  top: 0;
+  & {
+    height: 100%;
+    position: absolute;
+    right: units(2.5);
+    top: 0;
+  }
 }
 
 // Opened styles
 @mixin accordion-button-styles {
+  //
+  //* Because of the new recommendation, we have regressions in accordion.
+  //* This is because mixins that were being overriden are now at the end.
+  //
+  //
+  & {
+    background-position: right units(2.5) center;
+    background-size: units(3);
+    cursor: pointer;
+    display: inline-block;
+    font-weight: font-weight("bold");
+    margin: 0;
+    padding: units(2) units(2.5) * 2 + units(2) units(2) units(2.5);
+    text-decoration: none;
+    width: 100%;
+  }
+
   @include button-unstyled;
   @include set-text-and-bg(
     $theme-accordion-button-background-color,
@@ -63,17 +84,10 @@ $accordion-button-open-hc-icon: map-merge(
     "usa-icons/remove",
     "usa-icons-bg/remove--white"
   );
-  background-position: right units(2.5) center;
-  background-size: units(3);
-  cursor: pointer;
-  display: inline-block;
-  font-weight: font-weight("bold");
-  margin: 0;
-  padding: units(2) units(2.5) * 2 + units(2) units(2) units(2.5);
-  text-decoration: none;
-  width: 100%;
 
   &:hover {
+    text-decoration: none;
+
     @include set-text-and-bg(
       $accordion-button-background-active-color,
       $context: $accordion-context
@@ -83,7 +97,6 @@ $accordion-button-open-hc-icon: map-merge(
       "usa-icons/remove",
       "usa-icons-bg/remove--white"
     );
-    text-decoration: none;
   }
 
   @media (forced-colors: active) {
@@ -91,20 +104,23 @@ $accordion-button-open-hc-icon: map-merge(
     position: relative;
 
     &::before {
+      content: "";
       @include add-color-icon($accordion-button-open-hc-icon);
       @include accordion-hc-icon-styles();
-      content: "";
     }
   }
 }
 
 @mixin accordion-button-unopened-styles {
+  & {
+    background-size: units(3);
+  }
+
   @include set-icon-from-bg(
     $theme-accordion-button-background-color,
     "usa-icons/add",
     "usa-icons-bg/add--white"
   );
-  background-size: units(3);
 
   &:hover {
     @include set-icon-from-bg(
@@ -163,8 +179,8 @@ $accordion-button-open-hc-icon: map-merge(
 // kludge to override .usa-prose styles
 // TODO: work this into a mixin
 .usa-prose .usa-accordion__heading {
-  @include typeset($theme-accordion-font-family, $theme-body-font-size, 1);
   margin: 0;
+  @include typeset($theme-accordion-font-family, $theme-body-font-size, 1);
 
   &:not(:first-child) {
     margin-top: units(1);
@@ -172,13 +188,13 @@ $accordion-button-open-hc-icon: map-merge(
 }
 
 .usa-accordion__content {
+  margin-top: 0;
+  overflow: auto;
+  padding: units(2) units(2.5) calc(#{units(2)} - #{units(0.5)}) units(2.5);
   @include set-text-and-bg(
     $theme-accordion-background-color,
     $context: $accordion-context
   );
-  margin-top: 0;
-  overflow: auto;
-  padding: units(2) units(2.5) calc(#{units(2)} - #{units(0.5)}) units(2.5);
 
   > *:first-child {
     margin-top: 0;

--- a/packages/usa-accordion/src/styles/_usa-accordion.scss
+++ b/packages/usa-accordion/src/styles/_usa-accordion.scss
@@ -57,9 +57,19 @@ $accordion-button-open-hc-icon: map-merge(
 
 // Opened styles
 @mixin accordion-button-styles {
+  @include button-unstyled;
+  @include set-text-and-bg(
+    $theme-accordion-button-background-color,
+    $context: $accordion-context
+  );
+  @include set-icon-from-bg(
+    $theme-accordion-button-background-color,
+    "usa-icons/remove",
+    "usa-icons-bg/remove--white"
+  );
+
   //
-  //* Because of the new recommendation, we have regressions in accordion.
-  //* This is because mixins that were being overriden are now at the end.
+  //* Move declarations after mixins to preserve overrides.
   //
   //
   & {
@@ -73,17 +83,6 @@ $accordion-button-open-hc-icon: map-merge(
     text-decoration: none;
     width: 100%;
   }
-
-  @include button-unstyled;
-  @include set-text-and-bg(
-    $theme-accordion-button-background-color,
-    $context: $accordion-context
-  );
-  @include set-icon-from-bg(
-    $theme-accordion-button-background-color,
-    "usa-icons/remove",
-    "usa-icons-bg/remove--white"
-  );
 
   &:hover {
     text-decoration: none;

--- a/packages/uswds-core/src/styles/mixins/general/add-background-svg.scss
+++ b/packages/uswds-core/src/styles/mixins/general/add-background-svg.scss
@@ -4,7 +4,9 @@
 // See https://css-tricks.com/a-complete-guide-to-svg-fallbacks/
 
 @mixin add-background-svg($image-name, $image-path: $theme-image-path) {
-  background-image: url("#{$image-path}/#{$image-name}.svg"),
-    linear-gradient(transparent, transparent);
-  background-repeat: no-repeat;
+  & {
+    background-image: url("#{$image-path}/#{$image-name}.svg"),
+      linear-gradient(transparent, transparent);
+    background-repeat: no-repeat;
+  }
 }

--- a/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
+++ b/packages/uswds-core/src/styles/mixins/general/button-unstyled.scss
@@ -13,17 +13,19 @@
 /// }
 ///
 @mixin button-unstyled {
+  & {
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    font-weight: font-weight("normal");
+    justify-content: normal;
+    text-align: left;
+    margin: 0;
+    padding: 0;
+    width: auto;
+  }
   @include typeset-link;
-  background-color: transparent;
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
-  font-weight: font-weight("normal");
-  justify-content: normal;
-  text-align: left;
-  margin: 0;
-  padding: 0;
-  width: auto;
 
   &:hover,
   &.usa-button--hover,

--- a/packages/uswds-core/src/styles/mixins/general/icon.scss
+++ b/packages/uswds-core/src/styles/mixins/general/icon.scss
@@ -143,15 +143,17 @@
     "usa-icons/#{$filename-base}.svg"
   );
 
-  background-image: url("#{$path}/#{$filename-ie11}");
-  background-repeat: no-repeat;
-  background-position: $position-x $position-y;
-  background-size: $width $height;
-  display: inline-block;
-  height: if($container-height, $container-height, $height);
-  width: if($container-width, $container-width, $width);
-  @if $rotate {
-    transform: rotate($rotate);
+  & {
+    background-image: url("#{$path}/#{$filename-ie11}");
+    background-repeat: no-repeat;
+    background-position: $position-x $position-y;
+    background-size: $width $height;
+    display: inline-block;
+    height: if($container-height, $container-height, $height);
+    width: if($container-width, $container-width, $width);
+    @if $rotate {
+      transform: rotate($rotate);
+    }
   }
 
   // Mask supported styles
@@ -187,7 +189,6 @@
     null
   );
   &::#{$direction} {
-    @include add-color-icon($icon-object, $contrast-bg);
     content: "";
     vertical-align: $vertical-align;
 
@@ -196,6 +197,8 @@
     } @else {
       margin-right: units($margin);
     }
+
+    @include add-color-icon($icon-object, $contrast-bg);
   }
 
   @if $color-hover {

--- a/packages/uswds-core/src/styles/mixins/helpers/set-text-and-bg.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/set-text-and-bg.scss
@@ -12,7 +12,11 @@
   $important: null
 ) {
   $important: if($important, " !important", null);
+  $bg-color: if($bg-color == "default", get-default("bg-color"), $bg-color);
 
+  & {
+    background-color: color($bg-color) #{$important};
+  }
   @include set-text-from-bg(
     $bg-color,
     $preferred-text-color,
@@ -21,6 +25,4 @@
     $context,
     $important: $important
   );
-  $bg-color: if($bg-color == "default", get-default("bg-color"), $bg-color);
-  background-color: color($bg-color) #{$important};
 }

--- a/packages/uswds-core/src/styles/mixins/helpers/set-text-from-bg.scss
+++ b/packages/uswds-core/src/styles/mixins/helpers/set-text-from-bg.scss
@@ -18,5 +18,8 @@
     $wcag-target,
     $context
   );
-  color: color($accessible-color-token) #{$important};
+
+  & {
+    color: color($accessible-color-token) #{$important};
+  }
 }

--- a/packages/uswds-core/src/styles/mixins/typography/typeset.scss
+++ b/packages/uswds-core/src/styles/mixins/typography/typeset.scss
@@ -36,8 +36,10 @@ Sets:
 }
 
 @mixin typeset-heading-base {
+  & {
+    clear: both;
+  }
   @include u-margin-y(0);
-  clear: both;
 }
 
 @mixin typeset-heading {
@@ -53,8 +55,10 @@ Sets:
 }
 
 @mixin typeset-p-base {
-  line-height: line-height($theme-body-font-family, $theme-body-line-height);
-  max-width: measure($theme-text-measure);
+  & {
+    line-height: line-height($theme-body-font-family, $theme-body-line-height);
+    max-width: measure($theme-text-measure);
+  }
 }
 
 // typeset element mixins
@@ -72,8 +76,10 @@ Sets:
 }
 
 @mixin typeset-link {
-  color: color($theme-link-color);
-  text-decoration: underline;
+  & {
+    color: color($theme-link-color);
+    text-decoration: underline;
+  }
 
   &:visited {
     color: color($theme-link-visited-color);

--- a/packages/uswds-core/src/styles/mixins/typography/unstyled-list.scss
+++ b/packages/uswds-core/src/styles/mixins/typography/unstyled-list.scss
@@ -2,9 +2,12 @@
 
 // Unstyled list helper
 @mixin unstyled-list() {
+  & {
+    list-style-type: none;
+    padding-left: 0;
+  }
+
   @include u-margin-y(0);
-  list-style-type: none;
-  padding-left: 0;
 
   > li {
     margin-bottom: 0;

--- a/packages/uswds-core/src/styles/mixins/utilities/_font.scss
+++ b/packages/uswds-core/src/styles/mixins/utilities/_font.scss
@@ -9,7 +9,9 @@ Get a font-family stack
 */
 
 @mixin u-font-family($family) {
-  font-family: ff($family);
+  & {
+    font-family: ff($family);
+  }
 }
 
 /*
@@ -23,7 +25,9 @@ system scale or project scale
 */
 
 @mixin u-font-size($family, $scale) {
-  font-size: font-size($family, $scale);
+  & {
+    font-size: font-size($family, $scale);
+  }
 }
 
 /*
@@ -39,6 +43,8 @@ system scale or project scale
 */
 
 @mixin u-font($family, $scale) {
-  font-family: ff($family);
-  font-size: font-size($family, $scale);
+  & {
+    font-family: ff($family);
+    font-size: font-size($family, $scale);
+  }
 }

--- a/packages/uswds-core/src/styles/mixins/utilities/_line-height.scss
+++ b/packages/uswds-core/src/styles/mixins/utilities/_line-height.scss
@@ -15,5 +15,8 @@
   }
   $family: list.nth($value, 1);
   $scale: list.nth($value, 2);
-  line-height: lh($family, $scale) #{$important};
+
+  & {
+    line-height: lh($family, $scale) #{$important};
+  }
 }

--- a/packages/uswds-core/src/styles/mixins/utilities/_margin.scss
+++ b/packages/uswds-core/src/styles/mixins/utilities/_margin.scss
@@ -14,7 +14,9 @@
       }
       $important: " !important";
     }
-    margin: get-uswds-value(margin, $value...) #{$important};
+    & {
+      margin: get-uswds-value(margin, $value...) #{$important};
+    }
   } @else if $side == x {
     $important: null;
     @if has-important($value) {
@@ -24,8 +26,13 @@
       }
       $important: " !important";
     }
-    margin-left: get-uswds-value("margin-horizontal", $value...) #{$important};
-    margin-right: get-uswds-value("margin-horizontal", $value...) #{$important};
+
+    & {
+      margin-left: get-uswds-value("margin-horizontal", $value...)
+        #{$important};
+      margin-right: get-uswds-value("margin-horizontal", $value...)
+        #{$important};
+    }
   } @else if $side == y {
     $important: null;
     @if has-important($value) {
@@ -35,8 +42,12 @@
       }
       $important: " !important";
     }
-    margin-bottom: get-uswds-value("margin-vertical", $value...) #{$important};
-    margin-top: get-uswds-value("margin-vertical", $value...) #{$important};
+
+    & {
+      margin-bottom: get-uswds-value("margin-vertical", $value...)
+        #{$important};
+      margin-top: get-uswds-value("margin-vertical", $value...) #{$important};
+    }
   } @else if $side == t {
     $important: null;
     @if has-important($value) {
@@ -46,7 +57,9 @@
       }
       $important: " !important";
     }
-    margin-top: get-uswds-value("margin-vertical", $value...) #{$important};
+    & {
+      margin-top: get-uswds-value("margin-vertical", $value...) #{$important};
+    }
   } @else if $side == r {
     $important: null;
     @if has-important($value) {
@@ -56,7 +69,10 @@
       }
       $important: " !important";
     }
-    margin-right: get-uswds-value("margin-horizontal", $value...) #{$important};
+    & {
+      margin-right: get-uswds-value("margin-horizontal", $value...)
+        #{$important};
+    }
   } @else if $side == b {
     $important: null;
     @if has-important($value) {
@@ -66,7 +82,10 @@
       }
       $important: " !important";
     }
-    margin-bottom: get-uswds-value("margin-vertical", $value...) #{$important};
+    & {
+      margin-bottom: get-uswds-value("margin-vertical", $value...)
+        #{$important};
+    }
   } @else if $side == l {
     $important: null;
     @if has-important($value) {
@@ -76,7 +95,10 @@
       }
       $important: " !important";
     }
-    margin-left: get-uswds-value("margin-horizontal", $value...) #{$important};
+    & {
+      margin-left: get-uswds-value("margin-horizontal", $value...)
+        #{$important};
+    }
   }
 }
 

--- a/packages/uswds-core/src/styles/settings/_settings-general.scss
+++ b/packages/uswds-core/src/styles/settings/_settings-general.scss
@@ -39,7 +39,8 @@ Show updates and notifications.
 */
 
 $theme-show-compile-warnings: true !default;
-$theme-show-notifications: true !default;
+// @TODO: Revert back to `true` before merge.
+$theme-show-notifications: false !default;
 
 /*
 ----------------------------------------

--- a/packages/uswds-elements/src/styles/_body.scss
+++ b/packages/uswds-elements/src/styles/_body.scss
@@ -1,6 +1,6 @@
 @use "uswds-core/src/styles/mixins/helpers/set-text-and-bg" as *;
 
 body {
-  @include set-text-and-bg($context: "Body");
   overflow-x: hidden;
+  @include set-text-and-bg($context: "Body");
 }

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -24,6 +24,7 @@ module.exports = {
           outputStyle: "expanded",
           // @TODO: Remove `silenceDeprecations` before merge.
           silenceDeprecations: ["color-functions", "import", "global-builtin"],
+          verbose: true,
         }).on("error", function handleError(error) {
           dutil.logError(error);
           this.emit("end");

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -20,14 +20,14 @@ module.exports = {
       .pipe(sourcemaps.init({ largeFile: true }))
       .pipe(
         sass({
-          includePaths: [
-            "./packages",
-          ],
+          includePaths: ["./packages"],
           outputStyle: "expanded",
+          // @TODO: Remove `silenceDeprecations` before merge.
+          silenceDeprecations: ["color-functions", "import", "global-builtin"],
         }).on("error", function handleError(error) {
           dutil.logError(error);
           this.emit("end");
-        })
+        }),
       )
       .pipe(postcss(pluginsProcess))
       .pipe(replace(/\buswds @version\b/g, `uswds v${pkg.version}`))
@@ -36,7 +36,7 @@ module.exports = {
       .pipe(
         rename({
           suffix: ".min",
-        })
+        }),
       )
       .pipe(sourcemaps.write("."))
       .pipe(dest("dist/css"));


### PR DESCRIPTION
# Summary

Test branch to see what's involved in removing SASS deprecation warnings in accordion. 

## Breaking change

TK

## Related issue

Related to #5980.

## Related pull requests

_Indicate if there are other pull requests necessary to complete this issue._
<!--
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-sass-mixed-decl-accordion/?path=/story/components-accordion--default)

## Problem statement

_Summarize the problem this PR solves in a clear and concise statement._
<!--
A successful problem statement conveys:
1. The desired state,
2. The actual state, and
3. Consequences of remaining in the current state
   (who does this affect and to what degree?)
-->

## Solution

Wrapped declarations in mixins with `& { }`.


## Major changes

_For complex PRs, create a list of the significant updates made._

## Testing and review

Compiled CSS before/after below.

**Before**
```css
/* uswds 3.11.0 */
/* Note: There are duplicate styles in: 
      - color
      - text-decoration
      - background-color
      - font-weight
      - margin
      - padding 
      - width
*/ 
.usa-accordion__button {
  color: #005ea2;
  text-decoration: underline;
  background-color: transparent;
  border: 0;
  border-radius: 0;
  box-shadow: none;
  font-weight: normal;
  justify-content: normal;
  text-align: left;
  margin: 0;
  padding: 0;
  width: auto;
  color: #1b1b1b;
  background-color: #f0f0f0;
  background-image: url("../img/usa-icons/remove.svg"),
    linear-gradient(transparent, transparent);
  background-repeat: no-repeat;
  background-position: right 1.25rem center;
  background-size: 1.5rem;
  cursor: pointer;
  display: inline-block;
  font-weight: 700;
  margin: 0;
  padding: 1rem 3.5rem 1rem 1.25rem;
  text-decoration: none;
  width: 100%;
}
```

**After**
```css
/* This branch */
/* Output matches output in upcoming SASS 2.0.0 with the native CSS nesting changes. */
.usa-accordion__button {
  background-color: #f0f0f0;
}
.usa-accordion__button {
  color: #1b1b1b;
}
.usa-accordion__button {
  background-image: url("../img/usa-icons/remove.svg"),
    linear-gradient(transparent, transparent);
  background-repeat: no-repeat;
}
.usa-accordion__button {
  background-position: right 1.25rem center;
  background-size: 1.5rem;
  cursor: pointer;
  display: inline-block;
  font-weight: 700;
  margin: 0;
  padding: 1rem 3.5rem 1rem 1.25rem;
  text-decoration: none;
  width: 100%;
}
```

Based on this [comment](https://github.com/sass/dart-sass/issues/2276#issuecomment-2506299610) we'll have to use something like [clean-css](https://github.com/clean-css/clean-css) to consolidate the selectors.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
