### PR TITLE
chore: remove manual workflow_dispatch trigger from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g. 3.14.0, without leading v)'
-        required: true
-        type: string
 
 permissions:
   id-token: write  # Required for OIDC
@@ -79,11 +73,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${GITHUB_REF_NAME#v}"
-          fi
+          VERSION="${GITHUB_REF_NAME#v}"
           ARTIFACT_NAME="uswds-${VERSION}-release"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
**Removes the ability to trigger the release workflow manually.**

## Context
The `release.yml` workflow (Publish Package to npmjs) previously supported a `workflow_dispatch` trigger with a `version` input, allowing a manual publish. This PR removes that capability so the workflow only fires on `v*.*.*` tag pushes, its intended trigger.

## Changes
- Removed the `workflow_dispatch` trigger and its `version` input from `on:`.
- Simplified the "Locate release-prep artifact" step to always derive `VERSION` from `GITHUB_REF_NAME` (the pushed tag), since the manual-dispatch branch is no longer reachable.

## How to Test
- Confirm the workflow no longer appears with a "Run workflow" button in the Actions UI once merged.
- Confirm the workflow still triggers on a `v*.*.*` tag push.

## Rollback
Revert this commit to restore the `workflow_dispatch` trigger and version-branching logic.

## Security Impact
Reduces attack/misuse surface by removing a manual publish path; publishing is now gated solely on tag pushes.

_This change was made with AI assistance (OpenCode)._