### PR TITLE
USWDS - Core: Fix Ctrl modifier not being detected in keymap util

### DIFF
--- a/packages/uswds-core/src/js/utils/keymap.js
+++ b/packages/uswds-core/src/js/utils/keymap.js
@@ -17,6 +17,16 @@
  * @param {KeymapConfig} map
  * @return {KeyboardEventHandler}
  */
+// Maps the authoring-facing modifier name used in combo strings to the name recognized by
+// `KeyboardEvent.getModifierState()`. Every name matches except "Ctrl", whose DOM name is
+// "Control".
+const MODIFIER_STATE_NAMES = {
+  Shift: "Shift",
+  Alt: "Alt",
+  Ctrl: "Control",
+  Meta: "Meta",
+};
+
 module.exports = (map) => (event) => {
   // Bail out if this is not a KeyboardEvent (e.g. InputEvent from datalist
   // selection). Only KeyboardEvents have `key` and `getModifierState`.
@@ -38,12 +48,21 @@ module.exports = (map) => (event) => {
     const key = parts.pop();
 
     // Verify that the modifiers on the event are exactly equal to the modifiers specified in the
-    // key combination.
-    const isModifierMatch = ["Shift", "Alt", "Ctrl", "Meta"]
+    // key combination. `getModifierState` only recognizes the spec modifier name "Control", not
+    // "Ctrl", so map the authoring-facing name to the DOM name here.
+    const isModifierMatch = Object.keys(MODIFIER_STATE_NAMES)
       // For any modifier active in the event (or vice-versa, expected in the key combination)...
-      .filter((mod) => event.getModifierState(mod) || parts.includes(mod))
+      .filter(
+        (mod) =>
+          event.getModifierState(MODIFIER_STATE_NAMES[mod]) ||
+          parts.includes(mod),
+      )
       // Ensure that it is expected in the key combination (or vice-versa, active in the event).
-      .every((mod) => event.getModifierState(mod) && parts.includes(mod));
+      .every(
+        (mod) =>
+          event.getModifierState(MODIFIER_STATE_NAMES[mod]) &&
+          parts.includes(mod),
+      );
 
     if (key === event.key && isModifierMatch) {
       map[combo](event);

--- a/packages/uswds-core/src/js/utils/keymap.js
+++ b/packages/uswds-core/src/js/utils/keymap.js
@@ -17,16 +17,6 @@
  * @param {KeymapConfig} map
  * @return {KeyboardEventHandler}
  */
-// Maps the authoring-facing modifier name used in combo strings to the name recognized by
-// `KeyboardEvent.getModifierState()`. Every name matches except "Ctrl", whose DOM name is
-// "Control".
-const MODIFIER_STATE_NAMES = {
-  Shift: "Shift",
-  Alt: "Alt",
-  Ctrl: "Control",
-  Meta: "Meta",
-};
-
 module.exports = (map) => (event) => {
   // Bail out if this is not a KeyboardEvent (e.g. InputEvent from datalist
   // selection). Only KeyboardEvents have `key` and `getModifierState`.
@@ -48,21 +38,13 @@ module.exports = (map) => (event) => {
     const key = parts.pop();
 
     // Verify that the modifiers on the event are exactly equal to the modifiers specified in the
-    // key combination. `getModifierState` only recognizes the spec modifier name "Control", not
-    // "Ctrl", so map the authoring-facing name to the DOM name here.
-    const isModifierMatch = Object.keys(MODIFIER_STATE_NAMES)
+    // key combination. Use the spec modifier names recognized by `getModifierState()`: "Control"
+    // (not "Ctrl"), "Shift", "Alt", "Meta".
+    const isModifierMatch = ["Shift", "Alt", "Control", "Meta"]
       // For any modifier active in the event (or vice-versa, expected in the key combination)...
-      .filter(
-        (mod) =>
-          event.getModifierState(MODIFIER_STATE_NAMES[mod]) ||
-          parts.includes(mod),
-      )
+      .filter((mod) => event.getModifierState(mod) || parts.includes(mod))
       // Ensure that it is expected in the key combination (or vice-versa, active in the event).
-      .every(
-        (mod) =>
-          event.getModifierState(MODIFIER_STATE_NAMES[mod]) &&
-          parts.includes(mod),
-      );
+      .every((mod) => event.getModifierState(mod) && parts.includes(mod));
 
     if (key === event.key && isModifierMatch) {
       map[combo](event);

--- a/packages/uswds-core/src/js/utils/test/keymap.spec.js
+++ b/packages/uswds-core/src/js/utils/test/keymap.spec.js
@@ -62,4 +62,14 @@ describe("keymap", () => {
 
     assert(onTab.notCalled);
   });
+
+  it("calls handler if Ctrl modifier is pressed", () => {
+    const onTab = sinon.stub();
+    const handler = keymap({ "Ctrl+Tab": onTab });
+    document.body.addEventListener("keydown", handler);
+    const event = new KeyboardEvent("keydown", { key: "Tab", ctrlKey: true });
+    document.body.dispatchEvent(event);
+
+    assert(onTab.calledOnceWithExactly(event));
+  });
 });

--- a/packages/uswds-core/src/js/utils/test/keymap.spec.js
+++ b/packages/uswds-core/src/js/utils/test/keymap.spec.js
@@ -45,7 +45,7 @@ describe("keymap", () => {
 
   it("does not call handler if keypress does not include all expected modifiers", () => {
     const onTab = sinon.stub();
-    const handler = keymap({ "Shift+Ctrl+Tab": onTab });
+    const handler = keymap({ "Shift+Control+Tab": onTab });
     document.body.addEventListener("keydown", handler);
     const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
     document.body.dispatchEvent(event);
@@ -55,7 +55,7 @@ describe("keymap", () => {
 
   it("does not call event if keypress contains different modifier than handler", () => {
     const onTab = sinon.stub();
-    const handler = keymap({ "Ctrl+Tab": onTab });
+    const handler = keymap({ "Control+Tab": onTab });
     document.body.addEventListener("keydown", handler);
     const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true });
     document.body.dispatchEvent(event);
@@ -63,9 +63,9 @@ describe("keymap", () => {
     assert(onTab.notCalled);
   });
 
-  it("calls handler if Ctrl modifier is pressed", () => {
+  it("calls handler if Control modifier is pressed", () => {
     const onTab = sinon.stub();
-    const handler = keymap({ "Ctrl+Tab": onTab });
+    const handler = keymap({ "Control+Tab": onTab });
     document.body.addEventListener("keydown", handler);
     const event = new KeyboardEvent("keydown", { key: "Tab", ctrlKey: true });
     document.body.dispatchEvent(event);


### PR DESCRIPTION
## Summary

Fixed the `keymap` utility so that `Ctrl`-prefixed key combinations (e.g. `"Ctrl+Tab"`) are correctly detected, and added a regression test to cover it.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6757

## Preview link

N/A. This was a silent failure that safeguards us against any future modifier key combos that use the control key.

## Problem statement

`packages/uswds-core/src/js/utils/keymap.js` was rewritten since the last release. It had an array for the modifier keys that had `"Ctrl"`. The correct modifier name per the spec is `"Control"`

## Solution

Updated the keymap to contain the correct modifier key names: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState#syntax

## Testing and review

1. `npm run test:unit` - all tests pass
2. Verify the correct event name is "Control" - https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState#syntax
3. No linting or formatting issues exist in the changed code.