### PR TITLE
USWDS - Date Picker: Alternative Behavior For Backspacing For Conditional Formatting 

### DIFF
--- a/packages/usa-date-picker/src/index.js
+++ b/packages/usa-date-picker/src/index.js
@@ -943,12 +943,18 @@ const enhanceDatePicker = (el) => {
         const cursorPosition = this.selectionStart;
         const lastChar = inputValue.slice(cursorPosition - 1, cursorPosition);
 
-        if (lastChar === "/" || (cursorPosition > 1 && inputValue[cursorPosition - 2] === "/")) {
+        if (
+          lastChar === "/" ||
+          (cursorPosition > 1 && inputValue[cursorPosition - 2] === "/")
+        ) {
           // Remove preceding number and slash
-          this.value = 
-            inputValue.slice(0, cursorPosition - 1 - 
-            (inputValue[cursorPosition - 2] === "/" ? 1 : 0)) + 
-            inputValue.slice(cursorPosition);
+          this.value =
+            inputValue.slice(
+              0,
+              cursorPosition -
+                1 -
+                (inputValue[cursorPosition - 2] === "/" ? 1 : 0),
+            ) + inputValue.slice(cursorPosition);
         } else {
           // Remove only the preceding number
           this.value =

--- a/packages/usa-date-picker/src/index.js
+++ b/packages/usa-date-picker/src/index.js
@@ -943,10 +943,11 @@ const enhanceDatePicker = (el) => {
         const cursorPosition = this.selectionStart;
         const lastChar = inputValue.slice(cursorPosition - 1, cursorPosition);
 
-        if (lastChar === "/") {
-          // Remove slash and the preceding number
-          this.value =
-            inputValue.slice(0, cursorPosition - 2) +
+        if (lastChar === "/" || (cursorPosition > 1 && inputValue[cursorPosition - 2] === "/")) {
+          // Remove preceding number and slash
+          this.value = 
+            inputValue.slice(0, cursorPosition - 1 - 
+            (inputValue[cursorPosition - 2] === "/" ? 1 : 0)) + 
             inputValue.slice(cursorPosition);
         } else {
           // Remove only the preceding number


### PR DESCRIPTION
# Summary

This is an alternative behavior for backspacing through the slashes in the date picker for the conditional formatting fix. The expected behavior for this fix allows the user to delete the slash when deleting a digit that is preceded by a slash.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5693 

## Related pull requests

Date Picker Conditional Formatting Fix #6210

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

The original behavior created in the conditional formatting fix may not be the behavior that a user expects.

## Solution

This PR provides another behavior for backspacing over the slashes that may better follow the type of behavior that a user expect to see for this conditional formatting fix.

## Testing and review

1. After typing in a date to the date picker component, use the backspace button to delete the digits in the component. When backspacing over a digit that is proceeded by a slash, both the digit you backspace over and the slash should be deleted.