### PR TITLE
USWDS - uswds-core:  Sort all breakpoints (default and custom) by value

### DIFF
--- a/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
+++ b/packages/usa-layout-grid/src/styles/_usa-layout-grid.scss
@@ -8,6 +8,7 @@ $namespace-grid: ns("grid");
 
 $custom-breakpoints: map-deep-get($system-properties, breakpoints, extended);
 $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
+$sorted-breakpoints: sort-map-by-value($all-breakpoints);
 
 // basic container
 .#{$namespace-grid}container {
@@ -16,7 +17,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // container with custom widths
-@each $width-key, $width-value in $all-breakpoints {
+@each $width-key, $width-value in $sorted-breakpoints {
   .#{$namespace-grid}container-#{$width-key} {
     $props: append-important($grid-global, $width-key);
     @include grid-container($props);
@@ -24,7 +25,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // responsive containers...
-@each $mq-key, $mq-value in $all-breakpoints {
+@each $mq-key, $mq-value in $sorted-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}container {
@@ -33,7 +34,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
       }
 
       // ...with custom widths
-      @each $width-key, $width-value in $all-breakpoints {
+      @each $width-key, $width-value in $sorted-breakpoints {
         .#{$mq-key}#{$separator}#{$namespace-grid}container-#{$width-key} {
           $props: append-important($grid-global, $width-key);
           @include grid-container($props);
@@ -59,7 +60,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
   }
 
   // responsive column gaps
-  @each $mq-key, $mq-value in $all-breakpoints {
+  @each $mq-key, $mq-value in $sorted-breakpoints {
     @if map.get($theme-utility-breakpoints-complete, $mq-key) {
       @include at-media($mq-key) {
         @each $gap-key,
@@ -106,7 +107,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // responsive columns
-@each $mq-key, $mq-value in $all-breakpoints {
+@each $mq-key, $mq-value in $sorted-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @include at-media($mq-key) {
       .#{$mq-key}#{$separator}#{$namespace-grid}col {
@@ -145,7 +146,7 @@ $all-breakpoints: map-collect($system-breakpoints, $custom-breakpoints);
 }
 
 // responsive offsets
-@each $mq-key, $mq-value in $all-breakpoints {
+@each $mq-key, $mq-value in $sorted-breakpoints {
   @if map.get($theme-utility-breakpoints-complete, $mq-key) {
     @each $width-key, $width-value in $system-layout-grid-widths {
       @include at-media($mq-key) {

--- a/packages/uswds-core/src/styles/functions/general/_index.scss
+++ b/packages/uswds-core/src/styles/functions/general/_index.scss
@@ -8,6 +8,7 @@
 @forward "map-collect";
 @forward "map-deep-get";
 @forward "multi-cat";
+@forward "sort-map-by-value";
 @forward "remove";
 @forward "smart-quote";
 @forward "str-replace";

--- a/packages/uswds-core/src/styles/functions/general/sort-map-by-value.scss
+++ b/packages/uswds-core/src/styles/functions/general/sort-map-by-value.scss
@@ -1,0 +1,84 @@
+/*
+----------------------------------------
+sort-map-by-value()
+----------------------------------------
+Sort a map by its values in ascending
+numeric order. Useful for ensuring
+breakpoints are iterated from smallest
+to largest regardless of insertion order.
+
+@param {Map} $map - Map to sort
+@return {Map} - Map sorted by values
+----------------------------------------
+*/
+
+@use "sass:map";
+@use "sass:math";
+@use "sass:meta";
+@use "./strip-unit" as *;
+@use "./to-number" as *;
+
+@function normalize-breakpoint-value($value) {
+  $numeric: null;
+
+  @if meta.type-of($value) == "number" {
+    $numeric: $value;
+  } @else if meta.type-of($value) == "string" {
+    $numeric: to-number($value);
+  } @else {
+    @return $value;
+  }
+
+  $unit: math.unit($numeric);
+
+  @if $unit == "em" or $unit == "rem" {
+    @return strip-unit($numeric) * 16;
+  }
+
+  @return strip-unit($numeric);
+}
+
+@function sort-map-by-value($map) {
+  $sorted-map: ();
+  $sorted-keys: ();
+  $sorted-values: ();
+
+  // Convert map to parallel lists of keys and values
+  @each $key, $value in $map {
+    $numeric-value: normalize-breakpoint-value($value);
+
+    $sorted-keys: append($sorted-keys, $key);
+    $sorted-values: append($sorted-values, $numeric-value);
+  }
+
+  // Bubble sort the keys based on their corresponding values
+  // (Simple but effective for small breakpoint maps)
+  $length: length($sorted-keys);
+
+  @for $i from 1 through $length {
+    @for $j from $i through $length {
+      $val-i: nth($sorted-values, $i);
+      $val-j: nth($sorted-values, $j);
+
+      @if $val-j < $val-i {
+        // Swap values
+        $temp-val: $val-i;
+        $sorted-values: set-nth($sorted-values, $i, $val-j);
+        $sorted-values: set-nth($sorted-values, $j, $temp-val);
+
+        // Swap keys
+        $temp-key: nth($sorted-keys, $i);
+        $sorted-keys: set-nth($sorted-keys, $i, nth($sorted-keys, $j));
+        $sorted-keys: set-nth($sorted-keys, $j, $temp-key);
+      }
+    }
+  }
+
+  // Build the sorted map using the sorted keys in order
+  $sorted-map: ();
+  @each $key in $sorted-keys {
+    $sorted-map: map.set($sorted-map, $key, map.get($map, $key));
+  }
+
+  @return $sorted-map;
+}

--- a/packages/uswds-core/src/styles/functions/general/sort-map-by-value.scss
+++ b/packages/uswds-core/src/styles/functions/general/sort-map-by-value.scss
@@ -17,6 +17,7 @@ to largest regardless of insertion order.
 @use "sass:meta";
 @use "./strip-unit" as *;
 @use "./to-number" as *;
+@use "../units/root" as root;
 
 @function normalize-breakpoint-value($value) {
   $numeric: null;
@@ -32,7 +33,7 @@ to largest regardless of insertion order.
   $unit: math.unit($numeric);
 
   @if $unit == "em" or $unit == "rem" {
-    @return strip-unit($numeric) * 16;
+    @return strip-unit($numeric) * root.$root-font-size-equiv;
   }
 
   @return strip-unit($numeric);

--- a/packages/uswds-core/src/styles/mixins/_utility-builder.scss
+++ b/packages/uswds-core/src/styles/mixins/_utility-builder.scss
@@ -356,7 +356,10 @@ through all possible variants
   $our-breakpoints: map-deep-get($system-properties, breakpoints, standard);
   $custom-breakpoints: map-deep-get($system-properties, breakpoints, extended);
   $all-breakpoints: map-collect($our-breakpoints, $custom-breakpoints);
-  @each $media-key, $media-value in $all-breakpoints {
+  // Sort breakpoints by value to ensure consistent ordering (mobile-first)
+  // regardless of whether they're standard or custom breakpoints
+  $sorted-breakpoints: sort-map-by-value($all-breakpoints);
+  @each $media-key, $media-value in $sorted-breakpoints {
     @if (map.get($theme-utility-breakpoints-complete, $media-key)) {
       @include at-media($media-key) {
         @include these-utilities($utilities, $media-key);

--- a/packages/uswds-core/src/test/tests.scss
+++ b/packages/uswds-core/src/test/tests.scss
@@ -731,4 +731,71 @@ $this-function: "is-color-dark()";
   }
 }
 
+$this-function: "sort-map-by-value()";
+@include describe("[function] #{$this-function}") {
+  @include it("Sorts an unsorted breakpoint map in ascending order.") {
+    $test: sort-map-by-value(
+      (
+        "desktop": 64rem,
+        "mobile": 20rem,
+        "tablet": 40rem,
+      )
+    );
+    $expect: (
+      "mobile": 20rem,
+      "tablet": 40rem,
+      "desktop": 64rem,
+    );
+    @include assert-equal($test, $expect);
+  }
+
+  @include it("Sorts mixed unit values by normalized pixel value.") {
+    $test: sort-map-by-value(
+      (
+        "wide": 64em,
+        "narrow": 480px,
+        "medium": 40rem,
+      )
+    );
+    $expect: (
+      "narrow": 480px,
+      "medium": 40rem,
+      "wide": 64em,
+    );
+    @include assert-equal($test, $expect);
+  }
+
+  @include it("Preserves insertion order for breakpoints with equal values.") {
+    $test: sort-map-by-value(
+      (
+        "desktop": 1024px,
+        "widescreen": 1024px,
+        "mobile": 320px,
+      )
+    );
+    $expect: (
+      "mobile": 320px,
+      "desktop": 1024px,
+      "widescreen": 1024px,
+    );
+    @include assert-equal($test, $expect);
+  }
+
+  @include it("Returns the original map values in sorted key order.") {
+    $test: sort-map-by-value(
+      (
+        "desktop": 1024px,
+        "mobile": 320px,
+        "tablet": 640px,
+      )
+    );
+    $expect: (
+      "mobile": 320px,
+      "tablet": 640px,
+      "desktop": 1024px,
+    );
+    @include assert-equal($test, $expect);
+  }
+}
+
 // Debug


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.

- For security reasons, all commits to this repository must have a verified signature.
  Use one of the following GitHub guides to set up your commit verification signature:
    - GPG commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification
    - SSH commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

Fixed media query precedence by sorting breakpoints by screen size instead of insertion order. Prevents smaller custom breakpoints from overriding larger default ones.

## Breaking change
:warning: This is potentially a breaking change. This impacts the order of media-queries generated and could impact consuming code that has been written to overcome this issue


## Related issue

Closes #6412 

## Related pull requests

None

## Preview link

None

## Solution

This solution adds a sass function to sort breakpoints by value. 

packages/usa-layout-grid/src/styles/_usa-layout-grid.scss, and packages/uswds-core/src/styles/mixins/_utility-builder.scss were both updated to call the new function

Tests were added to validate outputs.

## Testing and review

For our use case the following config was used:

```
  $theme-utility-breakpoints: (
    "card": false,
    "card-lg": false,
    "mobile": true,
    "mobile-lg": true,
    "tablet": true,
    "tablet-lg": false,
    "desktop": true,
    "desktop-lg": true,
    "widescreen": true
  ),
  $theme-utility-breakpoints-custom: (
    "medium-screen": 768px
  ),
```
before these changes "medium-screen" breakpoints were being generating last and thus had more precedence than desktop and widescreen

After these changes the breakpoints are ordered by screen width

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
