### PR TITLE
Build diff comparison action

### DIFF
--- a/.github/actions/build-diff/action.yml
+++ b/.github/actions/build-diff/action.yml
@@ -1,0 +1,26 @@
+name: 'Build Diff Comparison'
+description: 'Compare two build output directories and generate a markdown diff report'
+inputs:
+  base-dir:
+    description: 'Path to the base (develop) build output directory'
+    required: true
+  head-dir:
+    description: 'Path to the head (PR) build output directory'
+    required: true
+  output-dir:
+    description: 'Directory to write the diff report and patch files'
+    required: true
+  section-title:
+    description: 'Heading for the markdown report section'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Run diff comparison
+      shell: bash
+      run: |
+        bash "${{ github.action_path }}/build-diff.sh" \
+          "${{ inputs.base-dir }}" \
+          "${{ inputs.head-dir }}" \
+          "${{ inputs.output-dir }}" \
+          "${{ inputs.section-title }}"

--- a/.github/actions/build-diff/action.yml
+++ b/.github/actions/build-diff/action.yml
@@ -13,6 +13,10 @@ inputs:
   section-title:
     description: 'Heading for the markdown report section'
     required: true
+  ignore-patterns:
+    description: 'Space-separated glob patterns for files to exclude from comparison'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -23,4 +27,5 @@ runs:
           "${{ inputs.base-dir }}" \
           "${{ inputs.head-dir }}" \
           "${{ inputs.output-dir }}" \
-          "${{ inputs.section-title }}"
+          "${{ inputs.section-title }}" \
+          "${{ inputs.ignore-patterns }}"

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -5,6 +5,7 @@ BASE_DIR="$1"
 HEAD_DIR="$2"
 OUTPUT_DIR="$3"
 SECTION_TITLE="$4"
+IGNORE_PATTERNS="${5:-}"
 
 if [[ ! -d "$BASE_DIR" ]]; then
   echo "Error: base directory does not exist: $BASE_DIR" >&2
@@ -71,6 +72,12 @@ while IFS= read -r file; do
     echo "Warning: skipping file with unsafe path: $file" >&2
     continue
   fi
