### PR TITLE
USWDS - Modal: Keep force-action modals scrollable on iOS

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -104,6 +104,16 @@ function toggleModal(event) {
       targetModal.setAttribute("data-opener", originalOpener);
     }
 
+    // Modals that force an action can't be dismissed by clicking the
+    // overlay. The overlay used to ignore pointer events to prevent this,
+    // but that also stopped iOS from scrolling a long modal.
+    if (
+      forceUserAction &&
+      clickedElement.classList.contains(OVERLAY_CLASSNAME)
+    ) {
+      return false;
+    }
+
     // This basically stops the propagation if the element
     // is inside the modal and not a close button or
     // element inside a close button

--- a/packages/usa-modal/src/styles/_usa-modal.scss
+++ b/packages/usa-modal/src/styles/_usa-modal.scss
@@ -4,6 +4,12 @@
   pointer-events: none;
   user-select: none;
 
+  // The overlay scrolls the modal, so it has to keep its pointer events.
+  // Without them iOS can't scroll a modal taller than the viewport.
+  .usa-modal-overlay {
+    pointer-events: auto;
+  }
+
   .usa-modal,
   .usa-modal * {
     pointer-events: auto;
@@ -57,14 +63,6 @@
     display: inline-block;
     height: 100%;
     vertical-align: middle;
-  }
-
-  &[data-force-action="true"] {
-    pointer-events: none;
-
-    * {
-      pointer-events: auto;
-    }
   }
 }
 

--- a/packages/usa-modal/src/test/force-action.template.html
+++ b/packages/usa-modal/src/test/force-action.template.html
@@ -1,0 +1,27 @@
+<button id="force-open-button" type="button" class="usa-button" aria-controls="force-modal" data-open-modal>
+  Open modal with forced action
+</button>
+<div class="usa-modal" id="force-modal" aria-labelledby="force-modal-heading" aria-describedby="force-modal-description" data-force-action>
+  <div class="usa-modal__content">
+    <div class="usa-modal__main">
+      <h2 class="usa-modal__heading" id="force-modal-heading">
+        Your session will end soon.
+      </h2>
+      <div id="force-modal-description" class="usa-prose">
+        <p>
+          You’ve been inactive for too long. Please choose to stay signed in or
+          sign out. Otherwise, you’ll be signed out automatically in 5 minutes.
+        </p>
+      </div>
+      <div class="usa-modal__footer">
+        <ul class="usa-button-group">
+          <li class="usa-button-group__item">
+            <button id="force-stay-button" type="button" class="usa-button" data-close-modal>
+              Yes, stay signed in
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/usa-modal/src/test/modal.spec.js
+++ b/packages/usa-modal/src/test/modal.spec.js
@@ -6,6 +6,9 @@ const modal = require("../index");
 const comboBox = require("../../../usa-combo-box/src/index");
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, "template.html"));
+const FORCE_ACTION_TEMPLATE = fs.readFileSync(
+  path.join(__dirname, "force-action.template.html"),
+);
 const modalWindowSelector = () => document.querySelector(".usa-modal");
 const bodySelector = () => document.body;
 const openButton1Selector = () => document.querySelector("#open-button1");
@@ -200,5 +203,53 @@ tests.forEach(({ name, selector: containerSelector }) => {
         assert.strictEqual(document.activeElement, closeButton);
       });
     });
+  });
+});
+
+describe("Modal window with a forced action", () => {
+  const { body } = document;
+
+  let modalWrapper;
+  let openButton;
+  let overlay;
+  let stayButton;
+
+  const isVisible = (el) => el.classList.contains("is-visible");
+
+  beforeEach(() => {
+    body.innerHTML = FORCE_ACTION_TEMPLATE;
+    modal.on(body);
+    modalWrapper = body.querySelector(".usa-modal-wrapper");
+    overlay = body.querySelector(".usa-modal-overlay");
+    openButton = body.querySelector("#force-open-button");
+    stayButton = body.querySelector("#force-stay-button");
+
+    openButton.click();
+  });
+
+  afterEach(() => {
+    modal.off(body);
+    body.innerHTML = "";
+    body.className = "";
+  });
+
+  it("stays open when the overlay is clicked", () => {
+    overlay.click();
+
+    assert.strictEqual(isVisible(modalWrapper), true);
+  });
+
+  it("closes when a close button is clicked", () => {
+    stayButton.click();
+
+    assert.strictEqual(isVisible(modalWrapper), false);
+  });
+
+  it("prevents clicks outside the modal while it is open", () => {
+    assert.strictEqual(body.classList.contains("usa-js-no-click"), true);
+
+    stayButton.click();
+
+    assert.strictEqual(body.classList.contains("usa-js-no-click"), false);
   });
 });


