### PR TITLE
USWDS - Contributors: Rewrite workflow to use signed commits and single-step table generation

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,91 +5,203 @@ on:
   push:
     branches: [develop]
 
+# Allow only one contributors-update run at a time.
+# If a second push to develop arrives while a run is in flight, the older
+# run is cancelled so we always work from the most recent develop SHA.
+concurrency:
+  group: contributors-update
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-contributors:
+    # Only run on the canonical repo; skip forks entirely.
+    if: github.repository == 'uswds/uswds'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Check if update needed
-        id: check_changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
-          REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
-          
-          CURRENT=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$OWNER/$REPO/contributors?per_page=100" | \
-            jq -r '[.[] | select(.type != "Bot" and (.login | test("\\[bot\\]$") | not) and (.login | test("-bot$") | not)) | .login] | sort | join(",")')
-          
-          EXISTING=$(grep -oP '(?<=github.com/)[^"]+(?=">)' COMMUNITY.md | \
-            grep -v "^$" | sort | uniq | tr '\n' ',' | sed 's/,$//')
-          
-          echo "Current contributors: $CURRENT"
-          echo "Existing contributors: $EXISTING"
-          
-          if [ "$CURRENT" = "$EXISTING" ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No new contributors found. Skipping update!"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "New contributors detected. Running update!"
-          fi
-
-      - name: Update contributor list
-        if: steps.check_changes.outputs.has_changes == 'true'
-        id: update_contributors
-        uses: akhilmhdh/contributors-readme-action@83ea0b4f1ac928fbfe88b9e8460a932a528eb79f
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build contributors block
+        id: build
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin v7.0.1
         with:
-          readme_path: COMMUNITY.md
-          commit_message: "updating contributors list"
-          pr_title_on_protected: "docs: update contributors information"
-          committer_username: "github-actions[bot]"
-          committer_email: "github-actions[bot]@users.noreply.github.com"
+          script: |
+            const fs = require('fs');
 
-      - name: Pull latest changes from action commit
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: git pull --rebase origin ${{ github.ref_name }}
+            const COLUMNS = 6;
+            const IMAGE_SIZE = 100;
+            const START_MARKER = '<!-- readme: contributors -start -->';
+            const END_MARKER   = '<!-- readme: contributors -end -->';
+            const COUNT_START  = '<!--CONTRIBUTOR COUNT START-->';
+            const COUNT_END    = '<!--CONTRIBUTOR COUNT END-->';
+            const README_PATH  = 'COMMUNITY.md';
 
-      - name: Apply post-processing changes to COMMUNITY.md
-        if: steps.check_changes.outputs.has_changes == 'true'
+            // ── 1. Fetch all non-bot contributors ────────────────────────────
+            const botPatterns = [/\[bot\]$/, /-bot$/i];
+            const isBot = (user) =>
+              user.type === 'Bot' || botPatterns.some((p) => p.test(user.login));
+
+            const allContributors = await github.paginate(
+              github.rest.repos.listContributors,
+              { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+            );
+            const contributors = allContributors.filter((u) => !isBot(u));
+
+            core.info(`Non-bot contributors: ${contributors.length}`);
+
+            // ── 2. Sanitisation helpers ──────────────────────────────────────
+            // Inlined from escape-html (MIT) https://github.com/component/escape-html
+            const matchHtmlRegExp = /["'&<>]/;
+            const escapeHtml = (string) => {
+              const str = '' + string;
+              const match = matchHtmlRegExp.exec(str);
+              if (!match) return str;
+              let escape, html = '', index = 0, lastIndex = 0;
+              for (index = match.index; index < str.length; index++) {
+                switch (str.charCodeAt(index)) {
+                  case 34: escape = '&quot;'; break; // "
+                  case 38: escape = '&amp;';  break; // &
+                  case 39: escape = '&#39;';  break; // '
+                  case 60: escape = '&lt;';   break; // <
+                  case 62: escape = '&gt;';   break; // >
+                  default: continue;
+                }
+                if (lastIndex !== index) html += str.substring(lastIndex, index);
+                lastIndex = index + 1;
+                html += escape;
+              }
+              return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
+            };
+
+            // avatar_url is always an https:// GitHub CDN URL, but sanitise it
+            // anyway so a malformed value can't inject an attribute or break src.
+            const safeUrl = (url) => {
+              try {
+                const parsed = new URL(url);
+                if (parsed.protocol !== 'https:') return '';
+                return escapeHtml(parsed.href);
+              } catch {
+                return '';
+              }
+            };
+
+            // ── 3. Resolve display names (avatar URLs come from the list) ───
+            const userCache = {};
+            for (const c of contributors) {
+              try {
+                const { data } = await github.rest.users.getByUsername({ username: c.login });
+                userCache[c.login] = { name: data.name || c.login, avatar: data.avatar_url };
+              } catch {
+                userCache[c.login] = { name: c.login, avatar: c.avatar_url };
+              }
+            }
+
+            // ── 4. Render the table ──────────────────────────────────────────
+            const td = ({ login, name, avatar }) => {
+              const safeLogin  = escapeHtml(login);
+              const safeName   = escapeHtml(name);
+              const safeAvatar = safeUrl(avatar);
+              return `
+                    <td align="center">
+                        <a href="https://github.com/${safeLogin}">
+                            <img src="${safeAvatar}" width="${IMAGE_SIZE};" alt="${safeLogin}"/>
+                            <br />
+                            <sub><b>${safeName}</b></sub>
+                        </a>
+                    </td>`;
+            };
+
+            const rows = Math.ceil(contributors.length / COLUMNS);
+            let tableRows = '';
+            for (let r = 0; r < rows; r++) {
+              const slice = contributors.slice(r * COLUMNS, r * COLUMNS + COLUMNS);
+              const cells = slice.map(({ login }) => {
+                const { name, avatar } = userCache[login];
+                return td({ login, name, avatar });
+              }).join('');
+              tableRows += `\t\t<tr>${cells}\n\t\t</tr>\n`;
+            }
+
+            const block =
+              `${START_MARKER}\n` +
+              `<table role="presentation">\n\t<tbody>\n` +
+              tableRows +
+              `\t</tbody>\n</table>\n` +
+              `${END_MARKER}`;
+
+            // ── 5. Splice into COMMUNITY.md ──────────────────────────────────
+            const original = fs.readFileSync(README_PATH, 'utf8');
+
+            const startIdx = original.indexOf(START_MARKER);
+            const endIdx   = original.indexOf(END_MARKER);
+            if (startIdx === -1 || endIdx === -1) {
+              core.setFailed('Could not find contributor markers in COMMUNITY.md');
+              return;
+            }
+            let content =
+              original.slice(0, startIdx) +
+              block +
+              original.slice(endIdx + END_MARKER.length);
+
+            // ── 6. Update contributor count ──────────────────────────────────
+            const count = contributors.length;
+            content = content.replace(
+              new RegExp(`${COUNT_START}[\\s\\S]*?${COUNT_END}`),
+              `${COUNT_START} ${count} ${COUNT_END}`
+            );
+
+            // ── 7. Check for a real diff before writing ───────────────────────
+            if (content === original) {
+              core.info('No changes to contributors list. Skipping.');
+              core.setOutput('changed', 'false');
+              core.setOutput('count', String(count));
+              return;
+            }
+
+            fs.writeFileSync(README_PATH, content, 'utf8');
+            core.info(`Wrote updated COMMUNITY.md (${count} contributors).`);
+            core.setOutput('changed', 'true');
+            core.setOutput('count', String(count));
+
+      - name: Create or update pull request
+        if: steps.build.outputs.changed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # pin v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
+          branch: automated/contributors-update
+          delete-branch: true
+          base: develop
+          add-paths: COMMUNITY.md
+          commit-message: "docs: update contributors list and add role=presentation to table"
+          title: "docs: update contributors information"
+          body: |
+            This PR was opened automatically by the **Update Contributors Information**
+            workflow after a push to `develop`.
+
+            **What changed**
+            - Refreshed the contributors table in `COMMUNITY.md` from the GitHub
+              `/contributors` API endpoint (bots excluded).
+            - Contributor count updated to **${{ steps.build.outputs.count }}**.
+            - The generated `<table>` carries `role="presentation"` so screen
+              readers do not announce it as a data table.
+
+            All commits on this PR are cryptographically signed by
+            `github-actions[bot]` via the GitHub git-data API.
+          labels: |
+            documentation
+
+      - name: Log pull request URL
+        if: steps.cpr.outputs.pull-request-url != ''
         run: |
-          sed -i 's/<table>/<table role="presentation">/g' COMMUNITY.md
-
-          COUNT=$(sed -n '/<!-- readme: contributors -start -->/,/<!-- readme: contributors -end -->/p' COMMUNITY.md | \
-            grep -oP '(?<=github\.com/)[^"]+(?=">)' | \
-            grep -v "^$" | sort | uniq | wc -l)
-          
-          sed -i -z "s|<!--CONTRIBUTOR COUNT START-->[^<]*<!--CONTRIBUTOR COUNT END-->|<!--CONTRIBUTOR COUNT START--> $COUNT <!--CONTRIBUTOR COUNT END-->|g" COMMUNITY.md
-
-      - name: Commit and push changes
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add COMMUNITY.md
-          git diff --cached --quiet || git commit -m "fix: add role=presentation to contributors table and update contributor count"
-          git push origin ${{ github.ref_name }}
-
-      - name: Update PR
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.update_contributors.outputs.pr_id != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        run: |
-          PR_NUMBER="${{ steps.update_contributors.outputs.pr_id }}"
-          
-          gh pr edit $PR_NUMBER \
-            --body "New contributors detected! This PR updates the contributors list in COMMUNITY.md." \
-            --add-label "documentation"
+          echo "PR: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Operation: ${{ steps.cpr.outputs.pull-request-operation }}"
+          echo "Commits verified: ${{ steps.cpr.outputs.pull-request-commits-verified }}"

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -92,41 +92,33 @@ jobs:
               }
             };
 
-            // ── 3. Resolve display names (avatar URLs come from the list) ───
-            const userCache = {};
-            for (const c of contributors) {
+            // ── 3. Resolve display names and render table cells ─────────────
+            const cells = [];
+            for (const contributor of contributors) {
+              let name = contributor.login, avatar = contributor.avatar_url;
               try {
-                const { data } = await github.rest.users.getByUsername({ username: c.login });
-                userCache[c.login] = { name: data.name || c.login, avatar: data.avatar_url };
-              } catch {
-                userCache[c.login] = { name: c.login, avatar: c.avatar_url };
-              }
-            }
+                const { data } = await github.rest.users.getByUsername({ username: contributor.login });
+                name   = data.name || contributor.login;
+                avatar = data.avatar_url;
+              } catch { /* fall back to list values */ }
 
-            // ── 4. Render the table ──────────────────────────────────────────
-            const td = ({ login, name, avatar }) => {
-              const safeLogin  = escapeHtml(login);
+              const safeLogin  = escapeHtml(contributor.login);
               const safeName   = escapeHtml(name);
               const safeAvatar = safeUrl(avatar);
-              return `
+              cells.push(`
                     <td align="center">
                         <a href="https://github.com/${safeLogin}">
                             <img src="${safeAvatar}" width="${IMAGE_SIZE};" alt="${safeLogin}"/>
                             <br />
                             <sub><b>${safeName}</b></sub>
                         </a>
-                    </td>`;
-            };
+                    </td>`);
+            }
 