+
+  for pattern in $IGNORE_PATTERNS; do
+    if [[ "$file" == $pattern ]]; then
+      continue 2
+    fi
+  done
 
   base_path="$BASE_DIR/$file"
   head_path="$HEAD_DIR/$file"

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -19,7 +19,8 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 
-# Helper: format file size
+# Converts a numeric byte value into a human-readable string (B, KB, or MB).
+# Uses awk for floating point division to provide one decimal place of precision.
 format_size() {
   local bytes=$1
   if (( bytes >= 1048576 )); then
@@ -31,7 +32,8 @@ format_size() {
   fi
 }
 
-# Helper: format diff string with optional percentage
+# Formats diff string with optional percentage representing the change in file size
+# relative to the base
 format_diff_string() {
   local diff_bytes=$1
   local base_size=${2:-0}
@@ -65,6 +67,9 @@ declare -a deleted_files=()
 declare -a modified_files=()
 declare -a unchanged_files=()
 
+# Iterate through the list of all unique files found in both directories.
+# 'IFS=' prevents leading/trailing whitespace from being trimmed.
+# 'read -r' prevents backslash escapes from being interpreted.
 while IFS= read -r file; do
   if [[ "$file" == *..* ]] || [[ "$file" == /* ]]; then
     echo "Warning: skipping file with unsafe path: $file" >&2

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$1"
+HEAD_DIR="$2"
+OUTPUT_DIR="$3"
+SECTION_TITLE="$4"
+
+if [[ ! -d "$BASE_DIR" ]]; then
+  echo "Error: base directory does not exist: $BASE_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -d "$HEAD_DIR" ]]; then
+  echo "Error: head directory does not exist: $HEAD_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Configuration constants
+BINARY_EXTENSIONS="woff|woff2|ttf|eot|png|jpg|jpeg|gif|ico|webp"
+MAX_CHANGES_BEFORE_COLLAPSE=50
+MAX_DIFF_LINES_PER_FILE=50
+MAX_TOTAL_DIFF_LINES=200
+
+# Helper: format file size
+format_size() {
+  local bytes=$1
+  if (( bytes >= 1048576 )); then
+    echo "$(awk "BEGIN {printf \"%.1f\", $bytes/1048576}") MB"
+  elif (( bytes >= 1024 )); then
+    echo "$(awk "BEGIN {printf \"%.1f\", $bytes/1024}") KB"
+  else
+    echo "${bytes} B"
+  fi
+}
+
+# Helper: check if file is binary
+is_binary() {
+  local file="$1"
+  local ext="${file##*.}"
+  [[ "$ext" =~ ^($BINARY_EXTENSIONS)$ ]]
+}
+
+# Helper: format summary line
+format_summary() {
+  local total=$1 modified=$2 added=$3 deleted=$4 unchanged=$5
+  echo "**Summary**: $total files changed ($modified modified, $added added, $deleted deleted), $unchanged unchanged."
+}
+
+# Helper: format diff string with optional percentage
+format_diff_string() {
+  local diff_bytes=$1
+  local base_size=${2:-0}
+  local formatted_size=$(format_size ${diff_bytes#-})
+
+  if (( base_size > 0 )); then
+    local pct=$(awk "BEGIN {printf \"%.1f\", ($diff_bytes/$base_size)*100}")
+    if (( diff_bytes >= 0 )); then
+      echo "+${formatted_size} (+${pct}%)"
+    else
+      echo "-${formatted_size} (${pct}%)"
+    fi
+  else
+    if (( diff_bytes >= 0 )); then
+      echo "+${formatted_size}"
+    else
+      echo "-${formatted_size}"
+    fi
+  fi
+}
+
+# Collect all unique file paths from both directories
+{
+  (cd "$BASE_DIR" && find . -type f | sed 's|^\./||' | sort)
+  (cd "$HEAD_DIR" && find . -type f | sed 's|^\./||' | sort)
+} | sort -u > "$OUTPUT_DIR/all-files.txt"
+
+# Categorize files
+declare -a added_files=()
+declare -a deleted_files=()
+declare -a modified_files=()
+declare -a unchanged_files=()
+
+while IFS= read -r file; do
+  if [[ "$file" == *..* ]] || [[ "$file" == /* ]]; then
+    echo "Warning: skipping file with unsafe path: $file" >&2
+    continue
+  fi
+
+  base_path="$BASE_DIR/$file"
+  head_path="$HEAD_DIR/$file"
+
+  if [[ ! -f "$base_path" ]]; then
+    added_files+=("$file")
+  elif [[ ! -f "$head_path" ]]; then
+    deleted_files+=("$file")
+  elif ! diff -q "$base_path" "$head_path" > /dev/null 2>&1; then
+    modified_files+=("$file")
+  else
+    unchanged_files+=("$file")
+  fi
+done < "$OUTPUT_DIR/all-files.txt"
+
+total_changes=$(( ${#added_files[@]} + ${#deleted_files[@]} + ${#modified_files[@]} ))
+
+# Build markdown table
+{
+  echo "### $SECTION_TITLE"
+  echo ""
+
+  if (( total_changes == 0 )); then
+    echo "> No differences found between builds."
+    echo ""
+  else
+    # If more than MAX_CHANGES_BEFORE_COLLAPSE changes, collapse the table
+    if (( total_changes > MAX_CHANGES_BEFORE_COLLAPSE )); then
+      format_summary "$total_changes" "${#modified_files[@]}" "${#added_files[@]}" "${#deleted_files[@]}" "${#unchanged_files[@]}"
+      echo ""
+      echo "<details><summary>Show detailed file list</summary>"
+      echo ""
+    fi
+
+    echo "| Status | File | Size (develop) | Size (PR) | Diff |"
+    echo "|--------|------|---------------|-----------|------|"
+
+    # Modified files
+    for file in "${modified_files[@]}"; do
+      base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
+      head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
+      diff_bytes=$(( head_size - base_size ))
+      diff_str=$(format_diff_string "$diff_bytes" "$base_size")
+
+      echo "| \`modified\` | \`$file\` | $(format_size $base_size) | $(format_size $head_size) | $diff_str |"
+    done
+
+    # Added files
+    for file in "${added_files[@]}"; do
+      head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
+      echo "| \`added\` | \`$file\` | - | $(format_size $head_size) | +$(format_size $head_size) |"
+    done
+
+    # Deleted files
+    for file in "${deleted_files[@]}"; do
+      base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
+      echo "| \`deleted\` | \`$file\` | $(format_size $base_size) | - | -$(format_size $base_size) |"
+    done
+
+    echo ""
+
+    if (( total_changes <= MAX_CHANGES_BEFORE_COLLAPSE )); then
+      format_summary "$total_changes" "${#modified_files[@]}" "${#added_files[@]}" "${#deleted_files[@]}" "${#unchanged_files[@]}"
+      echo ""
+    else
+      echo "</details>"
+      echo ""
+    fi
+  fi
+} > "$OUTPUT_DIR/report.md"
+
+# Generate text diff for non-binary modified files
+{
+  for file in "${modified_files[@]}"; do
+    if ! is_binary "$file"; then
+      echo "--- develop/$file"
+      echo "+++ pr/$file"
+      diff -u "$BASE_DIR/$file" "$HEAD_DIR/$file" 2>/dev/null | tail -n +3 | head -${MAX_DIFF_LINES_PER_FILE} || true
+      echo ""
+    fi
+  done
+} > "$OUTPUT_DIR/text-diff.patch"
+
+# Append collapsible diff to report if non-empty
+if [[ -s "$OUTPUT_DIR/text-diff.patch" ]]; then
+  {
+    echo "<details><summary>Text diff for non-binary changed files (click to expand)</summary>"
+    echo ""
+    echo '```diff'
+    # Limit to first MAX_TOTAL_DIFF_LINES lines to keep comment manageable
+    head -${MAX_TOTAL_DIFF_LINES} "$OUTPUT_DIR/text-diff.patch"
+    if (( $(wc -l < "$OUTPUT_DIR/text-diff.patch") > MAX_TOTAL_DIFF_LINES )); then
+      echo ""
+      echo "... (truncated, see full diff in artifact)"
+    fi
+    echo '```'
+    echo ""
+    echo "</details>"
+  } >> "$OUTPUT_DIR/report.md"
+fi

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -20,9 +20,9 @@ mkdir -p "$OUTPUT_DIR"
 
 # Configuration constants
 BINARY_EXTENSIONS="woff|woff2|ttf|eot|png|jpg|jpeg|gif|ico|webp"
-MAX_CHANGES_BEFORE_COLLAPSE=50
-MAX_DIFF_LINES_PER_FILE=50
-MAX_TOTAL_DIFF_LINES=200
+MAX_CHANGES_BEFORE_COLLAPSE=10
+MAX_DIFF_LINES_PER_FILE=10
+MAX_TOTAL_DIFF_LINES=30
 
 # Helper: format file size
 format_size() {
@@ -174,14 +174,13 @@ total_changes=$(( ${#added_files[@]} + ${#deleted_files[@]} + ${#modified_files[
 # Append collapsible diff to report if non-empty
 if [[ -s "$OUTPUT_DIR/text-diff.patch" ]]; then
   {
-    echo "<details><summary>Text diff for non-binary changed files (click to expand)</summary>"
+    echo "<details><summary>📄 Text diffs</summary>"
     echo ""
     echo '```diff'
-    # Limit to first MAX_TOTAL_DIFF_LINES lines to keep comment manageable
     head -${MAX_TOTAL_DIFF_LINES} "$OUTPUT_DIR/text-diff.patch"
     if (( $(wc -l < "$OUTPUT_DIR/text-diff.patch") > MAX_TOTAL_DIFF_LINES )); then
       echo ""
-      echo "... (truncated, see full diff in artifact)"
+      echo "... (truncated after ${MAX_TOTAL_DIFF_LINES} lines)"
     fi
     echo '```'
     echo ""

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -19,8 +19,6 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 
-# Configuration constants
-
 # Helper: format file size
 format_size() {
   local bytes=$1
@@ -37,7 +35,7 @@ format_size() {
 format_diff_string() {
   local diff_bytes=$1
   local base_size=${2:-0}
-  local formatted_size=$(format_size ${diff_bytes#-})
+  local formatted_size=$(format_size "${diff_bytes#-}")
 
   if (( base_size > 0 )); then
     local pct=$(awk "BEGIN {printf \"%.1f\", ($diff_bytes/$base_size)*100}")

--- a/.github/actions/build-diff/build-diff.sh
+++ b/.github/actions/build-diff/build-diff.sh
@@ -19,10 +19,6 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 # Configuration constants
-BINARY_EXTENSIONS="woff|woff2|ttf|eot|png|jpg|jpeg|gif|ico|webp"
-MAX_CHANGES_BEFORE_COLLAPSE=10
-MAX_DIFF_LINES_PER_FILE=10
-MAX_TOTAL_DIFF_LINES=30
 
 # Helper: format file size
 format_size() {
@@ -34,19 +30,6 @@ format_size() {
   else
     echo "${bytes} B"
   fi
-}
-
-# Helper: check if file is binary
-is_binary() {
-  local file="$1"
-  local ext="${file##*.}"
-  [[ "$ext" =~ ^($BINARY_EXTENSIONS)$ ]]
-}
-
-# Helper: format summary line
-format_summary() {
-  local total=$1 modified=$2 added=$3 deleted=$4 unchanged=$5
-  echo "**Summary**: $total files changed ($modified modified, $added added, $deleted deleted), $unchanged unchanged."
 }
 
 # Helper: format diff string with optional percentage
@@ -105,85 +88,41 @@ done < "$OUTPUT_DIR/all-files.txt"
 
 total_changes=$(( ${#added_files[@]} + ${#deleted_files[@]} + ${#modified_files[@]} ))
 
-# Build markdown table
+# Calculate total size delta
+total_base_size=0
+total_head_size=0
+
+for file in "${modified_files[@]}"; do
+  base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
+  head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
+  total_base_size=$(( total_base_size + base_size ))
+  total_head_size=$(( total_head_size + head_size ))
+done
+
+for file in "${added_files[@]}"; do
+  head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
+  total_head_size=$(( total_head_size + head_size ))
+done
+
+for file in "${deleted_files[@]}"; do
+  base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
+  total_base_size=$(( total_base_size + base_size ))
+done
+
+total_delta=$(( total_head_size - total_base_size ))
+
+# Build compact summary report
 {
   echo "### $SECTION_TITLE"
   echo ""
 
   if (( total_changes == 0 )); then
-    echo "> No differences found between builds."
-    echo ""
+    echo "✓ No changes"
   else
-    # If more than MAX_CHANGES_BEFORE_COLLAPSE changes, collapse the table
-    if (( total_changes > MAX_CHANGES_BEFORE_COLLAPSE )); then
-      format_summary "$total_changes" "${#modified_files[@]}" "${#added_files[@]}" "${#deleted_files[@]}" "${#unchanged_files[@]}"
-      echo ""
-      echo "<details><summary>Show detailed file list</summary>"
-      echo ""
-    fi
-
-    echo "| Status | File | Size (develop) | Size (PR) | Diff |"
-    echo "|--------|------|---------------|-----------|------|"
-
-    # Modified files
-    for file in "${modified_files[@]}"; do
-      base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
-      head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
-      diff_bytes=$(( head_size - base_size ))
-      diff_str=$(format_diff_string "$diff_bytes" "$base_size")
-
-      echo "| \`modified\` | \`$file\` | $(format_size $base_size) | $(format_size $head_size) | $diff_str |"
-    done
-
-    # Added files
-    for file in "${added_files[@]}"; do
-      head_size=$(stat -c%s "$HEAD_DIR/$file" 2>/dev/null || echo "0")
-      echo "| \`added\` | \`$file\` | - | $(format_size $head_size) | +$(format_size $head_size) |"
-    done
-
-    # Deleted files
-    for file in "${deleted_files[@]}"; do
-      base_size=$(stat -c%s "$BASE_DIR/$file" 2>/dev/null || echo "0")
-      echo "| \`deleted\` | \`$file\` | $(format_size $base_size) | - | -$(format_size $base_size) |"
-    done
-
+    echo "**Files changed:** $total_changes (${#modified_files[@]} modified, ${#added_files[@]} added, ${#deleted_files[@]} deleted)"
     echo ""
-
-    if (( total_changes <= MAX_CHANGES_BEFORE_COLLAPSE )); then
-      format_summary "$total_changes" "${#modified_files[@]}" "${#added_files[@]}" "${#deleted_files[@]}" "${#unchanged_files[@]}"
-      echo ""
-    else
-      echo "</details>"
-      echo ""
-    fi
+    echo "**Size change:** $(format_diff_string $total_delta $total_base_size)"
   fi
+  echo ""
 } > "$OUTPUT_DIR/report.md"
 
-# Generate text diff for non-binary modified files
-{
-  for file in "${modified_files[@]}"; do
-    if ! is_binary "$file"; then
-      echo "--- develop/$file"
-      echo "+++ pr/$file"
-      diff -u "$BASE_DIR/$file" "$HEAD_DIR/$file" 2>/dev/null | tail -n +3 | head -${MAX_DIFF_LINES_PER_FILE} || true
-      echo ""
-    fi
-  done
-} > "$OUTPUT_DIR/text-diff.patch"
-
-# Append collapsible diff to report if non-empty
-if [[ -s "$OUTPUT_DIR/text-diff.patch" ]]; then
-  {
-    echo "<details><summary>📄 Text diffs</summary>"
-    echo ""
-    echo '```diff'
-    head -${MAX_TOTAL_DIFF_LINES} "$OUTPUT_DIR/text-diff.patch"
-    if (( $(wc -l < "$OUTPUT_DIR/text-diff.patch") > MAX_TOTAL_DIFF_LINES )); then
-      echo ""
-      echo "... (truncated after ${MAX_TOTAL_DIFF_LINES} lines)"
-    fi
-    echo '```'
-    echo ""
-    echo "</details>"
-  } >> "$OUTPUT_DIR/report.md"
-fi

--- a/.github/actions/build-diff/compile-project/gulpfile.js
+++ b/.github/actions/build-diff/compile-project/gulpfile.js
@@ -1,0 +1,9 @@
+const uswds = require("@uswds/compile");
+
+// Use default USWDS compile settings (version 3)
+uswds.settings.version = 3;
+
+exports.init = uswds.init;
+exports.compile = uswds.compile;
+exports.copyAssets = uswds.copyAssets;
+exports.default = uswds.compile;

--- a/.github/actions/build-diff/compile-project/package.json
+++ b/.github/actions/build-diff/compile-project/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "uswds-compile-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Fixture project for build output comparison CI",
+  "devDependencies": {
+    "@uswds/uswds": "file:placeholder",
+    "@uswds/compile": "1.3.2"
+  }
+}

--- a/.github/actions/build-diff/compile-project/sass/styles.scss
+++ b/.github/actions/build-diff/compile-project/sass/styles.scss
@@ -1,0 +1,2 @@
+@forward "uswds-theme";
+@forward "uswds";

--- a/.github/actions/build-diff/compile-project/sass/styles.scss
+++ b/.github/actions/build-diff/compile-project/sass/styles.scss
@@ -1,2 +1,0 @@
-@forward "uswds-theme";
-@forward "uswds";

--- a/.github/workflows/build-diff.yml
+++ b/.github/workflows/build-diff.yml
@@ -68,6 +68,8 @@ jobs:
           cp -r pr-branch/.github/actions/build-diff/compile-project compile-project-pr
           cd compile-project-pr
           PR_TARBALL=$(ls ../tarballs/pr/*.tgz | head -1)
+          # Update the @uswds/uswds devDependency to use the local development tarball.
+          # This replaces the "file:placeholder" value defined in compile-project/package.json.
           npm pkg set "devDependencies.@uswds/uswds=file:${PR_TARBALL}"
           npm install
           npx gulp init
@@ -77,6 +79,8 @@ jobs:
           cp -r pr-branch/.github/actions/build-diff/compile-project compile-project-develop
           cd compile-project-develop
           DEV_TARBALL=$(ls ../tarballs/develop/*.tgz | head -1)
+          # Update the @uswds/uswds devDependency to use the local development tarball.
+          # This replaces the "file:placeholder" value defined in compile-project/package.json.
           npm pkg set "devDependencies.@uswds/uswds=file:${DEV_TARBALL}"
           npm install
           npx gulp init

--- a/.github/workflows/build-diff.yml
+++ b/.github/workflows/build-diff.yml
@@ -94,14 +94,12 @@ jobs:
             echo "## Build Output Comparison"
             echo ""
             cat direct-dist-diff/report.md
-            echo ""
             echo "---"
             echo ""
             cat compile-project-diff/report.md
-            echo ""
             echo "---"
             echo ""
-            echo "_Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+            echo "📦 [View detailed comparison artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > combined-report.md
 
       - name: Upload comparison artifacts

--- a/.github/workflows/build-diff.yml
+++ b/.github/workflows/build-diff.yml
@@ -1,0 +1,125 @@
+name: Build Output Comparison
+# This workflow compares the build output of the current Pull Request branch against the `develop` branch.
+# It performs a direct comparison of the `dist/` directory and a secondary comparison using a simulated
+# `@uswds/compile` project. The resulting diff report is posted as a sticky comment on the PR,
+# helping developers and reviewers identify unexpected changes in the compiled assets.
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  compare-builds:
+    name: Compare build output
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: pr-branch
+
+      - name: Checkout develop branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          path: develop-branch
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24.x' # pin this to a version since .nvm might differ between branches
+
+      - name: Install and build PR branch
+        working-directory: pr-branch
+        run: npm ci
+
+      - name: Install and build develop branch
+        working-directory: develop-branch
+        run: npm ci
+
+      - name: Generate direct dist comparison
+        uses: ./pr-branch/.github/actions/build-diff
+        with:
+          base-dir: develop-branch/dist
+          head-dir: pr-branch/dist
+          output-dir: direct-dist-diff
+          section-title: 'Direct `dist/` Comparison'
+
+      - name: Pack PR branch
+        working-directory: pr-branch
+        run: |
+          mkdir -p ../tarballs/pr
+          npm pack --pack-destination ../tarballs/pr
+
+      - name: Pack develop branch
+        working-directory: develop-branch
+        run: |
+          mkdir -p ../tarballs/develop
+          npm pack --pack-destination ../tarballs/develop
+
+      - name: Setup compile project (PR)
+        run: |
+          cp -r pr-branch/.github/actions/build-diff/compile-project compile-project-pr
+          cd compile-project-pr
+          PR_TARBALL=$(ls ../tarballs/pr/*.tgz | head -1)
+          npm pkg set "devDependencies.@uswds/uswds=file:${PR_TARBALL}"
+          npm install
+          npx gulp init
+
+      - name: Setup compile project (develop)
+        run: |
+          cp -r pr-branch/.github/actions/build-diff/compile-project compile-project-develop
+          cd compile-project-develop
+          DEV_TARBALL=$(ls ../tarballs/develop/*.tgz | head -1)
+          npm pkg set "devDependencies.@uswds/uswds=file:${DEV_TARBALL}"
+          npm install
+          npx gulp init
+
+      - name: Generate compile project comparison
+        uses: ./pr-branch/.github/actions/build-diff
+        with:
+          base-dir: compile-project-develop/assets
+          head-dir: compile-project-pr/assets
+          output-dir: compile-project-diff
+          section-title: '`@uswds/compile` Project Comparison'
+
+      - name: Combine diff reports
+        run: |
+          {
+            echo "## Build Output Comparison"
+            echo ""
+            cat direct-dist-diff/report.md
+            echo ""
+            echo "---"
+            echo ""
+            cat compile-project-diff/report.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "_Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+          } > combined-report.md
+
+      - name: Upload comparison artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: build-comparison
+          path: |
+            direct-dist-diff/
+            compile-project-diff/
+            pr-branch/dist/
+            develop-branch/dist/
+            compile-project-pr/assets/
+            compile-project-develop/assets/
+          retention-days: 14
+
+      - name: Post PR comment
+        if: ${{ !env.ACT }}
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          path: combined-report.md

--- a/.github/workflows/build-diff.yml
+++ b/.github/workflows/build-diff.yml
@@ -49,6 +49,7 @@ jobs:
           head-dir: pr-branch/dist
           output-dir: direct-dist-diff
           section-title: 'Direct `dist/` Comparison'
+          ignore-patterns: '*.map'
 
       - name: Pack PR branch
         working-directory: pr-branch
@@ -87,6 +88,7 @@ jobs:
           head-dir: compile-project-pr/assets
           output-dir: compile-project-diff
           section-title: '`@uswds/compile` Project Comparison'
+          ignore-patterns: '*.map'
 
       - name: Combine diff reports
         run: |

--- a/.github/workflows/verify-documentation-links.yml
+++ b/.github/workflows/verify-documentation-links.yml
@@ -1,4 +1,4 @@
-name: CI Documentation Checks
+name: Verify documentation links
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Added a GitHub Actions workflow that automatically compares compiled build output between a PR branch and the `develop` branch, posting a summary of file changes and size deltas as a sticky PR comment to help reviewers identify unexpected changes in compiled assets.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6707

## Problem statement

When reviewing pull requests, it can be difficult to understand the downstream impact of source changes on the compiled output of USWDS and on projects that consume USWDS via @uswds/compile. Reviewers have no automated way to see whether a PR introduces unexpected file additions, deletions, or size changes in the build artifacts. Without this visibility, unintended changes to compiled output could be merged without notice. 

## Solution

This PR introduces a new GitHub Actions workflow (build-diff.yml) and a reusable composite action (.github/actions/build-diff/) that:

1. Checks out the PR branch and `develop` side by side.
2. Builds both branches runs `npm ci` which triggers the full build via the prepare lifecycle script.
3. Compares `dist/` directories directly: categorizes files as added, deleted, modified, or unchanged and calculates total size delta.
4. Simulates a downstream consumer: packs each branch as a tarball, installs it into a minimal `@uswds/compile` fixture project, runs `gulp init`, and compares the resulting compiled assets.
5. Posts a sticky PR comment: combines both comparison reports into a single markdown summary on the pull request.

The composite action is designed to be reusable, accepting base/head directories, an output path, a section title, and optional ignore patterns (e.g., *.map files are excluded from comparison).

Additionally, the ci-docs.yml workflow was renamed to verify-documentation-links.yml for clarity.

### Future considerations

This workflow runs sequentially. There is an opportunity to parallelize the build steps if we find them too slow.

## Major changes

- `.github/actions/build-diff/action.yml`: reusable composite action that wraps the diff comparison shell script.
- `.github/actions/build-diff/build-diff.sh`: core comparison logic: collects file lists, categorizes changes, calculates size deltas, and generates a markdown report.
- `.github/actions/build-diff/compile-project/`: minimal fixture project (`package.json` + `gulpfile.js`) that simulates how a  real consumer uses USWDS via `@uswds/compile`.
- `.github/workflows/build-diff.yml`: orchestrates the full comparison pipeline: checkout, build, pack, compile, diff, and comment.

## Testing and review

1. View the actions status on this PR
2. Verify the PR comment below: https://github.com/uswds/uswds/pull/6708#issuecomment-4712459259
3. Verify the presence of the artifact zip at the bottom of the page here: https://github.com/uswds/uswds/actions/runs/27622934673.
