### PR TITLE
USWDS - Character Count: Remove status message elements when `.off()` is called  

### DIFF
--- a/packages/usa-character-count/src/index.js
+++ b/packages/usa-character-count/src/index.js
@@ -1,4 +1,5 @@
 const select = require("../../uswds-core/src/js/utils/select");
+const selectOrMatches = require("../../uswds-core/src/js/utils/select-or-matches");
 const behavior = require("../../uswds-core/src/js/utils/behavior");
 const debounce = require("../../uswds-core/src/js/utils/debounce");
 const { prefix: PREFIX } = require("../../uswds-core/src/js/config");
@@ -90,6 +91,26 @@ const createStatusMessages = (characterCountEl) => {
   srStatusMessage.textContent = defaultMessage;
 
   characterCountEl.append(statusMessage, srStatusMessage);
+};
+
+/**
+ * Teardown to remove status messages that were created on init
+ *
+ * @param {HTMLDivElement} characterCountEl - Div with `.usa-character-count` class
+ * @description  Remove the two status messages that were added during initialization of
+ * the character count module
+ */
+const removeStatusMessages = (characterCountEl) => {
+  const status = characterCountEl.getElementsByClassName(
+    `${STATUS_MESSAGE_CLASS} usa-hint`,
+  );
+  const srStatus = characterCountEl.getElementsByClassName(
+    `${STATUS_MESSAGE_SR_ONLY_CLASS} usa-sr-only`,
+  );
+
+  [...status, ...srStatus].forEach((node) => {
+    node.remove();
+  });
 };
 
 /**
@@ -215,6 +236,11 @@ const characterCount = behavior(
     createStatusMessages,
     getCountMessage,
     updateCountMessage,
+    teardown(root) {
+      selectOrMatches(CHARACTER_COUNT, root).forEach((node) => {
+        removeStatusMessages(node);
+      });
+    },
   },
 );
 


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.

- For security reasons, all commits to this repository must have a verified signature.
  Use one of the following GitHub guides to set up your commit verification signature:
    - GPG commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification
    - SSH commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

This PR adds a `teardown()` method to remove the status message elements that are added to the DOM when `.on()` is called for the character count module. 

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
-->

## Breaking change

This is not a breaking change.

<!--
Breaking changes include:
  - Changes to the JavaScript API
  - Changes to markup or content in our components
  - Significant changes to the display of a component
If applicable, explain what actions are required for the user to remediate the break.
-->

## Related issue

Closes #6386 
<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here:
https://github.com/uswds/uswds/issues/new/choose.
-->

## Problem statement

The character count module adds two status elements (one for visual, one for screen reader) to the DOM via `createStatusMessages()` on `init()`.  However, it does not remove these elements when `.off()` is called.  

This prevents this module from being used properly in [React's strict mode](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-ref-callbacks-in-development) because rendering and callback refs run twice.  Since `.on()` gets called twice, and `.off()` (in a cleanup function) does not remove the status elements, you end up having 4 total status elements in the DOM (instead of the intended 2 elements).

## Solution

This PR adds a `teardown()` method to the character count module that matches on the `CHARACTER_COUNT` class at the specified `root`, and queries for the elements there were added by `createStatusMessages()` and removes them.

Let me know if you all think there is a better way!

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
