### PR TITLE
USWDS - Sass: Fix output Sass directory pathing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const { series, parallel } = require("gulp");
 const { noCleanup, noTest } = require("./tasks/flags");
 const { buildSprite, buildSpriteStandalone } = require("./tasks/svg-sprite");
 const { compileJS, typeCheck } = require("./tasks/javascript");
-const { unitTests, sassTests } = require("./tasks/test");
+const { unitTests, sassTests, includeTests } = require("./tasks/test");
 const { lintSass, typecheck } = require("./tasks/lint");
 const { build } = require("./tasks/build");
 const { release } = require("./tasks/release");
@@ -44,6 +44,7 @@ exports.lint = parallel(lintSass, typecheck);
 
 exports.sassTests = sassTests;
 exports.unitTests = unitTests;
+exports.includeTests = includeTests;
 exports.test = series(
   typeCheck,
   lintSass,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:a11y": "build-storybook && axe-storybook",
     "test:sass": "gulp sassTests",
     "test:unit": "gulp unitTests",
+    "test:sassInclude": "gulp includeTests",
     "version": "gulp release",
     "watch": "gulp watch",
     "fix:icons": "npx svgo --folder ./packages/usa-icon/src/img/uswds-icons -q && npx svgo --folder ./packages/usa-icon/src/img/usa-icons-bg -q",

--- a/packages/uswds-core/src/js/utils/test/util.js
+++ b/packages/uswds-core/src/js/utils/test/util.js
@@ -21,7 +21,7 @@ exports.runGulp = (task) =>
 exports.compileString = (styles, loadPaths) => {
   sass.compileString(styles, {
     loadPaths,
-    silenceDeprecations: ["mixed-decls", "import"],
+    silenceDeprecations: ["mixed-decls"],
   });
 };
 
@@ -33,6 +33,6 @@ exports.compileString = (styles, loadPaths) => {
 exports.compile = (file, loadPaths) => {
   sass.compile(file, {
     loadPaths,
-    silenceDeprecations: ["mixed-decls", "import"],
+    silenceDeprecations: ["mixed-decls"],
   });
 };

--- a/packages/uswds-core/src/js/utils/test/util.js
+++ b/packages/uswds-core/src/js/utils/test/util.js
@@ -14,10 +14,15 @@ exports.runGulp = (task) =>
   });
 
 exports.compileString = (styles, loadPaths) => {
-  sass.compileString(styles, {loadPaths, silenceDeprecations: ["mixed-decls", "import"]},
-  );
-}
+  sass.compileString(styles, {
+    loadPaths,
+    silenceDeprecations: ["mixed-decls", "import"],
+  });
+};
 
-exports.compile = (file,  loadPaths) => {
-  sass.compile(file, {loadPaths, silenceDeprecations: ["mixed-decls", "import"]});
-}
+exports.compile = (file, loadPaths) => {
+  sass.compile(file, {
+    loadPaths,
+    silenceDeprecations: ["mixed-decls", "import"],
+  });
+};

--- a/packages/uswds-core/src/js/utils/test/util.js
+++ b/packages/uswds-core/src/js/utils/test/util.js
@@ -2,7 +2,7 @@ const path = require("path");
 const child = require("child_process");
 const sass = require("sass-embedded"); // eslint-disable-line import/no-extraneous-dependencies
 
-exports.distPath = path.resolve(path.join(__dirname, "../../../dist"));
+exports.distPath = path.resolve("./dist");
 exports.distCssPath = path.join(exports.distPath, "css");
 exports.distScssPath = path.join(exports.distPath, "scss");
 exports.runGulp = (task) =>
@@ -13,19 +13,11 @@ exports.runGulp = (task) =>
       .on("exit", () => resolve());
   });
 
-exports.render = (data, includePaths) =>
-  new Promise((resolve, reject) => {
-    sass.renderSync(
-      {
-        data,
-        includePaths,
-      },
-      (error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      },
-    );
-  });
+exports.compileString = (styles, loadPaths) => {
+  sass.compileString(styles, {loadPaths, silenceDeprecations: ["mixed-decls", "import"]},
+  );
+}
+
+exports.compile = (file,  loadPaths) => {
+  sass.compile(file, {loadPaths, silenceDeprecations: ["mixed-decls", "import"]});
+}

--- a/packages/uswds-core/src/js/utils/test/util.js
+++ b/packages/uswds-core/src/js/utils/test/util.js
@@ -13,6 +13,11 @@ exports.runGulp = (task) =>
       .on("exit", () => resolve());
   });
 
