### PR TITLE
USWDS - Focus trap: Ignore hidden inputs when it finds tab stops

### DIFF
--- a/packages/uswds-core/src/js/utils/focus-trap.js
+++ b/packages/uswds-core/src/js/utils/focus-trap.js
@@ -4,7 +4,7 @@ const select = require("./select");
 const activeElement = require("./active-element");
 
 const FOCUSABLE =
-  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+  'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
 
 const tabHandler = (context) => {
   const focusableElements = select(FOCUSABLE, context);

--- a/packages/uswds-core/src/js/utils/test/focus-trap.spec.js
+++ b/packages/uswds-core/src/js/utils/test/focus-trap.spec.js
@@ -105,4 +105,47 @@ describe("focus trap", () => {
       assert.strictEqual(document.activeElement, lastButton);
     });
   });
+  describe("hidden inputs", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <button type="button" id="outside">Outside</button>
+        <div id="trap">
+          <input type="hidden" id="csrf" name="csrf" value="token" />
+          <button type="button" id="first">First</button>
+          <button type="button" id="last">Last</button>
+        </div>
+      `;
+
+      container = document.getElementById("trap");
+      firstButton = document.getElementById("first");
+      lastButton = document.getElementById("last");
+    });
+
+    it("skips a leading hidden input when auto-focusing", () => {
+      trap = FocusTrap(container);
+      trap.update(true);
+
+      assert.strictEqual(document.activeElement, firstButton);
+    });
+
+    it("wraps Tab from the last tab stop past a leading hidden input", () => {
+      trap = FocusTrap(container);
+      trap.update(true);
+
+      lastButton.focus();
+      keydownTab();
+
+      assert.strictEqual(document.activeElement, firstButton);
+    });
+
+    it("wraps Shift+Tab from the first tab stop past a leading hidden input", () => {
+      trap = FocusTrap(container);
+      trap.update(true);
+
+      firstButton.focus();
+      keydownShiftTab();
+
+      assert.strictEqual(document.activeElement, lastButton);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #6056.

The `FOCUSABLE` list in `focus-trap.js` includes `input:not([disabled])`, which also matches `<input type="hidden">`. Hidden inputs can't take focus, so when one is the first match the trap treats it as the first tab stop and calling `focus()` on it does nothing.

What you actually see depends on the component. `usa-modal` passes `autoFocus: false` and sets the initial focus itself, so the symptom there is that tabbing forward from the last control never wraps and you get stuck, which is what @sanason reported from Touchpoints. `usa-header` and `usa-language-selector` use the default `autoFocus`, so they try to focus the hidden input on open and focus ends up on `<body>` instead of the first control.

The fix is to exclude hidden inputs from the selector.

@mejiaj asked whether this is only a focus trap issue. It is, and no component code changes. Two related things I left alone, happy to open separate issues if they're worth tracking:

- The selector matches elements hidden with `display: none`, `visibility: hidden`, or the `hidden` attribute the same way.
- `usa-header` and `usa-language-selector` build their tab stop list once in `init()`, so it goes stale if the container's contents change later.

I added three tests to `focus-trap.spec.js` covering auto focus, Tab from the last control, and Shift+Tab from the first. They fail before the change and pass after.