### PR TITLE
Pin action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
       - name: Install dependencies
         run: npm install
       - name: Build USWDS JavaScript bundle
@@ -29,6 +29,6 @@ jobs:
       - name: Check that compiled files are in workspace
         run: echo $(ls ./dist/js)
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # pin v4.35.1
       - name: Perform CodeQL analysis for dist
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # pin v4.35.1


### PR DESCRIPTION
## Summary

Pinned specific SHA versions for the CodeQL GitHub Actions used in the CI workflow to tighten security posture.

## Related issue

[#6601](https://github.com/uswds/uswds/issues/6601)

## Problem statement

The `.github/workflows/codeql-analysis.yml` file referenced mutable tags (`@v3`) for the CodeQL and checkout actions. The more secure option is to pin these to specific commit hashes so we know exactly which version is running.

## Solution

Replaced the floating tags with pinned commit SHAs for the following actions:
- `actions/checkout` pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `github/codeql-action/*` pinned to `c10b8064de6f491fea524254123dbe5e09572f13` (v4.35.1)

This ensures the workflow uses known versions of the actions, providing stability and predictability for future runs.
