### PR TITLE
USWDS - Use fullscreen layout for demo pages

### DIFF
--- a/packages/templates/usa-create-account/usa-create-account.stories.js
+++ b/packages/templates/usa-create-account/usa-create-account.stories.js
@@ -5,6 +5,9 @@ import EsContent from "./usa-create-account~lang-es.json";
 
 export default {
   title: "Pages/Create Account",
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export const CreateAccountPage = () =>

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -4,6 +4,9 @@ import Component from "./usa-docs.twig";
 export default {
   title: "Pages/Documentation Page",
   args: DefaultContent,
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 const Template = (args) => Component(args);

--- a/packages/templates/usa-error/usa-error.stories.js
+++ b/packages/templates/usa-error/usa-error.stories.js
@@ -4,6 +4,9 @@ import EsContent from "./usa-error~lang-es.json";
 
 export default {
   title: "Pages/Error",
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export const PageNotFound = () =>

--- a/packages/templates/usa-landing/usa-landing.stories.js
+++ b/packages/templates/usa-landing/usa-landing.stories.js
@@ -3,6 +3,9 @@ import DefaultContent from "./usa-landing.json";
 
 export default {
   title: "Pages/Landing Page",
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 const Template = (args) => Component(args);

--- a/packages/templates/usa-sign-in/usa-sign-in.stories.js
+++ b/packages/templates/usa-sign-in/usa-sign-in.stories.js
@@ -7,6 +7,9 @@ import EsMultipleContent from "./usa-sign-in--multiple/usa-sign-in--multiple~lan
 
 export default {
   title: "Pages/Sign-In",
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export const SignInPage = () =>


### PR DESCRIPTION
## Summary

Fixed page template stories to display edge-to-edge without unwanted padding by setting Storybook's fullscreen layout parameter.

##  Breaking change

This is not a breaking change.

## Related issue

Closes https://github.com/uswds/uswds-site/issues/3206

## Preview link

https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/bug/3206-demo-page-styles/?path=/story/pages-create-account--create-account-page


## Problem statement

Desired state: Page templates (Create Account, Sign-In, Landing, Error, Documentation) should render edge-to-edge in Storybook without any surrounding padding, as they represent complete full-page layouts.

Actual state: all page template stories were using Storybook's default padded layout, which applies 1rem padding around the story canvas.

<img width="1856" height="763" alt="Storybook UI depicting border around page template" src="https://github.com/user-attachments/assets/930d1427-3bbb-4165-b222-ab1906bfe630" />

Consequences: The unwanted padding made the template seem less like a deployed, standalone webpage and more of an embedded demo.

## Solution

What: Added `{ layout: "fullscreen" }` to the storybook configuration for the stories under the `Pages` heading.

Why: Storybook provides built-in layout parameters (padded, centered, fullscreen, none). The fullscreen layout removes all padding by applying the sb-main-fullscreen class with padding: 0, which is the appropriate choice for full-page templates.

How: Modified 5 story files in packages/templates/:
- usa-create-account/usa-create-account.stories.js
- usa-sign-in/usa-sign-in.stories.js
- usa-landing/usa-landing.stories.js
- usa-error/usa-error.stories.js
- usa-documentation/usa-docs.stories.js

Each file's export default block now includes a parameters property with the fullscreen layout setting.

Limitations: None. This uses Storybook's standard layout API and doesn't affect any other stories or components.

## Verification

1. Compare the padding around the story canvas for the pages layouts on the current site - https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/site/uswds/uswds/?path=/story/pages-create-account--create-account-page and verify that the pages have no borders on the preview branch: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/bug/3206-demo-page-styles/?path=/story/pages-create-account--create-account-page. 
2. Stories depicting individual UI components or patterns are unaffected by this change. Padding around the story canvas will be present both on both the live deployment and this preview branch.
