### PR TITLE
Add a workflow to verify commit signatures

### DIFF
--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -1,0 +1,101 @@
+name: Verify commit signatures
+
+# pull_request_target runs in the base-repo context, giving the GITHUB_TOKEN
+# write access to labels and comments even for PRs from forks. We never check
+# out PR code here, so there is no supply-chain risk from the fork.
+on:
+  pull_request_target:
+
+permissions:
+  contents: read       # list PR commits via gh api
+  pull-requests: write # post/update comments and apply labels
+
+jobs:
+  check-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check verification status of all PR commits
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CONTRIBUTOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # gh api fetches all commits on the PR (--paginate follows next-page
+          # links so PRs with more than 30 commits are handled correctly).
+          # jq then filters to commits where `verification.verified` is `false` and
+          # formats each one as a markdown list item with the short SHA and the
+          # first line of the commit message.
+          UNVERIFIED=$(gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" \
+            --paginate \
+            | jq -r '
+              .[] |
+              select(.commit.verification.verified == false) |
+              "- `" + (.sha[:7]) + "` — " + (.commit.message | split("\n")[0])
+            ')
+
+          echo "unverified_list<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$UNVERIFIED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$UNVERIFIED" ]; then
+            echo "all_verified=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_verified=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post reminder comment
+        if: steps.check.outputs.all_verified == 'false'
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          header: verify-commits
+          message: |
+            Hi @${{ github.event.pull_request.user.login }} — thanks for your contribution!
+
+            There is one thing that may be holding this up: any contribution here must be a [verified commit](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md#setting-up-verified-commits). The following commit(s) on this PR are not yet verified:
+
+            ${{ steps.check.outputs.unverified_list }}
+
+            Here's what's needed:
+
+            1. **Set up signature verification in GitHub.** Use one of the following GitHub guides to set up your verification signature:
+               - [GPG commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)
+               - [SSH commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification)
+
+            2. **Rebase your commits with your verified signature.** Once your signature is set up, complete the following steps in the terminal to update the verification status of your previous commits:
+               ```sh
+               git checkout ${{ github.event.pull_request.head.ref }}
+               git rebase origin/${{ github.event.pull_request.base.ref }}
+               git push --force-with-lease
+               ```
+
+            Please let us know if you have any questions. We appreciate your help here. This comment will update automatically once your commits are verified.
+
+      - name: Update comment when all commits are verified
+        if: steps.check.outputs.all_verified == 'true'
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          header: verify-commits
+          message: |
+            ✅ All commits on this PR now have a verified signature. Thanks for making that change!
+
+      - name: Add label when commits are unverified
+        if: steps.check.outputs.all_verified == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "Needs: Author Response 🔴" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Remove label when all commits are verified
+        if: steps.check.outputs.all_verified == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "Needs: Author Response 🔴" \
+            --repo "$GITHUB_REPOSITORY" || true

--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -55,7 +55,7 @@ jobs:
           message: |
             Hi @${{ github.event.pull_request.user.login }} — thanks for your contribution!
 
-            There is one thing that may be holding this up: any contribution here must be a [verified commit](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md#setting-up-verified-commits). The following commit(s) on this PR are not yet verified:
+            There is one thing that may be holding this up: for security reasons, USWDS requires that all commits to this repo have a [verified commit](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md#setting-up-verified-commits). The following commit(s) on this PR aren't verified:
 
             ${{ steps.check.outputs.unverified_list }}
 


### PR DESCRIPTION
## Summary

Added a GitHub Actions workflow that automatically detects unverified commits on pull requests and posts a sticky comment with setup instructions, removing the need for maintainers to manually identify and message contributors.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6710

## Problem statement

External contributors are often unaware that all commits to this repository must have a verified signature. When an unverified PR is opened, a maintainer must manually notice, post instructions, and apply the `Needs: Author Response 🔴` label, which is a process that delays review and merge.

## Solution

A new workflow, `.github/workflows/verify-commit-signatures.yml`, runs on `pull_request_target` (which has write access to labels and comments even for fork PRs, without checking out fork code). It uses the `gh` CLI and `jq` to fetch all PR commits via the GitHub API and filter for any with `verification.verified == false`. If any are found, it posts a sticky comment via `marocchino/sticky-pull-request-comment` (another one of my PRs is open with this action, so we'll standardize on this dependency) listing the unverified commits with setup instructions and applies the `Needs: Author Response 🔴` label. When the contributor rebases with a verified signature and force-pushes, the workflow re-runs, updates the comment to a ✅ confirmation, and removes the label.

`pull_request_target` was chosen over `pull_request` because the default `GITHUB_TOKEN` on fork PRs is read-only under `pull_request`, making it unable to post comments or apply labels.

`gh` and `jq` are part of the default Ubuntu image we use in GitHub workflows, so these are reliably installed in our CI environment.

## Major changes

- **`.github/workflows/verify-commit-signatures.yml`** (new): four-step job — check signatures, post reminder or post ✅ confirmation, add or remove label.

## Testing and review

This is the first repo that we'll add a workflow for automated signed commit verification. For review, the meat of it is to make sure the gh cli step in the first step of the workflow is correct. If you run the following command:

```sh
gh api "repos/uswds/uswds/pulls/6652/commits" --paginate | jq -r '
  .[] |
  select(.commit.verification.verified == false) |
  "- `" + (.sha[:7]) + "` — " + (.commit.message | split("\n")[0])
'
```

Will output the following because there is one unverified commit on the PR:

```sh
- `b57bb50` — docs: fix USPTO design system link
```

Whereas this command will have no output because all commits on the PR are signed and verified.

```sh
gh api "repos/uswds/uswds/pulls/6724/commits" --paginate | jq -r '
  .[] |
  select(.commit.verification.verified == false) |
  "- `" + (.sha[:7]) + "` — " + (.commit.message | split("\n")[0])
'
```

1. Open a PR from a fork with an unsigned commit and confirm:
   - The bot posts a comment listing the unverified commit(s) with setup instructions.
   - The `Needs: Author Response 🔴` label is applied.
2. Rebase with commit signing enabled and force-push so all commits are verified, then confirm:
   - The bot comment is updated to a ✅ confirmation.
   - The `Needs: Author Response 🔴` label is removed.
3. Open a PR where all commits are verified from the start and confirm no comment is posted.