### PR TITLE
USWDS - [site-alert]: sync variants with alert

### DIFF
--- a/packages/usa-site-alert/src/styles/_usa-site-alert.scss
+++ b/packages/usa-site-alert/src/styles/_usa-site-alert.scss
@@ -3,6 +3,9 @@
 
 // Alert variables ---------- //
 $site-alert-icons: (
+  success: "check_circle",
+  warning: "warning",
+  error: "error",
   info: "info",
   emergency: "error",
 );


### PR DESCRIPTION
# Summary

Adds the "error", "warning", "success" style variants to `site-alert`. These put it in sync with the available `alert` styles.

## Breaking change

This is not a breaking change.

## Problem statement

I attempted to use the `.usa-site-alert--error` class in my code and was met with an uncolored gray box with no icon. upon checking https://unpkg.com/browse/@uswds/uswds@3.11.0/dist/css/uswds.css and https://unpkg.com/browse/@uswds/uswds@3.11.0/packages/usa-site-alert/src/styles/_usa-site-alert.scss I realized it was because no such class existed.

## Solution

https://designsystem.digital.gov/components/alert/ and https://designsystem.digital.gov/components/site-alert/ being more in sync will cause less developer confusion and users will already be familiar with the styles.
