### PR TITLE
USWDS - Range slider: Fix webkit thumb centering after border increase

### DIFF
--- a/packages/usa-range/src/styles/_usa-range.scss
+++ b/packages/usa-range/src/styles/_usa-range.scss
@@ -86,7 +86,15 @@
   &::-webkit-slider-thumb {
     @include range-thumb;
     appearance: none;
-    margin-top: px-to-rem(-3px); // magic number
+    // Webkit positions ::-webkit-slider-thumb relative to the track centerline
+    // using content-box geometry. The track renders at:
+    //   height (units(2) = 16px) + border-top + border-bottom = 20px total
+    // because ::-webkit-slider-runnable-track does not inherit box-sizing and
+    // defaults to content-box. Without correction the thumb sits 1px low.
+    // Formula: -(border-width) = -(2px) = -2px half-correction per side, rounded
+    // to the nearest rem. Update this value whenever the track border-width changes.
+    // Current track border: units(2px) — see range-track mixin above.
+    margin-top: px-to-rem(-4px);
   }
 
   &::-moz-range-thumb {

--- a/packages/usa-range/src/styles/_usa-range.scss
+++ b/packages/usa-range/src/styles/_usa-range.scss
@@ -86,14 +86,15 @@
   &::-webkit-slider-thumb {
     @include range-thumb;
     appearance: none;
-    // Webkit positions ::-webkit-slider-thumb relative to the track centerline
-    // using content-box geometry. The track renders at:
-    //   height (units(2) = 16px) + border-top + border-bottom = 20px total
-    // because ::-webkit-slider-runnable-track does not inherit box-sizing and
-    // defaults to content-box. Without correction the thumb sits 1px low.
-    // Formula: -(border-width) = -(2px) = -2px half-correction per side, rounded
-    // to the nearest rem. Update this value whenever the track border-width changes.
-    // Current track border: units(2px) — see range-track mixin above.
+    // Webkit aligns the thumb's top edge to the track's content-box top.
+    // A negative margin-top pulls the thumb upward to center it on the track.
+    //
+    // Formula: margin-top = -(track_border_width + 2px)
+    //   The constant 2px is a fixed geometric offset independent of border size.
+    //   Confirmed empirically: border=1px → -3px (v3.13.0), border=2px → -4px (current).
+    //
+    // Update this value whenever the track border-width (range-track mixin) changes.
+    // Current track border: units(2px) → margin-top = -(2 + 2) = -4px.
     margin-top: px-to-rem(-4px);
   }
 


### PR DESCRIPTION
# Summary

Fixed off-center range slider thumb in Chromium and Safari by correcting the `margin-top` offset on `::-webkit-slider-thumb` to account for the track border width increase introduced in #6811.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6813

## Related pull requests

Depends on / follows #6811 (range slider track border width increase).

## Preview link

Preview link: N/A

## Problem statement

The range slider track border was widened from `1px` to `2px` in #6811 (commit `726e7750a`), but the webkit-specific `margin-top` correction on `::-webkit-slider-thumb` was not updated to match.

`::-webkit-slider-runnable-track` uses `content-box` sizing, so its rendered height equals `height + border-top + border-bottom`:

- v3.13.0: `16px + 1px + 1px = 18px` (centerline at `9px`)
- After #6811: `16px + 2px + 2px = 20px` (centerline at `10px`)

The `-3px` offset was calibrated to the 18px track. With a 20px track, the thumb sat 1px below center in Chromium and Safari at every viewport and container width.

## Solution

Updated the `margin-top` offset from `-3px` to `-4px` on `::-webkit-slider-thumb`. Replaced the `// magic number` comment with a full geometric explanation so the value can be maintained correctly when the track border changes in the future.

This is a one-line Sass change. No markup, JavaScript, or settings are affected.

## Testing and review

1. Build USWDS and open the Range component Storybook story.
2. View in Chromium (Chrome/Edge) and Safari — the thumb should be vertically centered on the track at all viewport widths.
3. Confirm Firefox is unaffected (Firefox uses `::-moz-range-thumb`, which has its own rule and was not changed).
