### PR TITLE
USWDS - Community: Add contributor onboarding documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,41 @@ If the pull request is accepted, we will schedule the issue and merge the pull r
 1. If your idea has already been suggested, upvote that feature request with a thumbs up emoji (👍) and comment on the issue to let us know why you need this feature request or enhancement and any other supporting information.
 Tip: If you want to find other feature requests open for upvoting, check out our [feature requests sorted by upvotes](https://github.com/uswds/uswds/issues?q=is%3Aissue+is%3Aopen+label%3A%22Status%3A+Voting+Open+%F0%9F%91%8D%22+sort%3Areactions-%2B1-desc).
 1. If your proposed fix is not in the [open issues backlog](https://github.com/uswds/uswds/issues), [create an issue](https://github.com/uswds/uswds/issues/new?assignees=&labels=Type%3A+Feature+Request%2CStatus%3A+Triage&template=feature_request.yaml&title=USWDS+-+Feature%3A+%5BYOUR+TITLE%5D) describing your proposal. This doesn’t mean we don’t want you to create a pull request. We simply want to start the process with an online conversation first. Plus, other community members might have supporting thoughts to add to your proposal. If you’ve already got a pull request, no worries. Go ahead and attach it to the issue.
+### Joining the USWDS Community as a Contributor
+
+If you'd like to be recognized as a USWDS contributor, you'll need to complete two steps: open an issue to request the role and open a pull request to add yourself to the community file. These two items reference each other, so start with the issue first.
+
+If you run into any trouble, feel free to open an issue or reach out at uswds@gsa.gov.
+
+#### Step 1: Open an issue
+
+1. Navigate to: `https://github.com/uswds/uswds/issues/new?template=contributor_ladder.md`
+2. Title your issue using this format: `[ROLE CHANGE]: Change to Contributor - YourUsername`
+3. Fill in your GitHub username and set "Requested role" to Contributor
+4. Skip the PR link for now — you'll come back to add it after Step 2
+5. Check off the Contributor responsibilities that apply to you
+6. Click **Create** to submit
+7. Make note of your issue number from the URL — you'll need it in Step 2 and at the end
+
+#### Step 2: Open a pull request
+
+1. Fork the USWDS repo at: `https://github.com/uswds/uswds/fork` and click **Create fork**
+2. Navigate to: `https://github.com/YOUR-USERNAME/uswds/edit/develop/COMMUNITY.md`
+3. Find the contributor table (around line 11) and add yourself as the last row:
+   `| Contributor | Your Name(https://github.com/YOUR-USERNAME) | Your Affiliation |`
+4. Scroll down and commit the change
+5. Navigate to: `https://github.com/uswds/uswds/compare/develop...YOUR-USERNAME:uswds:develop` and click **Create pull request**
+6. Title your PR: `USWDS - Community: Add [Your Name] as Contributor`
+7. In the **Related issue** field, paste the link to your issue from Step 1
+8. Click **Create pull request** and copy the URL of your new PR
+
+#### Last step
+
+Navigate to your issue at `https://github.com/uswds/uswds/issues/YOUR-ISSUE-NUMBER` and add the PR link from Step 2.
+
+The USWDS team will review both and follow up with next steps.
+
+Feel free to open an issue or email uswds@gsa.gov if you have questions.
 
 ### Proposing something else?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ If you run into any trouble, feel free to open an issue or reach out at uswds@gs
 7. In the **Related issue** field, paste the link to your issue from Step 1
 8. Click **Create pull request** and copy the URL of your new PR
 
-#### Last step
+#### Step 3: Link Issue to PR
 
 Navigate to your issue at `https://github.com/uswds/uswds/issues/YOUR-ISSUE-NUMBER` and add the PR link from Step 2.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,13 @@ If the pull request is accepted, we will schedule the issue and merge the pull r
 Tip: If you want to find other feature requests open for upvoting, check out our [feature requests sorted by upvotes](https://github.com/uswds/uswds/issues?q=is%3Aissue+is%3Aopen+label%3A%22Status%3A+Voting+Open+%F0%9F%91%8D%22+sort%3Areactions-%2B1-desc).
 1. If your proposed fix is not in the [open issues backlog](https://github.com/uswds/uswds/issues), [create an issue](https://github.com/uswds/uswds/issues/new?assignees=&labels=Type%3A+Feature+Request%2CStatus%3A+Triage&template=feature_request.yaml&title=USWDS+-+Feature%3A+%5BYOUR+TITLE%5D) describing your proposal. This doesn’t mean we don’t want you to create a pull request. We simply want to start the process with an online conversation first. Plus, other community members might have supporting thoughts to add to your proposal. If you’ve already got a pull request, no worries. Go ahead and attach it to the issue.
 ### Joining the USWDS Community as a Contributor
-> These instructions cover completing the process entirely through the GitHub dashboard, no local setup required.
 
-If you'd like to be recognized as a USWDS contributor, you'll need to complete two steps: open an issue to request the role and open a pull request to add yourself to the community file. These two items reference each other, so start with the issue first.
+If you're comfortable with git, the short version is: fork the repo, 
+add yourself to the contributor table in `COMMUNITY.md`, open a PR, 
+then open an issue and link them both together in their details.
+
+If you'd like a step-by-step walkthrough using the GitHub dashboard, 
+follow the instructions below.
 
 If you run into any trouble, feel free to open an issue or reach out at uswds@gsa.gov.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,7 @@ If the pull request is accepted, we will schedule the issue and merge the pull r
 Tip: If you want to find other feature requests open for upvoting, check out our [feature requests sorted by upvotes](https://github.com/uswds/uswds/issues?q=is%3Aissue+is%3Aopen+label%3A%22Status%3A+Voting+Open+%F0%9F%91%8D%22+sort%3Areactions-%2B1-desc).
 1. If your proposed fix is not in the [open issues backlog](https://github.com/uswds/uswds/issues), [create an issue](https://github.com/uswds/uswds/issues/new?assignees=&labels=Type%3A+Feature+Request%2CStatus%3A+Triage&template=feature_request.yaml&title=USWDS+-+Feature%3A+%5BYOUR+TITLE%5D) describing your proposal. This doesn’t mean we don’t want you to create a pull request. We simply want to start the process with an online conversation first. Plus, other community members might have supporting thoughts to add to your proposal. If you’ve already got a pull request, no worries. Go ahead and attach it to the issue.
 ### Joining the USWDS Community as a Contributor
+> These instructions cover completing the process entirely through the GitHub dashboard, no local setup required.
 
 If you'd like to be recognized as a USWDS contributor, you'll need to complete two steps: open an issue to request the role and open a pull request to add yourself to the community file. These two items reference each other, so start with the issue first.
 
@@ -124,6 +125,7 @@ If you run into any trouble, feel free to open an issue or reach out at uswds@gs
 7. Make note of your issue number from the URL — you'll need it in Step 2 and at the end
 
 #### Step 2: Open a pull request
+> Already have the repo forked? Skip to item 2.
 
 1. Fork the USWDS repo at: `https://github.com/uswds/uswds/fork` and click **Create fork**
 2. Navigate to: `https://github.com/YOUR-USERNAME/uswds/edit/develop/COMMUNITY.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ If you're comfortable with git, the short version is: fork the repo,
 add yourself to the contributor table in `COMMUNITY.md`, open a PR, 
 then open an issue and link them both together in their details.
 
-If you'd like a step-by-step walkthrough using the GitHub dashboard, 
+If you'd like a step-by-step walkthrough using only the GitHub dashboard without needing a local set-up, 
 follow the instructions below.
 
 If you run into any trouble, feel free to open an issue or reach out at uswds@gsa.gov.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,47 +107,6 @@ If the pull request is accepted, we will schedule the issue and merge the pull r
 1. If your idea has already been suggested, upvote that feature request with a thumbs up emoji (👍) and comment on the issue to let us know why you need this feature request or enhancement and any other supporting information.
 Tip: If you want to find other feature requests open for upvoting, check out our [feature requests sorted by upvotes](https://github.com/uswds/uswds/issues?q=is%3Aissue+is%3Aopen+label%3A%22Status%3A+Voting+Open+%F0%9F%91%8D%22+sort%3Areactions-%2B1-desc).
 1. If your proposed fix is not in the [open issues backlog](https://github.com/uswds/uswds/issues), [create an issue](https://github.com/uswds/uswds/issues/new?assignees=&labels=Type%3A+Feature+Request%2CStatus%3A+Triage&template=feature_request.yaml&title=USWDS+-+Feature%3A+%5BYOUR+TITLE%5D) describing your proposal. This doesn’t mean we don’t want you to create a pull request. We simply want to start the process with an online conversation first. Plus, other community members might have supporting thoughts to add to your proposal. If you’ve already got a pull request, no worries. Go ahead and attach it to the issue.
-### Joining the USWDS Community as a Contributor
-
-If you're comfortable with git, the short version is: fork the repo, 
-add yourself to the contributor table in `COMMUNITY.md`, open a PR, 
-then open an issue and link them both together in their details.
-
-If you'd like a step-by-step walkthrough using only the GitHub dashboard without needing a local set-up, 
-follow the instructions below.
-
-If you run into any trouble, feel free to open an issue or reach out at uswds@gsa.gov.
-
-#### Step 1: Open an issue
-
-1. Navigate to: `https://github.com/uswds/uswds/issues/new?template=contributor_ladder.md`
-2. Title your issue using this format: `[ROLE CHANGE]: Change to Contributor - YourUsername`
-3. Fill in your GitHub username and set "Requested role" to Contributor
-4. Skip the PR link for now — you'll come back to add it after Step 2
-5. Check off the Contributor responsibilities that apply to you
-6. Click **Create** to submit
-7. Make note of your issue number from the URL — you'll need it in Step 2 and at the end
-
-#### Step 2: Open a pull request
-> Already have the repo forked? Skip to item 2.
-
-1. Fork the USWDS repo at: `https://github.com/uswds/uswds/fork` and click **Create fork**
-2. Navigate to: `https://github.com/YOUR-USERNAME/uswds/edit/develop/COMMUNITY.md`
-3. Find the contributor table (around line 11) and add yourself as the last row:
-   `| Contributor | Your Name(https://github.com/YOUR-USERNAME) | Your Affiliation |`
-4. Scroll down and commit the change
-5. Navigate to: `https://github.com/uswds/uswds/compare/develop...YOUR-USERNAME:uswds:develop` and click **Create pull request**
-6. Title your PR: `USWDS - Community: Add [Your Name] as Contributor`
-7. In the **Related issue** field, paste the link to your issue from Step 1
-8. Click **Create pull request** and copy the URL of your new PR
-
-#### Step 3: Link Issue to PR
-
-Navigate to your issue at `https://github.com/uswds/uswds/issues/YOUR-ISSUE-NUMBER` and add the PR link from Step 2.
-
-The USWDS team will review both and follow up with next steps.
-
-Feel free to open an issue or email uswds@gsa.gov if you have questions.
 
 ### Proposing something else?
 
@@ -165,6 +124,48 @@ Note: We prioritize issues that affect accessibility.
 These considerations help us decide if and when we can work on the issue. If the issue is accepted, we will schedule them for an upcoming sprint (a 2-week work period).
 
 You can stay up to date on the status of your contributions through [GitHub email notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications) (external link) and the assigned labels on the issue.
+
+## Joining the USWDS Community as a Contributor
+
+If you're comfortable with git, the short version is: fork the repo, 
+add yourself to the contributor table in `COMMUNITY.md`, open a PR, 
+then open an issue and link them both together in their details.
+
+If you'd like a step-by-step walkthrough using only the GitHub dashboard without needing a local set-up, 
+follow the instructions below.
+
+If you run into any trouble, feel free to open an issue or reach out at uswds@gsa.gov.
+
+### Step 1: Open an issue
+
+1. Navigate to: `https://github.com/uswds/uswds/issues/new?template=contributor_ladder.md`
+2. Title your issue using this format: `[ROLE CHANGE]: Change to Contributor - YourUsername`
+3. Fill in your GitHub username and set "Requested role" to Contributor
+4. Skip the PR link for now — you'll come back to add it after Step 2
+5. Check off the Contributor responsibilities that apply to you
+6. Click **Create** to submit
+7. Make note of your issue number from the URL — you'll need it in Step 2 and at the end
+
+### Step 2: Open a pull request
+> Already have the repo forked? Skip to item 2.
+
+1. Fork the USWDS repo at: `https://github.com/uswds/uswds/fork` and click **Create fork**
+2. Navigate to: `https://github.com/YOUR-USERNAME/uswds/edit/develop/COMMUNITY.md`
+3. Find the contributor table (around line 11) and add yourself as the last row:
+   `| Contributor | Your Name(https://github.com/YOUR-USERNAME) | Your Affiliation |`
+4. Scroll down and commit the change
+5. Navigate to: `https://github.com/uswds/uswds/compare/develop...YOUR-USERNAME:uswds:develop` and click **Create pull request**
+6. Title your PR: `USWDS - Community: Add [Your Name] as Contributor`
+7. In the **Related issue** field, paste the link to your issue from Step 1
+8. Click **Create pull request** and copy the URL of your new PR
+
+### Step 3: Link Issue to PR
+
+Navigate to your issue at `https://github.com/uswds/uswds/issues/YOUR-ISSUE-NUMBER` and add the PR link from Step 2.
+
+The USWDS team will review both and follow up with next steps.
+
+Feel free to open an issue or email uswds@gsa.gov if you have questions.
 
 ## Common terms
 


### PR DESCRIPTION
# Summary

Added a step-by-step guide for joining the USWDS community as a contributor with less technical steps for completing the process through the GitHub dashboard. 

## Breaking change

This is not a breaking change.

## Related issue

Closes #_[issue_no]_

## Related pull requests

None

## Preview link

N/A

## Problem statement

Some community members may need steps outlined with a less technical approach to requesting to be added as contributors.

## Solution

Updated COMMUNITY.md with a quick summary for developers comfortable with git and step-by-step dashboard instructions for those less familiar with the workflow.

## Major changes

None

## Testing and review

No code changes. Review documentation update for accuracy against the current contributor ladder process and confirm steps/links are correct.
