### PR TITLE
expose theme color values as css variables for consumers of uswds.css

### DIFF
--- a/packages/uswds-elements/src/styles/_color.scss
+++ b/packages/uswds-elements/src/styles/_color.scss
@@ -8,7 +8,7 @@
     --theme-color-base-dark: #{color("base-dark")};
     --theme-color-base-darker: #{color("base-darker")};
     --theme-color-base-darkest: #{color("base-darkest")};
-    // --theme-color-base-ink: #{color("base-ink")};
+    --theme-color-base-ink: #{color("ink")};
 }
 :root {
     --theme-color-primary-lighter: #{color("primary-lighter")};

--- a/packages/uswds-elements/src/styles/_color.scss
+++ b/packages/uswds-elements/src/styles/_color.scss
@@ -1,0 +1,42 @@
+@use "uswds-core/src/styles/functions/utilities" as *;
+
+:root {
+    --theme-color-base-lightest: #{color("base-lightest")};
+    --theme-color-base-lighter: #{color("base-lighter")};
+    --theme-color-base-light: #{color("base-light")};
+    --theme-color-base: #{color("base")};
+    --theme-color-base-dark: #{color("base-dark")};
+    --theme-color-base-darker: #{color("base-darker")};
+    --theme-color-base-darkest: #{color("base-darkest")};
+    // --theme-color-base-ink: #{color("base-ink")};
+}
+:root {
+    --theme-color-primary-lighter: #{color("primary-lighter")};
+    --theme-color-primary-light: #{color("primary-light")};
+    --theme-color-primary: #{color("primary")};
+    --theme-color-primary-vivid: #{color("primary-vivid")};
+    --theme-color-primary-dark: #{color("primary-dark")};
+    --theme-color-primary-darker: #{color("primary-darker")};
+}
+:root {
+    --theme-color-secondary-lighter: #{color("secondary-lighter")};
+    --theme-color-secondary-light: #{color("secondary-light")};
+    --theme-color-secondary: #{color("secondary")};
+    --theme-color-secondary-vivid: #{color("secondary-vivid")};
+    --theme-color-secondary-dark: #{color("secondary-dark")};
+    --theme-color-secondary-darker: #{color("secondary-darker")};
+}
+:root {
+    --theme-color-accent-warm-lighter: #{color("accent-warm-lighter")};
+    --theme-color-accent-warm-light: #{color("accent-warm-light")};
+    --theme-color-accent-warm: #{color("accent-warm")};
+    --theme-color-accent-warm-dark: #{color("accent-warm-dark")};
+    --theme-color-accent-warm-darker: #{color("accent-warm-darker")};
+}
+:root {
+    --theme-color-accent-cool-lighter: #{color("accent-cool-lighter")};
+    --theme-color-accent-cool-light: #{color("accent-cool-light")};
+    --theme-color-accent-cool: #{color("accent-cool")};
+    --theme-color-accent-cool-dark: #{color("accent-cool-dark")};
+    --theme-color-accent-cool-darker: #{color("accent-cool-darker")};
+}

--- a/packages/uswds-elements/src/styles/_index.scss
+++ b/packages/uswds-elements/src/styles/_index.scss
@@ -1,4 +1,5 @@
 @forward "body";
+@forward "color";
 @forward "focus";
 @forward "img";
 @forward "sizing";


### PR DESCRIPTION
# Summary

Exposes CSS Variables parallel to the existing `$theme-color-` SCSS ones.
Does not use them internally yet.

While there were more variables listed in `packages/uswds-core/src/styles/settings/_settings-color.scss` I chose to for now only add variables for the tokens listed on https://designsystem.digital.gov/design-tokens/color/theme-tokens/

## Breaking change

This is not a breaking change.

## Related issue

Related: https://github.com/uswds/uswds/issues/4644

## Related pull requests

N/A.

## Preview link

<img width="1021" height="537" alt="image" src="https://github.com/user-attachments/assets/65a5d958-2f71-44d9-81db-3709e24b0629" />

## Problem Statement

The way I use USWDS is by manually importing the `uswds.css` in my HTML like so:

```html
<link rel="stylesheet" href="/-/npm/@uswds/uswds@3.11.0/dist/css/uswds.css" integrity="sha384-G0llpcOOfpdIocwce8kYFUqkiabzRMkzBn3zBHHRag3s/1wb6JKvEnArq0RXjZUT" crossorigin="anonymous" />
```

As a result, one of the things I lose out on is the ease of theming that comes with the sass build system. Now migrating to use these variables may be too soon to migrate internally ([Can I Use](https://caniuse.com/css-variables) reports a 95% support), but it will allow for easier consumption for folks like me, and an easier migration later.