### PR TITLE
USWDS - Dependencies: Use sass 6 in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,15 +15,15 @@ const pathGenerator = asGenerator((item, ...rest) => [
   item.isAbsolute
     ? null
     : /\.(png|svg|jpg|jpeg|gif)$/.test(item.uri)
-    ? imageDirectory
-    : /\.(woff|woff2|eot|ttf|otf)$/.test(item.uri)
-    ? fontsDirectory
-    : null,
+      ? imageDirectory
+      : /\.(woff|woff2|eot|ttf|otf)$/.test(item.uri)
+        ? fontsDirectory
+        : null,
 ]);
 
 const joinSassAssets = createJoinFunction(
   "joinSassAssets",
-  createJoinImplementation(pathGenerator)
+  createJoinImplementation(pathGenerator),
 );
 
 module.exports = {
@@ -39,7 +39,7 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
   ],
-  staticDirs: ['../dist'],
+  staticDirs: ["../dist"],
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
@@ -127,8 +127,11 @@ module.exports = {
             name: "[path][name].[ext]",
           },
         },
-        include: path.resolve(__dirname, "../packages/uswds-core/src/assets/fonts"),
-      }
+        include: path.resolve(
+          __dirname,
+          "../packages/uswds-core/src/assets/fonts",
+        ),
+      },
     );
 
     return config;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -98,11 +98,8 @@ module.exports = {
             options: {
               sourceMap: true,
               sassOptions: {
-                includePaths: [
-                  "./packages",
-                  "./node_modules/@uswds"
-                ],
-                implementation: require("sass-embedded")
+                loadPaths: ["./packages", "./node_modules/@uswds"],
+                implementation: require("sass-embedded"),
               },
             },
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "resolve-url-loader": "5.0.0",
         "sass": "1.83.0",
         "sass-embedded": "1.83.0",
-        "sass-loader": "13.3.2",
+        "sass-loader": "16.0.4",
         "sass-true": "6.0.1",
         "sinon": "12.0.1",
         "snyk": "1.1294.3",
@@ -28286,30 +28286,30 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.2.tgz",
-      "integrity": "sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.4.tgz",
+      "integrity": "sha512-LavLbgbBGUt3wCiYzhuLLu65+fWXaXLmq7YxivLhEqmiupCFZ5sKUAipK3do6V80YSU0jvSxNhEdT13IXNr3rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
+        "@rspack/core": "0.x || 1.x",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -28319,6 +28319,9 @@
           "optional": true
         },
         "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "resolve-url-loader": "5.0.0",
     "sass": "1.83.0",
     "sass-embedded": "1.83.0",
-    "sass-loader": "13.3.2",
+    "sass-loader": "16.0.4",
     "sass-true": "6.0.1",
     "sinon": "12.0.1",
     "snyk": "1.1294.3",

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -20,14 +20,12 @@ module.exports = {
       .pipe(sourcemaps.init({ largeFile: true }))
       .pipe(
         sass({
-          loadPaths: [
-            "./packages",
-          ],
+          loadPaths: ["./packages"],
           style: "expanded",
         }).on("error", function handleError(error) {
           dutil.logError(error);
           this.emit("end");
-        })
+        }),
       )
       .pipe(postcss(pluginsProcess))
       .pipe(replace(/\buswds @version\b/g, `uswds v${pkg.version}`))
@@ -36,7 +34,7 @@ module.exports = {
       .pipe(
         rename({
           suffix: ".min",
-        })
+        }),
       )
       .pipe(sourcemaps.write("."))
       .pipe(dest("dist/css"));


### PR DESCRIPTION
# Summary

Updates Storybook to match work done in #6285.

## Breaking change

This is an internal change.

## Related issue

Part of #6103.

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/jm-update-sass-6/) 

## Problem statement

Matching SASS in storybook will allow us to match what we're shipping on release.

## Testing and review

Ensure there aren't regressions in running local component library via `npm start`.

## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | --------------: | ---------: |
| sass-loader |     13.3.2      |   16.0.4   |

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
