### PR TITLE
[Task] Range Slider: Moved hint above the slider to match other component hints

### DIFF
--- a/packages/usa-range/src/test/template.html
+++ b/packages/usa-range/src/test/template.html
@@ -1,4 +1,5 @@
 <form class="usa-form">
+  <span class="usa-hint" id="range-hint">Move the slider to change the value</span>
   <input
     id="usa-range"
     class="usa-range"
@@ -10,7 +11,4 @@
     data-text-unit="percent"
     aria-describedby="range-hint"
   />
-  <span class="usa-hint" id="range-hint"
-    >Move the slider to change the value</span
-  >
 </form>

--- a/packages/usa-range/src/usa-range.twig
+++ b/packages/usa-range/src/usa-range.twig
@@ -1,5 +1,6 @@
 <form class="usa-form">
   <label class="usa-label" for="usa-range">Range slider</label>
+  <span class="usa-hint" id="range-hint">Move the slider to change the value</span>
   <input
     id="usa-range"
     class="usa-range"
@@ -14,5 +15,4 @@
     {% if disabled_state == 'aria-disabled' %} aria-disabled="true" {%- endif %}
     aria-describedby="range-hint"
   >
-  <span class="usa-hint" id="range-hint">Move the slider to change the value</span>
 </form>


### PR DESCRIPTION
# Summary
Minor follow-up after PR #6673. This fixes the Range Slider hint placement by moving the hint above the slider. Previously, the hint was introduced below the component, which doesn't match the system's pattern.

## Breaking change
This is not a breaking change.

## Related pull requests
Follow-up to #6673, which closed #6614.

## Screenshots
Before
<img width="455" height="157" alt="Screenshot 2026-08-14 at 11 50 20" src="https://github.com/user-attachments/assets/f42434f5-8e51-4a93-a1bf-a6082449fe91" />

After
<img width="421" height="156" alt="Screenshot 2026-08-14 at 11 51 06" src="https://github.com/user-attachments/assets/4140a375-e99c-4b55-a761-67b4655b8fca" />
