### PR TITLE
USWDS - README.md v1 and v2 clarification, removing v1 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,11 +523,11 @@ If you find any issues with our accessibility conformance, please create an issu
 
 ## Long-term support of v1.x
 
-[Version 1.x](https://v1.designsystem.digital.gov) is no longer maintained.
+USWDS version 1.x is no longer maintained.
 
 ## Long-term support of v2.x
 
-Version 2.x is no longer maintained.
+USWDS version 2.x is no longer maintained.
 
 ## Need installation help?
 


### PR DESCRIPTION
# Summary
Clarifying USWDS versions and deprecating the link to the v1 site since it's being decommissioned.

## Breaking change
This is not a breaking change.

## Related pull requests
Follow-up from #6502 

- internal note to check publishing afterwards

## Preview link

Preview link: [tbd]

