### PR TITLE
Update sticky-pull-request-comment action to v3.0.4 for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-diff.yml
+++ b/.github/workflows/build-diff.yml
@@ -124,6 +124,6 @@ jobs:
 
       - name: Post PR comment
         if: ${{ !env.ACT }}
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # pin v3.0.4
         with:
           path: combined-report.md

--- a/.github/workflows/verify-commit-signatures.yml
+++ b/.github/workflows/verify-commit-signatures.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Post reminder comment
         if: steps.check.outputs.all_verified == 'false'
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # pin v3.0.4
         with:
           header: verify-commits
           message: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Update comment when all commits are verified
         if: steps.check.outputs.all_verified == 'true'
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # pin v3.0.4
         with:
           header: verify-commits
           message: |


### PR DESCRIPTION
## Summary

Updates `marocchino/sticky-pull-request-comment` action from v2.9.2 to v3.0.4 to resolve Node 20 deprecation warnings in GitHub Actions workflows.

## Changes

- Updated action version in `.github/workflows/build-diff.yml`
- Updated action version in `.github/workflows/verify-commit-signatures.yml` (3 instances)
- Pinned to specific commit hash `0ea0beb66eb9baf113663a64ec522f60e49231c0` for security

## Motivation

GitHub Actions is deprecating Node 20 support, causing failures in workflows that use the PR comment action. The v3.0.4 release adds Node 24 support, resolving the "Resource not accessible by integration" error encountered in [run #28468490906](https://github.com/uswds/uswds/actions/runs/28468490906/job/84374454089?pr=6715).
