### PR TITLE
USWDS - Storybook: Initializing more stories with enhanced components

### DIFF
--- a/packages/templates/usa-create-account/usa-create-account.stories.js
+++ b/packages/templates/usa-create-account/usa-create-account.stories.js
@@ -2,12 +2,26 @@
 import Component from "./usa-create-account.twig";
 import DefaultContent from "./usa-create-account.json";
 import EsContent from "./usa-create-account~lang-es.json";
+import banner from "../../usa-banner/src/index";
 
 export default {
   title: "Pages/Create Account",
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => {
+      banner.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 export const CreateAccountPage = () =>

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -14,10 +14,13 @@ const Template = (args) => Component(args);
 export const DocumentationPage = Template.bind({});
 
 export const TestDocumentationReorder = Template.bind({});
+TestDocumentationReorder.args = {
+  ...DefaultContent,
+  sidenav_reorder: true,
+};
 TestDocumentationReorder.argTypes = {
   sidenav_reorder: {
     control: { type: "boolean" },
-    defaultValue: false,
     name: "Reorder with CSS",
   },
 };

--- a/packages/templates/usa-documentation/usa-docs.stories.js
+++ b/packages/templates/usa-documentation/usa-docs.stories.js
@@ -1,5 +1,8 @@
 import DefaultContent from "./usa-docs.json";
 import Component from "./usa-docs.twig";
+import banner from "../../usa-banner/src/index";
+import accordion from "../../usa-accordion/src/index";
+import navigation from "../../usa-header/src/index";
 
 export default {
   title: "Pages/Documentation Page",
@@ -7,6 +10,23 @@ export default {
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => {
+      banner.off?.();
+      accordion.off?.();
+      navigation.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+        accordion.on?.();
+        navigation.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (args) => Component(args);

--- a/packages/templates/usa-error/usa-error.stories.js
+++ b/packages/templates/usa-error/usa-error.stories.js
@@ -1,12 +1,26 @@
 import Component from "./usa-error.twig";
 import DefaultContent from "./usa-error.json";
 import EsContent from "./usa-error~lang-es.json";
+import banner from "../../usa-banner/src/index";
 
 export default {
   title: "Pages/Error",
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => {
+      banner.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 export const PageNotFound = () =>

--- a/packages/templates/usa-landing/usa-landing.stories.js
+++ b/packages/templates/usa-landing/usa-landing.stories.js
@@ -1,11 +1,25 @@
 import Component from "./usa-landing.twig";
 import DefaultContent from "./usa-landing.json";
+import banner from "../../usa-banner/src/index";
 
 export default {
   title: "Pages/Landing Page",
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => {
+      banner.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (args) => Component(args);

--- a/packages/templates/usa-sign-in/usa-sign-in.stories.js
+++ b/packages/templates/usa-sign-in/usa-sign-in.stories.js
@@ -4,12 +4,26 @@ import DefaultContent from "./usa-sign-in.json";
 import EsContent from "./usa-sign-in~lang-es.json";
 import MultipleContent from "./usa-sign-in--multiple/usa-sign-in--multiple.json";
 import EsMultipleContent from "./usa-sign-in--multiple/usa-sign-in--multiple~lang-es.json";
+import banner from "../../usa-banner/src/index";
 
 export default {
   title: "Pages/Sign-In",
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => {
+      banner.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 export const SignInPage = () =>

--- a/packages/usa-banner/src/usa-banner.stories.js
+++ b/packages/usa-banner/src/usa-banner.stories.js
@@ -5,7 +5,7 @@ import {
   MilContent,
   MilContentLangEs,
 } from "./content";
-import banner from "./index";
+import bannerComponent from "./index";
 
 const defaults = DefaultContent;
 
@@ -13,12 +13,12 @@ export default {
   title: "Components/Banner",
   decorators: [
     (Story) => {
-      banner.off?.();
+      bannerComponent.off?.();
 
       const story = Story();
 
       window.requestAnimationFrame(() => {
-        banner.on?.();
+        bannerComponent.on?.();
       });
 
       return story;

--- a/packages/usa-banner/src/usa-banner.stories.js
+++ b/packages/usa-banner/src/usa-banner.stories.js
@@ -5,11 +5,25 @@ import {
   MilContent,
   MilContentLangEs,
 } from "./content";
+import banner from "./index";
 
 const defaults = DefaultContent;
 
 export default {
   title: "Components/Banner",
+  decorators: [
+    (Story) => {
+      banner.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        banner.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (banner, domain, https, ...args) =>

--- a/packages/usa-button/src/usa-button.stories.js
+++ b/packages/usa-button/src/usa-button.stories.js
@@ -19,6 +19,12 @@ const iconNames = iconItems.map((item) => item.name);
 
 export default {
   title: "Components/Button",
+  args: {
+    is_demo: true,
+    type: "button",
+    add_icon: false,
+    icon_name: "add_circle_outline",
+  },
   argTypes: {
     modifier: {
       name: "Variant",
@@ -28,27 +34,21 @@ export default {
     },
     is_demo: {
       name: "View all states",
-      defaultValue: true,
       type: "boolean",
     },
     type: {
-      defaultValue: "button",
       name: "Type attribute",
       options: ["button", "reset", "submit"],
       control: { type: "radio" },
     },
     add_icon: {
       name: "Add icon",
-      defaultValue: false,
       type: "boolean",
     },
     icon_name: {
       name: "Icon name",
-      control: {
-        type: "select",
-        options: iconNames,
-        defaultValue: "add_circle_outline",
-      },
+      options: iconNames,
+      control: { type: "select" },
       if: { arg: "add_icon" },
     },
   },

--- a/packages/usa-checkbox/src/usa-checkbox.stories.js
+++ b/packages/usa-checkbox/src/usa-checkbox.stories.js
@@ -4,6 +4,9 @@ import TestComponent from "./test/test-patterns/test-usa-checkbox.twig";
 
 export default {
   title: "Components/Form Inputs/Checkbox",
+  args: {
+    indeterminate_state: false,
+  },
   argTypes: {
     disabled_state: {
       name: "Disabled state",
@@ -13,7 +16,6 @@ export default {
     indeterminate_state: {
       name: "Toggle indeterminate state",
       control: { type: "boolean" },
-      defaultValue: false,
     },
   },
 };
@@ -51,23 +53,27 @@ Test.argTypes = {
   disabled_state: {
     table: { disable: true },
   },
-  indeterminate: {
+  indeterminate_state: {
     table: { disable: true },
   },
 };
 
 export const Indeterminate = Template.bind({});
+Indeterminate.args = {
+  indeterminate_state: true,
+};
 Indeterminate.argTypes = {
   indeterminate_state: {
-    defaultValue: true,
     table: { disable: true },
   },
 };
 
 export const IndeterminateTile = TileTemplate.bind({});
+IndeterminateTile.args = {
+  indeterminate_state: true,
+};
 IndeterminateTile.argTypes = {
   indeterminate_state: {
-    defaultValue: true,
     table: { disable: true },
   },
 };

--- a/packages/usa-date-picker/src/usa-date-picker.stories.js
+++ b/packages/usa-date-picker/src/usa-date-picker.stories.js
@@ -46,10 +46,10 @@ const Template = (args) => Component(args);
 export const Default = Template.bind({});
 
 export const DefaultDate = Template.bind({});
+DefaultDate.args = {
+  defaultDate: "1995-03-06",
+};
 DefaultDate.argTypes = {
-  defaultDate: {
-    defaultValue: "1995-03-06",
-  },
   rangeDate: {
     table: { disable: true },
   },
@@ -62,10 +62,10 @@ DefaultDate.argTypes = {
 };
 
 export const RangeDate = Template.bind({});
+RangeDate.args = {
+  rangeDate: "2022-01-07",
+};
 RangeDate.argTypes = {
-  rangeDate: {
-    defaultValue: "2022-01-07",
-  },
   defaultDate: {
     table: { disable: true },
   },
@@ -78,13 +78,11 @@ RangeDate.argTypes = {
 };
 
 export const RestrictedDate = Template.bind({});
+RestrictedDate.args = {
+  restrictedDateStart: "1995-03-06",
+  restrictedDateEnd: "1995-03-15",
+};
 RestrictedDate.argTypes = {
-  restrictedDateStart: {
-    defaultValue: "1995-03-06",
-  },
-  restrictedDateEnd: {
-    defaultValue: "1995-03-15",
-  },
   defaultDate: {
     table: { disable: true },
   },
@@ -94,10 +92,10 @@ RestrictedDate.argTypes = {
 };
 
 export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled_state: "disabled",
+};
 Disabled.argTypes = {
-  disabled_state: {
-    defaultValue: "disabled",
-  },
   defaultDate: {
     table: { disable: true },
   },
@@ -113,10 +111,10 @@ Disabled.argTypes = {
 };
 
 export const AriaDisabled = Template.bind({});
+AriaDisabled.args = {
+  disabled_state: "aria-disabled",
+};
 AriaDisabled.argTypes = {
-  disabled_state: {
-    defaultValue: "aria-disabled",
-  },
   defaultDate: {
     table: { disable: true },
   },

--- a/packages/usa-date-range-picker/src/date-range-picker.stories.js
+++ b/packages/usa-date-range-picker/src/date-range-picker.stories.js
@@ -46,13 +46,11 @@ const Template = (args) => Component(args);
 export const Default = Template.bind({});
 
 export const DefaultDate = Template.bind({});
+DefaultDate.args = {
+  defaultDateStart: "1995-03-06",
+  defaultDateEnd: "1995-03-15",
+};
 DefaultDate.argTypes = {
-  defaultDateStart: {
-    defaultValue: "1995-03-06",
-  },
-  defaultDateEnd: {
-    defaultValue: "1995-03-15",
-  },
   restrictedDateStart: {
     table: { disable: true },
   },
@@ -62,13 +60,11 @@ DefaultDate.argTypes = {
 };
 
 export const RestrictedDate = Template.bind({});
+RestrictedDate.args = {
+  restrictedDateStart: "1995-03-06",
+  restrictedDateEnd: "1995-03-15",
+};
 RestrictedDate.argTypes = {
-  restrictedDateStart: {
-    defaultValue: "1995-03-06",
-  },
-  restrictedDateEnd: {
-    defaultValue: "1995-03-15",
-  },
   defaultDateStart: {
     table: { disable: true },
   },
@@ -78,10 +74,10 @@ RestrictedDate.argTypes = {
 };
 
 export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled_state: "disabled",
+};
 Disabled.argTypes = {
-  disabled_state: {
-    defaultValue: "disabled",
-  },
   defaultDateStart: {
     table: { disable: true },
   },
@@ -97,10 +93,10 @@ Disabled.argTypes = {
 };
 
 export const AriaDisabled = Template.bind({});
+AriaDisabled.args = {
+  disabled_state: "aria-disabled",
+};
 AriaDisabled.argTypes = {
-  disabled_state: {
-    defaultValue: "aria-disabled",
-  },
   defaultDateStart: {
     table: { disable: true },
   },

--- a/packages/usa-date-range-picker/src/date-range-picker.stories.js
+++ b/packages/usa-date-range-picker/src/date-range-picker.stories.js
@@ -1,5 +1,6 @@
 import Component from "./usa-date-range-picker.twig";
 import datePicker from "../../usa-date-picker/src/index";
+import dateRangePicker from "./index";
 
 export default {
   title: "Components/Form Inputs/Date Range Picker",
@@ -29,11 +30,13 @@ export default {
   decorators: [
     (Story) => {
       datePicker.off?.();
+      dateRangePicker.off?.();
 
       const story = Story();
 
       window.requestAnimationFrame(() => {
         datePicker.on();
+        dateRangePicker.on();
       });
 
       return story;

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -11,6 +11,10 @@ import fileInput from "./index";
 
 export default {
   title: "Components/Form Inputs/File Input",
+  args: {
+    error_hint_text: "",
+    invalid_file_text: "",
+  },
   argTypes: {
     disabled_state: {
       name: "Disabled state",
@@ -20,12 +24,10 @@ export default {
     error_hint_text: {
       name: "Error message - hint",
       control: { type: "text" },
-      defaultValue: "",
     },
     invalid_file_text: {
       name: "Error text - Invalid file type (data-errorMessage)",
       control: { type: "text" },
-      defaultValue: "",
     },
   },
   decorators: [

--- a/packages/usa-footer/src/usa-footer.stories.js
+++ b/packages/usa-footer/src/usa-footer.stories.js
@@ -5,9 +5,23 @@ import Slim from "./usa-footer--slim/usa-footer--slim.twig";
 import DefaultContent from "./usa-footer.json";
 import BigContent from "./usa-footer--big/usa-footer--big.json";
 import SlimContent from "./usa-footer--slim/usa-footer--slim.json";
+import footer from "./index";
 
 export default {
   title: "Components/Footer",
+  decorators: [
+    (Story) => {
+      footer.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        footer.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (args) => Medium(args);

--- a/packages/usa-form/src/usa-form.stories.js
+++ b/packages/usa-form/src/usa-form.stories.js
@@ -97,7 +97,7 @@ TestErrorFormElements.args = {
 };
 TestErrorFormElements.argTypes = {
   error_state: {
-    table: { disable: false },
+    table: { disable: true },
   },
 };
 TestErrorFormElements.decorators = [

--- a/packages/usa-form/src/usa-form.stories.js
+++ b/packages/usa-form/src/usa-form.stories.js
@@ -82,17 +82,21 @@ export const SignInMultipleSpanish = SignInMultipleTemplate.bind({});
 SignInMultipleSpanish.args = EsMultipleContent;
 
 export const DisabledFormElements = CollectionTemplate.bind({});
+DisabledFormElements.args = {
+  disabled_state: "disabled",
+};
 DisabledFormElements.argTypes = {
   disabled_state: {
-    defaultValue: "disabled",
     table: { disable: false },
   },
 };
 
 export const TestErrorFormElements = CollectionTemplate.bind({});
+TestErrorFormElements.args = {
+  error_state: true,
+};
 TestErrorFormElements.argTypes = {
   error_state: {
-    defaultValue: true,
     table: { disable: false },
   },
 };

--- a/packages/usa-in-page-navigation/src/usa-in-page-navigation.stories.js
+++ b/packages/usa-in-page-navigation/src/usa-in-page-navigation.stories.js
@@ -40,9 +40,11 @@ TestCustomContentSelector.args = {
 };
 
 export const TestCustomHeaderSelector = TestCustomHeaderTemplate.bind();
+TestCustomHeaderSelector.args = {
+  headingType: "All",
+};
 TestCustomHeaderSelector.argTypes = {
   headingType: {
-    defaultValue: "All",
     name: "Include these headers in link list",
     options: [
       "Default",
@@ -62,15 +64,17 @@ TestCustomHeaderSelector.argTypes = {
 export const TestHiddenHeaders = TestHiddenHeaderTemplate.bind();
 
 export const TestMinimumHeaders = TestMinimumHeaderTemplate.bind();
+TestMinimumHeaders.args = {
+  headerLevels: 1,
+  minimumHeaderCount: 1,
+};
 TestMinimumHeaders.argTypes = {
   headerLevels: {
-    defaultValue: 1,
     name: "Number of headers on page",
     options: [1, 2, 3, 4],
     control: { type: "select" },
   },
   minimumHeaderCount: {
-    defaultValue: 1,
     name: "Minimum number of headers required to show navigation",
     options: [1, 2, 3, 4],
     control: { type: "select" },

--- a/packages/usa-input-mask/src/index.js
+++ b/packages/usa-input-mask/src/index.js
@@ -30,6 +30,9 @@ const createMaskedInputShell = (input) => {
   const content = document.createElement("span");
   content.classList.add(MASK_CONTENT);
   content.setAttribute("aria-hidden", "true");
+  if (input.disabled || input.getAttribute("aria-disabled") === "true") {
+    content.setAttribute("aria-disabled", "true");
+  }
   content.id = `${input.id}Mask`;
   content.textContent = placeholder;
 

--- a/packages/usa-input-mask/src/usa-input-mask.stories.js
+++ b/packages/usa-input-mask/src/usa-input-mask.stories.js
@@ -5,6 +5,7 @@ import {
   ZipContent,
   AlphanumericContent,
 } from "./content";
+import inputMask from "./index";
 
 export default {
   title: "Components/Form Inputs/Text Input Mask",
@@ -15,6 +16,19 @@ export default {
       options: ["none", "disabled", "aria-disabled"],
     },
   },
+  decorators: [
+    (Story) => {
+      inputMask.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        inputMask.on();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (args) => Component(args);

--- a/packages/usa-input/src/usa-input.stories.js
+++ b/packages/usa-input/src/usa-input.stories.js
@@ -3,6 +3,9 @@ import Showcase from "./usa-input--showcase.twig";
 
 export default {
   title: "Components/Form Inputs/Text Input",
+  args: {
+    state: "default",
+  },
   argTypes: {
     state: {
       name: "State",
@@ -15,7 +18,6 @@ export default {
         "disabled",
         "aria-disabled",
       ],
-      defaultValue: "default",
     },
     utilities: {
       name: "Input/textarea utility classes",

--- a/packages/usa-radio/src/usa-radio.stories.js
+++ b/packages/usa-radio/src/usa-radio.stories.js
@@ -3,6 +3,10 @@ import Tile from "./usa-radio--tile.twig";
 
 export default {
   title: "Components/Form Inputs/Radio",
+  args: {
+    disabled_state: "none",
+    indeterminate_state: false,
+  },
   argTypes: {
     disabled_state: {
       name: "Disabled state",
@@ -12,7 +16,6 @@ export default {
     indeterminate_state: {
       name: "Toggle indeterminate state",
       control: { type: "boolean" },
-      defaultValue: false,
     },
   },
 };
@@ -45,15 +48,11 @@ TileAriaDisabled.args = {
 };
 
 export const Indeterminate = Template.bind({});
-Indeterminate.argTypes = {
-  indeterminate_state: {
-    defaultValue: true,
-  },
+Indeterminate.args = {
+  indeterminate_state: true,
 };
 
 export const IndeterminateTile = TileTemplate.bind({});
-IndeterminateTile.argTypes = {
-  indeterminate_state: {
-    defaultValue: true,
-  },
+IndeterminateTile.args = {
+  indeterminate_state: true,
 };

--- a/packages/usa-range/src/usa-range.stories.js
+++ b/packages/usa-range/src/usa-range.stories.js
@@ -3,6 +3,11 @@ import range from "./index";
 
 export default {
   title: "Components/Form Inputs/Range",
+  args: {
+    min: 0,
+    max: 100,
+    step: 10,
+  },
   argTypes: {
     disabled_state: {
       name: "Disabled state",
@@ -20,17 +25,14 @@ export default {
     min: {
       name: "Min",
       control: { type: "number" },
-      defaultValue: 0,
     },
     max: {
       name: "Max",
       control: { type: "number" },
-      defaultValue: 100,
     },
     step: {
       name: "Step",
       control: { type: "number" },
-      defaultValue: 10,
     },
   },
   decorators: [

--- a/packages/usa-range/src/usa-range.stories.js
+++ b/packages/usa-range/src/usa-range.stories.js
@@ -67,3 +67,13 @@ export const AriaDisabled = Template.bind({});
 AriaDisabled.args = {
   disabled_state: "aria-disabled",
 };
+
+export const WithNonZeroMin = Template.bind({});
+WithNonZeroMin.args = {
+  min: 50,
+};
+
+export const WithSmallStep = Template.bind({});
+WithSmallStep.args = {
+  step: 1,
+};

--- a/packages/usa-table/src/usa-table.stories.js
+++ b/packages/usa-table/src/usa-table.stories.js
@@ -10,16 +10,18 @@ import table from "./index";
 
 export default {
   title: "Components/Table",
+  args: {
+    scrollable: false,
+    sticky_header: false,
+  },
   argTypes: {
     scrollable: {
       name: "Scrollable (Turning this on will disable sticky headers)",
       control: { type: "boolean" },
-      defaultValue: false,
     },
     sticky_header: {
       name: "Sticky header",
       control: { type: "boolean" },
-      defaultValue: false,
     },
   },
   decorators: [
@@ -65,10 +67,10 @@ Sortable.args = {
 export const TestStickyHeaderMultipleRows = TestMultipleStickyRowsTemplate.bind(
   {},
 );
+TestStickyHeaderMultipleRows.args = {
+  sticky_header: true,
+};
 TestStickyHeaderMultipleRows.argTypes = {
-  sticky_header: {
-    defaultValue: true,
-  },
   scrollable: {
     table: { disable: true },
   },

--- a/packages/usa-validation/src/usa-validation.stories.js
+++ b/packages/usa-validation/src/usa-validation.stories.js
@@ -1,8 +1,22 @@
 import Component from "./usa-validation.twig";
 import TextareaComponent from "./usa-validation--textarea.twig";
+import validator from "./index";
 
 export default {
   title: "Components/Validation",
+  decorators: [
+    (Story) => {
+      validator.off?.();
+
+      const story = Story();
+
+      window.requestAnimationFrame(() => {
+        validator.on?.();
+      });
+
+      return story;
+    },
+  ],
 };
 
 const Template = (args) => Component(args);


### PR DESCRIPTION
# Summary

**Fixed remaining stories with enhanced components.** The remaining stories not captured in #6664 have been updated to initialize the enhanced components on mount.

## Breaking change

This is not a breaking change.

## Related issue

Closes [#6694](https://github.com/uswds/uswds/issues/6694)

## Related pull requests

This PR is for a branch off https://github.com/uswds/uswds/issues/6692.
I'm expecting that PR to be merged first, as some of these changes require those changes in order to be viewable.

## Preview link

_Not available_

## Problem statement

The USWDS Storybook app doesn't initialize a few enhanced components when the story renders.
Some of the consequences:

-- The banner and header submenu dropdown is expanded by default in each of the "PAGES" stories.
-- The date range picker with restricted dates stories don't apply the upper and lower bounds of the date range.
-- On small screens, the big footer variant is meant to render with the nav items collapsed into accordions, but instead they are expanded.
-- Input mask doesn't enforce any pattern.
-- Validation appears to work but dumps errors into the console.

All of these issues are resolved by initializing the appropriate enhanced components on mount.

## Solution

The solution is to initialize the component with <component>.on() on mount.

## Major changes

_Not applicable_

## Testing and review

Clone the repo, checkout this branch, execute npm install && npm start.
Manipulate and visually inspect the components affected by this PR.

Here are screenshots to show it's resolved:
<img width="1088" height="758" alt="image" src="https://github.com/user-attachments/assets/03faf02a-b788-4234-8f13-1a657613e9ba" />
<img width="1210" height="758" alt="image" src="https://github.com/user-attachments/assets/d72eac3e-cc07-4193-8f77-4a14ea29a77c" />
<img width="672" height="773" alt="image" src="https://github.com/user-attachments/assets/0b52e1e7-7184-4d94-877a-bfe21303f082" />
<img width="672" height="773" alt="image" src="https://github.com/user-attachments/assets/46585740-9457-421b-b052-c6d0523ded72" />
<img width="672" height="773" alt="image" src="https://github.com/user-attachments/assets/18d41a5a-5c77-46b9-9e73-e9644d8566f4" />
Warnings here, but no errors:
<img width="1070" height="916" alt="image" src="https://github.com/user-attachments/assets/858b143b-3e09-404a-930f-04b488b5b3af" />
Errors previously seen:
<img width="1262" height="799" alt="image" src="https://github.com/user-attachments/assets/90dd4fc2-3fde-4369-b265-1feefd381bd3" />