### PR DESCRIPTION
# Summary

**Long force-action modals scroll again on iOS.** The modal's scrolling area was set to ignore all pointer input while a force-action modal was open, and iOS won't scroll something it can't touch. That area now accepts touch again, and the rule that keeps a force-action modal from being dismissed by tapping the background moved into JavaScript, where it's covered by tests.

Sites that set their own `pointer-events` on `.usa-modal-overlay` keep their setting.

## Breaking change

This is not a breaking change, as long as the CSS and the JavaScript ship together.

- **Added:** `:where(.usa-js-no-click .usa-modal-overlay) { pointer-events: auto; }`. Wrapping the whole selector in `:where()` gives it zero specificity, so a site rule that sets `pointer-events` on `.usa-modal-overlay` still wins, whether it loads before or after `uswds.css`, exactly as it did before this branch. The first revision of this PR used `.usa-js-no-click .usa-modal-overlay`, which has two-class specificity and outranked those overrides — that's what the breaking-change label was raised for, and it's fixed in dcb9fae69.
- **Removed:** `.usa-modal-overlay[data-force-action="true"]` and its `*` child rule. They never matched anything (details below), so nothing that works today can depend on them.
- Nothing about the markup, the JavaScript API, or the look of the modal changes.
- **Ship both halves together.** The CSS makes the backdrop tappable, and the JavaScript is what stops that tap from closing a force-action modal. New CSS with an older `uswds.js` would let people dismiss a force-action modal by tapping the backdrop. Older CSS with the new JavaScript is harmless — it just keeps the iOS bug.

## Related issue

Closes #6717

## Related pull requests

None. No documentation site changes are needed for this.

## Preview link

No hosted preview. To see it locally:

