### PR TITLE
USWDS - Exclude links with usa-button class from text color change

### DIFF
--- a/packages/usa-dark-background/src/styles/_usa-dark-background.scss
+++ b/packages/usa-dark-background/src/styles/_usa-dark-background.scss
@@ -10,7 +10,7 @@ $background-context: "Background";
     color: color($theme-text-reverse-color);
   }
 
-  a {
+  a:not(.usa-button) {
     @include set-link-from-bg(
       "base-darker",
       $theme-link-reverse-color,

--- a/packages/usa-link/src/usa-link.twig
+++ b/packages/usa-link/src/usa-link.twig
@@ -10,7 +10,16 @@
   This is a link that opens in a <em>new</em> tab and goes to an <a class="usa-link usa-link--external" rel="noreferrer" target="_blank"  href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">external website</a>.
 </p>
 
+<div class="padding-1">
+  <a class="usa-button">This is a link styled as a button</a>
+  <a class="usa-button usa-button--accent-cool">This is a link styled as an accent button</a>
+</div>
+
+
 <div class="usa-dark-background padding-1 display-inline-block">
   <p>This is <a class="usa-link" href="javascript:void(0);">a text link on a dark background</a>.</p>
   <p><a class="usa-link usa-link--alt usa-link--external" rel="noreferrer" href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">This</a> is an alternate external text link on a dark background.</p>
+
+  <a class="usa-button">This is a link styled as a button</a>
+  <a class="usa-button usa-button--accent-cool">This is a link styled as an accent button</a>
 </div>


### PR DESCRIPTION

# Summary
Adds `:not(.usa-button)` to links contained in dark backgrounds so that the light colored link text does not override button styling.

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
-->

## Breaking change

This is not a breaking change.



## Related issue

Closes [#6258](https://github.com/uswds/uswds/issues/6258)


## Problem statement
Links styled with usa-button on dark backgrounds prior to this change take on the dark background link color.
<img width="668" alt="This is a link styled as a button" src="https://github.com/user-attachments/assets/beb8cc7e-2b6b-48bf-ab56-ad54805a7cc3" />


<!--
A successful problem statement conveys:
1. The desired state,
2. The actual state, and
3. Consequences of remaining in the current state
   (who does this affect and to what degree?)
-->

## Solution
There might be a better solution here, especially if the dark background impacts the link text color in other areas that might need to be excluded. I have excluded any links with classes `usa-button` from having their color overridden.

With exlcusion:
<img width="672" alt="This is a link styled as a button" src="https://github.com/user-attachments/assets/c64ee0f4-eac6-4880-b229-449e49dc66de" />


<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review
Added `<a class="usa-button ...">` to the test files.
