### PR TITLE
Add range limit labels example

### DIFF
--- a/packages/usa-range/src/usa-range.stories.js
+++ b/packages/usa-range/src/usa-range.stories.js
@@ -16,6 +16,14 @@ export default {
       name: "Preposition (of, for, in, de, etc.)",
       control: { type: "text" },
     },
+    range_min_label: {
+      name: "Minimum label",
+      control: { type: "text" },
+    },
+    range_max_label: {
+      name: "Maximum label",
+      control: { type: "text" },
+    },
     min: {
       name: "Min",
       control: { type: "number" },
@@ -40,6 +48,15 @@ export const Range = Template.bind({});
 Range.args = {
   text_unit: "",
   text_preposition: "",
+};
+
+export const WithRangeLimitLabels = Template.bind({});
+WithRangeLimitLabels.args = {
+  min: 0,
+  max: 100,
+  step: 10,
+  range_min_label: "0",
+  range_max_label: "100",
 };
 
 export const Disabled = Template.bind({});

--- a/packages/usa-range/src/usa-range.twig
+++ b/packages/usa-range/src/usa-range.twig
@@ -13,4 +13,13 @@
     {% if disabled_state == 'disabled' %} disabled {%- endif %}
     {% if disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
   >
+  {% if range_min_label or range_max_label %}
+    <div
+      class="display-flex flex-justify font-sans-3xs margin-top-1 text-base width-full"
+      aria-hidden="true"
+    >
+      <span>{{ range_min_label }}</span>
+      <span>{{ range_max_label }}</span>
+    </div>
+  {% endif %}
 </form>


### PR DESCRIPTION
## Summary
- Adds a range slider example variant with visible minimum and maximum labels.
- Keeps the labels hidden from assistive technology because the same limits are already exposed through the range input attributes.

## Why
Closes #4504.

## Changes
- Adds optional `range_min_label` and `range_max_label` markup to the range Twig template.
- Adds a Storybook example with `min="0"`, `max="100"`, and matching endpoint labels.

## Testing
- `git diff --check`

## Known Issues
- Full Storybook/build checks were not run locally because dependencies were not installed in this fresh clone.