### PR TITLE
Add data-attribute support for custom file-input strings

### DIFF
--- a/packages/usa-file-input/src/index.js
+++ b/packages/usa-file-input/src/index.js
@@ -191,13 +191,13 @@ const createTargetArea = (fileInputEl) => {
 const updateVisibleInstructions = (fileInputEl, instructions) => {
   const instructionsEl = instructions;
   const itemsLabel = getItemsLabel(fileInputEl);
-  const dragText = `Drag ${itemsLabel} here or`;
+  const dragText = fileInputEl.dataset.textDrag || `Drag ${itemsLabel} here or`;
   const dragTextEl = document.createElement("span");
   const chooseTextEl = document.createElement("span");
   const dragTextIsVisible = shouldShowDragText();
-  const chooseText = dragTextIsVisible
-    ? "choose from folder"
-    : "Choose from folder";
+  const chooseText =
+    fileInputEl.dataset.textChoose ||
+    (dragTextIsVisible ? "choose from folder" : "Choose from folder");
 
   // Create instructions text for aria-label
   DEFAULT_ARIA_LABEL_TEXT = dragTextIsVisible
@@ -271,7 +271,8 @@ const createSROnlyStatus = (fileInputEl) => {
   const fileInputParent = fileInputEl.closest(DROPZONE);
   const fileInputTarget = fileInputEl.closest(`.${TARGET_CLASS}`);
 
-  DEFAULT_FILE_STATUS_TEXT = `No ${itemsLabel} selected.`;
+  DEFAULT_FILE_STATUS_TEXT =
+    fileInputEl.dataset.textNoFileStatus || `No ${itemsLabel} selected.`;
 
   // Adds class names and other attributes
   statusEl.classList.add(SR_ONLY_CLASS);
@@ -394,7 +395,10 @@ const addPreviewHeading = (fileInputEl, fileNames) => {
   let previewHeadingText = "";
 
   if (fileNames.length === 1) {
-    previewHeadingText = Sanitizer.escapeHTML`Selected file <span class="usa-file-input__choose">${changeItemText}</span>`;
+    changeItemText = fileInputEl.dataset.textChangeFile || "Change file";
+    const selectedText =
+      fileInputEl.dataset.textSelectedFile || "Selected file";
+    previewHeadingText = Sanitizer.escapeHTML`${selectedText} <span class="usa-file-input__choose">${changeItemText}</span>`;
   } else if (fileNames.length > 1) {
     changeItemText = "Change files";
     previewHeadingText = Sanitizer.escapeHTML`${fileNames.length} files selected <span class="usa-file-input__choose">${changeItemText}</span>`;

--- a/packages/usa-file-input/src/test/file-input-custom-strings.spec.js
+++ b/packages/usa-file-input/src/test/file-input-custom-strings.spec.js
@@ -1,0 +1,99 @@
+const assert = require("assert");
+const fs = require("fs");
+const fileInput = require("../index");
+
+const TEMPLATE = fs.readFileSync(
+  `${__dirname}/file-input-custom-strings.template.html`,
+);
+
+const FINE_POINTER_MEDIA_QUERY = "(hover: hover) and (pointer: fine)";
+
+const mockMatchMedia = (matches) => {
+  const listeners = [];
+  const mediaQueryList = {
+    matches,
+    media: FINE_POINTER_MEDIA_QUERY,
+    addEventListener(type, listener) {
+      if (type === "change") {
+        listeners.push(listener);
+      }
+    },
+    removeEventListener(type, listener) {
+      if (type === "change") {
+        listeners.splice(listeners.indexOf(listener), 1);
+      }
+    },
+  };
+  return {
+    mediaQueryList,
+    matchMedia: () => mediaQueryList,
+    setMatches(nextMatches) {
+      mediaQueryList.matches = nextMatches;
+      listeners.forEach((listener) =>
+        listener({ matches: nextMatches, media: FINE_POINTER_MEDIA_QUERY }),
+      );
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+};
+
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  {
+    name: "file input",
+    selector: () => document.querySelector(".usa-file-input"),
+  },
+];
+
+tests.forEach(({ name, selector: containerSelector }) => {
+  describe(`File input initialized at ${name}`, () => {
+    describe("file input: custom instruction strings", () => {
+      const { body } = document;
+      const originalMatchMedia = window.matchMedia;
+
+      let dragText;
+      let chooseText;
+      let inputEl;
+
+      beforeEach(() => {
+        window.matchMedia = mockMatchMedia(true).matchMedia;
+        body.innerHTML = TEMPLATE;
+        fileInput.on(containerSelector());
+        dragText = body.querySelector(".usa-file-input__drag-text");
+        chooseText = body.querySelector(".usa-file-input__choose");
+        inputEl = body.querySelector(".usa-file-input__input");
+      });
+
+      afterEach(() => {
+        fileInput.off(containerSelector());
+        body.innerHTML = "";
+        window.matchMedia = originalMatchMedia;
+      });
+
+      it("uses the custom drag text when data-text-drag is set", () => {
+        assert.strictEqual(dragText.textContent, "Arrastre el archivo aquí o");
+      });
+
+      it("uses the custom choose text when data-text-choose is set", () => {
+        assert.strictEqual(chooseText.textContent, "elija de la carpeta");
+      });
+
+      it("applies the custom strings to the aria-label", () => {
+        assert.strictEqual(
+          inputEl.getAttribute("aria-label"),
+          "Arrastre el archivo aquí o elija de la carpeta",
+        );
+      });
+
+      it("uses the custom no-file status text", () => {
+        const statusMessage = body.querySelector(".usa-sr-only");
+        assert.strictEqual(
+          statusMessage.textContent,
+          "No se ha seleccionado ningún archivo.",
+        );
+      });
+    });
+  });
+});

--- a/packages/usa-file-input/src/test/file-input-custom-strings.template.html
+++ b/packages/usa-file-input/src/test/file-input-custom-strings.template.html
@@ -1,0 +1,20 @@
+<div class="usa-form-group">
+  <label class="usa-label" for="file-input-custom"
+    >Input with custom instruction strings</label
+  >
+  <span class="usa-hint" id="file-input-custom-hint"
+    >Custom translated strings</span
+  >
+  <input
+    id="file-input-custom"
+    class="usa-file-input"
+    type="file"
+    name="file-input-custom"
+    aria-describedby="file-input-custom-hint"
+    data-text-drag="Arrastre el archivo aquí o"
+    data-text-choose="elija de la carpeta"
+    data-text-change-file="cambiar archivo"
+    data-text-selected-file="Archivo seleccionado"
+    data-text-no-file-status="No se ha seleccionado ningún archivo."
+>
+</div>

--- a/packages/usa-file-input/src/usa-file-input.stories.js
+++ b/packages/usa-file-input/src/usa-file-input.stories.js
@@ -8,7 +8,6 @@ import {
   WildcardContent,
 } from "./content";
 import fileInput from "./index";
-
 export default {
   title: "Components/Form Inputs/File Input",
   args: {
@@ -33,48 +32,47 @@ export default {
   decorators: [
     (Story) => {
       fileInput.off?.();
-
       const story = Story();
-
       window.requestAnimationFrame(() => {
         fileInput.init();
       });
-
       return story;
     },
   ],
 };
-
 const Template = (args) => Component(args);
 const TestTemplate = (args) => TestComponent(args);
-
 export const Default = Template.bind({});
 Default.args = DefaultContent;
-
 export const Error = Template.bind({});
 Error.args = ErrorContent;
-
 export const Multiple = Template.bind({});
 Multiple.args = MultipleContent;
-
 export const Specific = Template.bind({});
 Specific.args = SpecificContent;
-
 export const Wildcard = Template.bind({});
 Wildcard.args = WildcardContent;
+
+export const CustomTranslatedString = Template.bind({});
+CustomTranslatedString.args = {
+  ...DefaultContent,
+  drag_text: "Arrastre el archivo aquí o",
+  choose_text: "elija de la carpeta",
+  change_file_text: "cambiar archivo",
+  selected_file_text: "Archivo seleccionado",
+  no_file_status_text: "No se ha seleccionado ningún archivo.",
+};
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   ...DefaultContent,
   disabled_state: "disabled",
 };
-
 export const AriaDisabled = Template.bind({});
 AriaDisabled.args = {
   ...DefaultContent,
   disabled_state: "aria-disabled",
 };
-
 export const TestMultipleInputs = TestTemplate.bind({});
 TestMultipleInputs.args = {
   DefaultContent,

--- a/packages/usa-file-input/src/usa-file-input.twig
+++ b/packages/usa-file-input/src/usa-file-input.twig
@@ -1,7 +1,6 @@
 {% set name = "file-input" %}
 {% set aria_hint =  id ~ "-hint" %}
 {% set aria_error = id ~ "-alert" %}
-
 <div class="usa-form-group{% if error %} usa-form-group--error{% endif %}">
   <label
     class="usa-label{% if error %} usa-label--error{% endif %}"
@@ -28,5 +27,10 @@
     {% if disabled_state == 'disabled' %}disabled{% endif %}
     {% if disabled_state == "aria-disabled" %}aria-disabled="true"{% endif %}
     {% if invalid_file_text %}data-errorMessage="{{ invalid_file_text }}"{% endif %}
+    {% if drag_text %}data-text-drag="{{ drag_text }}"{% endif %}
+    {% if choose_text %}data-text-choose="{{ choose_text }}"{% endif %}
+    {% if change_file_text %}data-text-change-file="{{ change_file_text }}"{% endif %}
+    {% if selected_file_text %}data-text-selected-file="{{ selected_file_text }}"{% endif %}
+    {% if no_file_status_text %}data-text-no-file-status="{{ no_file_status_text }}"{% endif %}
   />
 </div>


### PR DESCRIPTION
# Summary

Added optional `data-text-*` attributes to the file input so its instruction strings can be translated, falling back to the English defaults when unset.

## Breaking change

This is not a breaking change.

## Related issue

Related to #6206

## Problem statement

The file input renders its instruction strings ("Drag file here or", "choose from folder", "Selected file", "Change file", and the no file status) from hardcoded English in the JavaScript. Since they aren't exposed for overriding, apps serving non-English users can't translate them, so the input stays in English on otherwise translated pages.

## Solution

Added optional `data-text-*` attributes that let a consumer pass translated strings, defaulting to the existing English text when absent. This matches the `dataset.x || default` pattern already used in the codebase (the range component's `data-text-*` attributes and the file input's own `data-errormessage`), so it's fully backward compatible. The custom values also flow through to the `aria-label`.

This PR covers the non counted strings: drag text, choose text, "Selected file", "Change file", and the no file status.

I left the counted strings out ("N files selected" and the "You have selected N files" status). They can't be localized correctly across languages without plural rules support, since the component branches only on singular vs plural, while many languages (Polish, Russian, Arabic) need several plural forms selected by the number itself. That fits better with the larger restructure in #6206 / #5616, so I scoped this to the strings that translate soundly today.

## Major changes

- Added `data-text-drag`, `data-text-choose`, `data-text-change-file`, `data-text-selected-file`, and `data-text-no-file-status` overrides in `index.js`, each falling back to the English default.
- Added the matching conditional attributes to `usa-file-input.twig`.
- Added a `CustomTranslatedString` Storybook story demonstrating the strings in Spanish.
- Added unit tests for each override and the `aria-label`, using the existing `mockMatchMedia` pattern.

## Testing and review

1. Run `npm start` and open Components → Form Inputs → File Input.
2. Open the **Custom Translated String** story. The instructions render in Spanish, and selecting a file shows the translated "Selected file / Change file" text.
3. Confirm the **Default** story still renders the English defaults unchanged.
4. Run `npm test` and confirm all file input tests pass.