### PR TITLE
Update memorable date's visible hint to align with our style guide

### DIFF
--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -252,7 +252,7 @@
   <fieldset class="usa-fieldset">
     <legend class="usa-legend {% if error_state == true %}usa-label--error{% endif %}">Memorable date</legend>
     <span class="usa-hint" aria-hidden="true" id="{{ group_hint_id }}">
-      Select a month. Enter 1 or 2 digits for the day and 4 digits for the year.
+      Select a month. Enter one or two digits for the day and four digits for the year.
     </span>
     {% if error_state == true %}<span class="usa-error-message" id="{{ memorable_date_error_id }}" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-memorable-date">

--- a/packages/usa-memorable-date/src/test/template.html
+++ b/packages/usa-memorable-date/src/test/template.html
@@ -1,7 +1,7 @@
 <fieldset class="usa-fieldset">
   <legend class="usa-legend">Date of Birth</legend>
   <span class="usa-hint" aria-hidden="true" id="memorable-date-hint">
-    Select a month. Enter 1 or 2 digits for the day and 4 digits for the year.
+    Select a month. Enter one ot two digits for the day and four digits for the year.
   </span>
   <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group--month usa-form-group--select">

--- a/packages/usa-memorable-date/src/usa-memorable-date.twig
+++ b/packages/usa-memorable-date/src/usa-memorable-date.twig
@@ -10,7 +10,7 @@
 <fieldset class="usa-fieldset">
   <legend class="usa-legend">Date of Birth</legend>
   <span class="usa-hint" aria-hidden="true" id="{{ group_hint_id }}">
-    Select a month. Enter 1 or 2 digits for the day and 4 digits for the year.
+    Select a month. Enter one or two digits for the day and four digits for the year.
   </span>
   <div class="usa-memorable-date">
     <div class="usa-form-group usa-form-group--month usa-form-group--select">


### PR DESCRIPTION
# Summary
Quick follow up after PR #6725 to update the visible text-based hint to align with our [style guide (internal link 🔒)](https://docs.google.com/document/d/1RVSLe1lcLk8ehzm4axhYE-ohbQTwwrKu/edit):

> Spell out numbers  one  through  nine and use numerals for numbers 10 and greater.

The **visible** hint now reads:
`Select a month. Enter one or two digits for the day and four digits for the year.`

Previously the **visible** hint read:
`Select a month. Enter 1 or 2 digits for the day and 4 digits for the year.`

The **screen reader-only hint** still uses numerals, as numerals may be slightly better with any language translation.


## Breaking change
This is not a breaking change.

## Related pull requests
Follow-up to #6725, which closed #5902.