### PR TITLE
USWDS - Build: Remove dead deploy jobs from .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,65 +38,9 @@ jobs:
           name: Check formatting
           command: npm run prettier:check
 
-  deploy:
-    <<: *container
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v2-uswds-dependencies-{{ checksum "package-lock.json" }}
-      - run: npm install --ignore-scripts
-      - run: npm rebuild node-sass
-      - run:
-          name: Build the USWDS package
-          command: npm run build
-      - run:
-          name: Publish to NPM
-          command: |
-            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --access public
-  deploy-alpha:
-    <<: *container
-    steps:
-      - checkout
-      - run: npm install --ignore-scripts
-      - run: npm rebuild node-sass
-      - run:
-          name: Build the USWDS package
-          command: npm run build
-      - run:
-          name: Publish to NPM with `alpha` tag
-          command: |
-            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --access public --tag alpha
-  deploy-beta:
-    <<: *container
-    steps:
-      - checkout
-      - run: npm install --ignore-scripts
-      - run: npm rebuild node-sass
-      - run:
-          name: Build the USWDS package
-          command: npm run build
-      - run:
-          name: Publish to NPM with `beta` tag
-          command: |
-            npm config set "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-            npm publish --access public --tag beta
 workflows:
   version: 2
   circle-uswds:
     jobs:
       - build
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: main
-      - deploy-beta:
-          requires:
-            - build
-          filters:
-            branches:
-              only: library--main
+


### PR DESCRIPTION
## Summary

Removes dead CircleCI deploy jobs. The `deploy`, `deploy-alpha`, and `deploy-beta` job definitions were removed from `.circleci/config.yml`. Releases are now handled exclusively by `.github/workflows/release.yml` (triggered on `v*.*.*` tag pushes), making these CircleCI jobs dead code. The deploy jobs in CircleCI was failing on main, and that makes it a blocker for #6824 since CircleCI is required. 

Closes #6828

## Changes

- `.circleci/config.yml`: removed 3 job definitions (`deploy`, `deploy-alpha`, `deploy-beta`) and 2 workflow entries (`deploy`, `deploy-beta`)
- No functional changes. Only dead code removed

## How to Test

1. Confirm `.circleci/config.yml` no longer references `deploy`, `deploy-alpha`, or `deploy-beta`
2. Confirm the `circle-uswds` workflow jobs list contains only `build`
3. Confirm release publishing still works via `.github/workflows/release.yml` on a `v*.*.*` tag push (no change made to that workflow)