+/**
+ * Compiles a string of scss styles to css
+ * @param {string} styles - Scss style definitions to compile into css
+ * @param {*} loadPaths - Paths in which to look for stylesheets loaded by rules like @use and @import.
+ */
 exports.compileString = (styles, loadPaths) => {
   sass.compileString(styles, {
     loadPaths,
@@ -20,6 +25,11 @@ exports.compileString = (styles, loadPaths) => {
   });
 };
 
+/**
+ * Compiles a scss file to css
+ * @param {string} file - Path to file to compile into css
+ * @param {*} loadPaths - Paths in which to look for stylesheets loaded by rules like @use and @import.
+ */
 exports.compile = (file, loadPaths) => {
   sass.compile(file, {
     loadPaths,

--- a/src/test/include.spec.js
+++ b/src/test/include.spec.js
@@ -3,29 +3,26 @@ const path = require("path");
 const {
   runGulp,
   distScssPath,
-  render,
+  compileString,
+  compile
 } = require("../../packages/uswds-core/src/js/utils/test/util");
 
-const includePath = path.resolve(path.join(__dirname, "../"));
+const includePath = path.resolve("packages/");
 
 describe("include paths", () => {
   it('can be loaded with @import "uswds"', async () => {
-    setTimeout(() => {
-      render('@import "uswds";', [includePath]);
-    }, 20000);
+      compileString(`@import "uswds";`, [includePath]);
   });
 });
 
 describe("standalone dist scss", () => {
-  before(() => {
-    setTimeout(() => {
-      runGulp("copy-dist-sass");
-    }, 20000);
+  // Function expression required to use this.timeout() and prevent test from timing out
+  before(async function buildSass() {
+      this.timeout(10000)  
+      await runGulp("buildUSWDS");
   });
 
   it('can be loaded with @import "uswds"', () => {
-    setTimeout(() => {
-      render('@import "uswds";', [distScssPath]);
-    }, 20000);
+      compile(`${distScssPath}/uswds.scss`, [includePath]);
   });
 });

--- a/src/test/include.spec.js
+++ b/src/test/include.spec.js
@@ -10,8 +10,8 @@ const {
 const includePath = path.resolve("packages/");
 
 describe("include paths", () => {
-  it('can be loaded with @import "uswds"', async () => {
-      compileString(`@import "uswds";`, [includePath]);
+  it('can be loaded with @forward "uswds"', async () => {
+      compileString(`@forward "uswds";`, [includePath]);
   });
 });
 
@@ -22,7 +22,7 @@ describe("standalone dist scss", () => {
       await runGulp("buildUSWDS");
   });
 
-  it('can be loaded with @import "uswds"', () => {
+  it('can be loaded with @forward "uswds"', () => {
       compile(`${distScssPath}/uswds.scss`, [includePath]);
   });
 });

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -13,10 +13,9 @@ module.exports = {
   },
 
   // Copy Sass stylesheets to /dist directory
-  // TODO: Do we want to copy to the scss any more?
   copySass() {
     dutil.logMessage("copySass", "Copying Sass stylesheets to /dist/scss");
-    return src("src/**/**/*.scss").pipe(dest("dist/scss"));
+    return src("src/stylesheets/**/*.scss").pipe(dest("dist/scss"));
   },
 
   // Copy material icons to /dist/img/material-icons

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -22,4 +22,8 @@ module.exports = {
   sassTests() {
     return src("packages/uswds-core/src/test/sass.spec.js").pipe(mocha());
   },
+
+  includeTests() {
+    return src("src/test/include.spec.js").pipe(mocha(mochaConfig));
+  }
 };


### PR DESCRIPTION
# Summary

Updates compiled Sass directory to correctly point to `packages` directory that holds component styles.

This organization matches our `/src` directory and allows the Sass to be used as instructed in the [Install the package directly from GitHub](https://designsystem.digital.gov/documentation/developers/#install-the-package-directly-from-github-2) guidance.

## Breaking change

:warning: This is potentially a breaking change.

While the file structure is changed, the current structure fails to point to the right packages directory, which causes Sass compilation errors. 

It’s possible users have made changed their file structure to resolve this locally.

## Related issue

Closes #6414

Closes #6287

## Related pull requests

Related to #6417. Neither PR should block each other.

## Preview link

[Preview link →](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/cm-fix-include-test/)

## Problem statement

Current sass output does not have the correct pathing to point to `packages`. Following our [Install the package directly from GitHub](https://designsystem.digital.gov/documentation/developers/#install-the-package-directly-from-github-2) guidance, users are likely to run into pathing issues.

```node
 sass --load-path=src/assets/packages/ src/assets/dist/scss/stylesheets/uswds.scss dist/css/test.css
Error: Can't find stylesheet to import.
  ╷
1 │ @forward "../../packages/uswds";
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  src/assets/dist/scss/stylesheets/uswds.scss 1:1  root stylesheet
```

Our unit test to check that users can use `@import "uswds"` is also non-functional. This test should confirm the Sass structure is correct. 

## Solution

1. Change output Sass structure to correctly point to `packages` dir:

```diff
- /dist/scss/stylesheets/*
+ /dist/scss/*
```

1. Replace deprecated Sass `renderSync` with modern `compile` and `compileString` functions
2. Update `include.spec.js` to properly build output Sass directory and confirm Sass is usable.

## Major changes

- Dist scss directory structure updated
- Dist `uswds.scss` properly points to packages dir when installed via `npm` or downloading directly from GH
- Create `includeTests` test script in `test.js`
    - This test is included and exported in our gulpfile
    - Test can be ran via new `npm run test:sassInclude` script
    - Tests no relies on `@forward` instead of `@import`

## Testing and review

1. Checkout this branch locally
2. Delete the `/dist` directory
3. Run `npm run test:sassInclude`
4. Confirm the `/dist` directory is rebuilt
5. Confirm tests run without error
    - You can confirm test is running correctly by changing `@forward "uswds"` in either test in `include.spec.js`
    - Sass should fail to find incorrect stylesheet