### PR TITLE
USWDS - USA-Banner: replace <br> "empty group" with CSS

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -30,13 +30,13 @@
           <img class="usa-banner__icon usa-media-block__img" src="./img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
             {# Will cause error without trim because it doesn't know what to do with new lines #}
-            <p><strong>{{ domain.heading }}</strong><br/>{{ domain.text | trim | raw }}</p>
+            <p><strong class="display-block">{{ domain.heading }}</strong>{{ domain.text | trim | raw }}</p>
           </div>
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="./img/icon-https.svg" role="img" alt="" aria-hidden="true">
           <div class="usa-media-block__body">
-            <p><strong>{{ https.heading }}</strong><br/>{{ https.pretext | trim | raw }} ({{ lock }}) {{ https.posttext | trim | raw }}</p>
+            <p><strong class="display-block">{{ https.heading }}</strong>{{ https.pretext | trim | raw }} ({{ lock }}) {{ https.posttext | trim | raw }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.

- For security reasons, all commits to this repository must have a verified signature.
  Use one of the following GitHub guides to set up your commit verification signature:
    - GPG commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification
    - SSH commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification
 -->

# Summary

_Fixed a bug that caused screen readers to hear "empty group" in the Official gov website banner_ Previously, we used the line break element, `<br>`, to create a visual break in the banner detail. 

## Breaking change

This is not a breaking change.

## Problem statement

A bug in Edge causes Mac VoiceOver to read `<br>` as "empty group". VoiceOver users hear unneeded page structure data, which should be removed. This could cause confusion about whether the user is missing information.

## Solution

Our use of `<br>` causes this unneeded text to be read.  Because this is a visual separation and not a programmatic one, we should use CSS to style these elements.  
This change styles the separated text as its own block, which visually separates it.  

An alternative approach is to move the initial text into its own `<p>` element, and assign the following text the class `.margin-top-0`, but that doesn't offer significant benefit. We could also consider whether this is a header, or if there's a better HTML structure for this section.

## Testing and review

Tested on Mac Edge and Chrome with VoiceOver.  
With VO enabled, navigate to any USWDS page, as they all have this banner. Select "Here's how you know" to expand the accordion, and listen to the contents. The phrase "empty group" is read twice before this change, and not at all after.

Please suggest any HTML structure that is more appropriate.


Before opening this PR, make sure you’ve done whichever of these applies to you:
- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://guides.18f.org/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
