### PR TITLE
fix: add workflow_dispatch to release.yml and fix tarball path

### DIFF
--- a/.github/actions/verify-tarball-hash/action.yml
+++ b/.github/actions/verify-tarball-hash/action.yml
@@ -48,5 +48,5 @@ runs:
         fi
 
         echo "hash=$COMPUTED" >> "$GITHUB_OUTPUT"
-        echo "tarball-path=$TGZ" >> "$GITHUB_OUTPUT"
+        echo "tarball-path=./$TGZ" >> "$GITHUB_OUTPUT"
         echo "✓ Hash verified: $COMPUTED"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 3.14.0, without leading v)'
+        required: true
+        type: string
 
 permissions:
   id-token: write  # Required for OIDC
@@ -73,7 +79,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           ARTIFACT_NAME="uswds-${VERSION}-release"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Problem

The `release.yml` publish workflow failed when triggered by the `v3.14.0` tag push with:

```
npm error code EALLOWGIT
npm error Refusing to fetch "github:release-artifact/uswds-uswds-3.14.0.tgz"
```

npm was misinterpreting the bare path `release-artifact/uswds-uswds-3.14.0.tgz` as a GitHub package shorthand (`owner/repo`).

## Changes

- **`.github/actions/verify-tarball-hash/action.yml`**: Prefix tarball path output with `./` so npm treats it as a local file path, not a GitHub shorthand.
- **`.github/workflows/release.yml`**: Add `workflow_dispatch` trigger with a `version` input (e.g. `3.14.0`, without leading `v`) so the workflow can be manually re-triggered without re-pushing the tag.