### PR TITLE
USWDS - utils: replace `resolve-id-refs` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.11.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
+        "receptor": "1.0.0"
       },
       "devDependencies": {
         "@18f/identity-stylelint-config": "4.1.0",
@@ -27267,12 +27266,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-id-refs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-id-refs/-/resolve-id-refs-0.1.0.tgz",
-      "integrity": "sha512-hNS03NEmVpJheF7yfyagNh57XuKc0z+NkSO0oBbeO67o6IJKoqlDfnNIxhjp7aTWwjmSWZQhtiGrOgZXVyM90w==",
-      "license": "CC0-1.0"
     },
     "node_modules/resolve-options": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
   },
   "homepage": "https://github.com/uswds/uswds#readme",
   "dependencies": {
-    "receptor": "1.0.0",
-    "resolve-id-refs": "0.1.0"
+    "receptor": "1.0.0"
   },
   "devDependencies": {
     "@18f/identity-stylelint-config": "4.1.0",

--- a/packages/uswds-core/src/js/utils/toggle-form-input.js
+++ b/packages/uswds-core/src/js/utils/toggle-form-input.js
@@ -1,4 +1,3 @@
-const resolveIdRefs = require("resolve-id-refs");
 const toggleFieldMask = require("./toggle-field-mask");
 
 const CONTROLS = "aria-controls";
@@ -13,6 +12,21 @@ const HIDE_ATTR = "data-hide-text";
  */
 const getHideText = (showText) =>
   showText.replace(/\bShow\b/i, (show) => `${show[0] === "S" ? "H" : "h"}ide`);
+
+const resolveIdRefs = (id) => {
+  const ids = id.trim()
+    .split(/\s+/);
+
+  return ids
+    .map((i) => {
+      const el = document.getElementById(i);
+      if (!el) {
+        const err = `no element with id: ${i}`;
+        throw new Error(err);
+      }
+      return el;
+    })
+}
 
 /**
  * Component that decorates an HTML element with the ability to toggle the

--- a/packages/uswds-core/src/js/utils/toggle-form-input.js
+++ b/packages/uswds-core/src/js/utils/toggle-form-input.js
@@ -14,19 +14,17 @@ const getHideText = (showText) =>
   showText.replace(/\bShow\b/i, (show) => `${show[0] === "S" ? "H" : "h"}ide`);
 
 const resolveIdRefs = (id) => {
-  const ids = id.trim()
-    .split(/\s+/);
+  const ids = id.trim().split(/\s+/);
 
-  return ids
-    .map((i) => {
-      const el = document.getElementById(i);
-      if (!el) {
-        const err = `no element with id: ${i}`;
-        throw new Error(err);
-      }
-      return el;
-    })
-}
+  return ids.map((i) => {
+    const el = document.getElementById(i);
+    if (!el) {
+      const err = `no element with id: ${i}`;
+      throw new Error(err);
+    }
+    return el;
+  });
+};
 
 /**
  * Component that decorates an HTML element with the ability to toggle the


### PR DESCRIPTION
# Summary

This change removes the `resolve-id-refs` package and re-implements the functionality it was providing for the password reset form.

## Breaking change

This is not a breaking change.

## Problem statement

`resolve-id-refs` is triggering a [CodeQL vulnerability alert](https://github.com/uswds/uswds-tutorial/pull/67/checks?check_run_id=35615138469) in the compiled USWDS javascript. This PR just removes that dependency and re-implements the same functionality.

## Testing and review

I tested this change by running the unit test suite and by viewing the password reset form in Storybook to verify that there were no regressions.

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| `resolve-id-refs`  |     0.1.0     |     --      |
