### PR TITLE
USWDS - Core: Convert sanitizer.js to CommonJS and fix falsy-value bug

### DIFF
--- a/packages/uswds-core/src/js/utils/sanitizer.js
+++ b/packages/uswds-core/src/js/utils/sanitizer.js
@@ -36,7 +36,10 @@ const Sanitizer = {
     for (let i = 0; i < strings.length; i++) {
       result += strings[i];
       if (i + 1 < arguments.length) {
-        const value = arguments[i + 1] || "";
+        let value = arguments[i + 1];
+        if (value === null || value === undefined) {
+          value = "";
+        }
         result += String(value).replace(Sanitizer._entity, Sanitizer.getEntity);
       }
     }

--- a/packages/uswds-core/src/js/utils/sanitizer.js
+++ b/packages/uswds-core/src/js/utils/sanitizer.js
@@ -1,14 +1,12 @@
 /**
- * A simple library to help you escape HTML using template strings.
+ * A simple library to help you escape HTML using template strings. This originated
+ * from https://web.archive.org/web/20150910040110/https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation
  *
- * It's the counterpart to our eslint "no-unsafe-innerhtml" plugin that helps us
- * avoid unsafe coding practices.
- * A full write-up of the Hows and Whys are documented
- * for developers at
- *  https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation
- * with additional background information and design docs at
- *  https://wiki.mozilla.org/User:Fbraun/Gaia/SafeinnerHTMLRoadmap
+ * It was converted from UMD to CommonJS, and unused methods were removed,
+ * but the spirit remains the same.
  *
+ * See additional background information and design docs at
+ * https://wiki.mozilla.org/User:Fbraun/Gaia/SafeinnerHTMLRoadmap
  */
 
 const Sanitizer = {

--- a/packages/uswds-core/src/js/utils/sanitizer.js
+++ b/packages/uswds-core/src/js/utils/sanitizer.js
@@ -1,6 +1,3 @@
-/* eslint-disable */
-/* globals define, module */
-
 /**
  * A simple library to help you escape HTML using template strings.
  *
@@ -14,87 +11,38 @@
  *
  */
 
-!(function (factory) {
-  module.exports = factory();
-})(function () {
-  "use strict";
+const Sanitizer = {
+  _entity: /[&<>"'/]/g,
 
-  var Sanitizer = {
-    _entity: /[&<>"'/]/g,
+  _entities: {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&apos;",
+    "/": "&#x2F;",
+  },
 
-    _entities: {
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      '"': "&quot;",
-      "'": "&apos;",
-      "/": "&#x2F;",
-    },
+  getEntity: function (s) {
+    return Sanitizer._entities[s];
+  },
 
-    getEntity: function (s) {
-      return Sanitizer._entities[s];
-    },
+  /**
+   * Escapes HTML for all values in a tagged template string.
+   */
+  escapeHTML: function (strings) {
+    let result = "";
 
-    /**
-     * Escapes HTML for all values in a tagged template string.
-     */
-    escapeHTML: function (strings) {
-      var result = "";
-
-      for (var i = 0; i < strings.length; i++) {
-        result += strings[i];
-        if (i + 1 < arguments.length) {
-          var value = arguments[i + 1] || "";
-          result += String(value).replace(
-            Sanitizer._entity,
-            Sanitizer.getEntity,
-          );
-        }
+    for (let i = 0; i < strings.length; i++) {
+      result += strings[i];
+      if (i + 1 < arguments.length) {
+        const value = arguments[i + 1] || "";
+        result += String(value).replace(Sanitizer._entity, Sanitizer.getEntity);
       }
+    }
 
-      return result;
-    },
-    /**
-     * Escapes HTML and returns a wrapped object to be used during DOM insertion
-     */
-    createSafeHTML: function (strings) {
-      var _len = arguments.length;
-      var values = new Array(_len > 1 ? _len - 1 : 0);
-      for (var _key = 1; _key < _len; _key++) {
-        values[_key - 1] = arguments[_key];
-      }
+    return result;
+  },
+};
 
-      var escaped = Sanitizer.escapeHTML.apply(
-        Sanitizer,
-        [strings].concat(values),
-      );
-      return {
-        __html: escaped,
-        toString: function () {
-          return "[object WrappedHTMLObject]";
-        },
-        info:
-          "This is a wrapped HTML object. See https://developer.mozilla.or" +
-          "g/en-US/Firefox_OS/Security/Security_Automation for more.",
-      };
-    },
-    /**
-     * Unwrap safe HTML created by createSafeHTML or a custom replacement that
-     * underwent security review.
-     */
-    unwrapSafeHTML: function () {
-      var _len = arguments.length;
-      var htmlObjects = new Array(_len);
-      for (var _key = 0; _key < _len; _key++) {
-        htmlObjects[_key] = arguments[_key];
-      }
-
-      var markupList = htmlObjects.map(function (obj) {
-        return obj.__html;
-      });
-      return markupList.join("");
-    },
-  };
-
-  return Sanitizer;
-});
+module.exports = Sanitizer;

--- a/packages/uswds-core/src/js/utils/test/sanitizer.spec.js
+++ b/packages/uswds-core/src/js/utils/test/sanitizer.spec.js
@@ -1,0 +1,54 @@
+const assert = require("assert");
+const Sanitizer = require("../sanitizer");
+
+describe("sanitizer", () => {
+  describe("escapeHTML", () => {
+    it("returns the plain string when there are no interpolated values", () => {
+      const result = Sanitizer.escapeHTML`hello world`;
+      assert.strictEqual(result, "hello world");
+    });
+
+    it("leaves the static template parts untouched", () => {
+      const value = "safe";
+      const result = Sanitizer.escapeHTML`<span>${value}</span>`;
+      assert.strictEqual(result, "<span>safe</span>");
+    });
+
+    it("escapes &, <, >, \", ', and / in interpolated values", () => {
+      const value = `& < > " ' /`;
+      const result = Sanitizer.escapeHTML`${value}`;
+      assert.strictEqual(result, "&amp; &lt; &gt; &quot; &apos; &#x2F;");
+    });
+
+    it("escapes a script-injection attempt", () => {
+      const value = '<script>alert("xss")</script>';
+      const result = Sanitizer.escapeHTML`${value}`;
+      assert.strictEqual(
+        result,
+        "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;",
+      );
+    });
+
+    it("handles multiple interpolated values in one tagged template", () => {
+      const first = "<b>";
+      const second = "</b>";
+      const result = Sanitizer.escapeHTML`${first}bold${second}`;
+      assert.strictEqual(result, "&lt;b&gt;bold&lt;&#x2F;b&gt;");
+    });
+
+    it("coerces non-string interpolated values via String()", () => {
+      const result = Sanitizer.escapeHTML`count: ${42}`;
+      assert.strictEqual(result, "count: 42");
+    });
+
+    it("treats null interpolated values as an empty string", () => {
+      const result = Sanitizer.escapeHTML`value: ${null}`;
+      assert.strictEqual(result, "value: ");
+    });
+
+    it("treats undefined interpolated values as an empty string", () => {
+      const result = Sanitizer.escapeHTML`value: ${undefined}`;
+      assert.strictEqual(result, "value: ");
+    });
+  });
+});

--- a/packages/uswds-core/src/js/utils/test/sanitizer.spec.js
+++ b/packages/uswds-core/src/js/utils/test/sanitizer.spec.js
@@ -20,6 +20,11 @@ describe("sanitizer", () => {
       assert.strictEqual(result, "&amp; &lt; &gt; &quot; &apos; &#x2F;");
     });
 
+    it("should escape all apostrophes in an interpolated value", () => {
+      const result = Sanitizer.escapeHTML`${"foo''bar"}`;
+      assert.strictEqual(result, "foo&apos;&apos;bar");
+    });
+
     it("escapes a script-injection attempt", () => {
       const value = '<script>alert("xss")</script>';
       const result = Sanitizer.escapeHTML`${value}`;
@@ -39,6 +44,21 @@ describe("sanitizer", () => {
     it("coerces non-string interpolated values via String()", () => {
       const result = Sanitizer.escapeHTML`count: ${42}`;
       assert.strictEqual(result, "count: 42");
+    });
+
+    it("preserves 0 as a string '0'", () => {
+      const result = Sanitizer.escapeHTML`count: ${0}`;
+      assert.strictEqual(result, "count: 0");
+    });
+
+    it("preserves false as a string 'false'", () => {
+      const result = Sanitizer.escapeHTML`value: ${false}`;
+      assert.strictEqual(result, "value: false");
+    });
+
+    it("coerces NaN to 'NaN'", () => {
+      const result = Sanitizer.escapeHTML`value: ${NaN}`;
+      assert.strictEqual(result, "value: NaN");
     });
 
     it("treats null interpolated values as an empty string", () => {

--- a/tasks/vite-plugin-uswds-cjs.mjs
+++ b/tasks/vite-plugin-uswds-cjs.mjs
@@ -8,10 +8,10 @@
  * This plugin performs a simple mechanical transformation:
  * - `const x = require("path")` → `import x from "path"`
  * - `const { a, b } = require("path")` → `import _modN from "path"; const { a, b } = _modN;`
- * - `module.exports = x` → `export default x`
+ * - `module.exports = x` (at column 0) → `export default x`
  * - `exports.name = value` → `export { value as name }`
  *
- * It only processes files under packages/ that are NOT .twig or .stories.js files.
+ * It only processes .js files under packages/ that are NOT .stories.js files.
  */
 
 import path from "node:path";
@@ -120,29 +120,6 @@ export default function uswdsCjsPlugin(options = {}) {
           "export default ",
         );
         hasChanges = true;
-      }
-
-      // Check for remaining module.exports (indented, e.g. inside UMD/IIFE)
-      const current = s.toString();
-      if (current.includes("module.exports")) {
-        // Handle UMD/IIFE: !(function(factory){ module.exports = factory(); })(function(){ ... })
-        const umdMatch = current.match(
-          /^!\(function\s*\([^)]*\)\s*\{[\s\S]*?module\.exports\s*=\s*\w+\(\);?\s*\}\)\((function\s*\([^)]*\)\s*\{[\s\S]*\})\);?\s*$/m,
-        );
-        if (umdMatch) {
-          // For UMD, replace the entire file content
-          s.overwrite(0, code.length, `export default (${umdMatch[1]})();`);
-          hasChanges = true;
-        } else {
-          // Fallback: replace any remaining module.exports
-          const fallbackMatch = current.match(/\s*module\.exports\s*=\s*/);
-          if (fallbackMatch && fallbackMatch.index !== undefined) {
-            const start = fallbackMatch.index;
-            const end = start + fallbackMatch[0].length;
-            s.overwrite(start, end, "\nexport default ");
-            hasChanges = true;
-          }
-        }
       }
 
       // Transform: exports.name = value

--- a/tasks/vite-plugin-uswds-cjs.spec.mjs
+++ b/tasks/vite-plugin-uswds-cjs.spec.mjs
@@ -99,16 +99,6 @@ describe("vite-plugin-uswds-cjs", () => {
       const out = transform(`exports.publicName = internalName;`);
       assert.match(out.code, /export \{ internalName as publicName \};/);
     });
-
-    it("converts a UMD/IIFE module.exports wrapper to export default", () => {
-      const out = transform(
-        `!(function (factory) { module.exports = factory(); })(function () { return 42; });`,
-      );
-      assert.match(
-        out.code,
-        /export default \(function \(\) \{ return 42; \}\)\(\);/,
-      );
-    });
   });
 
   describe("skip rules", () => {


### PR DESCRIPTION
# Summary

Modernized the internal `Sanitizer` utility to plain CommonJS, removed its unused `createSafeHTML`/`unwrapSafeHTML` methods, fixed a bug that silently dropped falsy interpolated values (`0`, `false`) from escaped output, and added unit test coverage for `escapeHTML`.

## Breaking change

This is not a breaking change.
<!-- Sanitizer is an internal-only utility (not re-exported from uswds-core's public entry point), and the only method used anywhere in the codebase, escapeHTML, keeps the same signature and behavior for all previously-supported inputs. -->

## Related issue

Addresses #6752
<!--
Not using "Closes" because one acceptance criterion of #6752 — simplifying the
vite plugin's UMD handling — can't land until #6715 (Storybook 9 / Vite migration,
which introduces tasks/vite-plugin-uswds-cjs.mjs) is merged. This PR delivers the
other three: convert sanitizer.js to CommonJS, keep escapeHTML as a tagged
template, and add tests for escapeHTML.
-->

## Related pull requests

#6715 must merge first; a follow-up PR should then simplify `tasks/vite-plugin-uswds-cjs.mjs` to drop its UMD detection now that `sanitizer.js` is the only UMD module and has been converted.

## Preview link

Preview link: https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/task/update-sanitizer-js/?path=/story/design-tokens-fonts--fonts

## Problem statement

`packages/uswds-core/src/js/utils/sanitizer.js` was written as a UMD module wrapped in an IIFE, with `/* eslint-disable */` at the top of the file so it was excluded from linting. It also shipped `createSafeHTML` and `unwrapSafeHTML` helpers that are unused anywhere in the codebase, and had no unit tests. Additionally, `escapeHTML` used `arguments[i + 1] || ""` to default missing interpolated values, which meant falsy-but-valid values like `0` and `false` were silently replaced with an empty string instead of being rendered.

## Solution

Rewrote `sanitizer.js` as a plain CommonJS module (matching how every consumer already imports it via `require`), removed the dead `createSafeHTML`/`unwrapSafeHTML` methods, and re-enabled linting on the file. `escapeHTML` now only substitutes an empty string when a value is `null` or `undefined`, so `0` and `false` are preserved. Added a `sanitizer.spec.js` test suite covering entity escaping, multiple interpolations, falsy values, and `null`/`undefined` handling.

## Major changes

- Converted `sanitizer.js` from a UMD/IIFE pattern to CommonJS (`module.exports = Sanitizer`).
- Removed unused `createSafeHTML` and `unwrapSafeHTML` methods.
- Removed `/* eslint-disable */` so the file is linted like the rest of the codebase.
- Fixed `escapeHTML` to preserve falsy interpolated values (`0`, `false`) instead of dropping them.
- Added `packages/uswds-core/src/js/utils/test/sanitizer.spec.js` with unit tests for `escapeHTML`.
- Simplifies the `cjs` plugin for Vite that's used in Storybook now that the codebase no longer contains UMD-formatted modules

## Testing and review

1. All tests sgould pass in CI. New tests were added to cover the changes.
2. Linting and prettier formatting are clean in CI.
3. Reviewers should confirm no other package relies on the removed `createSafeHTML`/`unwrapSafeHTML` methods (a repo-wide search found none) and spot-check `escapeHTML` call sites (`usa-file-input`, `usa-date-picker`, `usa-table`, `usa-in-page-navigation`, `usa-combo-box`) still render correctly in Storybook with `npm run start:storybook` on your local environment or the [pages preview link](https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/task/update-sanitizer-js/?path=/story/design-tokens-fonts--fonts).
