### PR TITLE
USWDS - Build: fix svgo warnings

### DIFF
--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   plugins: [
     {
+      // removeViewBox is intentionally excluded. In svgo v4, it is not part
+      // of preset-default and must be explicitly added to run. Omitting it
+      // ensures viewBox attributes are preserved on all optimized SVGs.
       name: 'preset-default',
     },
   ],
 }
+

--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,12 +1,7 @@
 module.exports = {
-  plugins: [ 
+  plugins: [
     {
       name: 'preset-default',
-      params: {
-        overrides: {
-          removeViewBox: false,
-        },
-      },
-    }
-  ]
+    },
+  ],
 }


### PR DESCRIPTION
# Summary

Removed a deprecated `removeViewBox` override from the svgo config that was no longer valid in svgo v4, eliminating build warnings during `npm run build:storybook`.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6819

## Related pull requests

None.

## Preview link

N/A

## Problem statement

After upgrading to svgo v4, the `params.overrides.removeViewBox: false` setting in `svgo.config.js` triggered a deprecation warning on every build. In svgo v4, `removeViewBox` was removed from `preset-default` entirely.

## Solution

Removed the `params.overrides.removeViewBox` block. Because `removeViewBox` is no longer part of `preset-default` in svgo v4, it will not run unless explicitly added to the plugins list, meaning `viewBox` attributes are preserved by default without any override. A comment was added to make this intent explicit and prevent the override from being re-added in the future.

## Major changes

- `svgo.config.js`: Removed deprecated `params: { overrides: { removeViewBox: false } }` block; added an explanatory comment documenting why the override is not needed.

## Testing and review

1. Run `npm run fix:icons` and confirm no svgo deprecation warnings appear in the output.
2. Run `npm run build:storybook` and confirm no svgo-related warnings appear.
3. Inspect a sample of processed SVGs in `packages/usa-icon/src/img/` and confirm `viewBox` attributes are intact.
