### PR TITLE
USWDS - Unit Tests: Fix USWDS build unit test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const { series, parallel } = require("gulp");
 const { noCleanup, noTest } = require("./tasks/flags");
 const { buildSprite, buildSpriteStandalone } = require("./tasks/svg-sprite");
 const { compileJS, typeCheck } = require("./tasks/javascript");
-const { unitTests, sassTests } = require("./tasks/test");
+const { unitTests, sassTests, buildTests } = require("./tasks/test");
 const { lintSass, typecheck } = require("./tasks/lint");
 const { build } = require("./tasks/build");
 const { release } = require("./tasks/release");
@@ -44,6 +44,7 @@ exports.lint = parallel(lintSass, typecheck);
 
 exports.sassTests = sassTests;
 exports.unitTests = unitTests;
+exports.buildTests = buildTests;
 exports.test = series(
   typeCheck,
   lintSass,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:a11y": "build-storybook && axe-storybook",
     "test:sass": "gulp sassTests",
     "test:unit": "gulp unitTests",
+    "test:build": "gulp buildTests",
     "version": "gulp release",
     "watch": "gulp watch",
     "fix:icons": "npx svgo --folder ./packages/usa-icon/src/img/uswds-icons -q && npx svgo --folder ./packages/usa-icon/src/img/usa-icons-bg -q",

--- a/packages/uswds-core/src/js/utils/test/.mocharc.json
+++ b/packages/uswds-core/src/js/utils/test/.mocharc.json
@@ -3,5 +3,5 @@
     "jsdom-global/register"
   ],
   "exit": true,
-  "timeout": 4000
+  "timeout": 6000
 }

--- a/packages/uswds-core/src/js/utils/test/util.js
+++ b/packages/uswds-core/src/js/utils/test/util.js
@@ -2,7 +2,7 @@ const path = require("path");
 const child = require("child_process");
 const sass = require("sass-embedded"); // eslint-disable-line import/no-extraneous-dependencies
 
-exports.distPath = path.resolve(path.join(__dirname, "../../../dist"));
+exports.distPath = path.resolve("./dist");
 exports.distCssPath = path.join(exports.distPath, "css");
 exports.distScssPath = path.join(exports.distPath, "scss");
 exports.runGulp = (task) =>

--- a/src/test/build.spec.js
+++ b/src/test/build.spec.js
@@ -4,8 +4,8 @@ const path = require("path");
 const pkg = require("../../package.json");
 const { runGulp, distCssPath } = require("../../packages/uswds-core/src/js/utils/test/util");
 
-before(() => {
-  setTimeout(() => runGulp("sass"), 20000);
+before(async () => {
+  await runGulp("compileSass");
 });
 
 describe("build output", () => {

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -22,4 +22,8 @@ module.exports = {
   sassTests() {
     return src("packages/uswds-core/src/test/sass.spec.js").pipe(mocha());
   },
+
+  buildTests() {
+    return src("src/test/build.spec.js").pipe(mocha(mochaConfig));
+  },
 };


### PR DESCRIPTION
# Summary

Fix the existing `build.spec.js` test which tests USWDS css output. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #6413

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-fix-build-test/)

## Problem statement

The current unit test fails when being ran and does not have a script to easily run it.

## Solution

- Update test to run `compileSass` instead of `sass` which no longer exists
- Update test to properly await gulp compilation before testing
- Create `buildTests` test script in `test.js`
    - This test is being included and exported in our gulpfile
    - I also created a new script in our `package.json` to run this test

## Major changes

- Test can now be run using `npm run test:build`
- Test properly calls for sass compilation and checks output after dist is built
- Mocha timeout increased by 2 seconds to give compilation more time to complete

> [!NOTE]
This build script is currently only testing output `css`. Since this is all it was checking before I wanted to scope the work to fixing the existing functionality.
I’ve created #6415 to consider adding additional tests to check for other dist files.
> 

## Testing and review

1. Checkout this branch locally
2. Delete the `/dist` directory
3. Run `npm run test:build`
4. Confirm `/dist` is rebuilt with css dir:
    - `uswds.css`
    - `uswds.min.css`
    - `uswds.min.css.map`
5. Confirm tests run without failure