### PR TITLE
USWDS - Storybook: Fixes SCSS import

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import "../packages/uswds/_index.scss";
 import "../packages/uswds-core/src/js/start";
 
 /** @type { import('@storybook/html').Preview } */

--- a/package-lock.json
+++ b/package-lock.json
@@ -8619,6 +8619,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8636,6 +8639,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8653,6 +8659,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8670,6 +8679,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8687,6 +8699,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8704,6 +8719,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10041,6 +10059,7 @@
         "x64"
       ],
       "dev": true,
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26019,6 +26038,7 @@
       "cpu": [
         "x64"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8619,9 +8619,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8639,9 +8636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8659,9 +8653,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8679,9 +8670,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8699,9 +8687,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -8719,9 +8704,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10059,7 +10041,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26038,7 +26019,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.stories.js
+++ b/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.stories.js
@@ -1,5 +1,3 @@
-// TODO: Why is this here and not elsewhere?
-import "../../../uswds/_index.scss";
 import Component from "./usa-icon--sizes.twig";
 import Content from "./usa-icon--sizes.json";
 


### PR DESCRIPTION
## Summary

Moves `_index.scss` import into the base `.storybook/preview.js` so SCSS renders correctly for all stories

## Breaking change

This is not a breaking change.

## Related issue

Closes #6675

## Related pull requests

_Indicate if there are other pull requests necessary to complete this issue._
<!--
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->

## Preview link

Preview link:
<!-- If available, provide a link to a demo of the solution in action. -->

## Problem statement

`_index.scss` was only being imported into `usa-icon--sizes.stories.js`. Not exactly sure why this made CSS rendering sometimes work. Nonetheless, it should be imported into the Storybook base.

## Solution

Move `_index.scss` into `.storybook/preview.js`

## Testing and review

1. Run storybook
2. Open Button story
3. Reload
4. Before, you would see buttons with no CSS. After you should see correctly rendered buttons

---

- [x] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [x] Run `npm run prettier:sass` to format any Sass updates.
- [x] Run `npm test` and confirm that all tests pass.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.