### PR TITLE
USWDS - Prettier fixes

### DIFF
--- a/packages/usa-date-picker/src/index.js
+++ b/packages/usa-date-picker/src/index.js
@@ -82,12 +82,12 @@ const VALIDATION_MESSAGE = "Please enter a valid date";
 
 // An array of Dates that represent each month in the year
 const MONTH_DATE_SEED = Array.from({ length: 12 }).map(
-  (_, i) => new Date(0, i)
+  (_, i) => new Date(0, i),
 );
 
 // An array of Dates that represent each day of the week
 const DAY_OF_WEEK_DATE_SEED = Array.from({ length: 7 }).map(
-  (_, i) => new Date(0, 0, i)
+  (_, i) => new Date(0, 0, i),
 );
 
 const CALENDAR_LABELS_BY_LANG = new Map();
@@ -707,17 +707,17 @@ const getDatePickerContext = (el) => {
   if (!CALENDAR_LABELS_BY_LANG.has(lang)) {
     CALENDAR_LABELS_BY_LANG.set(lang, {
       monthLabels: MONTH_DATE_SEED.map((date) =>
-        date.toLocaleString(lang, { month: "long" })
+        date.toLocaleString(lang, { month: "long" }),
       ),
       dayOfWeeklabels: DAY_OF_WEEK_DATE_SEED.map((date) =>
         date.toLocaleString(lang, {
           weekday: "long",
-        })
+        }),
       ),
       dayOfWeeksAbv: DAY_OF_WEEK_DATE_SEED.map((date) =>
         date.toLocaleString(lang, {
           weekday: "narrow",
-        })
+        }),
       ),
     });
   }

--- a/packages/usa-date-picker/src/test/date-picker-i18n.spec.js
+++ b/packages/usa-date-picker/src/test/date-picker-i18n.spec.js
@@ -5,7 +5,7 @@ const EVENTS = require("./events");
 const DatePicker = require("../index");
 
 const TEMPLATE = fs.readFileSync(
-  path.join(__dirname, "/date-picker-default-date.template.html")
+  path.join(__dirname, "/date-picker-default-date.template.html"),
 );
 
 const datePickerSelector = () => document.querySelector(".usa-date-picker");
@@ -44,7 +44,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const selectedMonth = root.querySelector(
-        ".usa-date-picker__calendar__month-selection"
+        ".usa-date-picker__calendar__month-selection",
       );
 
       assert.strictEqual(selectedMonth.innerHTML, "May");
@@ -56,7 +56,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const selectedMonth = root.querySelector(
-        ".usa-date-picker__calendar__month-selection"
+        ".usa-date-picker__calendar__month-selection",
       );
 
       assert.strictEqual(selectedMonth.innerHTML, "mayo");
@@ -68,12 +68,12 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const selectedMonth = root.querySelector(
-        ".usa-date-picker__calendar__month-selection"
+        ".usa-date-picker__calendar__month-selection",
       );
 
       assert.strictEqual(
         selectedMonth.getAttribute("aria-label"),
-        "mayo. Select month"
+        "mayo. Select month",
       );
     });
 
@@ -81,13 +81,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const selectedMonth = root.querySelector(
-        ".usa-date-picker__calendar__month-selection"
+        ".usa-date-picker__calendar__month-selection",
       );
 
       EVENTS.click(selectedMonth);
 
       const months = Array.from(
-        root.querySelectorAll(".usa-date-picker__calendar__table button")
+        root.querySelectorAll(".usa-date-picker__calendar__table button"),
       ).map((btn) => btn.innerHTML);
 
       assert.deepEqual(months, [
@@ -112,13 +112,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const selectedMonth = root.querySelector(
-        ".usa-date-picker__calendar__month-selection"
+        ".usa-date-picker__calendar__month-selection",
       );
 
       EVENTS.click(selectedMonth);
 
       const months = Array.from(
-        root.querySelectorAll(".usa-date-picker__calendar__table button")
+        root.querySelectorAll(".usa-date-picker__calendar__table button"),
       ).map((btn) => btn.innerHTML);
 
       assert.deepEqual(months, [
@@ -141,7 +141,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const daysOfTheWeek = Array.from(
-        root.querySelectorAll(".usa-date-picker__calendar__day-of-week")
+        root.querySelectorAll(".usa-date-picker__calendar__day-of-week"),
       ).map((btn) => btn.innerHTML);
 
       assert.deepEqual(daysOfTheWeek, ["S", "M", "T", "W", "T", "F", "S"]);
@@ -153,7 +153,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const daysOfTheWeek = Array.from(
-        root.querySelectorAll(".usa-date-picker__calendar__day-of-week")
+        root.querySelectorAll(".usa-date-picker__calendar__day-of-week"),
       ).map((btn) => btn.innerHTML);
 
       assert.deepEqual(daysOfTheWeek, ["D", "L", "M", "X", "J", "V", "S"]);
@@ -165,7 +165,7 @@ tests.forEach(({ name, selector: containerSelector }) => {
       EVENTS.click(button);
 
       const daysOfTheWeek = Array.from(
-        root.querySelectorAll(".usa-date-picker__calendar__day-of-week")
+        root.querySelectorAll(".usa-date-picker__calendar__day-of-week"),
       ).map((btn) => btn.getAttribute("aria-label"));
 
       assert.deepEqual(daysOfTheWeek, [


### PR DESCRIPTION
# Summary

Ran prettier on `develop`. 

## Breaking change

This is not a breaking change.

## Related issue

N/A

## Related pull requests

N/A

## Preview link

N/A

## Problem statement

We recently updated the prettier version in PR #6257, which changed the formatting output on our files. 

We then merged #5679 into `develop`, but I suspect that that branch was out of date with `develop` and did not contain this prettier version update. This means that a some differences in prettier formatting made it into `develop`.

## Solution

Run prettier on `develop`

## Testing and review

- Confirm no regressions from these changes
- Confirm prettier passes