### PR TITLE
USWDS - uswds-core: Expand box-sizing notification to all affected form input components

### DIFF
--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -266,11 +266,11 @@ $uswds-notifications:
 + "\A   against XSS vulnerabilities through unsanitized `data-tag` values."
 + "\A   ✏️ Teams should review any footer `data-tag` values that aren't heading"
 + "\A     elements."
-+ "\A - Display, Settings: [usa-select] Set `box-sizing: border-box` on select"
++ "\A - Display, Settings: [usa-input, usa-textarea, usa-range, usa-combo-box,"
++ "\A   usa-input-prefix-suffix, usa-select] Set `box-sizing: border-box` on form inputs"
 + "\A   to prevent overflow in host environments that reset global box sizing."
-+ "\A   ✏️ Teams should verify that select elements display correctly in projects"
-+ "\A     with custom global `box-sizing` resets, such as content management"
-+ "\A     systems that provide extra theming."
++ "\A   ✏️ Teams should verify these elements display correctly in projects with custom global"
++ "\A     box-sizing resets (i.e. those using `$theme-global-border-box-sizing: false`)."
 + "\A ";
 
 /* prettier-ignore */

--- a/packages/uswds-core/src/styles/_notifications.scss
+++ b/packages/uswds-core/src/styles/_notifications.scss
@@ -270,7 +270,7 @@ $uswds-notifications:
 + "\A   usa-input-prefix-suffix, usa-select] Set `box-sizing: border-box` on form inputs"
 + "\A   to prevent overflow in host environments that reset global box sizing."
 + "\A   ✏️ Teams should verify these elements display correctly in projects with custom global"
-+ "\A     box-sizing resets (i.e. those using `$theme-global-border-box-sizing: false`)."
++ "\A     box-sizing resets (i.e. those who set `$theme-global-border-box-sizing: false`)."
 + "\A ";
 
 /* prettier-ignore */


### PR DESCRIPTION
# Summary

Updated the `box-sizing: border-box` notification message to accurately reflect all form input components affected by the change, and refined the migration guidance to reference the relevant theme setting.

## Problem statement

The existing notification message for the `box-sizing: border-box` fix only listed `usa-select` as the affected component. In reality, the fix applies to a wider set of form inputs: `usa-input`, `usa-textarea`, `usa-range`, `usa-combo-box`, `usa-input-prefix-suffix`, and `usa-select`. Teams relying on the notification to assess impact would have an incomplete picture of what to verify in their projects.

## Solution

Updated the component list in the notification string and rewrote the migration hint to name the exact USWDS theme setting (`$theme-global-border-box-sizing: false`) that triggers the affected behavior, replacing the more general "content management systems that provide extra theming" phrasing. This makes the guidance actionable and precise.

## Major changes

- `packages/uswds-core/src/styles/_notifications.scss`: Expanded the affected component list in the `box-sizing` notification entry from `[usa-select]` to include `usa-input`, `usa-textarea`, `usa-range`, `usa-combo-box`, and `usa-input-prefix-suffix`.
- Updated the migration hint to reference `$theme-global-border-box-sizing: false` directly.

## Testing and review

1. Run `npm run build` and confirm no Sass compilation errors.
2. In a consuming project, set `$theme-show-notifications: true` and verify the updated notification text appears in the build output with the correct component list and hint.
3. No functional behavior changes — review is limited to verifying notification string accuracy.