### PR TITLE
USWDS - Banner: Use element JSDoc tag

### DIFF
--- a/packages/usa-banner/src/usa-banner.component.js
+++ b/packages/usa-banner/src/usa-banner.component.js
@@ -30,7 +30,7 @@ import iconHttps from "./img/icon-https.svg";
  * @slot https-heading - Heading for HTTPs section.
  * @slot https-text - Body text for HTTPs section.
  *
- * @tagname usa-banner
+ * @element usa-banner
  */
 
 export default class UsaBanner extends LitElement {


### PR DESCRIPTION
# Summary

Updated the usa-banner web component JSDoc to use the supported `@element` tag for the component name.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6522

## Related pull requests

None.

## Preview link

Preview link: Not available.

## Problem statement

The usa-banner web component JSDoc currently uses `@tagname` for the component name, but `@element` is the correct JSDoc decorator for web components.

## Solution

Changed the JSDoc tag from `@tagname usa-banner` to `@element usa-banner` in `packages/usa-banner/src/usa-banner.component.js`.

## Major changes

- Updated the usa-banner web component JSDoc tag.

## Testing and review

- Verified the change is limited to `packages/usa-banner/src/usa-banner.component.js`.
- Not run locally; change is a one-line JSDoc update.