### PR TITLE
Updated "Internal Team" name

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor_ladder.md
+++ b/.github/ISSUE_TEMPLATE/contributor_ladder.md
@@ -74,7 +74,7 @@ This issue is used to request role changes within the USWDS repository contribut
 - [ ] No longer responsible for actively contributing to the repository :)
 
 ---
-### For Core Team only
+### For Internal Team only
 Please copy and paste the following as a comment on the issue:
 
 #### Review checklist:


### PR DESCRIPTION
Changing "Core Team" to "Internal Team" for consistency, to reflect COMMUNITY.md change