### PR TITLE
Backfill test coverage for character count fix.

### DIFF
--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           header: verify-commits
           message: |
-            ✅ All commits on this PR now have a verified signature. Thanks for making that change!
+            ✅ All commits on this PR have a verified signature. Thanks!
 
       - name: Add label when commits are unverified
         if: steps.check.outputs.all_verified == 'false'

--- a/packages/usa-character-count/src/test/character-count.spec.js
+++ b/packages/usa-character-count/src/test/character-count.spec.js
@@ -179,3 +179,38 @@ tests.forEach(({ name, selector: containerSelector }) => {
     });
   });
 });
+
+describe("character count with special characters in input ID", () => {
+  const { body } = document;
+  const SPECIAL_ID_TEMPLATE = `
+    <div class="usa-character-count">
+      <div class="usa-form-group">
+        <label class="usa-label" for="character-count-:r0:">Label</label>
+        <input class="usa-character-count__field" id="character-count-:r0:" maxlength="20" />
+        <span class="usa-character-count__message"></span>
+      </div>
+    </div>
+  `;
+
+  afterEach(() => {
+    CharacterCount.off(document.body);
+    body.textContent = "";
+  });
+
+  it("initializes without error when the input ID contains colons", () => {
+    body.innerHTML = SPECIAL_ID_TEMPLATE;
+    assert.doesNotThrow(() => CharacterCount.on(document.body));
+  });
+
+  it("applies error class to the label found via for attribute", () => {
+    body.innerHTML = SPECIAL_ID_TEMPLATE;
+    CharacterCount.on(document.body);
+
+    const input = body.querySelector(".usa-character-count__field");
+    const label = body.querySelector(".usa-label");
+    input.value = "123456789012345678901";
+    EVENTS.input(input);
+
+    assert.strictEqual(label.classList.contains(LABEL_ERROR_CLASS), true);
+  });
+});


### PR DESCRIPTION
## Summary

Added test coverage for the fix in PR #6385 that ensures the character count component handles input IDs containing special characters like colons.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6727

## Problem statement

PR #6385 fixed a bug where the character count component would fail if an input element ID contained special characters   (like colons) that make CSS selector queries invalid. The fix was merged without test coverage to avoid delaying the   contributor further after a long review wait.

## Solution

Added a test suite that verifies the character count component works correctly when input IDs contain special characters   (specifically colons, which are common in React-generated IDs like :r0:). The tests confirm:

1. The component initializes without throwing errors when the input ID contains colons
2. The label is correctly found via its for attribute and receives the error class when validation fails