### PR TITLE
USWDS - Table: Fixes .usa-sr-only table caption heading row collapse

### DIFF
--- a/packages/uswds-core/src/styles/mixins/general/table.scss
+++ b/packages/uswds-core/src/styles/mixins/general/table.scss
@@ -246,6 +246,18 @@ $table-unsorted-icon-color: get-color-token-from-bg(
     font-weight: fw("bold");
     margin-bottom: units(1.5);
     text-align: left;
+
+    // Override default sr-only styles to prevent table borders from combining when collapsing
+    &.usa-sr-only {
+      position: static;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   /* stylelint-disable selector-class-pattern */


### PR DESCRIPTION
# Summary

Fixes an issue where table header borders don't collapse correctly when position: absolute is applies to the `caption`. The solution follows a similar pattern used by [Bootstrap](https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden.scss#L19-L21).

You can view the before and after in practice here: [Stackblitz - Table caption .usa-sr-only border-collapse repro](https://stackblitz.com/edit/stackblitz-starters-ubvprmfg?description=HTML/CSS/JS%20Starter&file=index.html&terminalHeight=10&title=Static%20Starter)

## Breaking change

This is not a breaking change.

## Related issue

Closes #6486 

## Preview link

[Stackblitz](https://stackblitz.com/edit/stackblitz-starters-ubvprmfg?description=HTML/CSS/JS%20Starter&file=index.html&terminalHeight=10&title=Static%20Starter)


- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.