-            const rows = Math.ceil(contributors.length / COLUMNS);
+            // ── 4. Build the table ───────────────────────────────────────────
             let tableRows = '';
-            for (let r = 0; r < rows; r++) {
-              const slice = contributors.slice(r * COLUMNS, r * COLUMNS + COLUMNS);
-              const cells = slice.map(({ login }) => {
-                const { name, avatar } = userCache[login];
-                return td({ login, name, avatar });
-              }).join('');
-              tableRows += `\t\t<tr>${cells}\n\t\t</tr>\n`;
+            for (let i = 0; i < cells.length; i += COLUMNS) {
+              tableRows += `\t\t<tr>${cells.slice(i, i + COLUMNS).join('')}\n\t\t</tr>\n`;
             }
 
             const block =
@@ -184,18 +176,14 @@ jobs:
           commit-message: "docs: update contributors list and add role=presentation to table"
           title: "docs: update contributors information"
           body: |
-            This PR was opened automatically by the **Update Contributors Information**
-            workflow after a push to `develop`.
+            This PR was opened automatically by the **Update Contributors Information** workflow after a push to `develop`.
 
             **What changed**
-            - Refreshed the contributors table in `COMMUNITY.md` from the GitHub
-              `/contributors` API endpoint (bots excluded).
+            - Refreshed the contributors table in `COMMUNITY.md` from the GitHub `/contributors` API endpoint (bots excluded).
             - Contributor count updated to **${{ steps.build.outputs.count }}**.
-            - The generated `<table>` carries `role="presentation"` so screen
-              readers do not announce it as a data table.
+            - The generated `<table>` carries `role="presentation"` so screen readers do not announce it as a data table.
 
-            All commits on this PR are cryptographically signed by
-            `github-actions[bot]` via the GitHub git-data API.
+            All commits on this PR are cryptographically signed by `github-actions[bot]` via the GitHub git-data API.
           labels: |
             documentation
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,8 +2,8 @@ name: Update Contributors Information
 
 on:
   workflow_dispatch: {}
-  push:
-    branches: [develop]
+  schedule:
+    - cron: "0 22 * * *"
 
 # Allow only one contributors-update run at a time.
 # If a second push to develop arrives while a run is in flight, the older
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
         with:
+          ref: develop
           fetch-depth: 0
 
       - name: Build contributors block


### PR DESCRIPTION
## Summary

Replaced the multi-step contributors workflow with a single-pass implementation that generates the `COMMUNITY.md` table and opens a signed-commit PR in one run.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6706

## Preview link

N/A — CI workflow change only.

## Problem statement

**Desired state:** The contributors workflow should keep `COMMUNITY.md` up to date on a regular schedule and produce cryptographically signed commits.

**Actual state:** The previous workflow used a two step process that resulted in unsigned commits. It ran on every push to `develop` and tried to push to `develop` directly (protected branch). This was also causing some issues with forked repos that lack branch protection rules for `develop` and was confusing for contributors - see https://github.com/uswds/uswds/pull/6715#issuecomment-4784637708

**Consequences:** The automated PR landed unsigned commits, and the multi-step shell pipeline was fragile (shell parsing of Markdown, `sed` over structured data).

## Solution

Rewrote `.github/workflows/contributors.yml` to:

1. **Trigger on a nightly cron (`0 22 * * *`)** instead of every push to `develop`, plus `workflow_dispatch` for manual runs.
2. **Always check out `develop` explicitly** (`ref: develop`) so the workflow operates on the right branch regardless of how it was triggered.
3. **Build the contributors block in a single `actions/github-script` step** — fetches all non-bot contributors via the GitHub API (paginated), resolves display names, renders the `<table role="presentation">` HTML with inlined HTML escaping and URL sanitisation, splices the result into `COMMUNITY.md` between the existing markers, and updates the contributor count. Skips writing if nothing changed.
4. **Open or update the PR with `peter-evans/create-pull-request`** using `sign-commits: true` so every commit is cryptographically signed by `github-actions[bot]`.

Limitations: display-name resolution makes one extra API call per contributor; for the current contributor count this is well within Actions rate limits.

## Major changes

- `.github/workflows/contributors.yml` fully rewritten
- Trigger changed from `push: branches: [develop]` to `schedule: cron: '0 22 * * *'` + `workflow_dispatch`
- Explicit `ref: develop` added to the checkout step
- Replaced `akhilmhdh/contributors-readme-action` with `actions/github-script` + `peter-evans/create-pull-request`
- `sign-commits: true` ensures all generated commits are verified
- Added `concurrency` group (`contributors-update`, `cancel-in-progress: true`) to prevent overlapping runs
- Added `if: github.repository == 'uswds/uswds'` guard to skip forks
- Permissions moved to job scope

## Testing and review

This was tested locally with `act` and a few PRs were opened. You can see one of them here: https://github.com/uswds/uswds/pull/6732. Note: you'll see unsigned commits from me on this PR. That is to be expected because of how `act` works when testing locally and the container isolation it uses. See https://github.com/nektos/act/issues/5962. When running via an action runner on GitHub directly, commits should be signed.