### PR TITLE
Add @opensource-joe to USWDS Community Contributors

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -28,6 +28,7 @@ Members of the USWDS Open Source Community are responsible for guiding its devel
 - [@mgifford](https://github.com/mgifford), CivicActions Open Standards and Practices Lead, Drupal Core Accessibility Maintainer, W3C Invited Expert
 - [@acolter](https://github.com/acolter), The Bridge Chief Operating Officer, Former Executive Director at 18F
 - [@jeana-adhoc](https://github.com/jeana-adhoc), Design Lead & Accessibility Specialist at Ad Hoc; Contractor on VA.gov Design System
+- [@opensource-joe](https://github.com/opensource-joe), Principal technologist building open-source AI; Former Code.gov Director (GSA / TTS)
 
 ### USWDS Alumni
 


### PR DESCRIPTION
Adds me to the USWDS Community Contributors list in `COMMUNITY.md`, following the [process of becoming a USWDS Contributor](https://github.com/uswds/uswds/blob/develop/COMMUNITY.md#process-of-becoming-a-uswds-contributor).

@annepetersen invited me to join in https://github.com/uswds/uswds/pull/6795, and pointed me at COMMUNITY.md and the contributor ladder issue template as the first move.

The companion role change request issue, with justification and supporting evidence, is linked below. That issue is the right place to weigh whether I meet the bar; this PR is just the list entry.

Per COMMUNITY.md, this needs approval from at least one current USWDS Maintainer, including their reasoning for the decision.