1. `npm install && npm start`
2. Open the **Modal → Forced Action** story in Storybook.
3. Add enough text to the modal to make it taller than the window.
4. Open it, put the pointer on the dark background beside the modal, and scroll **up** with the wheel or trackpad. (Opening the modal focuses the footer button, which scrolls the overlay to the bottom, so scrolling down shows nothing on either build. A plain mouse drag doesn't scroll on either build — use DevTools device mode with touch to drag.)

On `develop` the background is inert and nothing scrolls. With this change it scrolls.

## Problem statement

When a force-action modal is taller than the screen, people on iOS can't scroll it. They can't read the rest of the message and they can't reach the buttons at the bottom — and because it's a force-action modal, there's no way out of it. Regular modals scroll on iOS just fine, so this only strands people on the one kind of modal they can't dismiss.

## Solution

The part of a modal that actually scrolls is `.usa-modal-overlay`. While a force-action modal is open, `usa-js-no-click` is added to `<body>` with `pointer-events: none`, and that value is **inherited** all the way down to the overlay. Desktop browsers still scroll it when the cursor is over the modal text, but iOS decides what to scroll by hit-testing where your finger lands — and an element with `pointer-events: none` can't be hit. So the scroll never starts.

The fix has two halves:

1. The overlay keeps its pointer events while `usa-js-no-click` is active, so it can be touched and scrolled. The rule has zero specificity, so a site that sets `.usa-modal-overlay { pointer-events: none }` keeps today's behavior — including the iOS scrolling problem — until it removes that override.
2. Because the overlay can now be clicked, `toggleModal` explicitly ignores clicks that land on the overlay of a force-action modal. That's the behavior the `pointer-events: none` was quietly providing before — now it's stated in code and covered by a test.

**How much of the symptom this covers.** The measured difference is specific to touches that land on the dark gutter around the modal. A drag that starts on the modal's own content already scrolls on `develop`, because `.usa-js-no-click .usa-modal *` keeps pointer events there. So this restores scrolling from the backdrop; if the iOS report also covers drags on the content itself, that has a different cause and this doesn't address it. Device testing would settle which.

**A note on the CSS that the issue points at.** The issue blames `.usa-modal-overlay[data-force-action="true"] { pointer-events: none }`. That rule never actually applied: `setModalAttributes` copies `data-force-action` onto `.usa-modal-wrapper`, not onto the overlay, so the selector matched nothing — and it's been that way since 216b47c0d (Feb 2021), which stopped setting the attribute on the overlay. The real cause was the inherited value from `usa-js-no-click`. The dead rule is removed here so it can't cause the same confusion again — happy to put it back if you'd rather keep the change smaller.

**One thing worth knowing about the design.** The overlay is the only element that listens for clicks inside a modal — close buttons don't get their own listener, they rely on the click bubbling up to it. So excluding the overlay from the closer list would have broken every close button in a force-action modal. That's why the fix guards inside `toggleModal` instead. (The `:not([data-force-action])` in the JS `CLOSERS` selector is dead for the same reason the removed CSS rule was: the attribute lives on the wrapper. Left alone here — it's pre-existing and outside this PR.)

## Major changes

- `packages/usa-modal/src/styles/_usa-modal.scss` — adds `:where(.usa-js-no-click .usa-modal-overlay) { pointer-events: auto; }` (zero specificity, so existing `.usa-modal-overlay` overrides still win) and removes the dead `[data-force-action="true"]` block.
- `packages/usa-modal/src/index.js` — `toggleModal` returns early when the click target is the overlay of a force-action modal.
- `packages/usa-modal/src/test/modal.spec.js` + `force-action.template.html` — first tests for force-action modals: the overlay doesn't dismiss them and the modal can still be closed afterwards, close buttons still work, and `usa-js-no-click` is added and removed correctly.

## Testing and review

**Automated.** `gulp test` passes: 801 unit, 122 Sass, 28 build-tooling tests, no failures. stylelint and Prettier are clean on the changed files. `npm test` also runs `snyk test`, which needs an account, so that step was skipped. Note for reproducing locally: the repo's pinned Node 24 is required — on Node 26, mocha's bundled `yargs` fails to load before any test runs.

The overlay test **fails on `develop`** — a force-action modal closes when its overlay is clicked, because nothing in JavaScript prevented it — and passes with this change. It also fails against a variant of this branch where the guard runs *after* `body.classList.toggle(ACTIVE_CLASS, …)`, which would leave the modal impossible to close.

**Cascade and behavior**, measured on the full `uswds.css` built through the repo's own pipeline (sass-embedded → discard-comments + autoprefixer → postcss-csso), driven in Chromium, WebKit and Firefox, comparing the merge-base, the first revision of this PR, and the current one:

| | `develop` | first revision | now |
| --- | --- | --- | --- |
| overlay `pointer-events`, no site override | `none` | `auto` | `auto` |
| `.usa-modal-overlay{pointer-events:none}` after `uswds.css` | `none` | `auto` | `none` |
| the same rule before `uswds.css` | `none` | `auto` | `none` |
| `body > div > div{pointer-events:none}` after `uswds.css` | `none` | `auto` | `none` |
| force-action modal, backdrop click or tap | stays open | stays open | stays open |
| force-action close button | closes, focus returns | same | same |
| ordinary modal, backdrop click / Escape | closes | closes | closes |

Touch-drag scrolling could only be synthesized in Chromium (Playwright's WebKit has no touch-drag): there, dragging the dark gutter scrolls nothing on `develop` and scrolls normally here.

**Browsers without `:where()`.** Of the 25 targets this repo's browserslist resolves, three lack it — Opera Mini, KaiOS 2.5 and QQ 14.9, about 0.11% combined usage. Only that one rule is dropped (csso keeps it standalone, so no selector list is invalidated) and the overlay falls back to inheriting `pointer-events: none`, which is exactly `develop`'s behavior. Those browsers don't get the fix; nothing gets worse. Opera Mini doesn't support `pointer-events` at all, so the no-click mechanism never worked there.

**Cases that still differ from `develop`,** none avoidable by specificity alone:

1. A site override inside an `@layer` while USWDS is unlayered — unlayered beats layered regardless of specificity.
2. A zero-specificity site rule loaded before `uswds.css` (`:where(.usa-modal-overlay)`, `*`) — it ties at (0,0,0) and loses on source order.
3. A rule on an **ancestor**, such as `.usa-modal-wrapper { pointer-events: none }`, which used to reach the overlay by inheritance. Any rule that declares the property on the overlay ends that inheritance. The JS guard still keeps the modal open on a backdrop click, so the likely intent survives.

**What I could not test, and where I'd like your help.** I don't have an iOS device, so I have not confirmed the fix on iOS Safari itself. What's demonstrated above is the mechanism behind the reported symptom — the scrolling container becoming hit-testable again — not the symptom on real hardware. **Please verify on an actual iOS device before merging**, including a drag that starts on the dark gutter and one that starts on the modal text.

I'd also welcome a second opinion on three judgment calls: removing the dead CSS rule rather than leaving it, moving the dismissal-blocking from CSS into JavaScript, and wrapping the whole selector in `:where()` rather than only the ancestor. All are easy to walk back.
