### PR TITLE
USWDS: fix deprecation warnings for global functions

### DIFF
--- a/packages/uswds-core/src/styles/functions/units/rem-to-user-em.scss
+++ b/packages/uswds-core/src/styles/functions/units/rem-to-user-em.scss
@@ -11,7 +11,7 @@ queries
 @use "sass:math";
 
 @function rem-to-user-em($grid-in-rem) {
-  @if unit($grid-in-rem) != "rem" {
+  @if math.unit($grid-in-rem) != "rem" {
     @error 'This value must be in rem';
   }
   $rem-to-user-em: (math.div($grid-in-rem, 1rem)) * 1em;

--- a/packages/uswds-core/src/styles/mixins/general/add-bar.scss
+++ b/packages/uswds-core/src/styles/mixins/general/add-bar.scss
@@ -28,12 +28,12 @@
       bottom: units($offset-y);
       top: units($offset-y);
       width: units($weight);
-      #{unquote($side)}: units($offset-x);
+      #{$side}: units($offset-x);
     } @else {
       height: units($weight);
       left: units($offset-x);
       right: units($offset-x);
-      #{unquote($side)}: units($offset-y);
+      #{$side}: units($offset-y);
 
       @media (forced-colors: active) {
         background-color: ButtonText;

--- a/packages/uswds-core/src/styles/mixins/general/layout-grid.scss
+++ b/packages/uswds-core/src/styles/mixins/general/layout-grid.scss
@@ -1,5 +1,6 @@
 @use "sass:list";
 @use "sass:map";
+@use "sass:string";
 @use "../layout-grid" as *;
 @use "../../functions" as *;
 @use "../../mixins/helpers" as *;
@@ -29,7 +30,7 @@
   }
 
   @include u-margin-x(
-    unquote("#{$neg-prefix}-#{calc-gap-offset($gap-mobile)}")
+    string.unquote("#{$neg-prefix}-#{calc-gap-offset($gap-mobile)}")
   );
 
   > * {
@@ -39,7 +40,7 @@
 
   @include at-media("desktop") {
     @include u-margin-x(
-      unquote("#{$neg-prefix}-#{calc-gap-offset($gap-desktop)}")
+      string.unquote("#{$neg-prefix}-#{calc-gap-offset($gap-desktop)}")
     );
 
     > * {
@@ -51,7 +52,7 @@
 
 @mixin grid-gap($props...) {
   $props: unpack($props);
-  @if length($props) == 0 {
+  @if list.length($props) == 0 {
     @include grid-gap-responsive;
   } @else {
     $gap: smart-quote(list.nth($props, 1));
@@ -71,7 +72,7 @@
       @include u-margin-x(
         append-important(
           $props,
-          unquote("#{$neg-prefix}-#{calc-gap-offset($gap)}")
+          string.unquote("#{$neg-prefix}-#{calc-gap-offset($gap)}")
         )
       );
       > * {
@@ -86,7 +87,7 @@
   $props: unpack($props);
   @include this-border-box-sizing;
 
-  @if length($props) == 0 {
+  @if list.length($props) == 0 {
     @include u-flex(fill);
     @include u-width(auto);
   } @else {

--- a/packages/uswds-core/src/styles/mixins/layout-grid/_grid-container.scss
+++ b/packages/uswds-core/src/styles/mixins/layout-grid/_grid-container.scss
@@ -7,7 +7,7 @@
 @use "../../mixins/helpers" as *;
 
 @mixin grid-container($props...) {
-  @if length($props) == 0 {
+  @if list.length($props) == 0 {
     @include u-margin-x(auto);
     @include u-maxw($theme-grid-container-max-width);
   } @else {


### PR DESCRIPTION
## Summary

Fixes Sass deprecation warnings for `length()`, `unquote()`, and `unit()` by replacing global built-in function calls with their namespaced module equivalents.

## Breaking change

This is not a breaking change

## Related issue

Closes #6216

## Problem statment

Sass is deprecating global built in functions like `length`, `unquote`, and `unit` and moving them to namespaced equivalents. Output of a sass build shows warnings in the terminal and has caused some confusion with downstream consumers.

## Solution

Replaced deprecated global function calls with their modern equivalent to fix the root cause of the warnings and prepare for future updates.

## Changes

- `rem-to-user-em.scss`: Replace `unit()` with `math.unit()`
- `add-bar.scss`: Remove unnecessary `unquote()` calls on interpolated string properties (interpolation already produces unquoted output)
- `layout-grid.scss`: Replace `unquote()` with `string.unquote()`, replace `length()` with `list.length()`, add `@use "sass:string"`
- `_grid-container.scss`: Replace `length()` with `list.length()`


## Testing and review

Run `npm run test:sass` to confirm tests pass. Run `npm run build` to verify that the only deprecation warnings remaining are releated to the `if` which will be updated in a subsequent PR.