### PR TITLE
USWDS - Documentation: Fix 18F guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,8 @@ The values of `$theme-font-path` and `$theme-image-path` will be appended to USW
 ## CSS architecture
 
 - The CSS foundation of this site is built with the **[Sass](https://sass-lang.com)** preprocessor language.
-- The CSS organization and naming conventions follow **[18F’s Engineering Guide](https://guides.18f.gov/engineering/languages-runtimes/css/#naming)**.
-- We format our code with [Prettier](https://prettier.io/), per the formatting section of the **[18F Engineering Guide](https://guides.18f.gov/engineering/languages-runtimes/css/#formatting)**.
+- The CSS organization and naming conventions follow **[18F’s Engineering Guide](https://guides.18f.org/engineering/languages-runtimes/css/#naming)**.
+- We format our code with [Prettier](https://prettier.io/), per the formatting section of the **[18F Engineering Guide](https://guides.18f.org/engineering/languages-runtimes/css/#formatting)**.
 - CSS selectors are **prefixed** with `usa` (For example: `.usa-button`). This identifier helps the design system avoid conflicts with other styles on a site which are not part of USWDS.
 - Uses a **[BEM](http://getbem.com/)** approach for naming CSS selectors. Blocks are separated from elements with two underscores (`__`). Multi-word blocks use single hyphens instead of spaces. Modifier classes are additive — proper markup requires the base class _and_ the modifier class or classes. Modifier classes consist of the base class plus a modifier suffix, separated by two hyphens (`--`) as in `.usa-button.usa-button--secondary` or `usa-accordion.usa-accordion--bordered`.
 - Uses **modular CSS** for scalable, modular, and flexible code.
@@ -502,7 +502,7 @@ The values of `$theme-font-path` and `$theme-image-path` will be appended to USW
 - **Spacing units** are set with the `units()` function as described in [the USWDS 3.0 documentation](https://designsystem.digital.gov/design-tokens/spacing-units/). In general, we use spacing in multiples of `8px` — expressed as a multiple in `units([multiple])`. For instance `units(2)` is the equivalent of `2 * 8px` or `16px`. In the final, compiled CSS, this value will be expressed in rem, as a multiple of the base font size set with `$theme-base-font-size`.
 
 **For more information, visit:**
-[18F’s CSS Guide](https://guides.18f.gov/engineering/languages-runtimes/css/)
+[18F’s CSS Guide](https://guides.18f.org/engineering/languages-runtimes/css/)
 
 ## Browser support
 


### PR DESCRIPTION
# Summary

**Fixed broken 18F guide links.** Updated README links from `guides.18f.gov` to `guides.18f.org` so CSS architecture documentation links resolve correctly.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6543

## Related pull requests

None.

## Preview link

Preview link: N/A

## Problem statement

The README links to 18F CSS guidance on the retired `guides.18f.gov` domain. That domain no longer resolves, so readers cannot access the linked CSS naming, formatting, and architecture guidance.

## Solution

Updated the three README links to use the current `guides.18f.org` domain while preserving the existing guide paths and section anchors.

## Major changes

- Updated two 18F Engineering Guide links.
- Updated the 18F CSS Guide link.

## Testing and review

- Confirmed `guides.18f.gov` does not resolve.
- Confirmed `https://guides.18f.org/engineering/languages-runtimes/css/` returns HTTP 200.
- Ran `git diff --check`.