### PR TITLE
USWDS - Agents: Add a code review skill

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,47 @@
+# USWDS Agent Tools
+
+This directory contains AI agent tools and skills for working with the USWDS repository.
+
+## Skills
+
+Skills are task-specific workflows that can be invoked by AI coding assistants. They encode USWDS-specific knowledge, conventions, and judgment.
+
+### `skills/uswds-code-review/`
+
+A judgment-based code review skill that reproduces the calibration of the USWDS core review team. It:
+
+- Enforces 16 specific gates (size, dependencies, test coverage, sanitization, etc.)
+- Distinguishes personal preference from what all downstream consumers inherit
+- Routes decisions to specialists (accessibility, breaking changes, new API surface)
+- Stays silent on formatting, naming, and other tooling-owned concerns
+- Uses the team's actual review voice and severity levels
+
+**Usage:**
+```bash
+# Review a PR
+/uswds-code-review 6767
+/uswds-code-review https://github.com/uswds/uswds/pull/6789
+
+# Review current branch
+/uswds-code-review
+```
+
+See `skills/uswds-code-review/SKILL.md` for full documentation and `VERIFICATION.md` for test cases.
+
+**Installation:**
+
+The skill is automatically available if you have this repo cloned and your AI assistant is configured to use repo-local skills. For manual installation:
+
+```bash
+ln -s /path/to/uswds/.agents/skills/uswds-code-review ~/.claude/skills/uswds-code-review
+```
+
+## Background
+
+These tools are designed for use with [Claude Code](https://claude.ai/code) and other AI coding assistants that support the skill/agent pattern. They assume:
+
+- Node 24 (`.nvmrc`)
+- `gh` CLI authenticated to `uswds/uswds`
+- Working directory is the USWDS repo root
+
+See `AGENTS.md` in the repo root for general agent guidance.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -38,9 +38,9 @@ ln -s /path/to/uswds/.agents/skills/uswds-code-review ~/.claude/skills/uswds-cod
 
 ## Background
 
-These tools are designed for use with [Claude Code](https://claude.ai/code) and other AI coding assistants that support the skill/agent pattern. They assume:
+These tools are designed for use with AI coding assistants that support the skill/agent pattern. They assume:
 
-- Node 24 (`.nvmrc`)
+- Node is installed. See `.nvmrc`
 - `gh` CLI authenticated to `uswds/uswds`
 - Working directory is the USWDS repo root
 

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -92,7 +92,7 @@ Each gate is documented in `references/gates.md` with runnable checks and carve-
 13. **New API surface** — manual follow-up; flag $theme-* settings, new data-* attrs, breaking markup
 14. **Breaking changes** — manual follow-up; carry thisisdano's design-vs-code split
 15. **New variants / default changes** — manual follow-up
-16. **Accessibility** — manual follow-up; name the test (NVDA, VoiceOver, forced-colors), don't conclude
+16. **Accessibility** — two sub-gates: 16a (SR text content, flag-only, an a11y specialist can judge without live AT); 16b (AT behavior verdict, manual follow-up — name the test matrix, don't conclude)
 
 For each finding, apply **the cascade test** before including it: *Does this change what every downstream consumer gets, or is it how I would have written it?* If the latter, downgrade to non-blocking or drop entirely.
 
@@ -119,7 +119,8 @@ For each finding, apply **the cascade test** before including it: *Does this cha
 State these with an explicit escape hatch: *"This is far from being a blocker, but worth considering"* or *"Not a blocker here though."* The dominant mode in the corpus is "I can approve once [this small thing is resolved]."
 
 **Manual follow-up** — route to a specialist, don't conclude:
-- Accessibility / AT behavior → name the test, don't render a verdict
+- Accessibility / AT behavior → name the test matrix, don't render a verdict (16b)
+- A11y SR text content → an a11y specialist can flag whether hint text is redundant with role or missing interaction guidance; non-blocking, does not need live AT testing (16a)
 - Breaking-change classification → flag it, cite the repo definition, note thisisdano's design-vs-code split
 - New API surface ($theme-* settings, `data-*` attrs, CSS class names)
 - New variants or default changes
@@ -186,9 +187,12 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 [If any. Name the specific test or specialist area, don't conclude.]
 
 **Accessibility:**
-- [ ] Test with NVDA + [specific scenario]
+- [ ] **16a — SR text content** (a11y specialist, no live AT needed): is hint/label text redundant with role? Does it explain interaction? Flag as `**polish (non-blocking)**` with suggested text; note any uswds-site guidance follow-up separately.
+- [ ] **16b — AT behavior** (hands-on testing required): Test with NVDA + [specific scenario]
 - [ ] Test with VoiceOver + Safari [specific scenario]
+- [ ] Test with VoiceOver + Chrome [specific scenario, if behavior differs]
 - [ ] Verify in forced-colors mode
+- [ ] Keyboard-only navigation
 
 **Breaking change classification:**
 - [ ] Review impact on [specific area]

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uswds-code-review
-description: Review USWDS PRs or branches using the team's calibrated judgment. Enforces 16 specific gates, distinguishes personal preference from what all consumers inherit, and routes decisions to the right specialist. Use when reviewing USWDS code changes, either from a PR number or the current branch.
+description: Review USWDS PRs or branches using the core team's calibrated judgment. Enforces 16 specific gates (size, dependencies, DRY, sanitization, test regression, etc.), distinguishes personal preference from what all consumers inherit, and routes specialist decisions (a11y, breaking changes, new API surface). Use when the user says "review this", "code review", "review the PR", asks for feedback on changes, or explicitly invokes /uswds-code-review.
 args:
   pr_or_branch: (optional) PR number/URL, or omit for current branch vs develop
 ---
@@ -42,7 +42,8 @@ git diff develop...HEAD
 git diff -M --numstat develop...HEAD
 ```
 
-Also fetch the USWDS Elements ADR list once (used by gate 4):
+Also fetch the USWDS ADR list once (used by gate 4). Distinguish which repo they are intended to apply to. Some are for
+USWDS, and others are for the `uswds-elements` repo:
 ```bash
 gh api repos/uswds/uswds-proposals/git/trees/HEAD?recursive=1 --jq '.tree[] | select(.path | startswith("decisions/")) | .path'
 ```

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: uswds-code-review
+description: Review USWDS PRs or branches using the team's calibrated judgment. Enforces 16 specific gates, distinguishes personal preference from what all consumers inherit, and routes decisions to the right specialist. Use when reviewing USWDS code changes, either from a PR number or the current branch.
+args:
+  pr_or_branch: (optional) PR number/URL, or omit for current branch vs develop
+---
+
+# USWDS Code Review
+
+Perform a judgment-based code review of USWDS changes, reproducing the calibration of the core review team (ethangardner, heymatthenry, mejiaj, thisisdano). This skill enforces 16 specific gates, distinguishes personal preference from what cascades to all downstream consumers, and explicitly routes calls that aren't a code reviewer's to make.
+
+## Entry point
+
+**Auto-detected:**
+- **Given a PR number or URL** → fetch via `gh pr view --json body,title,additions,deletions,files,baseRefName` + `gh pr diff`. All gates apply, including PR-body hygiene and definition-of-done checks.
+- **No argument (local branch)** → `git diff develop...HEAD`. PR-body and DoD gates are *skipped* and reported as such, not silently passed.
+
+Example invocations:
+- `/uswds-code-review 6767`
+- `/uswds-code-review https://github.com/uswds/uswds/pull/6789`
+- `/uswds-code-review` (reviews current branch)
+
+## Process
+
+### 1. Gather context
+
+Run these in parallel:
+
+**If reviewing a PR:**
+```bash
+gh pr view <N> --repo uswds/uswds --json number,title,body,additions,deletions,changedFiles,files,baseRefName,url
+gh pr diff <N> --repo uswds/uswds
+gh api repos/uswds/uswds/pulls/<N>/files --paginate --jq '.[] | {filename, additions, deletions, status, patch}'
+```
+
+**If reviewing a branch:**
+```bash
+git status
+git log develop..HEAD --oneline
+git diff develop...HEAD --name-status
+git diff develop...HEAD
+git diff -M --numstat develop...HEAD
+```
+
+Also fetch the USWDS Elements ADR list once (used by gate 4):
+```bash
+gh api repos/uswds/uswds-proposals/git/trees/HEAD?recursive=1 --jq '.tree[] | select(.path | startswith("decisions/")) | .path'
+```
+
+Identify:
+- What files changed (runtime code vs tests vs config vs docs)
+- Scope: feature, fix, refactor, dependency, tooling, docs
+- If a PR: linked issue via `Closes #N` in body
+- Base branch (should be `develop` for this repo)
+
+### 2. Read changed files
+
+**Never review the diff alone.** Read the actual changed files to understand:
+- What the change does and why
+- Whether it touches shared selectors, utilities, or public API
+- Impact radius: isolated feature vs. core utility vs. component used by nav/banner/form
+- Test coverage: are there tests, and what do they actually verify?
+
+If a PR body exists, parse it for:
+- Summary (must be release-note shaped: `**Brief statement.** Additional context.`)
+- Breaking change declaration (must pick one of three options from template)
+- Related issue (`Closes #N`)
+- Related PRs (uswds-site companion for new settings/variants)
+- Problem statement, Solution, Testing and review steps
+
+If the linked issue exists, fetch it:
+```bash
+gh issue view <N> --repo uswds/uswds --json title,body,labels
+```
+
+### 3. Apply the 16 gates
+
+Each gate is documented in `references/gates.md` with runnable checks and carve-outs. The critical ones:
+
+1. **Size** (flag only) — counts authored runtime + test lines against 400, with carve-outs for generated churn
+2. **Dependencies** — blocking unless called for; `lit` is the only runtime dep
+3. **Definition of done** — issue acceptance criteria vs actual diff, both directions
+4. **Existing pattern or ADR** — grep `uswds-core` utils; check uswds-proposals repo; distinguish Elements vs Core ADRs
+5. **Test coverage** — must fail on base branch (ethangardner's test)
+6. **DRY tests / 3-location threshold** — cite the existing `events.js` triplicate
+7. **Duplication** — blocking if a core utility already exists
+8. **Simplification pass** — dispatch `code-simplification` skill subagent, filter to readability wins only
+9. **Error handling** — guards, fallbacks, teardown symmetry, `@warn` on bad settings
+10. **Sanitization** — `Sanitizer.escapeHTML` for any `innerHTML` with interpolation
+11. **Modular code** — cited from engineering-values.md "Support repairability"
+12. **Input validation** — at system boundaries, checked against the sanitizer precedents
+13. **New API surface** — manual follow-up; flag $theme-* settings, new data-* attrs, breaking markup
+14. **Breaking changes** — manual follow-up; carry thisisdano's design-vs-code split
+15. **New variants / default changes** — manual follow-up
+16. **Accessibility** — manual follow-up; name the test (NVDA, VoiceOver, forced-colors), don't conclude
+
+For each finding, apply **the cascade test** before including it: *Does this change what every downstream consumer gets, or is it how I would have written it?* If the latter, downgrade to non-blocking or drop entirely.
+
+### 4. Classify findings into three dispositions
+
+**Blocking** — must be fixed before merge:
+- Correctness bugs (especially latent ones found by reading, not caught by CI)
+- Security issues (unsanitized interpolation, supply-chain, unsigned commits in workflows)
+- Missing regression test (test passes on base branch)
+- Duplicated `uswds-core` utility
+- De-themed token (literal replacing `color()`, `units()`)
+- Undeclared semver impact (CSS order, specificity, markup, default flip)
+- Scope creep (changes unrelated to the issue)
+- Sass/token misuse
+- Unmet definition of done
+
+**Non-blocking** — improvements, style, or follow-up work:
+- Readability refactors
+- Optional chaining / concision opportunities
+- Test DRYness (unless it's at the 3+ threshold)
+- Naming improvements that don't affect clarity
+- Architecture concerns that pre-date this PR (convert to issue)
+
+State these with an explicit escape hatch: *"This is far from being a blocker, but worth considering"* or *"Not a blocker here though."* The dominant mode in the corpus is "I can approve once [this small thing is resolved]."
+
+**Manual follow-up** — route to a specialist, don't conclude:
+- Accessibility / AT behavior → name the test, don't render a verdict
+- Breaking-change classification → flag it, cite the repo definition, note thisisdano's design-vs-code split
+- New API surface ($theme-* settings, `data-*` attrs, CSS class names)
+- New variants or default changes
+- Anything that affects visual design intent
+
+### 5. Structure the report
+
+Use **mejiaj's Conventional Comments labels** (real repo practice):
+- `**issue**` — blocking
+- `**polish**` — non-blocking improvement
+- `**question**` — genuine uncertainty
+- `**suggestion**` — optional
+- `**thought**` — bigger-picture, often converted to an issue
+- `**quibble**` — very minor
+- `**praise**` — call out good work
+- `(non-blocking)` — append to downgrade severity
+
+**Summary structure** (ethangardner's three-move template):
+1. Specific, non-generic compliment
+2. Census of what's below ("a few suggestions and one question")
+3. What clearing them earns ("then we can get this merged")
+
+**Report sections:**
+
+```markdown
+## PR Review: [Short title]
+
+### Overview
+[1-2 sentences: what this does, why it matters]
+
+### Context
+- **PR**: #N / branch `<name>`
+- **Scope**: [feature|fix|refactor|dependency|tooling|docs]
+- **Size**: +X/-Y across Z files ([flag if >400 authored lines, with reason])
+- **Base**: `develop`
+- **Linked issue**: #N (or "none found")
+
+### Gate checklist
+| Gate | Status | Notes |
+|------|--------|-------|
+| Size <400 authored lines | ✅/⚠️/❌ | [carve-out reason if flagged] |
+| Dependencies justified | ✅/⚠️/❌/⏭️ | |
+| Definition of done met | ✅/⚠️/❌/⏭️ | |
+| [... all 16 gates ...] | | |
+
+Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skipped (local branch)
+
+---
+
+### ❌ Blocking issues
+
+[If any. Each with `**issue**` label, file:line reference, code block or repro steps, and fix suggestion.]
+
+---
+
+### ⚠️ Non-blocking suggestions
+
+[If any. Each with `**polish**`, `**suggestion**`, or `**thought**` label, and explicit escape hatch.]
+
+---
+
+### 🔍 Manual follow-up required
+
+[If any. Name the specific test or specialist area, don't conclude.]
+
+**Accessibility:**
+- [ ] Test with NVDA + [specific scenario]
+- [ ] Test with VoiceOver + Safari [specific scenario]
+- [ ] Verify in forced-colors mode
+
+**Breaking change classification:**
+- [ ] Review impact on [specific area]
+- [ ] Note design vs. code distinction
+
+**New API surface:**
+- [ ] $theme-* setting needs SASSDoc + @warn + uswds-site docs PR
+- [ ] [etc.]
+
+---
+
+### 📋 Not reviewed (per team practice)
+
+- Formatting, indentation, quote style — delegated to Prettier/ESLint
+- `dist/` contents — generated; verify byte-identical instead
+- Naming in isolation
+- Micro-performance
+- Screen-reader verdicts — routed to a11y specialist
+- [any other items from silence list]
+
+---
+
+### Recommendation
+
+[One of:]
+- ✅ **Approve** — no blocking issues found. [Manual follow-up items to complete before merge.]
+- ✅ **Approve with suggestions** — no blockers; suggestions above are optional improvements.
+- ⏸️ **Hold** — pending [ADR / team decision / architectural discussion].
+- 🔄 **Request changes** — blocking issues above must be addressed.
+
+[Close with ethangardner's escape hatch:]
+Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.
+```
+
+### 6. Evidence and voice
+
+**Every substantive finding must include:**
+- A code block showing the issue, OR
+- A `file_path:line_number` reference (clickable), OR
+- Numbered repro steps
+
+Never "this is wrong" without showing the fix or the mechanism.
+
+**Approval compliments escalate with effort:**
+- Small fix: "LGTM. Thanks for the contribution."
+- Solid work: "Thanks for addressing the feedback. This looks really good!"
+- Complex PR: "Killer work! This is ready for prime time now." / "Thanks for the strong work on this and working through the issues."
+
+**Hedging for non-blocking asks:**
+- "Can we..." / "Would it be better to..." / "Should we..." (questions, not commands)
+- "I think it would be good to..." (most-used construction in corpus)
+- "My opinion: I'd prefer X, but I can also see a case for Y."
+
+**When uncertain, admit it:**
+- "Just doublechecking that..."
+- "Question about this."
+- "I'm not sure..."
+
+## The judgment doctrine
+
+The skill applies judgment according to the **USWDS engineering values** (https://github.com/uswds/uswds-proposals/blob/main/docs/engineering-values.md) and the precedence order from uswds-proposals/README.md:
+
+1. Product values
+2. Design principles
+3. **Engineering values** (the primary tiebreaker)
+4. Established ADRs (scoped to Core vs. Elements)
+
+Key principles that map directly to the gates:
+
+- **"Our opinions cascade. ...choices made at the Design System level establish the floor for performance and accessibility."** → The personal-preference vs. all-consumers test.
+- **"Avoid lock-in... keeping our reliance on dependencies as low as possible"** → The dependency gate.
+- **"Embrace the idiom. Be cautious about how you introduce new abstractions, idiosyncrasies, or concepts."** → The existing-pattern-or-ADR gate.
+- **"Write for reading."** / **"We use plain language so that others can follow along"** → The simplification pass.
+- **"Use semantic versioning. Be clear when things change."** → The breaking-change flag.
+- **"Make accessibility easier, not invisible."** → Flag for specialist review, don't conclude.
+- **"Support repairability."** → Modularity gate.
+
+## The silence list
+
+The following are **never** reviewed, per observed team practice:
+
+1. **Formatting, indentation, quote style, line length** — Prettier/ESLint/`.editorconfig` own these. Not one style nit exists in the 200+ PR corpus.
+2. **Naming in isolation** — flagged only when genuinely confusing or inconsistent with repo convention (e.g. `data-errorMessage` vs. other `data-*` naming).
+3. **Micro-performance** — performance comes up only as build-time or semver concerns, never as runtime micro-optimization.
+4. **JSDoc/type coverage as a blanket ask** — SASSDoc is required for new Sass mixins/functions; JSDoc is not broadly enforced.
+5. **Diff size as a blocker** — zero "please split this up" reviews exist. The +12k/-14k Storybook migration was approved without comment on size.
+6. **`dist/` contents as source** — it's generated. The review path is byte-identical verification, not line-by-line diff.
+7. **Any AT/screen-reader verdict** — routed explicitly: *"Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior."* (#6595)
+8. **Dependabot lockfile diffs** — bare APPROVED; hygiene is `@dependabot rebase`.
+9. **Variable/function naming disputes** — accepted after one round of discussion.
+10. **Hypothetical future requirements** — not in scope.
+11. **Refactoring opportunities unrelated to the change** — unless they block understanding, convert to an issue instead.
+
+## Reference files
+
+- `references/gates.md` — the 16 gates with runnable checks and carve-outs
+- `references/calibration.md` — mined review patterns, verbatim quotes, severity anchors
+- `references/uswds-anchors.md` — lookup tables (core utils, tokens, public API, CI, test idiom)
+
+## Example: applying the cascade test
+
+**Scenario:** A PR uses `body.innerHTML = ""` in teardown, but another spec in the same package uses `body.textContent = ""`.
+
+**Question:** Block for inconsistency?
+
+**Cascade test:** Does this inconsistency change what downstream consumers get?
+- **No** — it's internal test code, not part of the public API or shipped artifact.
+- **Judgment:** Non-blocking `**thought**`: "There's an inconsistency here (`innerHTML` vs `textContent` in teardown). Both work, but for clarity we might standardize on one. Not a blocker."
+
+**Scenario:** A PR replaces `color("base")` with `#f0f0f0`.
+
+**Question:** Block?
+
+**Cascade test:** Does this change what downstream consumers get?
+- **Yes** — consumers who override `$theme-color-base` will no longer see this element respect their theme.
+- **Judgment:** Blocking `**issue**`: "This replaces a theme token with a literal. **The before diff uses a [theme color token](link), `color("base")`. Since the intent is to go darker for more contrast, my suggestion is to keep the color themeable as it was before.** You might try `color("base-darker")` as a replacement."
+
+## Special cases
+
+### Dependabot / version bumps
+
+Stay near-silent. The review path:
+1. Confirm it's lockfile-only or a controlled dep update
+2. Note whether it's in `dependencies` (runtime, rare) or `devDependencies` (common)
+3. If a large diff: verify `dist/` is byte-identical or note the delta
+4. **Do not review the lockfile line-by-line**
+
+Example approval (from #6783):
+> **AI-assisted review**
+>
+> Verification:
+> - Diff scope: lockfile-only. `undici` is a transitive test dependency; not in browser-distributed code.
+> - `npm ci`: clean
+> - `npm run lint`: ✅
+> - `npx gulp test`: ✅
+> - `dist/` sha256 comparison vs develop baseline: ✅ **byte-identical**
+>
+> Safe to merge.
+
+### Releases and mechanical transforms
+
+Size flag triggers, but report the carve-out immediately:
+> **Size: +22,340/-31,152 across 202 files**
+> ⚠️ Exceeds 400-line guideline, but this is **a release** (v3.14.0). The bulk is `dist/` regeneration, `package-lock.json`, and `COMMUNITY.md` contributor updates. Authored runtime changes: ~45 lines across 3 components. **Not flagging as oversized.**
+
+### PRs held pending team decision
+
+When a genuinely new architectural pattern appears (e.g. i18n strategy, tokens-as-CSS-custom-props), the right disposition is **Hold**, not **Request changes**:
+
+> ⏸️ **Hold** — pending core team architectural decision
+>
+> This introduces [describe the pattern]. The proposals repo has no Core-scoped ADR covering this approach yet. Per team practice (#6738, #6650), a decision of this scope requires:
+> 1. Core team discussion
+> 2. A new `decisions/0012-*.md` ADR in uswds/uswds-proposals (Core-scoped)
+> 3. Reopen this PR once the ADR is Approved
+>
+> The code implementation looks solid; the hold is purely on the architectural choice, not the execution.
+
+## Notes
+
+- **Read-only by design.** This skill never writes to GitHub. It produces a local markdown report; posting is the user's call.
+- **ADR scope matters.** Most `decisions/` entries govern uswds-elements, not this repo. Never cite an Elements ADR as authority for a Core change. See `references/gates.md` gate 4 for the mapping.
+- **The corpus is the regression suite.** PRs 6767, 6659, 6789, 6786, 6783, 6715, 6597 have known outcomes; the skill's findings on them can be checked against what the reviewers actually said.
+- **Calibration, not perfection.** The goal is to match the *severity and scope* of the team's reviews, not word-match them. Blocking findings should be blocking; approved-cleanly PRs should stay quiet.

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -128,7 +128,7 @@ State these with an explicit escape hatch: *"This is far from being a blocker, b
 
 ### 5. Structure the report
 
-Use **the team's Conventional Comments labels** (real repo practice):
+Use **the Conventional Comments labels**:
 - `**issue**` — blocking
 - `**polish**` — non-blocking improvement
 - `**question**` — genuine uncertainty
@@ -244,7 +244,7 @@ Never "this is wrong" without showing the fix or the mechanism.
 - "My opinion: I'd prefer X, but I can also see a case for Y."
 
 **When uncertain, admit it:**
-- "Just doublechecking that..."
+- "Just double-checking that..."
 - "Question about this."
 - "I'm not sure..."
 
@@ -274,11 +274,11 @@ The following are **never** reviewed, per observed team practice:
 1. **Formatting, indentation, quote style, line length** — Prettier/ESLint/`.editorconfig` own these. Not one style nit exists in the 200+ PR corpus.
 2. **Naming in isolation** — flagged only when genuinely confusing or inconsistent with repo convention (e.g. `data-errorMessage` vs. other `data-*` naming).
 3. **Micro-performance** — performance comes up only as build-time or semver concerns, never as runtime micro-optimization.
-4. **JSDoc/type coverage as a blanket ask** — SASSDoc is required for new Sass mixins/functions; JSDoc is not broadly enforced.
-5. **Diff size as a blocker** — zero "please split this up" reviews exist. The +12k/-14k Storybook migration was approved without comment on size.
+4. **JSDoc/type coverage as a blanket ask** — SASSDoc is required for new Sass mixins/functions; JSDoc is not broadly enforced for historical code but should be for new additions.
+5. **Diff size as a blocker** — "please split this up" reviews exist but should use deterministic measurements and judgment.
 6. **`dist/` contents as source** — it's generated. The review path is byte-identical verification, not line-by-line diff.
 7. **Any AT/screen-reader verdict** — routed explicitly: *"Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior."* (#6595)
-8. **Dependabot lockfile diffs** — bare APPROVED; hygiene is `@dependabot rebase`.
+8. **Dependabot lockfile diffs** — bare APPROVED if the build and tests are passing.
 9. **Variable/function naming disputes** — accepted after one round of discussion.
 10. **Hypothetical future requirements** — not in scope.
 11. **Refactoring opportunities unrelated to the change** — unless they block understanding, convert to an issue instead.

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -148,6 +148,16 @@ Use **the team's Conventional Comments labels** (real repo practice):
 ```markdown
 ## PR Review: [Short title]
 
+### Recommendation
+
+[One of:]
+- ✅ **Approve** — no blocking issues found. [Manual follow-up items to complete before merge.]
+- ✅ **Approve with suggestions** — no blockers; suggestions above are optional improvements.
+- ⏸️ **Hold** — pending [ADR / team decision / architectural discussion].
+- 🔄 **Request changes** — blocking issues above must be addressed.
+
+---
+
 ### Overview
 [1-2 sentences: what this does, why it matters]
 
@@ -212,19 +222,6 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 - Micro-performance
 - Screen-reader verdicts — routed to accessibility specialist
 - [any other items from silence list]
-
----
-
-### Recommendation
-
-[One of:]
-- ✅ **Approve** — no blocking issues found. [Manual follow-up items to complete before merge.]
-- ✅ **Approve with suggestions** — no blockers; suggestions above are optional improvements.
-- ⏸️ **Hold** — pending [ADR / team decision / architectural discussion].
-- 🔄 **Request changes** — blocking issues above must be addressed.
-
-[Close with the escape hatch:]
-Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.
 ```
 
 ### 6. Evidence and voice

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -42,8 +42,7 @@ git diff develop...HEAD
 git diff -M --numstat develop...HEAD
 ```
 
-Also fetch the USWDS ADR list once (used by gate 4). Distinguish which repo they are intended to apply to. Some are for
-USWDS, and others are for the `uswds-elements` repo:
+Also fetch the USWDS ADR list once (used by gate 4). Distinguish which repo they are intended to apply to. Some are for USWDS, and others are for the `uswds-elements` repo:
 ```bash
 gh api repos/uswds/uswds-proposals/git/trees/HEAD?recursive=1 --jq '.tree[] | select(.path | startswith("decisions/")) | .path'
 ```

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: uswds-code-review
-description: Review USWDS PRs or branches using the core team's calibrated judgment. Enforces 16 specific gates (size, dependencies, DRY, sanitization, test regression, etc.), distinguishes personal preference from what all consumers inherit, and routes specialist decisions (a11y, breaking changes, new API surface). Use when the user says "review this", "code review", "review the PR", asks for feedback on changes, or explicitly invokes /uswds-code-review.
+description: Review USWDS PRs or branches using the core team's calibrated judgment. Enforces 16 specific gates (size, dependencies, DRY, sanitization, test regression, etc.), distinguishes personal preference from what all consumers inherit, and routes specialist decisions (accessibility, breaking changes, new API surface). Use when the user says "review this", "code review", "review the PR", asks for feedback on changes, or explicitly invokes /uswds-code-review.
 args:
   pr_or_branch: (optional) PR number/URL, or omit for current branch vs develop
 ---
 
 # USWDS Code Review
 
-Perform a judgment-based code review of USWDS changes, reproducing the calibration of the core review team (ethangardner, heymatthenry, mejiaj, thisisdano). This skill enforces 16 specific gates, distinguishes personal preference from what cascades to all downstream consumers, and explicitly routes calls that aren't a code reviewer's to make.
+Perform a judgment-based code review of USWDS changes, reproducing the calibration of the core review team (engineering leads and senior engineers who set technical direction, a product lead, and an accessibility specialist). This skill enforces 16 specific gates, distinguishes personal preference from what cascades to all downstream consumers, and explicitly routes calls that aren't a code reviewer's to make.
 
 ## Entry point
 
@@ -81,7 +81,7 @@ Each gate is documented in `references/gates.md` with runnable checks and carve-
 2. **Dependencies** — blocking unless called for; `lit` is the only runtime dep
 3. **Definition of done** — issue acceptance criteria vs actual diff, both directions
 4. **Existing pattern or ADR** — grep `uswds-core` utils; check uswds-proposals repo; distinguish Elements vs Core ADRs
-5. **Test coverage** — must fail on base branch (ethangardner's test)
+5. **Test coverage** — must fail on base branch (the senior-engineer regression test)
 6. **DRY tests / 3-location threshold** — cite the existing `events.js` triplicate
 7. **Duplication** — blocking if a core utility already exists
 8. **Simplification pass** — dispatch `code-simplification` skill subagent, filter to readability wins only
@@ -90,9 +90,9 @@ Each gate is documented in `references/gates.md` with runnable checks and carve-
 11. **Modular code** — cited from engineering-values.md "Support repairability"
 12. **Input validation** — at system boundaries, checked against the sanitizer precedents
 13. **New API surface** — manual follow-up; flag $theme-* settings, new data-* attrs, breaking markup
-14. **Breaking changes** — manual follow-up; carry thisisdano's design-vs-code split
+14. **Breaking changes** — manual follow-up; carry the product lead's design-vs-code split
 15. **New variants / default changes** — manual follow-up
-16. **Accessibility** — two sub-gates: 16a (SR text content, flag-only, an a11y specialist can judge without live AT); 16b (AT behavior verdict, manual follow-up — name the test matrix, don't conclude)
+16. **Accessibility** — two sub-gates: 16a (SR text content, flag-only, an accessibility specialist can judge without live AT); 16b (AT behavior verdict, manual follow-up — name the test matrix, don't conclude)
 
 For each finding, apply **the cascade test** before including it: *Does this change what every downstream consumer gets, or is it how I would have written it?* If the latter, downgrade to non-blocking or drop entirely.
 
@@ -120,15 +120,15 @@ State these with an explicit escape hatch: *"This is far from being a blocker, b
 
 **Manual follow-up** — route to a specialist, don't conclude:
 - Accessibility / AT behavior → name the test matrix, don't render a verdict (16b)
-- A11y SR text content → an a11y specialist can flag whether hint text is redundant with role or missing interaction guidance; non-blocking, does not need live AT testing (16a)
-- Breaking-change classification → flag it, cite the repo definition, note thisisdano's design-vs-code split
+- A11y SR text content → an accessibility specialist can flag whether hint text is redundant with role or missing interaction guidance; non-blocking, does not need live AT testing (16a)
+- Breaking-change classification → flag it, cite the repo definition, note the product lead's design-vs-code split
 - New API surface ($theme-* settings, `data-*` attrs, CSS class names)
 - New variants or default changes
 - Anything that affects visual design intent
 
 ### 5. Structure the report
 
-Use **mejiaj's Conventional Comments labels** (real repo practice):
+Use **the team's Conventional Comments labels** (real repo practice):
 - `**issue**` — blocking
 - `**polish**` — non-blocking improvement
 - `**question**` — genuine uncertainty
@@ -138,7 +138,7 @@ Use **mejiaj's Conventional Comments labels** (real repo practice):
 - `**praise**` — call out good work
 - `(non-blocking)` — append to downgrade severity
 
-**Summary structure** (ethangardner's three-move template):
+**Summary structure** (the engineering-lead three-move template):
 1. Specific, non-generic compliment
 2. Census of what's below ("a few suggestions and one question")
 3. What clearing them earns ("then we can get this merged")
@@ -187,7 +187,7 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 [If any. Name the specific test or specialist area, don't conclude.]
 
 **Accessibility:**
-- [ ] **16a — SR text content** (a11y specialist, no live AT needed): is hint/label text redundant with role? Does it explain interaction? Flag as `**polish (non-blocking)**` with suggested text; note any uswds-site guidance follow-up separately.
+- [ ] **16a — SR text content** (accessibility specialist, no live AT needed): is hint/label text redundant with role? Does it explain interaction? Flag as `**polish (non-blocking)**` with suggested text; note any uswds-site guidance follow-up separately.
 - [ ] **16b — AT behavior** (hands-on testing required): Test with NVDA + [specific scenario]
 - [ ] Test with VoiceOver + Safari [specific scenario]
 - [ ] Test with VoiceOver + Chrome [specific scenario, if behavior differs]
@@ -210,7 +210,7 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 - `dist/` contents — generated; verify byte-identical instead
 - Naming in isolation
 - Micro-performance
-- Screen-reader verdicts — routed to a11y specialist
+- Screen-reader verdicts — routed to accessibility specialist
 - [any other items from silence list]
 
 ---
@@ -223,7 +223,7 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 - ⏸️ **Hold** — pending [ADR / team decision / architectural discussion].
 - 🔄 **Request changes** — blocking issues above must be addressed.
 
-[Close with ethangardner's escape hatch:]
+[Close with the escape hatch:]
 Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.
 ```
 

--- a/.agents/skills/uswds-code-review/VERIFICATION.md
+++ b/.agents/skills/uswds-code-review/VERIFICATION.md
@@ -7,7 +7,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 1. `/uswds-code-review 6767` — Character count: over-limit SR announcements
 
 **Size:** +308/-44, 5 files  
-**Reviewer:** ethangardner (CHANGES_REQUESTED ×2 → APPROVED)  
+**Reviewer:** senior engineer (CHANGES_REQUESTED ×2 → APPROVED)  
 **Expected findings (4 independent):**
 
 1. **Duplicated `debounce` from core** (blocking) — #6767: *"We have `packages/uswds-core/src/js/utils/debounce.js` in the repo already. It was removed in this PR. Would it be possible to refactor the existing debounce function so we don't inline it here and have to maintain multiple implementations?"*
@@ -25,7 +25,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 2. `/uswds-code-review 6659` — Range slider: improve border visibility
 
 **Size:** +3/-3, 1 file  
-**Reviewer:** ethangardner (CHANGES_REQUESTED → APPROVED)  
+**Reviewer:** engineering lead (CHANGES_REQUESTED → APPROVED)  
 **Expected findings (2 independent):**
 
 1. **De-themed token** (blocking) — #6659: *"**The before diff uses a [theme color token](link), `color("base")`. Since the intent is to go darker for more contrast, my suggestion is to keep the color themeable as it was before.** You might try `color("base-darker")` as a replacement."*
@@ -39,7 +39,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 3. `/uswds-code-review 6789` — Accordion: start/end icon alignment
 
 **Size:** +285/-8, 10 files  
-**Reviewers:** ethangardner (CHANGES_REQUESTED → COMMENTED → APPROVED)  
+**Reviewer:** senior engineer (CHANGES_REQUESTED → COMMENTED → APPROVED)  
 **Expected findings (4-5):**
 
 1. **Shared-selector blast radius** (blocking) — #6789: *"**The nav and the banner both use `.usa-accordion__button` as well. Let's add a safeguard to prevent a change in icon position if someone tried:**"* (with two concrete HTML repros showing the misuse, resolved via `:not()` selectors)
@@ -59,10 +59,10 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 4. `/uswds-code-review 6786` — Modal: restore page content when opener has left
 
 **Size:** +28/-6, 2 files  
-**Reviewer:** ethangardner (APPROVED with AT hand-off)  
-**Actual outcome:** *"This looks good to me. This touches modal code that was written previously. Passing off to the a11y specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. It passes my review."*
+**Reviewer:** engineering lead (APPROVED with AT hand-off)  
+**Actual outcome:** *"This looks good to me. This touches modal code that was written previously. Passing off to role:accessibility-specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. It passes my review."*
 
-**Expected findings:** No blocking issues. One manual-follow-up flag for a11y testing (16b — focus behavior when the opener is removed from the DOM). Gate 16a (SR text content) does not apply here — no hint text or aria-label copy changed.
+**Expected findings:** No blocking issues. One manual-follow-up flag for accessibility testing (16b — focus behavior when the opener is removed from the DOM). Gate 16a (SR text content) does not apply here — no hint text or aria-label copy changed.
 
 **Success criteria:** Guards against false positives. The skill should stay quiet on code correctness and flag only the AT verification (16b).
 
@@ -71,7 +71,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 4a. `/uswds-code-review 6673` — Range slider: add visual hint instruction
 
 **Size:** +17/-1, 3 files  
-**Reviewer:** a11y specialist (COMMENTED → approved after wording update)  
+**Reviewer:** accessibility specialist (COMMENTED → approved after wording update)  
 **Actual outcome:** The code change (adding `aria-describedby` wiring between the hint and the input) was technically sound. The reviewer flagged that the hint text read *"slider"* — which AT users already know from the element's role announcement — and suggested it instead explain interaction ("use arrow keys to increase or decrease the value"). A follow-up uswds-site guidance issue was noted as a separate non-blocking concern. Approval proceeded once the hint wording was updated.
 
 **Expected findings (gate 16a):**
@@ -84,7 +84,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 **Success criteria:** Proves gate 16a fires on SR-text-redundant-with-role without triggering a blocking verdict or a false 16b routing. The skill should distinguish the code-level fix (ARIA wiring, already correct) from the content-level flag (hint text quality).
 
 **Size:** lockfile-only (dependabot)  
-**Reviewer:** ethangardner (APPROVED with verification transcript)  
+**Reviewer:** engineering lead (APPROVED with verification transcript)  
 **Actual outcome:** Verified lockfile-only, `npm ci` clean, `npm run lint` ✅, `gulp test` ✅, `dist/` byte-identical. *"Safe to merge."*
 
 **Expected findings:** None blocking. The skill should stay near-silent, note it's lockfile-only, and take the byte-identical `dist/` verification route rather than reviewing the lockfile line-by-line.
@@ -96,7 +96,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 6. `/uswds-code-review 6715` — Storybook 9 + Webpack→Vite migration
 
 **Size:** +8239/-8433, 11 files  
-**Reviewer:** ethangardner (CHANGES_REQUESTED ×2 → COMMENTED → APPROVED)  
+**Reviewer:** engineering lead (CHANGES_REQUESTED ×2 → COMMENTED → APPROVED)  
 **Expected findings:**
 
 1. **Size flag** (advisory) — but with a stated carve-out rationale: *"⚠️ Exceeds 400-line guideline, but this is **a Storybook 9 migration** (framework upgrade touching config + story files). Authored logic changes: ~120 lines across 3 files. Not flagging as oversized."*
@@ -114,7 +114,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 ### 7. `/uswds-code-review 6597` — Replace postcss/autoprefixer with Lightning CSS
 
 **Size:** (not merged, closed)  
-**Reviewer:** ethangardner (COMMENTED, closed)  
+**Reviewer:** engineering lead (COMMENTED, closed)  
 **Actual outcome:** Declined on Core-specific grounds — *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output... Shipping this safely would require a thorough audit and a major version bump."*
 
 **Expected behavior:** The skill must reach the Core-specific objection (CSS property-order change → major bump) **without** citing `decisions/0009-use-lightning-css.md` as either authorization or precedent, since that ADR governs Elements, not Core.
@@ -149,7 +149,7 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 Success is **not** word-matching the original reviews. It's that:
 1. Every blocking finding the reviewers made appears at blocking severity
 2. Non-blocking suggestions are marked non-blocking
-3. Manual-follow-up items (a11y, breaking-change classification, API surface) are flagged for specialist review, not concluded
+3. Manual-follow-up items (accessibility, breaking-change classification, API surface) are flagged for specialist review, not concluded
 4. #6786 and #6783 (clean PRs) stay quiet — no spurious findings
 5. The skill's voice matches the team's — specific compliments, escape hatches on non-blocking items, evidence (code blocks / permalinks / repro steps) for every substantive finding
 

--- a/.agents/skills/uswds-code-review/VERIFICATION.md
+++ b/.agents/skills/uswds-code-review/VERIFICATION.md
@@ -83,6 +83,10 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 
 **Success criteria:** Proves gate 16a fires on SR-text-redundant-with-role without triggering a blocking verdict or a false 16b routing. The skill should distinguish the code-level fix (ARIA wiring, already correct) from the content-level flag (hint text quality).
 
+---
+
+### 5. `/uswds-code-review 6783` — Bump undici (dependabot)
+
 **Size:** lockfile-only (dependabot)  
 **Reviewer:** engineering lead (APPROVED with verification transcript)  
 **Actual outcome:** Verified lockfile-only, `npm ci` clean, `npm run lint` ✅, `gulp test` ✅, `dist/` byte-identical. *"Safe to merge."*
@@ -156,7 +160,8 @@ Success is **not** word-matching the original reviews. It's that:
 ## Running the suite
 
 ```bash
-cd /home/egardner/devspace/uswds
+# Run from the repo root
+cd /path/to/uswds
 
 # 1. Richest test (4 independent findings)
 /uswds-code-review 6767

--- a/.agents/skills/uswds-code-review/VERIFICATION.md
+++ b/.agents/skills/uswds-code-review/VERIFICATION.md
@@ -60,15 +60,28 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 
 **Size:** +28/-6, 2 files  
 **Reviewer:** ethangardner (APPROVED with AT hand-off)  
-**Actual outcome:** *"This looks good to me. @jonathanbobel — **this touches modal code that you wrote previously.** ... Passing off to you to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+**Actual outcome:** *"This looks good to me. This touches modal code that was written previously. Passing off to the a11y specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. It passes my review."*
 
-**Expected findings:** No blocking issues. One manual-follow-up flag for a11y testing (focus behavior when the opener is removed from the DOM).
+**Expected findings:** No blocking issues. One manual-follow-up flag for a11y testing (16b — focus behavior when the opener is removed from the DOM). Gate 16a (SR text content) does not apply here — no hint text or aria-label copy changed.
 
-**Success criteria:** Guards against false positives. The skill should stay quiet on code correctness and flag only the AT verification.
+**Success criteria:** Guards against false positives. The skill should stay quiet on code correctness and flag only the AT verification (16b).
 
 ---
 
-### 5. `/uswds-code-review 6783` — Bump undici from 7.28.0 to 7.29.0
+### 4a. `/uswds-code-review 6673` — Range slider: add visual hint instruction
+
+**Size:** +17/-1, 3 files  
+**Reviewer:** a11y specialist (COMMENTED → approved after wording update)  
+**Actual outcome:** The code change (adding `aria-describedby` wiring between the hint and the input) was technically sound. The reviewer flagged that the hint text read *"slider"* — which AT users already know from the element's role announcement — and suggested it instead explain interaction ("use arrow keys to increase or decrease the value"). A follow-up uswds-site guidance issue was noted as a separate non-blocking concern. Approval proceeded once the hint wording was updated.
+
+**Expected findings (gate 16a):**
+1. **SR text content flag** (non-blocking `**polish**`) — the hint text is redundant with the element's role. Suggest interaction-guidance text instead. Note the uswds-site guidance angle as a separate issue, explicitly not a blocker.
+
+**Expected non-findings:**
+- No gate 16b (AT behavior) flag needed — the ARIA *wiring* is the fix; there's no AT behavior regression to route.
+- No blocking issues.
+
+**Success criteria:** Proves gate 16a fires on SR-text-redundant-with-role without triggering a blocking verdict or a false 16b routing. The skill should distinguish the code-level fix (ARIA wiring, already correct) from the content-level flag (hint text quality).
 
 **Size:** lockfile-only (dependabot)  
 **Reviewer:** ethangardner (APPROVED with verification transcript)  
@@ -156,6 +169,9 @@ cd /home/egardner/devspace/uswds
 
 # 4. False-positive guard (clean PR with AT hand-off)
 /uswds-code-review 6786
+
+# 4a. Gate 16a (SR text quality, non-blocking flag, no AT routing)
+/uswds-code-review 6673
 
 # 5. Noise guard (dependabot, stay silent)
 /uswds-code-review 6783

--- a/.agents/skills/uswds-code-review/VERIFICATION.md
+++ b/.agents/skills/uswds-code-review/VERIFICATION.md
@@ -1,0 +1,182 @@
+# Verification Suite for `uswds-code-review`
+
+The corpus doubles as a regression suite — these PRs have known outcomes, so the skill's output can be checked against what the reviewers actually said.
+
+## Test cases
+
+### 1. `/uswds-code-review 6767` — Character count: over-limit SR announcements
+
+**Size:** +308/-44, 5 files  
+**Reviewer:** ethangardner (CHANGES_REQUESTED ×2 → APPROVED)  
+**Expected findings (4 independent):**
+
+1. **Duplicated `debounce` from core** (blocking) — #6767: *"We have `packages/uswds-core/src/js/utils/debounce.js` in the repo already. It was removed in this PR. Would it be possible to refactor the existing debounce function so we don't inline it here and have to maintain multiple implementations?"*
+
+2. **Arrow function vs. `.apply()` `this` bug** (blocking, latent correctness) — #6767: *"I noticed the `apply` method uses `this`, and we're using an arrow function here. The arrow function was there in the code previously, but I think we should fix it now since it would be a one line change. **Using the arrow function is problematic because it would capture the module scope's `this` instead, silently dropping the call-site context passed to `.apply()`.** Changing this line to `const debounced = function debounced(...args) {` should be all we need to correct the bug."*
+
+3. **Missing test coverage on the new cancel behavior** (blocking) — #6767: *"I think we should add unit tests for this given the new cancel behavior and bug fix I mentioned on line 16. If you can write test that covers the `debounced`, `.cancel`, and **a regression test for the arrow function**, we should be all set here."*
+
+4. **DRY-able timeout setup** (non-blocking) — #6767: *"Thanks for adding these tests. I think we can DRY them out some if you extract the timeout part to a helper. Something along the lines of this might work..."* and *"I think `AT_DEFER_MS + 50` could be its own constant. It's used in this spec as well as the one for character count. Also, I'm wondering if for some of the timers in this PR, we might be able to use https://sinonjs.org/concepts/fake-timers/. **Sinon is already a project dependency.**"*
+
+**Success criteria:** All four findings appear at the right severity (3 blocking, 1 non-blocking).
+
+---
+
+### 2. `/uswds-code-review 6659` — Range slider: improve border visibility
+
+**Size:** +3/-3, 1 file  
+**Reviewer:** ethangardner (CHANGES_REQUESTED → APPROVED)  
+**Expected findings (2 independent):**
+
+1. **De-themed token** (blocking) — #6659: *"**The before diff uses a [theme color token](link), `color("base")`. Since the intent is to go darker for more contrast, my suggestion is to keep the color themeable as it was before.** You might try `color("base-darker")` as a replacement."*
+
+2. **Sass variable convention** (blocking) — #6659: *"Looking elsewhere in the codebase, **the convention we follow in [permalink to `_usa-nav.scss`] is to define only the value as a variable and to not assign the function result to the variable.** i.e. this would become `$-range-border-width: 2px;`, and then its usage below would be `units($-range-border-width)`. The same comment I left about the variable being private or sticking to direct usage applies to this as well."*
+
+**Success criteria:** Both blocking. Proves a 3-line diff can still be blocking, and that the skill isn't keying on size.
+
+---
+
+### 3. `/uswds-code-review 6789` — Accordion: start/end icon alignment
+
+**Size:** +285/-8, 10 files  
+**Reviewers:** ethangardner (CHANGES_REQUESTED → COMMENTED → APPROVED)  
+**Expected findings (4-5):**
+
+1. **Shared-selector blast radius** (blocking) — #6789: *"**The nav and the banner both use `.usa-accordion__button` as well. Let's add a safeguard to prevent a change in icon position if someone tried:**"* (with two concrete HTML repros showing the misuse, resolved via `:not()` selectors)
+
+2. **Undeclared breaking default flip** (manual follow-up) — #6789: *"can you update the PR body so it reflects that the new default is icon-start (left) in the 'Solution' heading and **indicate that this is a breaking change. It still has default right and non-breaking in the PR body.**"*
+
+3. **Missing `sass-true` coverage** (blocking) — #6789: *"Since our last release, **I added a good deal of test coverage for branching logic in `*.spec.js` files using the `sass-true` package, and I think it would be good to do the same here for the branching logic.**"*
+
+4. **Missing `@warn` fallback** (blocking or non-blocking) — #6789: *"In the `@else` branches in this file, I think it would be good to **add a `@warn` if the `$side` value is not `end` and that we're executing a fallback. That will help people catch typos in their config.**"*
+
+5. **New API surface** (manual follow-up) — this adds `$theme-accordion-icon-position`, which triggers the 6-file ripple (settings → component Sass → fixture → story → `_notifications.scss` → uswds-site docs PR).
+
+**Success criteria:** Blast radius and test coverage are blocking; breaking-change and API-surface are manual follow-up.
+
+---
+
+### 4. `/uswds-code-review 6786` — Modal: restore page content when opener has left
+
+**Size:** +28/-6, 2 files  
+**Reviewer:** ethangardner (APPROVED with AT hand-off)  
+**Actual outcome:** *"This looks good to me. @jonathanbobel — **this touches modal code that you wrote previously.** ... Passing off to you to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+
+**Expected findings:** No blocking issues. One manual-follow-up flag for a11y testing (focus behavior when the opener is removed from the DOM).
+
+**Success criteria:** Guards against false positives. The skill should stay quiet on code correctness and flag only the AT verification.
+
+---
+
+### 5. `/uswds-code-review 6783` — Bump undici from 7.28.0 to 7.29.0
+
+**Size:** lockfile-only (dependabot)  
+**Reviewer:** ethangardner (APPROVED with verification transcript)  
+**Actual outcome:** Verified lockfile-only, `npm ci` clean, `npm run lint` ✅, `gulp test` ✅, `dist/` byte-identical. *"Safe to merge."*
+
+**Expected findings:** None blocking. The skill should stay near-silent, note it's lockfile-only, and take the byte-identical `dist/` verification route rather than reviewing the lockfile line-by-line.
+
+**Success criteria:** Guards against noise. This is a dependabot PR; the skill must not flag spurious issues or review 3000 lines of JSON.
+
+---
+
+### 6. `/uswds-code-review 6715` — Storybook 9 + Webpack→Vite migration
+
+**Size:** +8239/-8433, 11 files  
+**Reviewer:** ethangardner (CHANGES_REQUESTED ×2 → COMMENTED → APPROVED)  
+**Expected findings:**
+
+1. **Size flag** (advisory) — but with a stated carve-out rationale: *"⚠️ Exceeds 400-line guideline, but this is **a Storybook 9 migration** (framework upgrade touching config + story files). Authored logic changes: ~120 lines across 3 files. Not flagging as oversized."*
+
+2. **devDependency missing** (blocking) — #6715: *"Since this is being imported, I'd like it to make sure it's also **added to `package.json` as a `devDependency` to make sure we're not relying on a transitive dependency from Storybook.**"*
+
+3. **Deployment-path issue** (blocking or question) — #6715: *"Question about this. When this is in dev mode, serving from the root directory is reliable. However, when this is built and deployed, it ends up on a preview URL like this: https://federalist-.../preview/uswds/uswds/develop/?path=... **When the storybook assets are going to be deployed to a non-root directory, can we expect the paths to resolve correctly or are there other changes that need to be made to support this?**"*
+
+4. **HMR error** (blocking) — #6715: *"I see this comment, but there's an error with HMR currently. **Steps to reproduce:** 1) start storybook... 2) Navigate to a component... 3) Open the browser console. 4) Edit the corresponding `.twig` file... 5) See error below."* (with the `TwigException` payload)
+
+**Success criteria:** Size is flagged but not blocking. The devDependency and HMR issues are blocking. The skill correctly distinguishes mechanical churn from authored logic.
+
+---
+
+### 7. `/uswds-code-review 6597` — Replace postcss/autoprefixer with Lightning CSS
+
+**Size:** (not merged, closed)  
+**Reviewer:** ethangardner (COMMENTED, closed)  
+**Actual outcome:** Declined on Core-specific grounds — *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output... Shipping this safely would require a thorough audit and a major version bump."*
+
+**Expected behavior:** The skill must reach the Core-specific objection (CSS property-order change → major bump) **without** citing `decisions/0009-use-lightning-css.md` as either authorization or precedent, since that ADR governs Elements, not Core.
+
+**Success criteria:** The ADR-scoping test. If the skill treats an Elements ADR as authority for a Core change, this case catches it. The skill should either ignore 0009 entirely or flag it as "this ADR is Elements-scoped, does not apply here."
+
+---
+
+### 8. Local-branch mode (no PR)
+
+**Setup:** Create a scratch branch with a small change (e.g., edit a comment), run `/uswds-code-review` with no argument.
+
+**Expected behavior:** The skill reports PR-body and definition-of-done gates as `⏭️ skipped (no PR in local mode)`, not as passed. The gate table should show explicit skips, and the report should note that those checks are unavailable in local-branch mode.
+
+**Success criteria:** Verifies that the skill doesn't silently pass gates when it can't actually run them.
+
+---
+
+### 9. Read-only verification
+
+**Check:** After running any of the above, confirm:
+- No `gh pr review` or `gh pr comment` calls were made
+- No writes outside `/tmp` or the review report itself
+- The skill produced a local markdown report only
+
+**Success criteria:** The skill never touches GitHub without explicit user action. All output is local.
+
+---
+
+## Success definition
+
+Success is **not** word-matching the original reviews. It's that:
+1. Every blocking finding the reviewers made appears at blocking severity
+2. Non-blocking suggestions are marked non-blocking
+3. Manual-follow-up items (a11y, breaking-change classification, API surface) are flagged for specialist review, not concluded
+4. #6786 and #6783 (clean PRs) stay quiet — no spurious findings
+5. The skill's voice matches the team's — specific compliments, escape hatches on non-blocking items, evidence (code blocks / permalinks / repro steps) for every substantive finding
+
+## Running the suite
+
+```bash
+cd /home/egardner/devspace/uswds
+
+# 1. Richest test (4 independent findings)
+/uswds-code-review 6767
+
+# 2. Tiny diff, still blocking (de-themed token + convention)
+/uswds-code-review 6659
+
+# 3. Blast radius + breaking-change + API surface
+/uswds-code-review 6789
+
+# 4. False-positive guard (clean PR with AT hand-off)
+/uswds-code-review 6786
+
+# 5. Noise guard (dependabot, stay silent)
+/uswds-code-review 6783
+
+# 6. Size + carve-out + mechanical churn
+/uswds-code-review 6715
+
+# 7. ADR-scoping test (Elements ADR doesn't govern Core)
+/uswds-code-review 6597
+
+# 8. Local-branch mode (gates correctly skipped)
+git checkout -b test-branch
+echo "// test comment" >> packages/usa-accordion/src/index.js
+/uswds-code-review
+git checkout develop
+git branch -D test-branch
+
+# 9. Read-only check
+# After any of the above: confirm no gh pr review/comment calls, no writes to the repo
+```
+
+## Reference: what the reviewers actually said
+
+See `references/calibration.md` for verbatim quotes and the full context of each review. The verification suite compares the skill's findings against those anchors.

--- a/.agents/skills/uswds-code-review/references/calibration.md
+++ b/.agents/skills/uswds-code-review/references/calibration.md
@@ -2,7 +2,7 @@
 
 This file anchors severity decisions and voice so the skill's output matches the team's actual practice, not generic review templates. Sources: ethangardner (60 PRs, 43 inline comments), heymatthenry (28 PRs, 8 inline comments), mejiaj (~100 PRs, extensive inline + review-body evidence), thisisdano (~70 PRs, 30+ inline comments).
 
-**Note on recency:** mejiaj's last review here is #6418 (2025-02-18), thisisdano's is #6320 (2025-01-23). Current active reviewers: ethangardner, jonathanbobel. Patterns below represent the team's durable judgment, not individual voices.
+**Note on recency:** mejiaj's last review here is #6418 (2025-02-18), thisisdano's is #6320 (2025-01-23). The team includes an active a11y specialist who handles hands-on AT verification and a11y-content review. Patterns below represent the team's durable judgment, not individual voices.
 
 ---
 
@@ -324,7 +324,18 @@ These are **never** reviewed, backed by corpus facts:
 - #6595: *"@chandracarney — **Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior.**"*
 - #6703: *"LGTM! @chandracarney do you want to take a look at this for final approval?"*
 - #6725: *"@chandracarney — you're up for a final a11y review."*
-- #6786: *"This looks good to me. @jonathanbobel — **this touches modal code that you wrote previously.** ... Passing off to you to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+- #6786: *"This looks good to me. **This touches modal code that was written previously.** ... Passing off to the a11y specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+
+**A11y-content critique (code-reviewable, does not route):**
+
+An a11y specialist can judge whether the *text* of a screen reader hint is useful — distinct from judging AT *behavior*, which requires hands-on device testing. The distinction:
+
+- **AT behavior** (route, don't conclude): does the AT announce it, in what order, with what voice mode? Needs real devices and a named test matrix.
+- **SR text content** (reviewable by an a11y specialist): is the text redundant with the element's role? Does it explain purpose or interaction, or just restate what AT already derives from markup semantics?
+
+Example (#6673): a range slider hint read *"slider"* — which AT users already know from the element's role announcement. The reviewer flagged that a more useful hint would explain *how to interact* (e.g., "use arrow keys to increase or decrease the value"), and noted that guidance on communicating `min`/`max`/`step` context belongs in the uswds-site component guidance — not as a code blocker, but as a follow-up issue. The approval went through once the immediate hint wording was addressed.
+
+**Voice for a11y-content findings:** Non-blocking flag. State what the current text says, why it's redundant or insufficient, suggest more useful text, and explicitly separate guidance-site follow-up from the approval gate: *"That recommendation doesn't interfere with this approval."*
 
 **Unblocks stale review states:**
 - #6611: *"@annepetersen — You had a previous change request, so this will need an approval from you as well if it looks good to you."*

--- a/.agents/skills/uswds-code-review/references/calibration.md
+++ b/.agents/skills/uswds-code-review/references/calibration.md
@@ -1,0 +1,361 @@
+# Calibration Data — Mined Patterns and Verbatim Quotes
+
+This file anchors severity decisions and voice so the skill's output matches the team's actual practice, not generic review templates. Sources: ethangardner (60 PRs, 43 inline comments), heymatthenry (28 PRs, 8 inline comments), mejiaj (~100 PRs, extensive inline + review-body evidence), thisisdano (~70 PRs, 30+ inline comments).
+
+**Note on recency:** mejiaj's last review here is #6418 (2025-02-18), thisisdano's is #6320 (2025-01-23). Current active reviewers: ethangardner, jonathanbobel. Patterns below represent the team's durable judgment, not individual voices.
+
+---
+
+## Approval patterns
+
+### What qualifies for outright approval
+
+**ethangardner:**
+- One-line, single-token fixes using the right token (#6669: `+1/-1`, file input error border → error token): *"LGTM! Thanks for the contribution."*
+- A fix where the mechanism is obviously right (#6713): *"The runtime code change itself looks good. Replacing that stale callback with the existing dropdown close path makes sense."*
+- Security hardening (#6674): *"Nice catch. Thanks for this improvement and contribution!"*
+- Docs/meta/typos — essentially always waved through: #6762, #6720, #6580
+- **He verifies by running it.** #6811: *"I tested this in Storybook and compared it to how we handle other components."* #6673: *"I tested it with NVDA, and the readout I got made more sense with the id and aria than it did without it."*
+
+**mejiaj:**
+- Arrives with a **checked list** as the approval body (#6168):
+  > ### Tested
+  > - [x] Dragging invalid file reads error message in VoiceOver (both Chrome & Safari)
+  > - [x] Code quality
+- Names the **browser + OS matrix** (#5919): "No issues found. Tested in Safari, Firefox, and Chromium." (#5885): "Looks good. I tested in Chromium 125, Firefox 127, and Safari 17.4.1."
+- **Before/after preview links** or screenshots (#6165 video of loader icon), (#6037 Federalist preview URL table)
+- **Builds his own test harness before approving** (#6048): "I've created a branch on uswds-sandbox `test-uswds-breakpoints-6048`, so others can test as well."
+
+**thisisdano:**
+- Bare approvals are the norm, with a one-line human note. Verbatim: "Thank you!" (#6165, #5885, #6013), "Nice work." (#5713), "Very nice. Both features work together as expected" (#5919), "A lot of work here! It will be nice to move this gnarly little issue off your plate!" (#5636), "🎉" (#5624)
+- Explicitly delegates (#5908): "LGTM. Passing it over to @heymatthenry for his take."
+
+### Approve-with-nits: the "I can approve once..." contract
+
+**mejiaj** (his most characteristic mode):
+- #5999: "Just a minor question and non-blocking issue. **I can approve PR once resolved.**"
+- #6013: "Otherwise LGTM and **I can approve once we have clarity on question above** and Charlie's changes have been addressed."
+- #6038: "Added a few non-blocking suggestions. **I can approve once comments are resolved.**"
+
+**ethangardner** (approve now, name the follow-up explicitly):
+- #6725: *"This looks good. ... If you wanted to do a follow-up enhancement PR, you might want to consider... **That's not a blocker here though.**"*
+- #6715: *"Looking at the cjs plugin you wrote, I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks... **I'll create the issue for it and hold off on doing it so you're not dealing with conflicts** or things changing while this work is in progress."*
+- #6703: *"This keeps the defensive focus handling more concise and readable in my opinion. **This is far from being a blocker**, but it's worth considering if you're touching this code again."*
+
+**heymatthenry** (accepts debt on purpose):
+- #6173: *"**Approving as-is so help move the other related PRs (#6174, #6175) along** rather than chasing down anywhere else `ignore` may have been used historically."*
+- #6308: *"for something we're trying to get in ASAP **I'd prefer to leave the current behavior for now**. This feature also doesn't have adequate test coverage. So what I'd prefer to do is to make an issue for your suggested improvements and write some tests such that next time something comes up here we can make changes more confidently."*
+
+### Approval escalation (effort-proportional sign-offs)
+
+**ethangardner's scale:**
+- Small: "LGTM"
+- Medium: "LGTM! Thanks for the contribution."
+- Solid: *"Thanks for addressing the feedback. This looks really good! You did great on the handling of the `rtl` treatment as well."* (#6789)
+- Complex: *"**Killer work!** Thanks for addressing the suggestions I made. **This is ready for prime time now.**"* (#6767)
+- Very complex: *"Thanks for the strong work on this and working through the issues. Thanks for your patience waiting for me to get this reviewed."* (#6715)
+
+Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for his own mistakes (#6611: *"Apologies, @natalialuzuriaga. I had previously approved this, but..."*).
+
+---
+
+## Changes-requested: the 17 blocking categories
+
+### 1. Functional bug found by hands-on testing
+
+**mejiaj** (the dominant practitioner of this):
+- #6302: *"Multiple range sliders cause the value for span to render in the wrong place. ... The value is also updated incorrectly. It happens even when you wrap the label and input with `.usa-form-group`."* (with repro steps + GIF)
+- #6203: *"running into an issue on **Alphanumeric** where _sometimes_ it'll show an incorrect error on &lt;kbd&gt;SHIFT+A&lt;/kbd&gt;... If I don't let go of &lt;kbd&gt;SHIFT&lt;/kbd&gt; fast enough it'll tell me to enter a letter."*
+- #6203: *"**Steps to reproduce** / 1. Open SSN / 2. Paste the string `The quick brown fox jumps over the lazy dog` / 3. Confirm that incorrect input is accepted"*
+- #5624: *"I still see invalid CSS and an error on latest... **Steps to reproduce** 1. Set `$theme-header-min-width: 'none'` 2. Run `npx gulp buildSass` 3. Confirm error at the end."* (with full `CssSyntaxError` stack)
+
+**ethangardner:**
+- #6715: *"I see this comment, but there's an error with HMR currently. **Steps to reproduce:** 1) start storybook... 2) Navigate to a component... 3) Open the browser console. 4) Edit the corresponding `.twig` file... 5) See error below in the browser's console."* (with the `TwigException` payload)
+- #6715 follow-up: *"I'm still seeing the error with the new changes. **Interestingly, the problem didn't happen with playwright mcp but it did happen when I tested it manually.** ... if you keep the changes you made from this round and add back in the `Twig.cache(false)` you had on line 30, that fixes the problem."*
+
+**Voice:** Blocking. Always include repro steps or a GIF/video. Number the steps.
+
+### 2. Missing test coverage (the #1 code-level blocker)
+
+**The sharp form** (ethangardner #6713, this becomes gate 5):
+> *"Thanks for adding a test, however, **I noticed this test passes even on the base branch before this fix, which means it doesn't capture potential regressions.** Could you update the test so it exercises the FocusTrap Escape callback or captures that the FocusTrap path no longer throws and closes the dropdown? Something like this would work:"* [followed by a ~25-line drop-in test using `window.onerror`]
+
+**Also:**
+- #6767: *"I think we should add unit tests for this given the new cancel behavior and bug fix I mentioned on line 16. If you can write test that covers the `debounced`, `.cancel`, and **a regression test for the arrow function**, we should be all set here."*
+- #6703: *"I see a test for the 2nd condition of this assignment... I think it would be good to add test cases for: - Custom data-focus element taking priority over default (condition 1) - Fallback to any button when no footer button exists (condition 3)"*
+- #6789: *"I added a good deal of test coverage for branching logic in `*.spec.js` files using the `sass-true` package, and I think it would be good to do the same here for the branching logic."*
+
+**mejiaj:**
+- #6302: *"Can you add a unit test to ensure this component initializes and updates correctly?"*
+- #6203: *"Overall this is looking good! I've only tested the functionality so far. **Please don't forget to create unit tests.**"*
+- #6168: *"Since we've added a new feature to support the custom text, could we create a small unit test to ensure it works as we'd expect? **It should cover the customization and the fallback.**"*
+
+**Sub-pattern — test quality, not just presence:**
+- #6767: *"Thanks for adding these tests. I think **we can DRY them out some** if you extract the timeout part to a helper."* / *"I think `AT_DEFER_MS + 50` could be its own constant. It's used in this spec as well as the one for character count. Also, I'm wondering if for some of the timers in this PR, we might be able to use https://sinonjs.org/concepts/fake-timers/. **Sinon is already a project dependency.**"*
+- #6673: *"Can we remove these comments? I think the description in the `it` function argument sufficiently captures it."* and *"Can you restore this comment please? I think it's helpful to understand the intent of the test assertion and desired behavior."*
+
+**Voice:** Blocking. Show what's missing and either sketch the test or point to an existing one as a template.
+
+### 3. Duplicated existing utility (this is gate 4a / 7)
+
+- #6767: *"**We have `packages/uswds-core/src/js/utils/debounce.js` in the repo already. It was removed in this PR.** Would it be possible to refactor the existing debounce function so we don't inline it here and **have to maintain multiple implementations of a debounce function**?"*
+- #6736 (heymatthenry): *"This works, but **it might be better to put the line inside the `%block-input-styles` mixin directly** (in `_forms.scss`). I think the `select` probably isn't the only place this is happening."*
+- #6592: *"There was a similar change from #6567 that also addressed the `datalist` scenario in the library code. If you can accept the version from the `develop` branch with the change I approved and merged, that should resolve the conflict in `keymap.js`. I think the test you wrote for it is great, and I'd like to get that part merged once the conflict is resolved."* (Keeps the test, discards the duplicate fix.)
+
+**Voice:** Blocking. Name the existing util with a full path.
+
+### 4. Sass token misuse / de-themeing
+
+- #6659: *"**The before diff uses a [theme color token](link), `color("base")`. Since the intent is to go darker for more contrast, my suggestion is to keep the color themeable as it was before.** You might try `color("base-darker")` as a replacement. Also, I would suggest making this variable private by using the leading dash (`-`) convention or simply by using `color("base-darker")` directly where it appears below. I have a personal preference for the latter."*
+- #6650 (declined PR): *"I agree there's a need to provide the tokens as CSS custom properties. ... We have some of the token work started in the `uswds/uswds-elements` repo in the `tokens` directory. ... we're using style dictionary as the source of truth, and this is on our roadmap."*
+
+**Voice:** Blocking. Cite the token function that was replaced, suggest the right token alternative, and link to the design-tokens docs.
+
+### 5. Established codebase convention (cited with permalink)
+
+- #6659: *"Looking elsewhere in the codebase, **the convention we follow in [permalink to `_usa-nav.scss`] is to define only the value as a variable and to not assign the function result to the variable.** i.e. this would become `$-range-border-width: 2px;`, and then its usage below would be `units($-range-border-width)`. The same comment I left about the variable being private or sticking to direct usage applies to this as well."*
+- #6691 (heymatthenry): *"I think this might need a `:where(.usa-button-group)` **to keep the specificity pattern established elsewhere**?"*
+- #6660: *"The current logic defaults to showing drag text and removes it for touch devices, which is desktop-first. A small inversion makes this mobile-first **which aligns with how USWDS handles responsive CSS and our progressive enhancement philosophy.**"*
+
+**Voice:** Blocking or non-blocking depending on impact. Always cite the exemplar with a permalink.
+
+### 6. Breaking change / semver risk (usually a hard decline unless declared)
+
+- #6566: *"This does speed up the build time, but there is also a small in the source order of a small amount of the built CSS that **could potentially be a breaking change for people and require a major version update per the semver convention** and makes it more complex for us to maintain right now."*
+- #6597: *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output. **Shipping this safely would require a thorough audit and a major version bump to USWDS, which is more than our team has the bandwidth to take on at the moment.**"* (then four linked upstream Lightning CSS issues)
+- #6691 (heymatthenry): *"This also increases the specificity so it might have unintended consequences for users who have made their own tweaks to this (admittedly probably a small group, but **it's arguably a breaking change**)."*
+- #6789: *"can you update the PR body so it reflects that the new default is icon-start (left) in the 'Solution' heading and **indicate that this is a breaking change. It still has default right and non-breaking in the PR body.**"*
+
+**Voice:** Blocking if undeclared. Explain *why* it's breaking (CSS order / specificity / default flip / markup), cite semver, and either request declaration or decline.
+
+### 7. Blast radius / shared-selector collateral damage
+
+- #6789: *"**The nav and the banner both use `.usa-accordion__button` as well. Let's add a safeguard to prevent a change in icon position if someone tried:**"* (with two concrete HTML repros showing the misuse, then) *"The concern I had about it was sufficiently addressed with the `:not` selectors you added."*
+- #6691 (heymatthenry): *"Unless I misunderstand, I think this does a little more than it's intended to do. **The `:has` will apply to the whole form, so once that rule applies it'll hit any `.usa-button`s in that form whether or not that particular button is in a group or not.**"*
+- #6703: *"I'm also curious what your thoughts are about **adding test coverage for the Language Selector component that also relies on the `focus-trap` utility.** I think it would be good to have a test to verify backward compatibility on it since the focus trap could have an impact there now or in the future."*
+
+**Voice:** Blocking. Show the collateral case with an HTML snippet or a component name, then suggest the guard (`:not()`, scoping selector).
+
+### 8. Latent correctness bug found by reading (not caught by CI)
+
+- #6767 (the sharpest example): *"I noticed the `apply` method uses `this`, and we're using an arrow function here. The arrow function was there in the code previously, but I think we should fix it now since it would be a one line change. **Using the arrow function is problematic because it would capture the module scope's `this` instead, silently dropping the call-site context passed to `.apply()`.** Changing this line to `const debounced = function debounced(...args) {` should be all we need to correct the bug."*
+- #6703: *"**Before, the code in the conditional beginning at L142 did not executed if the `openFocusEl` was falsy. Just doublechecking that the rest of the code should execute if `openFocusEl` did does not exist.** I'm wondering if there should be an early return statement here."*
+- #6594: *"There's one small addition I think would be good here. Would you mind adding an additional check for `!(event instanceof KeyboardEvent)` to the other two conditions so we're left with `!(event instanceof KeyboardEvent) || typeof event.key === "undefined" || typeof event.getModifierState !== "function"`"*
+
+**Voice:** Blocking. Explain the mechanism (what would go wrong), cite the specific line, suggest the fix as a code block.
+
+### 9. Supply-chain / CI security (always blocking, always specific)
+
+- #6611: *"**Our repo (uswds) has a security requirement on the repository that enforces that GitHub actions are pinned to a specific commit hash as opposed to the version number.** I find that a comment after the SHA is also helpful so the installed version is more readily identified. This would look like: `- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2`. This also applies to the markdown link check action below."*
+- #6612: *"Would you mind pinning the actions to a specific commit hash **to prevent potential supply chain risks and ensure consistent builds**? Our repo has this configured as a requirement in the settings."*
+- #6611 (re-requested changes after approving): *"**Apologies, @natalialuzuriaga. I had previously approved this, but I notice** when I go to the `gaurav-nelson/github-action-markdown-link-check` repository. It indicates this action has been deprecated. ... Would you be able to swap these out?"*
+- #6715: *"Since this is being imported, I'd like it to make sure it's also **added to `package.json` as a `devDependency` to make sure we're not relying on a transitive dependency from Storybook.**"*
+
+**Voice:** Blocking. Cite the repo requirement, show the format (`# pin vX.Y.Z`), check whether the action is deprecated.
+
+### 10. Unrelated changes in the diff (scope creep)
+
+- #6673: *"**Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the a11y improvement. If they are necessary, could you indicate why in the PR description?**"*
+- #6767: *"I think this should be removed so we can **stick to NPM as our package manager. Switching to something else would require a larger discussion.**"* (a stray `packageManager` field)
+
+**Voice:** Blocking. Ask for rollback, and explicitly ask "if they are necessary, explain why."
+
+### 11. Dead legacy code / browser support policy
+
+- #6660: *"Would you mind dropping this legacy check? **It applies to IE11 and the original versions of Edge before they were based on Chromium, and both of those fall outside of our [browser support policy](link)**"*
+
+**Voice:** Blocking. Cite the browser support policy doc.
+
+### 12. Real-device / progressive-enhancement edge cases
+
+- #6660: *"`shouldShowDragText()` runs when the component first renders and the DOM is built from that result. **On convertible/hybrid devices (Surface tablets, iPads with keyboards, etc.) the pointer type can change mid-session** when the user detaches or attaches a keyboard. If you add a `change` listener on the `matchMedia`... **This event listener would also need to be removed when the component is unmounted (i.e. in the `teardown` function).**"*
+- #6660: *"This means **if `matchMedia` is unavailable for any reason, the component falls back to the simple 'Choose from folder' state rather than showing drag instructions that may never work.** ... The baseline is always the safe mobile state, and drag text is added on top for fine-pointer devices."*
+
+**Voice:** Blocking or non-blocking depending on severity. Explain the edge case (convertible device, API absent), show the guard code, cite progressive enhancement.
+
+### 13. Developer-experience guardrails for consumers
+
+- #6789: *"In the `@else` branches in this file, I think it would be good to **add a `@warn` if the `$side` value is not `end` and that we're executing a fallback. That will help people catch typos in their config.**"*
+- #6789: *"Since users can set a global default to make the icon appear on the right, **I think it would be good to also add a story here for IconStart to show how they would execute the per-instance override in that case.**"*
+
+**Voice:** Non-blocking but strongly suggested. Frame as "help consumers catch mistakes."
+
+### 14. Storybook story metadata correctness
+
+- #6697: *"Let's add `disabled_state: "none"`"* / *"Should this property be updated to `indeterminate_state`?"*
+
+**Voice:** Varies — blocking if metadata mismatch breaks the story, non-blocking if it's just naming.
+
+### 15. Deployment-context correctness (not just localhost)
+
+- #6715: *"Question about this. When this is in dev mode, serving from the root directory is reliable. However, when this is built and deployed, it ends up on a preview URL like this: https://federalist-.../preview/uswds/uswds/develop/?path=... **When the storybook assets are going to be deployed to a non-root directory, can we expect the paths to resolve correctly or are there other changes that need to be made to support this?**"*
+
+**Voice:** Blocking. Name the deployment environment (Federalist preview), describe the path issue.
+
+### 16. Wrong solution shape (right problem, wrong fix)
+
+- #6679: *"There's a **non-obvious wrinkle with twig and how it's used. The site in the `uswds/uswds-site` repo consumes the code produced by Twig to make the example code that's live on designsystem.digital.gov, which is also why these are formatted with Prettier.** What you pointed out is a bug where prettier is run against a non-existent directory. **If you wanted to fix that part, think a node script that does a quick check before the `prettier:html` task would be a good addition that wouldn't have as big of an impact on the example code that's on the site.**"*
+
+**Voice:** Non-blocking to block, depending on impact. Explain the system constraint, then hand back a viable narrower fix.
+
+### 17. Needs an architecture decision before any code review
+
+- #6738: *"I agree with the need to provide translations for the strings that are baked into some of our interactive components... However, I think the direction we take with USWDS some planning from our team... **While the `data` attribute might work in some cases, I think we need to have some discussion about pros and cons of this approach and weigh its merits against other approaches like providing i18n hooks and a translation files** ... I'm going to close this PR for now... **If this is the approach we end up deciding on, we'll reopen the PR and give this a full review.**"*
+- #6681: *"I feel like this is a step in the right direction, but I think we (the USWDS team) needs to revisit this overall layout. ... **For the time being, I do want to hold off on any further review of this until we have the discussion internally.**"*
+
+**Voice:** Hold, not Request changes. State the scope of the decision, point to the proposals repo ADR process, say the code looks solid but the architectural choice needs team buy-in first.
+
+---
+
+## Voice and tone (by reviewer)
+
+### ethangardner
+
+**Structure of every CHANGES_REQUESTED:** Three moves, fixed template:
+1. Thanks + specific compliment
+2. Census of what's below
+3. What clearing them earns
+
+Verbatim:
+- *"Overall, nice work. I have a few suggestions to help with test setup and one question about the new debounce function that was added to the runtime."* (#6767)
+- *"Thanks for these changes. There was a minor bug I spotted and some test coverage to add on the `debounce` function. **After that, we can get this merged.**"* (#6767)
+- *"Thank you so much for this contribution! I appreciated your notes about the diagnosis and how to reproduce the issue, as well as the comments you added to the file. **I have one small change request, but this looks good otherwise.**"* (#6594)
+
+**No `nit:` / `blocking:` prefixes.** Severity is carried by modal verbs:
+
+| Register | Phrasing |
+|---|---|
+| Blocking, non-negotiable | *"Would you mind rolling back..."*, *"Let's add a safeguard..."*, *"I think we should fix it now"*, *"I'd like to see a small, focused test"* |
+| Blocking but negotiable | *"I think it would be good to..."* (10+ uses), *"my suggestion is to..."*, *"Could you update the test so..."* |
+| Explicitly non-blocking | *"This is far from being a blocker"*, *"That's not a blocker here though."*, *"I have a personal preference for the latter."* |
+| Genuine question | *"Question about this."*, *"Should this property be updated to...?"*, *"Just doublechecking that..."* |
+| Invitation to push back | *"**Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.**"* (#6703) |
+
+**Approval sign-offs escalate with effort** — see above.
+
+**Almost every substantive comment ships a code block, a permalink, or repro steps.** Rarely "this is wrong" without showing the replacement.
+
+### mejiaj
+
+**Uses Conventional Comments labels in bold:**
+`**issue**`, `**polish**`, `**question**`, `**suggestion**`, `**thought**`, `**quibble**`, `**praise**`, with `(non-blocking)` to downgrade.
+
+Examples:
+- `**issue**: The `hidden` attribute would save you some CSS.` (#6203)
+- `**issue (non-blocking)**: This should be a component, instead of hardcoded.` (#6165)
+- `**polish**: You can avoid this CSS by making the error message a block element.` (#6203)
+- `**question**: We're hiding this because the error is now in the label, right?` (#6168)
+- `**suggestion**: You could improve readability by saving this separately.` (#6168)
+- `**thought**: We need to clearly communicate this change to users. The PR summary would be a good place.` (#6205)
+- `**quibble**: Minor, but we can set the text before appending it to the DOM. You can swap 516 and 517.` (#6168)
+- `**praise**: Thanks for updating and adding unit tests!` (#6122)
+
+**Also uses GitHub alert callouts:**
+- `> [!NOTE] Need to convert this comment into an issue.` (#6165)
+- `> [!TIP] Not new; just matching work done in [commit].` (#6297)
+- `> [!CAUTION] Inspect **all** compiled HTML templates for table to ensure there aren't regressions on site.` (#5783)
+- `> [!WARNING] Adding responsive variants has an impact on CSS compile size.` (#6048)
+
+**Structural habits:** Bold `**Steps to reproduce**`, `**Before**`, `**After**`; `<details><summary>` for logs; `| Before | After |` screenshot tables; footnotes `[^1]` for MDN links; ` ```suggestion ` blocks (one-click apply); `<kbd>` for keys; `~strikethrough~` when retracting, plus "Resolved in `<sha>`" to close threads.
+
+**Opening lines are gratitude-first, even on CR:**
+- *"@mahoneycm **a tricky issue, thanks for taking this on.** The PR description and additional draft PR are helpful."* (#6168)
+- *"@mlloydbixal **thanks for all your work on this so far.**"* (#6203)
+- *"**Thanks for the update and such thorough documentation** @mahoneycm!"* (#5774)
+
+**Hedges requests as questions:** "Can we...?", "Would it be better to...?", "Should we...?" States his own position separately: "**My opinion** I'd prefer to rely on guidance, but I can also see a case for throwing an error." (#5908)
+
+### heymatthenry
+
+**Short, hedged, first-person, sometimes emoji:**
+- "I'm comfortable releasing this as-is" (#6035)
+- "I _think_ this sounds reasonable" (#5286)
+- "This change feels less intuitive, but 🤷‍♀️" (#6257)
+- "I don't understand this formatting rule" (#5782, three times)
+- "ooh docs ❤️" (#6161) / "✨" (#5310) / "🎉" (#5624)
+
+**Posts ` ```suggestion ` blocks with final wording, no preamble** (#6038 ×4). Is the copy editor: "`Ellipsis` is the correct singular here" (#5197).
+
+### thisisdano
+
+**Shortest, most colloquial:**
+- "Unless I misunderstand, I think this does a little more than it's intended to do." (#6691)
+- "I think this might need a `:where(.usa-button-group)` to keep the specificity pattern established elsewhere?" (#6691) — question mark on a change request
+- "and I recognize I'm probably being overly conservative!" (#6308)
+- "WDYT @ethangardner?" (#6736) — escalates rather than deciding alone
+- "Ship it!" / "Woohoo!" / "Thank you, @aduth 🫡"
+
+**Distinguishes "good practice" from "design-system guidance":** *"everyone should always set the `lang` attribute if for no other reason than it's important for performance and accessibility—**i just don't necessarily want to bak assumptions about best practices into a component without making adoption of those practices an explicit part of the design system.**"* (#6460)
+
+---
+
+## The silence list — evidence
+
+These are **never** reviewed, backed by corpus facts:
+
+1. **Formatting, indentation, quote style, line length** — Zero style nits exist across 200+ PRs.
+2. **Naming in isolation** — Flagged only when confusing or convention-breaking (e.g., `data-errorMessage` vs. repo's dash-case).
+3. **Micro-performance** — Perf comes up as build-time or breaking-change concerns, never as runtime micro-optimization.
+4. **JSDoc/type coverage as a blanket ask** — SASSDoc required for Sass; JSDoc not broadly enforced.
+5. **Diff size as a blocker** — Zero "split this up" comments exist. +12k/-14k Storybook PR approved without size comment.
+6. **`dist/` contents as source** — Never reviewed line-by-line. #6783 did byte-identical sha256 verification.
+7. **Any AT/screen-reader verdict** — Explicitly routed: *"Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior."* (#6595)
+8. **Dependabot lockfile diffs** — Bare APPROVED, no review.
+9. **Variable/function naming disputes** — Accepted after one discussion round.
+10. **Hypothetical future requirements** — Not in scope.
+11. **Refactoring opportunities unrelated to the change** — Converted to issues (#6165: "Created #6183.")
+
+---
+
+## Linked issue, definition of done, and review routing
+
+**The PR body is a reviewable artifact** and can trigger CHANGES_REQUESTED:
+- #6789: *"**For documentation purposes**, can you update the PR body so it reflects that the new default is icon-start (left) in the 'Solution' heading and indicate that this is a breaking change."*
+- #6673: *"They don't appear to be necessary. **If they are necessary, could you indicate why in the PR description?**"*
+
+**Duplicate-issue enforcement:** Cross-link PRs, close the newer/duplicate with credit. #6591 → *"There was a PR that was just merged #6659 that covers this change, so I am closing this as a duplicate."*
+
+**Follow-up work converted to tracked issues by the reviewer:**
+- #6715: *"I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks. **I'll create the issue for it**."*
+- #6700: *"it would probably be helpful to add a description to populate the comment body. **I'll create an issue for it.**"*
+- #6308 (heymatthenry): *"what I'd prefer to do is to make an issue for your suggested improvements and write some tests."*
+
+**Explicit two-key routing** (code review ≠ a11y approval):
+- #6595: *"@chandracarney — **Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior.**"*
+- #6703: *"LGTM! @chandracarney do you want to take a look at this for final approval?"*
+- #6725: *"@chandracarney — you're up for a final a11y review."*
+- #6786: *"This looks good to me. @jonathanbobel — **this touches modal code that you wrote previously.** ... Passing off to you to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+
+**Unblocks stale review states:**
+- #6611: *"@annepetersen — You had a previous change request, so this will need an approval from you as well if it looks good to you."*
+- #6660: *"If this is ready for review, please let me know or **click the 're-request' review button**."*
+
+---
+
+## Dependabot / version-bump handling
+
+Almost always bare APPROVED. Hygiene: `@dependabot rebase` / `@dependabot recreate`.
+
+**The one exception — the reusable artifact** (#6783, ethangardner):
+> **AI-assisted review — OpenCode Agent**
+>
+> Verification transcript for Bump undici 7.28.0 → 7.29.0 (#6783):
+>
+> - Diff scope: lockfile-only (package-lock.json, 3 lines changed). undici is a transitive test dependency; not used in browser-distributed code.
+> - `npm ci`: clean
+> - `npm run lint` (ESLint + Sass): ✅ exit 0
+> - `npx gulp test` (unit + Sass + tasks): ✅ all passing
+> - `npx gulp` build: ✅ exit 0
+> - `dist/` sha256 comparison vs develop baseline (2679 files): ✅ **byte-identical**
+>
+> All safety criteria met. Safe to merge.
+
+---
+
+## Notes for the skill
+
+- **Match severity, not wording.** The corpus is anchors for *what gets blocked* and *what doesn't*, not templates to copy.
+- **ethangardner's three-move structure** is the canonical shape for a CHANGES_REQUESTED summary.
+- **mejiaj's Conventional Comments labels** are the right taxonomy for inline findings, because they're already in use.
+- **The "I can approve once..." precondition** is the dominant mode for non-blocking findings — use it.
+- **Always close with the escape hatch:** *"Don't take any of this for absolute. It's all open for discussion."*

--- a/.agents/skills/uswds-code-review/references/calibration.md
+++ b/.agents/skills/uswds-code-review/references/calibration.md
@@ -2,7 +2,7 @@
 
 This file anchors severity decisions and voice so the skill's output matches the team's actual practice, not generic review templates. Sources: 200+ merged PRs and their inline review comments across the project's review history.
 
-The team includes at least one engineering lead / senior engineer who sets technical direction and oversees code contributions, a product lead who owns design-system guidance decisions, and an accessibility specialist who handles accessibility-content review and hands-on AT verification. Patterns below represent durable team judgment, not individual voices.
+The team includes at least an engineering lead who sets technical direction and oversees code contributions, a senior engineer who contributes to design system development, a product lead who owns design system guidance decisions, and an accessibility specialist who handles accessibility-content review and hands-on AT verification. Patterns below represent durable team judgment, not individual voices.
 
 ---
 
@@ -14,7 +14,7 @@ The team includes at least one engineering lead / senior engineer who sets techn
 - One-line, single-token fixes using the right token (#6669: `+1/-1`, file input error border → error token): *"LGTM! Thanks for the contribution."*
 - A fix where the mechanism is obviously right (#6713): *"The runtime code change itself looks good. Replacing that stale callback with the existing dropdown close path makes sense."*
 - Security hardening (#6674): *"Nice catch. Thanks for this improvement and contribution!"*
-- Docs/meta/typos — essentially always waved through: #6762, #6720, #6580
+- Docs/meta/typo fixes — essentially always waved through: #6762, #6720, #6580
 - **Verifies by running it.** #6811: *"I tested this in Storybook and compared it to how we handle other components."* #6673: *"I tested it with NVDA, and the readout I got made more sense with the id and aria than it did without it."*
 
 **Senior engineer:**
@@ -28,7 +28,7 @@ The team includes at least one engineering lead / senior engineer who sets techn
 
 **Product lead:**
 - Bare approvals are the norm, with a one-line human note. Verbatim: "Thank you!" (#6165, #5885, #6013), "Nice work." (#5713), "Very nice. Both features work together as expected" (#5919), "A lot of work here! It will be nice to move this gnarly little issue off your plate!" (#5636), "🎉" (#5624)
-- Asks another engineer for a second opinion rather than deciding alone (#5908): "LGTM. Passing it over to another engineer for a take."
+- Asks an engineer for a second opinion rather than deciding alone (#5908): "LGTM. Passing it over to an engineer for a take."
 
 ### Approve-with-nits: the "I can approve once..." contract
 
@@ -39,12 +39,14 @@ The team includes at least one engineering lead / senior engineer who sets techn
 
 **Engineering lead** (approve now, name the follow-up explicitly):
 - #6725: *"This looks good. ... If you wanted to do a follow-up enhancement PR, you might want to consider... **That's not a blocker here though.**"*
-- #6715: *"Looking at the cjs plugin you wrote, I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks... **I'll create the issue for it and hold off on doing it so you're not dealing with conflicts** or things changing while this work is in progress."*
+- #6715: *"Looking at the cjs plugin you wrote, I'm going to suggest a follow-up PR once and issue so we can remove the UMD-related checks... **I'll create the issue for it and hold off on doing it so you're not dealing with conflicts** or things changing while this work is in progress."*
 - #6703: *"This keeps the defensive focus handling more concise and readable in my opinion. **This is far from being a blocker**, but it's worth considering if you're touching this code again."*
 
-**Engineering lead** (accepts debt on purpose):
+**Engineering lead** (weighs the impact of accepting technical debt on purpose if it moves the project forward):
 - #6173: *"**Approving as-is so help move the other related PRs (#6174, #6175) along** rather than chasing down anywhere else `ignore` may have been used historically."*
 - #6308: *"for something we're trying to get in ASAP **I'd prefer to leave the current behavior for now**. This feature also doesn't have adequate test coverage. So what I'd prefer to do is to make an issue for your suggested improvements and write some tests such that next time something comes up here we can make changes more confidently."*
+
+**There should be relevant ADRs** with an escape hatch to indicate when the technical debt can be paid down. This most likely requires explicit documentation and insight into the thought process, alternatives considered, and context of the decision.
 
 ### Approval escalation (effort-proportional sign-offs)
 
@@ -162,7 +164,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 ### 11. Dead legacy code / browser support policy
 
-- #6660: *"Would you mind dropping this legacy check? **It applies to IE11 and the original versions of Edge before they were based on Chromium, and both of those fall outside of our [browser support policy](link)**"*
+- #6660: *"Would you mind dropping this legacy check? **It applies to IE11 and the original versions of Edge before they were based on Chromium, and both of those fall outside our [browser support policy](link)**"*
 
 **Voice:** Blocking. Cite the browser support policy doc.
 
@@ -223,13 +225,13 @@ Verbatim:
 
 **No `nit:` / `blocking:` prefixes.** Severity is carried by modal verbs:
 
-| Register | Phrasing |
-|---|---|
+| Register                 | Phrasing                                                                                                                                      |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Blocking, non-negotiable | *"Would you mind rolling back..."*, *"Let's add a safeguard..."*, *"I think we should fix it now"*, *"I'd like to see a small, focused test"* |
-| Blocking but negotiable | *"I think it would be good to..."* (10+ uses), *"my suggestion is to..."*, *"Could you update the test so..."* |
-| Explicitly non-blocking | *"This is far from being a blocker"*, *"That's not a blocker here though."*, *"I have a personal preference for the latter."* |
-| Genuine question | *"Question about this."*, *"Should this property be updated to...?"*, *"Just doublechecking that..."* |
-| Invitation to push back | *"**Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.**"* (#6703) |
+| Blocking but negotiable  | *"I think it would be good to..."* (10+ uses), *"my suggestion is to..."*, *"Could you update the test so..."*                                |
+| Explicitly non-blocking  | *"This is far from being a blocker"*, *"That's not a blocker here though."*, *"I have a personal preference for the latter."*                 |
+| Genuine question         | *"Question about this."*, *"Should this property be updated to...?"*, *"Just doublechecking that..."*                                         |
+| Invitation to push back  | *"**Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.**"* (#6703)            |
 
 **Approval sign-offs scale with effort** — see approval escalation section above.
 
@@ -283,7 +285,7 @@ Examples:
 - "WDYT?" (#6736) — asks another engineer for a second opinion rather than deciding alone
 - "Ship it!" / "Woohoo!" / "Thank you 🫡"
 
-**Distinguishes "good practice" from "design-system guidance":** *"everyone should always set the `lang` attribute if for no other reason than it's important for performance and accessibility—**i just don't necessarily want to bak assumptions about best practices into a component without making adoption of those practices an explicit part of the design system.**"* (#6460)
+**Distinguishes "good practice" from "design system guidance":** *"everyone should always set the `lang` attribute if for no other reason than it's important for performance and accessibility—**I just don't necessarily want to bake assumptions about best practices into a component without making adoption of those practices an explicit part of the design system.**"* (#6460)
 
 ---
 
@@ -314,7 +316,7 @@ These are **never** reviewed, backed by corpus facts:
 **Duplicate-issue enforcement:** Cross-link PRs, close the newer/duplicate with credit. #6591 → *"There was a PR that was just merged #6659 that covers this change, so I am closing this as a duplicate."*
 
 **Follow-up work converted to tracked issues by the reviewer:**
-- #6715: *"I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks. **I'll create the issue for it**."*
+- #6715: *"I'm going to suggest a follow-up PR once and issue so we can remove the UMD-related checks. **I'll create the issue for it**."*
 - #6700: *"it would probably be helpful to add a description to populate the comment body. **I'll create an issue for it.**"*
 - #6308: *"what I'd prefer to do is to make an issue for your suggested improvements and write some tests."*
 
@@ -343,7 +345,7 @@ Example (#6673): a range slider hint read *"slider"* — which AT users already 
 
 ## Dependabot / version-bump handling
 
-Almost always bare APPROVED. Hygiene: `@dependabot rebase` / `@dependabot recreate`.
+A passing build is *REQUIRED*. Almost always bare APPROVED for dev-only dependencies with a patch or minor version update.
 
 **The one exception — the reusable artifact** (#6783, engineering lead):
 > **AI-assisted review — OpenCode Agent**
@@ -367,4 +369,3 @@ Almost always bare APPROVED. Hygiene: `@dependabot rebase` / `@dependabot recrea
 - **The engineering-lead three-move structure** is the canonical shape for a CHANGES_REQUESTED summary.
 - **The team's Conventional Comments labels** are the right taxonomy for inline findings, because they're already in use.
 - **The "I can approve once..." precondition** is the dominant mode for non-blocking findings — use it.
-- **Always close with the escape hatch:** *"Don't take any of this for absolute. It's all open for discussion."*

--- a/.agents/skills/uswds-code-review/references/calibration.md
+++ b/.agents/skills/uswds-code-review/references/calibration.md
@@ -1,8 +1,8 @@
 # Calibration Data — Mined Patterns and Verbatim Quotes
 
-This file anchors severity decisions and voice so the skill's output matches the team's actual practice, not generic review templates. Sources: ethangardner (60 PRs, 43 inline comments), heymatthenry (28 PRs, 8 inline comments), mejiaj (~100 PRs, extensive inline + review-body evidence), thisisdano (~70 PRs, 30+ inline comments).
+This file anchors severity decisions and voice so the skill's output matches the team's actual practice, not generic review templates. Sources: 200+ merged PRs and their inline review comments across the project's review history.
 
-**Note on recency:** mejiaj's last review here is #6418 (2025-02-18), thisisdano's is #6320 (2025-01-23). The team includes an active a11y specialist who handles hands-on AT verification and a11y-content review. Patterns below represent the team's durable judgment, not individual voices.
+The team includes at least one engineering lead / senior engineer who sets technical direction and oversees code contributions, a product lead who owns design-system guidance decisions, and an accessibility specialist who handles accessibility-content review and hands-on AT verification. Patterns below represent durable team judgment, not individual voices.
 
 ---
 
@@ -10,52 +10,52 @@ This file anchors severity decisions and voice so the skill's output matches the
 
 ### What qualifies for outright approval
 
-**ethangardner:**
+**Senior engineer / engineering lead:**
 - One-line, single-token fixes using the right token (#6669: `+1/-1`, file input error border → error token): *"LGTM! Thanks for the contribution."*
 - A fix where the mechanism is obviously right (#6713): *"The runtime code change itself looks good. Replacing that stale callback with the existing dropdown close path makes sense."*
 - Security hardening (#6674): *"Nice catch. Thanks for this improvement and contribution!"*
 - Docs/meta/typos — essentially always waved through: #6762, #6720, #6580
-- **He verifies by running it.** #6811: *"I tested this in Storybook and compared it to how we handle other components."* #6673: *"I tested it with NVDA, and the readout I got made more sense with the id and aria than it did without it."*
+- **Verifies by running it.** #6811: *"I tested this in Storybook and compared it to how we handle other components."* #6673: *"I tested it with NVDA, and the readout I got made more sense with the id and aria than it did without it."*
 
-**mejiaj:**
+**Senior engineer:**
 - Arrives with a **checked list** as the approval body (#6168):
   > ### Tested
   > - [x] Dragging invalid file reads error message in VoiceOver (both Chrome & Safari)
   > - [x] Code quality
 - Names the **browser + OS matrix** (#5919): "No issues found. Tested in Safari, Firefox, and Chromium." (#5885): "Looks good. I tested in Chromium 125, Firefox 127, and Safari 17.4.1."
 - **Before/after preview links** or screenshots (#6165 video of loader icon), (#6037 Federalist preview URL table)
-- **Builds his own test harness before approving** (#6048): "I've created a branch on uswds-sandbox `test-uswds-breakpoints-6048`, so others can test as well."
+- **Builds a test harness before approving** (#6048): "I've created a branch on uswds-sandbox `test-uswds-breakpoints-6048`, so others can test as well."
 
-**thisisdano:**
+**Product lead:**
 - Bare approvals are the norm, with a one-line human note. Verbatim: "Thank you!" (#6165, #5885, #6013), "Nice work." (#5713), "Very nice. Both features work together as expected" (#5919), "A lot of work here! It will be nice to move this gnarly little issue off your plate!" (#5636), "🎉" (#5624)
-- Explicitly delegates (#5908): "LGTM. Passing it over to @heymatthenry for his take."
+- Asks another engineer for a second opinion rather than deciding alone (#5908): "LGTM. Passing it over to another engineer for a take."
 
 ### Approve-with-nits: the "I can approve once..." contract
 
-**mejiaj** (his most characteristic mode):
+**Senior engineer** (most characteristic mode):
 - #5999: "Just a minor question and non-blocking issue. **I can approve PR once resolved.**"
-- #6013: "Otherwise LGTM and **I can approve once we have clarity on question above** and Charlie's changes have been addressed."
+- #6013: "Otherwise LGTM and **I can approve once we have clarity on question above** and changes have been addressed."
 - #6038: "Added a few non-blocking suggestions. **I can approve once comments are resolved.**"
 
-**ethangardner** (approve now, name the follow-up explicitly):
+**Engineering lead** (approve now, name the follow-up explicitly):
 - #6725: *"This looks good. ... If you wanted to do a follow-up enhancement PR, you might want to consider... **That's not a blocker here though.**"*
 - #6715: *"Looking at the cjs plugin you wrote, I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks... **I'll create the issue for it and hold off on doing it so you're not dealing with conflicts** or things changing while this work is in progress."*
 - #6703: *"This keeps the defensive focus handling more concise and readable in my opinion. **This is far from being a blocker**, but it's worth considering if you're touching this code again."*
 
-**heymatthenry** (accepts debt on purpose):
+**Engineering lead** (accepts debt on purpose):
 - #6173: *"**Approving as-is so help move the other related PRs (#6174, #6175) along** rather than chasing down anywhere else `ignore` may have been used historically."*
 - #6308: *"for something we're trying to get in ASAP **I'd prefer to leave the current behavior for now**. This feature also doesn't have adequate test coverage. So what I'd prefer to do is to make an issue for your suggested improvements and write some tests such that next time something comes up here we can make changes more confidently."*
 
 ### Approval escalation (effort-proportional sign-offs)
 
-**ethangardner's scale:**
+**Engineering lead sign-off scale:**
 - Small: "LGTM"
 - Medium: "LGTM! Thanks for the contribution."
 - Solid: *"Thanks for addressing the feedback. This looks really good! You did great on the handling of the `rtl` treatment as well."* (#6789)
 - Complex: *"**Killer work!** Thanks for addressing the suggestions I made. **This is ready for prime time now.**"* (#6767)
 - Very complex: *"Thanks for the strong work on this and working through the issues. Thanks for your patience waiting for me to get this reviewed."* (#6715)
 
-Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for his own mistakes (#6611: *"Apologies, @natalialuzuriaga. I had previously approved this, but..."*).
+Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for own mistakes (#6611: *"Apologies, @contributor. I had previously approved this, but..."*).
 
 ---
 
@@ -63,13 +63,13 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 ### 1. Functional bug found by hands-on testing
 
-**mejiaj** (the dominant practitioner of this):
+**Senior engineer** (the dominant practitioner of this):
 - #6302: *"Multiple range sliders cause the value for span to render in the wrong place. ... The value is also updated incorrectly. It happens even when you wrap the label and input with `.usa-form-group`."* (with repro steps + GIF)
 - #6203: *"running into an issue on **Alphanumeric** where _sometimes_ it'll show an incorrect error on &lt;kbd&gt;SHIFT+A&lt;/kbd&gt;... If I don't let go of &lt;kbd&gt;SHIFT&lt;/kbd&gt; fast enough it'll tell me to enter a letter."*
 - #6203: *"**Steps to reproduce** / 1. Open SSN / 2. Paste the string `The quick brown fox jumps over the lazy dog` / 3. Confirm that incorrect input is accepted"*
 - #5624: *"I still see invalid CSS and an error on latest... **Steps to reproduce** 1. Set `$theme-header-min-width: 'none'` 2. Run `npx gulp buildSass` 3. Confirm error at the end."* (with full `CssSyntaxError` stack)
 
-**ethangardner:**
+**Engineering lead:**
 - #6715: *"I see this comment, but there's an error with HMR currently. **Steps to reproduce:** 1) start storybook... 2) Navigate to a component... 3) Open the browser console. 4) Edit the corresponding `.twig` file... 5) See error below in the browser's console."* (with the `TwigException` payload)
 - #6715 follow-up: *"I'm still seeing the error with the new changes. **Interestingly, the problem didn't happen with playwright mcp but it did happen when I tested it manually.** ... if you keep the changes you made from this round and add back in the `Twig.cache(false)` you had on line 30, that fixes the problem."*
 
@@ -77,7 +77,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 ### 2. Missing test coverage (the #1 code-level blocker)
 
-**The sharp form** (ethangardner #6713, this becomes gate 5):
+**The sharp form** (senior engineer #6713, this becomes gate 5):
 > *"Thanks for adding a test, however, **I noticed this test passes even on the base branch before this fix, which means it doesn't capture potential regressions.** Could you update the test so it exercises the FocusTrap Escape callback or captures that the FocusTrap path no longer throws and closes the dropdown? Something like this would work:"* [followed by a ~25-line drop-in test using `window.onerror`]
 
 **Also:**
@@ -85,7 +85,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 - #6703: *"I see a test for the 2nd condition of this assignment... I think it would be good to add test cases for: - Custom data-focus element taking priority over default (condition 1) - Fallback to any button when no footer button exists (condition 3)"*
 - #6789: *"I added a good deal of test coverage for branching logic in `*.spec.js` files using the `sass-true` package, and I think it would be good to do the same here for the branching logic."*
 
-**mejiaj:**
+**Senior engineer:**
 - #6302: *"Can you add a unit test to ensure this component initializes and updates correctly?"*
 - #6203: *"Overall this is looking good! I've only tested the functionality so far. **Please don't forget to create unit tests.**"*
 - #6168: *"Since we've added a new feature to support the custom text, could we create a small unit test to ensure it works as we'd expect? **It should cover the customization and the fallback.**"*
@@ -99,7 +99,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 ### 3. Duplicated existing utility (this is gate 4a / 7)
 
 - #6767: *"**We have `packages/uswds-core/src/js/utils/debounce.js` in the repo already. It was removed in this PR.** Would it be possible to refactor the existing debounce function so we don't inline it here and **have to maintain multiple implementations of a debounce function**?"*
-- #6736 (heymatthenry): *"This works, but **it might be better to put the line inside the `%block-input-styles` mixin directly** (in `_forms.scss`). I think the `select` probably isn't the only place this is happening."*
+- #6736: *"This works, but **it might be better to put the line inside the `%block-input-styles` mixin directly** (in `_forms.scss`). I think the `select` probably isn't the only place this is happening."*
 - #6592: *"There was a similar change from #6567 that also addressed the `datalist` scenario in the library code. If you can accept the version from the `develop` branch with the change I approved and merged, that should resolve the conflict in `keymap.js`. I think the test you wrote for it is great, and I'd like to get that part merged once the conflict is resolved."* (Keeps the test, discards the duplicate fix.)
 
 **Voice:** Blocking. Name the existing util with a full path.
@@ -114,7 +114,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 ### 5. Established codebase convention (cited with permalink)
 
 - #6659: *"Looking elsewhere in the codebase, **the convention we follow in [permalink to `_usa-nav.scss`] is to define only the value as a variable and to not assign the function result to the variable.** i.e. this would become `$-range-border-width: 2px;`, and then its usage below would be `units($-range-border-width)`. The same comment I left about the variable being private or sticking to direct usage applies to this as well."*
-- #6691 (heymatthenry): *"I think this might need a `:where(.usa-button-group)` **to keep the specificity pattern established elsewhere**?"*
+- #6691: *"I think this might need a `:where(.usa-button-group)` **to keep the specificity pattern established elsewhere**?"*
 - #6660: *"The current logic defaults to showing drag text and removes it for touch devices, which is desktop-first. A small inversion makes this mobile-first **which aligns with how USWDS handles responsive CSS and our progressive enhancement philosophy.**"*
 
 **Voice:** Blocking or non-blocking depending on impact. Always cite the exemplar with a permalink.
@@ -123,7 +123,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 - #6566: *"This does speed up the build time, but there is also a small in the source order of a small amount of the built CSS that **could potentially be a breaking change for people and require a major version update per the semver convention** and makes it more complex for us to maintain right now."*
 - #6597: *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output. **Shipping this safely would require a thorough audit and a major version bump to USWDS, which is more than our team has the bandwidth to take on at the moment.**"* (then four linked upstream Lightning CSS issues)
-- #6691 (heymatthenry): *"This also increases the specificity so it might have unintended consequences for users who have made their own tweaks to this (admittedly probably a small group, but **it's arguably a breaking change**)."*
+- #6691: *"This also increases the specificity so it might have unintended consequences for users who have made their own tweaks to this (admittedly probably a small group, but **it's arguably a breaking change**)."*
 - #6789: *"can you update the PR body so it reflects that the new default is icon-start (left) in the 'Solution' heading and **indicate that this is a breaking change. It still has default right and non-breaking in the PR body.**"*
 
 **Voice:** Blocking if undeclared. Explain *why* it's breaking (CSS order / specificity / default flip / markup), cite semver, and either request declaration or decline.
@@ -131,7 +131,7 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 ### 7. Blast radius / shared-selector collateral damage
 
 - #6789: *"**The nav and the banner both use `.usa-accordion__button` as well. Let's add a safeguard to prevent a change in icon position if someone tried:**"* (with two concrete HTML repros showing the misuse, then) *"The concern I had about it was sufficiently addressed with the `:not` selectors you added."*
-- #6691 (heymatthenry): *"Unless I misunderstand, I think this does a little more than it's intended to do. **The `:has` will apply to the whole form, so once that rule applies it'll hit any `.usa-button`s in that form whether or not that particular button is in a group or not.**"*
+- #6691: *"Unless I misunderstand, I think this does a little more than it's intended to do. **The `:has` will apply to the whole form, so once that rule applies it'll hit any `.usa-button`s in that form whether or not that particular button is in a group or not.**"*
 - #6703: *"I'm also curious what your thoughts are about **adding test coverage for the Language Selector component that also relies on the `focus-trap` utility.** I think it would be good to have a test to verify backward compatibility on it since the focus trap could have an impact there now or in the future."*
 
 **Voice:** Blocking. Show the collateral case with an HTML snippet or a component name, then suggest the guard (`:not()`, scoping selector).
@@ -148,14 +148,14 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 - #6611: *"**Our repo (uswds) has a security requirement on the repository that enforces that GitHub actions are pinned to a specific commit hash as opposed to the version number.** I find that a comment after the SHA is also helpful so the installed version is more readily identified. This would look like: `- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2`. This also applies to the markdown link check action below."*
 - #6612: *"Would you mind pinning the actions to a specific commit hash **to prevent potential supply chain risks and ensure consistent builds**? Our repo has this configured as a requirement in the settings."*
-- #6611 (re-requested changes after approving): *"**Apologies, @natalialuzuriaga. I had previously approved this, but I notice** when I go to the `gaurav-nelson/github-action-markdown-link-check` repository. It indicates this action has been deprecated. ... Would you be able to swap these out?"*
+- #6611 (re-requested changes after approving): *"**Apologies, @contributor. I had previously approved this, but I notice** when I go to the `gaurav-nelson/github-action-markdown-link-check` repository. It indicates this action has been deprecated. ... Would you be able to swap these out?"*
 - #6715: *"Since this is being imported, I'd like it to make sure it's also **added to `package.json` as a `devDependency` to make sure we're not relying on a transitive dependency from Storybook.**"*
 
 **Voice:** Blocking. Cite the repo requirement, show the format (`# pin vX.Y.Z`), check whether the action is deprecated.
 
 ### 10. Unrelated changes in the diff (scope creep)
 
-- #6673: *"**Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the a11y improvement. If they are necessary, could you indicate why in the PR description?**"*
+- #6673: *"**Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the accessibility improvement. If they are necessary, could you indicate why in the PR description?**"*
 - #6767: *"I think this should be removed so we can **stick to NPM as our package manager. Switching to something else would require a larger discussion.**"* (a stray `packageManager` field)
 
 **Voice:** Blocking. Ask for rollback, and explicitly ask "if they are necessary, explain why."
@@ -207,9 +207,9 @@ Also: apologies for latency (#6385: *"Sorry for the looooooong delay"*) and for 
 
 ---
 
-## Voice and tone (by reviewer)
+## Voice and tone
 
-### ethangardner
+### Senior engineer / engineering lead voice
 
 **Structure of every CHANGES_REQUESTED:** Three moves, fixed template:
 1. Thanks + specific compliment
@@ -231,13 +231,11 @@ Verbatim:
 | Genuine question | *"Question about this."*, *"Should this property be updated to...?"*, *"Just doublechecking that..."* |
 | Invitation to push back | *"**Don't take any of this for absolute. It's all open for discussion if you disagree with any of it or have feedback.**"* (#6703) |
 
-**Approval sign-offs escalate with effort** — see above.
+**Approval sign-offs scale with effort** — see approval escalation section above.
 
 **Almost every substantive comment ships a code block, a permalink, or repro steps.** Rarely "this is wrong" without showing the replacement.
 
-### mejiaj
-
-**Uses Conventional Comments labels in bold:**
+**Also uses Conventional Comments labels in bold:**
 `**issue**`, `**polish**`, `**question**`, `**suggestion**`, `**thought**`, `**quibble**`, `**praise**`, with `(non-blocking)` to downgrade.
 
 Examples:
@@ -259,13 +257,11 @@ Examples:
 **Structural habits:** Bold `**Steps to reproduce**`, `**Before**`, `**After**`; `<details><summary>` for logs; `| Before | After |` screenshot tables; footnotes `[^1]` for MDN links; ` ```suggestion ` blocks (one-click apply); `<kbd>` for keys; `~strikethrough~` when retracting, plus "Resolved in `<sha>`" to close threads.
 
 **Opening lines are gratitude-first, even on CR:**
-- *"@mahoneycm **a tricky issue, thanks for taking this on.** The PR description and additional draft PR are helpful."* (#6168)
-- *"@mlloydbixal **thanks for all your work on this so far.**"* (#6203)
-- *"**Thanks for the update and such thorough documentation** @mahoneycm!"* (#5774)
+- *"@contributor **a tricky issue, thanks for taking this on.** The PR description and additional draft PR are helpful."* (#6168)
+- *"@contributor **thanks for all your work on this so far.**"* (#6203)
+- *"**Thanks for the update and such thorough documentation** @contributor!"* (#5774)
 
-**Hedges requests as questions:** "Can we...?", "Would it be better to...?", "Should we...?" States his own position separately: "**My opinion** I'd prefer to rely on guidance, but I can also see a case for throwing an error." (#5908)
-
-### heymatthenry
+**Hedges requests as questions:** "Can we...?", "Would it be better to...?", "Should we...?" States own position separately: "**My opinion** I'd prefer to rely on guidance, but I can also see a case for throwing an error." (#5908)
 
 **Short, hedged, first-person, sometimes emoji:**
 - "I'm comfortable releasing this as-is" (#6035)
@@ -274,16 +270,18 @@ Examples:
 - "I don't understand this formatting rule" (#5782, three times)
 - "ooh docs ❤️" (#6161) / "✨" (#5310) / "🎉" (#5624)
 
-**Posts ` ```suggestion ` blocks with final wording, no preamble** (#6038 ×4). Is the copy editor: "`Ellipsis` is the correct singular here" (#5197).
+**Posts ` ```suggestion ` blocks with final wording, no preamble** (#6038 ×4). Copy-edits with precision: "`Ellipsis` is the correct singular here" (#5197).
 
-### thisisdano
+---
+
+### Product lead voice
 
 **Shortest, most colloquial:**
 - "Unless I misunderstand, I think this does a little more than it's intended to do." (#6691)
 - "I think this might need a `:where(.usa-button-group)` to keep the specificity pattern established elsewhere?" (#6691) — question mark on a change request
 - "and I recognize I'm probably being overly conservative!" (#6308)
-- "WDYT @ethangardner?" (#6736) — escalates rather than deciding alone
-- "Ship it!" / "Woohoo!" / "Thank you, @aduth 🫡"
+- "WDYT?" (#6736) — asks another engineer for a second opinion rather than deciding alone
+- "Ship it!" / "Woohoo!" / "Thank you 🫡"
 
 **Distinguishes "good practice" from "design-system guidance":** *"everyone should always set the `lang` attribute if for no other reason than it's important for performance and accessibility—**i just don't necessarily want to bak assumptions about best practices into a component without making adoption of those practices an explicit part of the design system.**"* (#6460)
 
@@ -318,27 +316,27 @@ These are **never** reviewed, backed by corpus facts:
 **Follow-up work converted to tracked issues by the reviewer:**
 - #6715: *"I'm going to suggest a follow up PR once and issue so we can remove the UMD-related checks. **I'll create the issue for it**."*
 - #6700: *"it would probably be helpful to add a description to populate the comment body. **I'll create an issue for it.**"*
-- #6308 (heymatthenry): *"what I'd prefer to do is to make an issue for your suggested improvements and write some tests."*
+- #6308: *"what I'd prefer to do is to make an issue for your suggested improvements and write some tests."*
 
-**Explicit two-key routing** (code review ≠ a11y approval):
-- #6595: *"@chandracarney — **Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior.**"*
-- #6703: *"LGTM! @chandracarney do you want to take a look at this for final approval?"*
-- #6725: *"@chandracarney — you're up for a final a11y review."*
-- #6786: *"This looks good to me. **This touches modal code that was written previously.** ... Passing off to the a11y specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
+**Explicit two-key routing** (code review ≠ accessibility approval):
+- #6595: *"Code-wise this looks fine to me, but I'd like to defer to role:accessibility-specialist on the screen reader behavior."*
+- #6703: *"LGTM! role:accessibility-specialist do you want to take a look at this for final approval?"*
+- #6725: *"role:accessibility-specialist — you're up for a final accessibility review."*
+- #6786: *"This looks good to me. **This touches modal code that was written previously.** ... Passing off to role:accessibility-specialist to see if it makes sense for AT. If it looks good, go ahead and approve and merge. **It passes my review.**"*
 
 **A11y-content critique (code-reviewable, does not route):**
 
-An a11y specialist can judge whether the *text* of a screen reader hint is useful — distinct from judging AT *behavior*, which requires hands-on device testing. The distinction:
+An accessibility specialist can judge whether the *text* of a screen reader hint is useful — distinct from judging AT *behavior*, which requires hands-on device testing. The distinction:
 
 - **AT behavior** (route, don't conclude): does the AT announce it, in what order, with what voice mode? Needs real devices and a named test matrix.
-- **SR text content** (reviewable by an a11y specialist): is the text redundant with the element's role? Does it explain purpose or interaction, or just restate what AT already derives from markup semantics?
+- **SR text content** (reviewable by an accessibility specialist): is the text redundant with the element's role? Does it explain purpose or interaction, or just restate what AT already derives from markup semantics?
 
 Example (#6673): a range slider hint read *"slider"* — which AT users already know from the element's role announcement. The reviewer flagged that a more useful hint would explain *how to interact* (e.g., "use arrow keys to increase or decrease the value"), and noted that guidance on communicating `min`/`max`/`step` context belongs in the uswds-site component guidance — not as a code blocker, but as a follow-up issue. The approval went through once the immediate hint wording was addressed.
 
-**Voice for a11y-content findings:** Non-blocking flag. State what the current text says, why it's redundant or insufficient, suggest more useful text, and explicitly separate guidance-site follow-up from the approval gate: *"That recommendation doesn't interfere with this approval."*
+**Voice for accessibility-content findings:** Non-blocking flag. State what the current text says, why it's redundant or insufficient, suggest more useful text, and explicitly separate guidance-site follow-up from the approval gate: *"That recommendation doesn't interfere with this approval."*
 
 **Unblocks stale review states:**
-- #6611: *"@annepetersen — You had a previous change request, so this will need an approval from you as well if it looks good to you."*
+- #6611: *"role:product-lead — You had a change request, so this will need an approval from them as well if it looks good."*
 - #6660: *"If this is ready for review, please let me know or **click the 're-request' review button**."*
 
 ---
@@ -347,7 +345,7 @@ Example (#6673): a range slider hint read *"slider"* — which AT users already 
 
 Almost always bare APPROVED. Hygiene: `@dependabot rebase` / `@dependabot recreate`.
 
-**The one exception — the reusable artifact** (#6783, ethangardner):
+**The one exception — the reusable artifact** (#6783, engineering lead):
 > **AI-assisted review — OpenCode Agent**
 >
 > Verification transcript for Bump undici 7.28.0 → 7.29.0 (#6783):
@@ -366,7 +364,7 @@ Almost always bare APPROVED. Hygiene: `@dependabot rebase` / `@dependabot recrea
 ## Notes for the skill
 
 - **Match severity, not wording.** The corpus is anchors for *what gets blocked* and *what doesn't*, not templates to copy.
-- **ethangardner's three-move structure** is the canonical shape for a CHANGES_REQUESTED summary.
-- **mejiaj's Conventional Comments labels** are the right taxonomy for inline findings, because they're already in use.
+- **The engineering-lead three-move structure** is the canonical shape for a CHANGES_REQUESTED summary.
+- **The team's Conventional Comments labels** are the right taxonomy for inline findings, because they're already in use.
 - **The "I can approve once..." precondition** is the dominant mode for non-blocking findings — use it.
 - **Always close with the escape hatch:** *"Don't take any of this for absolute. It's all open for discussion."*

--- a/.agents/skills/uswds-code-review/references/gates.md
+++ b/.agents/skills/uswds-code-review/references/gates.md
@@ -8,7 +8,7 @@ This is the concrete enforcement layer. Each gate has a check, a disposition (bl
 
 **Disposition:** Flag only (advisory, not blocking)
 
-**Why advisory:** Zero "please split this up" reviews exist in the corpus, even on +12k/-14k PRs. The one precedent is mejiaj on #5793: *"Smaller PR's. Breaking out the work helps us reliably and quickly test one thing at a time."* Sampling the 60 most recent merged PRs: substantive work lands at +28 to +351 lines; everything over 400 is generated churn.
+**Why advisory:** Zero "please split this up" reviews exist in the corpus, even on +12k/-14k PRs. The one precedent is a senior engineer on #5793: *"Smaller PR's. Breaking out the work helps us reliably and quickly test one thing at a time."* Sampling the 60 most recent merged PRs: substantive work lands at +28 to +351 lines; everything over 400 is generated churn.
 
 **Check:**
 
@@ -92,7 +92,7 @@ gh issue view <issue_number> --repo uswds/uswds --json title,body,labels
    Feature template supplies:
    - *Describe the solution you'd like*
 
-2. **Scope creep** — diff includes Y, which the issue never mentioned. This is a live blocking category (#6673: *"Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the a11y improvement. If they are necessary, could you indicate why in the PR description?"*)
+2. **Scope creep** — diff includes Y, which the issue never mentioned. This is a live blocking category (#6673: *"Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the accessibility improvement. If they are necessary, could you indicate why in the PR description?"*)
 
 **Carve-outs:**
 - Follow-up improvements explicitly marked as such in the PR body
@@ -179,7 +179,7 @@ If the change introduces a pattern not covered by any Core-scoped ADR (e.g., a n
 
 **Disposition:** Blocking for new features and bug fixes
 
-**The sharp test** (ethangardner #6713): *"I noticed this test passes even on the base branch before this fix, which means it doesn't capture potential regressions."*
+**The sharp test** (senior engineer #6713): *"I noticed this test passes even on the base branch before this fix, which means it doesn't capture potential regressions."*
 
 **Executable check:**
 ```bash
@@ -243,7 +243,7 @@ All three are near-identical synthetic-event kits. Precedent: #6767 *"I think we
 **Examples:**
 - #6767: Inline `debounce` when `uswds-core` already has one
 - #6736: Added `box-sizing` to `select` when it should go in the `%block-input-styles` placeholder (affects all inputs, not just select)
-- #6592: Duplicate fix for `datalist` scenario when #6567 already handled it — ethangardner kept the test, discarded the duplicate fix
+- #6592: Duplicate fix for `datalist` scenario when #6567 already handled it — an engineering lead kept the test, discarded the duplicate fix
 
 **Check:**
 1. Does this JS/Sass introduce a helper that smells like it might already exist?
@@ -422,7 +422,7 @@ From `package.json` `exports` and observed practice:
 - Specificity increases (#6691 — even with `:where()`, it's "arguably a breaking change")
 - Default value flips (#6789)
 
-**Thisisdano's design-vs-code split** — carry this, don't collapse it (#6037):
+**The product lead's design-vs-code split** — carry this, don't collapse it (#6037):
 > "This one is probably technically a breaking change because of the UX and design implications — but it might be worth noting that I don't believe teams will have to make any changes _to their code_ to make this work, so **change does not introduce a breaking change on the code side**"
 
 **Check:**
@@ -436,7 +436,7 @@ From `package.json` `exports` and observed practice:
 > This changes [specificity / CSS output order / default value of `$theme-*` / markup structure / JS API]. Consider:
 > - **Design impact:** Does this change what users see, even if code doesn't break?
 > - **Code impact:** Do consuming teams need to update their implementation?
-> - Per thisisdano's distinction, these can differ.
+> - Per the product lead's distinction, these can differ.
 >
 > If breaking:
 > - [ ] PR body must pick ":warning: This is a breaking change." (not "not breaking")
@@ -478,7 +478,7 @@ Gate 16 has two distinct sub-gates with different dispositions. Apply both when 
 
 ### 16a. A11y content: SR text quality (flag-only, non-blocking)
 
-**Disposition:** Flag / non-blocking. An a11y specialist reviewer can make this judgment without live AT testing.
+**Disposition:** Flag / non-blocking. An accessibility specialist reviewer can make this judgment without live AT testing.
 
 **What this covers:** Whether the *text* of screen reader hints, `aria-label`s, and status messages is actually useful — distinct from whether the AT *announces* them (which requires hands-on testing, see 16b).
 
@@ -503,12 +503,12 @@ Gate 16 has two distinct sub-gates with different dispositions. Apply both when 
 
 ### 16b. AT behavior verdict: route to a specialist, don't conclude
 
-**Disposition:** Manual follow-up — route to an a11y specialist for hands-on AT verification. Never render a verdict on AT behavior from code review alone.
+**Disposition:** Manual follow-up — route to an accessibility specialist for hands-on AT verification. Never render a verdict on AT behavior from code review alone.
 
-**The routing rule** (ethangardner, documented practice):
+**The routing rule** (engineering lead, documented practice):
 > "Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior." (#6595)
 >
-> "It passes my review." (#6786, passing to the a11y specialist)
+> "It passes my review." (#6786, passing to role:accessibility-specialist)
 
 **What to flag:**
 - New interactive components or changes to focus behavior
@@ -517,7 +517,7 @@ Gate 16 has two distinct sub-gates with different dispositions. Apply both when 
 - Visual-only cues (color, icon-only without text alternative)
 - Form error messaging (must be programmatically associated)
 
-**The bar for a thorough a11y PR** (drawn from #6767, #6758, #6750): a well-scoped a11y change includes a named AT × browser matrix (e.g., VoiceOver + Safari/Chrome/Firefox, NVDA + Chrome), an explicit Limitations / not-in-scope section, a citation to ARIA Authoring Practices or ARIA spec where the pattern is non-obvious, and a statement of what was verified vs. what was pre-existing behavior ("not a regression from develop"). Flag if any of these are absent on a PR that makes substantive a11y claims.
+**The bar for a thorough accessibility PR** (drawn from #6767, #6758, #6750): a well-scoped accessibility change includes a named AT × browser matrix (e.g., VoiceOver + Safari/Chrome/Firefox, NVDA + Chrome), an explicit Limitations / not-in-scope section, a citation to ARIA Authoring Practices or ARIA spec where the pattern is non-obvious, and a statement of what was verified vs. what was pre-existing behavior ("not a regression from develop"). Flag if any of these are absent on a PR that makes substantive accessibility claims.
 
 **Voice:**
 > **Manual follow-up required: AT behavior verification**
@@ -531,13 +531,13 @@ Gate 16 has two distinct sub-gates with different dispositions. Apply both when 
 >
 > Code review: [note any code-level issues visible in the diff, e.g., missing `aria-describedby` wiring or an `aria-live` region that lacks a `role`. Explicitly state that the AT announcement behavior verdict is not within this review's scope.]
 
-**Mejiaj's testing pattern** (for reference, not always required):
+**Senior engineer's testing pattern** (for reference, not always required):
 > ### Tested
 > - [x] Dragging invalid file reads error message in VoiceOver (both Chrome & Safari)
 > - [x] Code quality
 >
 > MacOS Sonoma 14.6.1 / Chromium 131 / Safari 17.6 / VoiceOver
 
-**Engineering-values.md cite:** *"Make accessibility easier, not invisible."* The goal is to keep a11y testing visible and in the critical path, not to declare it handled at the code level.
+**Engineering-values.md cite:** *"Make accessibility easier, not invisible."* The goal is to keep accessibility testing visible and in the critical path, not to declare it handled at the code level.
 
 **Carve-out:** If the PR is docs-only, workflow-only, or dependency-only, skip this gate.

--- a/.agents/skills/uswds-code-review/references/gates.md
+++ b/.agents/skills/uswds-code-review/references/gates.md
@@ -11,6 +11,18 @@ This is the concrete enforcement layer. Each gate has a check, a disposition (bl
 **Why advisory:** Zero "please split this up" reviews exist in the corpus, even on +12k/-14k PRs. The one precedent is mejiaj on #5793: *"Smaller PR's. Breaking out the work helps us reliably and quickly test one thing at a time."* Sampling the 60 most recent merged PRs: substantive work lands at +28 to +351 lines; everything over 400 is generated churn.
 
 **Check:**
+
+Use the metrics script for a full breakdown:
+```bash
+# From a PR URL
+node .agents/skills/uswds-code-review/scripts/pr-metrics.mjs --pr https://github.com/uswds/uswds/pull/6767
+
+# From a local diff
+git diff develop...HEAD > changes.patch
+node .agents/skills/uswds-code-review/scripts/pr-metrics.mjs --diff changes.patch
+```
+
+Or manually count with:
 ```bash
 git diff -M --numstat develop...HEAD -- \
   'packages/**/src/**' 'src/**' 'tasks/**' \

--- a/.agents/skills/uswds-code-review/references/gates.md
+++ b/.agents/skills/uswds-code-review/references/gates.md
@@ -1,0 +1,499 @@
+# The 16 Gates — Runnable Checks and Carve-outs
+
+This is the concrete enforcement layer. Each gate has a check, a disposition (blocking / flag / manual follow-up), and its carve-outs grounded in observed practice.
+
+---
+
+## 1. Size: authored runtime + test code ≤400 lines
+
+**Disposition:** Flag only (advisory, not blocking)
+
+**Why advisory:** Zero "please split this up" reviews exist in the corpus, even on +12k/-14k PRs. The one precedent is mejiaj on #5793: *"Smaller PR's. Breaking out the work helps us reliably and quickly test one thing at a time."* Sampling the 60 most recent merged PRs: substantive work lands at +28 to +351 lines; everything over 400 is generated churn.
+
+**Check:**
+```bash
+git diff -M --numstat develop...HEAD -- \
+  'packages/**/src/**' 'src/**' 'tasks/**' \
+  ':(exclude)dist/**' ':(exclude)_site/**' ':(exclude)**/*.md' \
+  ':(exclude)package-lock.json' ':(exclude)COMMUNITY.md' \
+  ':(exclude)*.snap' ':(exclude)*.twig' \
+  | awk '{runtime+=$1} END {print runtime}'
+```
+
+**Carve-outs (suppress the flag and state why):**
+- **Releases** — `dist/` regeneration, `package-lock.json`, `COMMUNITY.md` contributor updates. Example: #6822 (+22340/-31152).
+- **Dependency upgrades** — Example: #6790 gulp v5, #6791 devDeps, #6782 minor versions, #6778 simplify deps.
+- **Mechanical transforms** — Single-transformation codemods applied across many files. Example: #6770 Sass `if()` syntax migration across 41 files (+423/-395).
+- **Storybook/tooling migrations** — Framework upgrades that touch config + stories. Example: #6715 Storybook 9 + Webpack→Vite (+8239/-8433).
+
+When flagging, always state the carve-out: "⚠️ Exceeds 400-line guideline, but this is **a release** (v3.14.0). Authored runtime changes: ~45 lines across 3 components."
+
+---
+
+## 2. Dependencies: new runtime dep must be explicitly called for
+
+**Disposition:** Blocking unless justified in issue or PR body
+
+**Context:** `dependencies` currently holds **exactly one** package: `lit@3.3.3` (for web components). 75 `devDependencies`. A new runtime dep is therefore glaring.
+
+**Check:**
+```bash
+# Compare package.json dependencies field against develop
+git show develop:package.json | jq -r '.dependencies | keys[]' | sort > /tmp/deps-base.txt
+jq -r '.dependencies | keys[]' package.json | sort > /tmp/deps-head.txt
+comm -13 /tmp/deps-base.txt /tmp/deps-head.txt  # new deps
+comm -23 /tmp/deps-base.txt /tmp/deps-head.txt  # removed deps
+```
+
+**What to verify:**
+1. **Is it in `dependencies` or `devDependencies`?** Only runtime-shipped code justifies `dependencies`.
+2. **Is it declared in the PR body?** The template has a commented-out *Dependency updates* table. If a dep is added, that section must be uncommented and filled.
+3. **Is the lockfile in sync?** CI runs `npm ci`, so `package-lock.json` must be committed and match.
+4. **Is a new import relying on a transitive dep?** (#6715: *"I'd like it to make sure it's also added to `package.json` as a `devDependency` to make sure we're not relying on a transitive dependency from Storybook."*)
+5. **Could an existing dep be reused?** (#6767: *"Sinon is already a project dependency."* Don't inline a new helper when one exists.)
+
+**Cite against:** Engineering-values.md *"Avoid lock-in... By keeping our reliance on dependencies as low as possible"*
+
+**Exception:** Dependabot PRs and bulk devDependency updates approved by core team.
+
+---
+
+## 3. Definition of done: issue acceptance criteria vs. actual diff
+
+**Disposition:** Blocking when unmet or exceeded
+
+**Check:**
+```bash
+# Extract issue number from PR body or commits
+gh pr view <N> --json body --jq '.body' | grep -oP 'Closes #\K\d+'
+# OR: git log develop..HEAD --oneline | grep -oP '#\K\d+' | head -1
+
+# Fetch the issue
+gh issue view <issue_number> --repo uswds/uswds --json title,body,labels
+```
+
+**Compare in both directions:**
+
+1. **Unmet criteria** — issue asks for X, diff doesn't deliver it. Bug template supplies:
+   - *Expected Behavior*
+   - *Steps to reproduce*
+   Feature template supplies:
+   - *Describe the solution you'd like*
+
+2. **Scope creep** — diff includes Y, which the issue never mentioned. This is a live blocking category (#6673: *"Would you mind rolling back the updates to package.json and package-lock.json that were included with this PR? They don't appear to be necessary for the a11y improvement. If they are necessary, could you indicate why in the PR description?"*)
+
+**Carve-outs:**
+- Follow-up improvements explicitly marked as such in the PR body
+- Dependency bumps needed to unblock the feature (if stated)
+- Test refactors that don't change behavior
+
+**Local branch mode:** Skip this gate and report `⏭️ skipped (no linked issue in local mode)`.
+
+---
+
+## 4. Existing pattern, or ADR justifying a new one
+
+**Disposition:** Blocking if duplicating a `uswds-core` utility; Hold if a new architectural pattern needs team decision
+
+**Check in three parts:**
+
+### 4a. Grep the core utilities inventory
+
+Before accepting any new JS helper, search:
+```bash
+find packages/uswds-core/src/js/utils -name '*.js' -exec basename {} .js \;
+```
+
+**The 15 core utils** (see `uswds-anchors.md` for full descriptions):
+`select`, `select-or-matches`, `behavior`, `focus-trap`, `keymap`, `active-element`, `debounce`, `toggle`, `toggle-form-input`, `toggle-field-mask`, `validate-input`, `is-in-viewport`, `is-ios-device`, `scrollbar-width`, `sanitizer`
+
+Plus `packages/uswds-core/src/js/events.js` (exports `CLICK`) and `config.js` (exports `prefix: "usa"`).
+
+**Blocking precedent:** #6767 reintroduced a `debounce` function when `packages/uswds-core/src/js/utils/debounce.js` already exists. *"We have `packages/uswds-core/src/js/utils/debounce.js` in the repo already. It was removed in this PR. Would it be possible to refactor the existing debounce function so we don't inline it here and have to maintain multiple implementations?"*
+
+Also: #6736 added a `box-sizing` line to `select` when it should have gone into the `%block-input-styles` mixin in `_forms.scss` — *"it might be better to put the line inside the `%block-input-styles` mixin directly... the `select` probably isn't the only place this is happening."*
+
+**If a genuinely new utility is needed and no core util exists:** non-blocking suggestion to extract it to `uswds-core/src/js/utils/` for reuse.
+
+### 4b. Check uswds-proposals ADRs — and resolve scope first
+
+Fetch the decision list:
+```bash
+gh api repos/uswds/uswds-proposals/git/trees/HEAD?recursive=1 \
+  --jq '.tree[] | select(.path | startswith("decisions/")) | .path'
+```
+
+**Critical:** Most ADRs govern **uswds-elements** (web components), not this repo (USWDS Core). The template has no *Applies to* field, so scope must be inferred from prose.
+
+**Current mapping** (as of August 2026, 11 ADRs):
+
+| Scope | ADRs |
+|---|---|
+| **uswds-elements** / web components | 0001 (use web components), 0002 (use lit), 0003 (don't use a monorepo), 0004 (link as HTML web component), 0006 (use TypeScript), 0007 (author styles in CSS), 0009 (use Lightning CSS) |
+| **USWDS Core** (this repo) | 0005 (continue Core, move toward semver) |
+| **Ambiguous** — confirm, don't assume | 0008 (JSON design tokens — no scope signal), 0010 (use Playwright), 0011 (custom Vite plugins) |
+
+**The Lightning CSS cautionary case:** `decisions/0009-use-lightning-css.md` is Approved *for Elements*; it never governed this repo. PR #6597 proposing Lightning CSS here was declined on Core-specific grounds: *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output... Shipping this safely would require a thorough audit and a major version bump."*
+
+**Rule:** Never cite an Elements ADR as authority for a Core change, in either direction. It is neither a green light nor a precedent.
+
+**If an ambiguous ADR (0008, 0010, 0011) seems relevant:** surface it as a `**question**` and ask for confirmation, don't assume.
+
+### 4c. When a new architectural pattern appears
+
+If the change introduces a pattern not covered by any Core-scoped ADR (e.g., a new build-tool abstraction, a module-loading convention, an i18n strategy), the disposition is **Hold**, not **Request changes**.
+
+**Why:** The proposals repo restricts formal proposals to core team members. All 11 existing `decisions/` entries are team-authored. So the ADR ask lands on the **core team, not the contributor**.
+
+**Response template:**
+
+> ⏸️ **Hold** — pending core team architectural decision
+>
+> This introduces [describe the pattern: what it is, why it's new, what precedent it breaks or extends]. The proposals repo has no Core-scoped ADR covering this approach yet. Per team practice (#6738 i18n, #6681 range-slider layout), a decision of this scope requires:
+> 1. Core team discussion (likely in a dev sync or Slack thread)
+> 2. A new `decisions/0012-*.md` ADR in uswds/uswds-proposals, scoped to **USWDS Core**
+> 3. Reopen this PR once the ADR moves to Approved status
+>
+> The code implementation looks solid; the hold is purely on the architectural choice, not the execution.
+
+**Precedents:**
+- #6738 (data-* i18n strings): *"I think we need to have some discussion about pros and cons of this approach and weigh its merits against other approaches like providing i18n hooks and a translation files... I'm going to close this PR for now... If this is the approach we end up deciding on, we'll reopen the PR and give this a full review."*
+- #6650 (tokens as CSS custom props): *"We have some of the token work started in the `uswds/uswds-elements` repo... we're using style dictionary as the source of truth, and this is on our roadmap."* (redirected to Elements)
+- #6681 (range-slider layout): *"I think we (the USWDS team) needs to revisit this overall layout... For the time being, I do want to hold off on any further review of this until we have the discussion internally."*
+
+---
+
+## 5. Test coverage: must fail on the base branch
+
+**Disposition:** Blocking for new features and bug fixes
+
+**The sharp test** (ethangardner #6713): *"I noticed this test passes even on the base branch before this fix, which means it doesn't capture potential regressions."*
+
+**Executable check:**
+```bash
+# Apply only the test files onto develop
+git switch --detach develop
+git checkout <branch> -- packages/<pkg>/src/test/<name>.spec.js
+
+# Run the test
+npx mocha --require jsdom-global/register packages/<pkg>/src/test/<name>.spec.js
+
+# Expected: FAIL. If it passes, it's not a regression test.
+git switch -  # return to original branch
+```
+
+**What to verify:**
+1. Do new tests actually test the change? Not just "is there a test file," but "does this test fail on base?"
+2. Are edge cases covered? (Null, empty, boundary values, error paths)
+3. Are tests clear about what they verify? (Test names describe the assertion)
+4. Do tests avoid brittle coupling to implementation? (Don't assert internal state unless necessary)
+
+**Sass tests:** Any `@if/@else` branching on a `$theme-*` setting needs `sass-true` coverage. Precedent: #6789 *"I added a good deal of test coverage for branching logic in `*.spec.js` files using the `sass-true` package, and I think it would be good to do the same here for the branching logic."*
+
+**Carve-outs** (observed consistently):
+- Docs-only changes
+- Workflow / CI config changes
+- Dependency bumps (unless they change API behavior)
+- Storybook config / story additions (test the component itself, not the story metadata)
+
+---
+
+## 6. DRY tests: 3+ locations → extract a helper
+
+**Disposition:** Non-blocking until threshold is met; then blocking
+
+**The threshold:** If setup/helper code is duplicated in **3 or more** test files, extract it to a shared helper. Below that, leave it alone.
+
+**Evidence from the repo:**
+
+**At/over threshold (extract):**
+- `packages/usa-combo-box/src/test/events.js`
+- `packages/usa-date-picker/src/test/events.js`
+- `packages/usa-date-range-picker/src/test/events.js`
+
+All three are near-identical synthetic-event kits. Precedent: #6767 *"I think we can DRY them out some if you extract the timeout part to a helper."* #6168: *"This is repeated in several tests, why not move it to it's own function? Could be named `addFiles()`"*
+
+**Under threshold (leave alone):**
+- The `matchMedia` / `matchFinePointer` stub duplicated in `packages/usa-file-input/src/test/file-input.spec.js` and `file-input-accepts.spec.js` (2 locations only).
+
+**Also cite:** The canonical `tests.forEach([document.body, componentRoot])` dual-initialization pattern is DRY-ish but not extracted — it's a table-driven idiom that works inline.
+
+**Teardown inconsistency worth a rule:** some specs use `body.innerHTML = ""`, others `body.textContent = ""`. This is internal test code (doesn't affect consumers), so flag as a `**thought (non-blocking)**: "For clarity, we might standardize teardown on one (`textContent` is slightly more explicit). Not urgent."
+
+---
+
+## 7. Duplication: check if existing functionality is being reinvented
+
+**Disposition:** Blocking
+
+**Context:** Closely related to gate 4a (core utils), but broader — includes Sass mixins, helper functions, and patterns.
+
+**Examples:**
+- #6767: Inline `debounce` when `uswds-core` already has one
+- #6736: Added `box-sizing` to `select` when it should go in the `%block-input-styles` placeholder (affects all inputs, not just select)
+- #6592: Duplicate fix for `datalist` scenario when #6567 already handled it — ethangardner kept the test, discarded the duplicate fix
+
+**Check:**
+1. Does this JS/Sass introduce a helper that smells like it might already exist?
+2. Grep the repo for similar names or functionality
+3. Read `uswds-anchors.md` section on "Reusable utilities" for the full inventory
+
+**If duplication is found:** Blocking. Suggest using the existing one, or if the new one is better, suggest replacing the old one repo-wide (but that's a separate PR).
+
+---
+
+## 8. Simplification pass: dispatch a subagent
+
+**Disposition:** Non-blocking by nature (this is a quality pass)
+
+**Mechanism:** Dispatch the existing `code-simplification` skill as a subagent, with an explicit filter.
+
+```
+Agent({
+  subagent_type: "code-simplification",
+  description: "Readability simplification pass on changed files",
+  prompt: `Run the code-simplification skill on the following files: [list]. Filter: report **only** rewrites a newcomer would understand faster. Discard anything clever, anything that changes behavior, and anything that's a pure style preference. Focus on: deeply nested conditionals, imperative loops that could be `map`/`filter`/`for...of`, unclear variable names, missing "why" comments on non-obvious logic.`
+})
+```
+
+**Grounding precedents:**
+- #6122: *"The nested logic can be confusing or hard to follow. Consider another approach that's a bit more readable... the general idea is isolating unique use cases, avoid nesting logic, and general improvements to readability."* (with a full rewrite using early returns)
+- #6203: *"Can we avoid these types of loops? For clarity, we can improve it by using other methods, like `map()`, `every()`, or `for…of`, if appropriate."*
+- #6203: *"A switch statement might be a better fit here."*
+- #6122: *"Can you add a brief comment describing the use case? The function is named `inputValueMatches`, but only the select option is passed, not the input."*
+
+**Voice for these findings:** Always `**polish**` or `**suggestion (non-blocking)**`, with the escape hatch that readable code is the goal, not fewer lines.
+
+---
+
+## 9. Error handling: guards, fallbacks, teardown symmetry
+
+**Disposition:** Blocking when absent in brittle areas
+
+**What to check:**
+
+### Guard non-Event input
+#6594: *"Would you mind adding an additional check for `!(event instanceof KeyboardEvent)` to the other two conditions?"*
+
+### Fall back when a platform API is unavailable
+#6660 (matchMedia): *"This means if `matchMedia` is unavailable for any reason, the component falls back to the simple 'Choose from folder' state rather than showing drag instructions that may never work. The baseline is always the safe mobile state, and drag text is added on top for fine-pointer devices."*
+
+### Early return on falsy
+#6703: *"Before, the code in the conditional beginning at L142 did not execute if the `openFocusEl` was falsy. Just doublechecking that the rest of the code should execute if `openFocusEl` does not exist. I'm wondering if there should be an early return statement here."*
+
+### @warn on unrecognized Sass setting values
+#6789: *"In the `@else` branches in this file, I think it would be good to add a `@warn` if the `$side` value is not `end` and that we're executing a fallback. That will help people catch typos in their config."*
+
+### A setting must not break the build when overridden
+#5624: Setting `$theme-header-min-width: "none"` → `CssSyntaxError`. Tests must exercise the settings with various values.
+
+### Teardown symmetry
+#6660: *"This event listener would also need to be removed when the component is unmounted (i.e. in the `teardown` function)."*
+
+Every listener added in `init` or component lifecycle must be removed in `teardown`. Applies to `addEventListener`, `matchMedia` change listeners, mutation observers, etc.
+
+**Voice:** These are blocking when the absence is a real correctness bug (throws on valid input, leaks listeners). Non-blocking when it's defensive hardening on an unlikely edge case.
+
+---
+
+## 10. Sanitization: `Sanitizer.escapeHTML` for innerHTML with interpolation
+
+**Disposition:** Blocking (security)
+
+**The rule:** Any `innerHTML` or `insertAdjacentHTML` call that interpolates user data or external content must use the `` Sanitizer.escapeHTML`...` `` tagged template from `packages/uswds-core/src/js/utils/sanitizer.js`.
+
+**Why it's load-bearing:** ESLint has `no-unsanitized/method` and `no-unsanitized/property` set to `error`, **but both are disabled for `**/*.spec.js`**. So lint is not a safety net — the reviewer must read production `index.js` directly.
+
+**Check:**
+```bash
+# Find innerHTML/insertAdjacentHTML in changed production files
+git diff develop...HEAD -- 'packages/*/src/index.js' 'packages/*/src/*.js' ':(exclude)**/*.spec.js' \
+  | grep -E 'innerHTML|insertAdjacentHTML'
+```
+
+**Precedents:**
+- `packages/usa-file-input/src/index.js:397,400,463`
+- `packages/usa-combo-box/src/index.js:236,245`
+- `packages/usa-table/src/index.js:197`
+- `packages/usa-in-page-navigation/src/index.js:273`
+- `packages/usa-date-picker/src/index.js` (multiple uses)
+
+**What `Sanitizer.escapeHTML` does:** It's a *tagged template* that escapes only interpolated values (`& < > " ' /` → entities), leaving static HTML intact. `null`/`undefined` → `""`. Contract is tested in `packages/uswds-core/src/js/utils/test/sanitizer.spec.js`.
+
+**Voice:** Blocking. Cite the security rationale and the existing precedents. Offer a code block with the fix.
+
+---
+
+## 11. Code is modular: "Support repairability"
+
+**Disposition:** Non-blocking (architectural quality)
+
+**Cite:** Engineering-values.md *"Support repairability. We want teams to have the ability to repair and improve our work — first for their project, but hopefully also later for an improvement we can incorporate."*
+
+**What to flag:**
+- Functions/components that are >100 lines and do multiple unrelated things
+- Deeply coupled code where changing one part requires changing three others
+- Hard-coded values that should be extracted to settings or constants
+- Logic that could be broken into smaller, testable pieces
+
+**Voice:** `**suggestion (non-blocking)**: "This function handles both X and Y. Consider splitting into two so teams can override just the part they need."` or `**thought**: "This might be a candidate for extracting to a separate module if we see other components needing similar logic."`
+
+---
+
+## 12. Input is sanitized, validated, and escaped
+
+**Disposition:** Blocking at system boundaries
+
+**Context:** Overlaps with gate 10 (sanitization) but broader — covers validation and type guards.
+
+**What to check:**
+1. **At component boundaries:** Does the JS read `data-*` attributes or query params and trust them blindly?
+2. **Type guards:** Are string inputs checked before being passed to functions that expect specific formats? (e.g., dates, numbers, enum values)
+3. **Sass functions:** Do they return meaningful errors for invalid tokens via `error-not-token()`, or silently pass garbage through?
+
+**Precedent:** The `validate-input.js` utility (data-attribute-driven validation against a checklist) is the established pattern for form-input validation. If a component introduces its own validation, it should follow similar conventions.
+
+**Voice:** Blocking if absence allows incorrect or unsafe behavior. Non-blocking if it's defensive hardening on unlikely input.
+
+---
+
+## 13. New API surface: flag for manual follow-up
+
+**Disposition:** Manual follow-up (not blocking, but must be completed before merge)
+
+**What counts as API surface in this repo:**
+
+From `package.json` `exports` and observed practice:
+1. **Every component's `src/index.js`** is public (via `"./js/*"` → `./packages/*/src/index.js`)
+2. **Every package's `_index.scss`** is public (via `"./scss/*"`)
+3. **`$theme-*` settings** — names, defaults, accepted token vocabulary are all API
+4. **Sass functions/mixins** forwarded through `packages/uswds-core/src/styles/functions/_index.scss` or `mixins/_index.scss`
+5. **Twig template variable names** — consumed by webpack
+6. **CSS class names** derived from `prefix: "usa"` (e.g., `.usa-accordion__button`)
+7. **`data-*` attributes** defined as constants in `packages/*/src/index.js` (~30 exist)
+
+**The 6-file ripple for a new `$theme-*` setting** (verified against #6789):
+1. `packages/uswds-core/src/styles/settings/_settings-components.scss` — add the setting
+2. `packages/usa-<component>/src/styles/_usa-<component>.scss` — consume it (often via a new mixin)
+3. `packages/usa-<component>/src/content/usa-<component>~<variant>.json` — new story fixture
+4. `packages/usa-<component>/src/content/index.js` — export the fixture
+5. `packages/usa-<component>/src/usa-<component>.stories.js` — new named export
+6. `packages/uswds-core/src/styles/_notifications.scss` — release note entry
+
+**Plus:** SASSDoc (#5713, #6268 — this is a requirement, not optional), `@warn` fallback (#6789), and a **uswds-site docs PR** for settings/usage documentation.
+
+**Check:** If the diff adds a `$theme-*` variable, a new `data-*` attribute, a new public mixin/function, or changes CSS class names / markup, flag it.
+
+**Voice:**
+> **Manual follow-up required: new API surface**
+>
+> This adds `$theme-<component>-<prop>` (or `data-<name>`, or `.usa-<class>`). Before merge:
+> - [ ] SASSDoc annotations for any new mixins/functions (required, not optional)
+> - [ ] `@warn` fallback for unrecognized setting values (helps consumers catch typos)
+> - [ ] `_notifications.scss` entry for the release this ships in
+> - [ ] Companion PR to uswds-site for settings docs (link once filed)
+> - [ ] Storybook story showing usage (if a new variant)
+
+---
+
+## 14. Breaking changes: flag for classification, don't conclude
+
+**Disposition:** Manual follow-up
+
+**Repo definition** (from `.github/PULL_REQUEST_TEMPLATE.md`):
+- Changes to the JavaScript API
+- Changes to markup or content in components
+- Significant changes to a component's display
+
+**Corpus additions** (from observed reviews):
+- Built-CSS source order (#6566)
+- Specificity increases (#6691 — even with `:where()`, it's "arguably a breaking change")
+- Default value flips (#6789)
+
+**Thisisdano's design-vs-code split** — carry this, don't collapse it (#6037):
+> "This one is probably technically a breaking change because of the UX and design implications — but it might be worth noting that I don't believe teams will have to make any changes _to their code_ to make this work, so **change does not introduce a breaking change on the code side**"
+
+**Check:**
+1. Does the PR body declare breaking-change status? (Template requires picking one of three options)
+2. If it says "not breaking," does the diff actually change API, markup, CSS output, or defaults?
+3. If it says "breaking," is remediation guidance included?
+
+**Voice:**
+> **Manual follow-up required: breaking-change classification**
+>
+> This changes [specificity / CSS output order / default value of `$theme-*` / markup structure / JS API]. Consider:
+> - **Design impact:** Does this change what users see, even if code doesn't break?
+> - **Code impact:** Do consuming teams need to update their implementation?
+> - Per thisisdano's distinction, these can differ.
+>
+> If breaking:
+> - [ ] PR body must pick ":warning: This is a breaking change." (not "not breaking")
+> - [ ] Remediation steps must be included (what actions are required to upgrade?)
+> - [ ] `_notifications.scss` entry must describe the break
+> - [ ] Major version bump on next release (per ADR 0005 move toward semver)
+
+---
+
+## 15. New variants or changes in defaults: flag for manual follow-up
+
+**Disposition:** Manual follow-up
+
+**Context:** Closely related to gates 13 (API surface) and 14 (breaking changes), but specifically about component variants and defaults.
+
+**What to flag:**
+- A new modifier class (e.g., `.usa-accordion--bordered` → `.usa-accordion--borderless`)
+- A new `$theme-*` setting that changes component behavior by default
+- A flip in what the unstyled / no-class state does
+
+**Why manual follow-up:** These are design-system decisions, not just code correctness. They need review for: naming consistency with other components, whether it fits the design-system's principles, whether the default serves the common case.
+
+**Voice:**
+> **Manual follow-up required: new variant / default change**
+>
+> This introduces [describe the variant or default flip]. Before merge:
+> - [ ] Naming consistent with other USWDS component variants?
+> - [ ] Does the new default serve the common case, or should it be opt-in?
+> - [ ] Storybook story demonstrating the variant?
+> - [ ] uswds-site guidance on when to use / when not to use?
+
+---
+
+## 16. Accessibility: flag for specialist review, don't conclude
+
+**Disposition:** Manual follow-up (never blocking on code-reviewer's judgment alone)
+
+**The routing rule** (ethangardner, documented practice):
+> "Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior." (#6595)
+>
+> "It passes my review." (#6786, handing off to @jonathanbobel)
+
+**What to flag:**
+- New interactive components or changes to focus behavior
+- Changes to ARIA attributes (`aria-label`, `aria-describedby`, `aria-live`, etc.)
+- SR-only text (`usa-sr-only` class, `aria-label` on icons)
+- Changes that affect keyboard navigation (tab order, focus trap, Escape handling)
+- Visual-only cues (color, icon-only without text alternative)
+- Form error messaging (must be programmatically associated)
+
+**Voice:**
+> **Manual follow-up required: accessibility verification**
+>
+> This changes [focus behavior / ARIA wiring / SR announcements / keyboard nav]. Manual testing needed:
+> - [ ] Test with NVDA + [describe scenario, e.g. "drag-drop error message on invalid file"]
+> - [ ] Test with VoiceOver + Safari [describe scenario]
+> - [ ] Test with VoiceOver + Chrome [describe scenario, if behavior differs]
+> - [ ] Verify in forced-colors mode (Windows high-contrast)
+> - [ ] Keyboard-only navigation (tab, shift-tab, arrow keys, escape, enter)
+>
+> Code review: [note any code-level issues, like missing `aria-describedby` wiring, but explicitly state that AT behavior verdict is not within this review's scope].
+
+**Mejiaj's testing pattern** (for reference, not always required):
+> ### Tested
+> - [x] Dragging invalid file reads error message in VoiceOver (both Chrome & Safari)
+> - [x] Code quality
+>
+> MacOS Sonoma 14.6.1 / Chromium 131 / Safari 17.6 / VoiceOver
+
+**Engineering-values.md cite:** *"Make accessibility easier, not invisible."* The goal is to keep a11y testing visible and in the critical path, not to declare it handled at the code level.
+
+**Carve-out:** If the PR is docs-only, workflow-only, or dependency-only, skip this gate.

--- a/.agents/skills/uswds-code-review/references/gates.md
+++ b/.agents/skills/uswds-code-review/references/gates.md
@@ -139,11 +139,11 @@ gh api repos/uswds/uswds-proposals/git/trees/HEAD?recursive=1 \
 
 **Current mapping** (as of August 2026, 11 ADRs):
 
-| Scope | ADRs |
-|---|---|
-| **uswds-elements** / web components | 0001 (use web components), 0002 (use lit), 0003 (don't use a monorepo), 0004 (link as HTML web component), 0006 (use TypeScript), 0007 (author styles in CSS), 0009 (use Lightning CSS) |
-| **USWDS Core** (this repo) | 0005 (continue Core, move toward semver) |
-| **Ambiguous** — confirm, don't assume | 0008 (JSON design tokens — no scope signal), 0010 (use Playwright), 0011 (custom Vite plugins) |
+| Scope                                 | ADRs                                                                                                                                                                                    |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **uswds-elements** / web components   | 0001 (use web components), 0002 (use lit), 0003 (don't use a monorepo), 0004 (link as HTML web component), 0006 (use TypeScript), 0007 (author styles in CSS), 0009 (use Lightning CSS) |
+| **USWDS Core** (this repo)            | 0005 (continue Core, move toward semver)                                                                                                                                                |
+| **Ambiguous** — confirm, don't assume | 0008 (JSON design tokens — no scope signal), 0010 (use Playwright), 0011 (custom Vite plugins)                                                                                          |
 
 **The Lightning CSS cautionary case:** `decisions/0009-use-lightning-css.md` is Approved *for Elements*; it never governed this repo. PR #6597 proposing Lightning CSS here was declined on Core-specific grounds: *"adopting Lightning CSS introduces some significant changes to how CSS properties are ordered in the built output... Shipping this safely would require a thorough audit and a major version bump."*
 
@@ -457,7 +457,7 @@ From `package.json` `exports` and observed practice:
 - A new `$theme-*` setting that changes component behavior by default
 - A flip in what the unstyled / no-class state does
 
-**Why manual follow-up:** These are design-system decisions, not just code correctness. They need review for: naming consistency with other components, whether it fits the design-system's principles, whether the default serves the common case.
+**Why manual follow-up:** These are design system decisions, not just code correctness. They need review for: naming consistency with other components, whether it fits the design system's principles, whether the default serves the common case.
 
 **Voice:**
 > **Manual follow-up required: new variant / default change**

--- a/.agents/skills/uswds-code-review/references/gates.md
+++ b/.agents/skills/uswds-code-review/references/gates.md
@@ -470,34 +470,66 @@ From `package.json` `exports` and observed practice:
 
 ---
 
-## 16. Accessibility: flag for specialist review, don't conclude
+## 16. Accessibility
 
-**Disposition:** Manual follow-up (never blocking on code-reviewer's judgment alone)
+Gate 16 has two distinct sub-gates with different dispositions. Apply both when a PR touches interactive behavior, ARIA, SR text, focus, or keyboard nav.
+
+---
+
+### 16a. A11y content: SR text quality (flag-only, non-blocking)
+
+**Disposition:** Flag / non-blocking. An a11y specialist reviewer can make this judgment without live AT testing.
+
+**What this covers:** Whether the *text* of screen reader hints, `aria-label`s, and status messages is actually useful — distinct from whether the AT *announces* them (which requires hands-on testing, see 16b).
+
+**Flag when:**
+- An `aria-label` or hint text restates the element's role, which AT users already receive from the semantic markup (e.g., a slider hint that says "slider")
+- A status message or error text does not explain purpose, expected values, or how to interact — just describes what users already know
+- Interaction guidance (how to operate the control: keys, gestures, value range) is missing from a non-obvious component
+- Content that should inform *developer guidance* on uswds-site is baked directly into a component string rather than left to the implementer
+
+**Precedent (#6673):** A range slider hint read "slider" — AT users already know the role. The reviewer flagged that a more useful hint would explain interaction ("use arrow keys to increase or decrease the value"), and noted that guidance on communicating `min`/`max`/`step` belongs in the uswds-site component docs — not as a code blocker but as a follow-up issue. The PR was approved once the immediate hint wording was improved.
+
+**Voice:**
+> **`**polish**` (non-blocking): SR text content**
+>
+> The current hint/label says `"[text]"`. AT users will already know [role / property] from the element's semantics. A more useful message would explain [purpose / interaction / range]. For example: `"[suggested text]"`.
+>
+> Separately, guidance on when developers should customize this (e.g., communicating `min`/`max`/`step` values for range inputs) may be worth a follow-up issue for the uswds-site component docs. That doesn't affect this approval.
+
+**Carve-out:** Do not flag SR text that is a correct ARIA pattern even if brief (e.g., `aria-label="Close"` on an `×` button is correct — the verb is the guidance). The failure mode is redundancy with role or absence of interaction guidance on a non-obvious control, not brevity.
+
+---
+
+### 16b. AT behavior verdict: route to a specialist, don't conclude
+
+**Disposition:** Manual follow-up — route to an a11y specialist for hands-on AT verification. Never render a verdict on AT behavior from code review alone.
 
 **The routing rule** (ethangardner, documented practice):
 > "Code-wise this looks fine to me, but I'd like to defer to you on the screen reader behavior." (#6595)
 >
-> "It passes my review." (#6786, handing off to @jonathanbobel)
+> "It passes my review." (#6786, passing to the a11y specialist)
 
 **What to flag:**
 - New interactive components or changes to focus behavior
 - Changes to ARIA attributes (`aria-label`, `aria-describedby`, `aria-live`, etc.)
-- SR-only text (`usa-sr-only` class, `aria-label` on icons)
 - Changes that affect keyboard navigation (tab order, focus trap, Escape handling)
 - Visual-only cues (color, icon-only without text alternative)
 - Form error messaging (must be programmatically associated)
 
+**The bar for a thorough a11y PR** (drawn from #6767, #6758, #6750): a well-scoped a11y change includes a named AT × browser matrix (e.g., VoiceOver + Safari/Chrome/Firefox, NVDA + Chrome), an explicit Limitations / not-in-scope section, a citation to ARIA Authoring Practices or ARIA spec where the pattern is non-obvious, and a statement of what was verified vs. what was pre-existing behavior ("not a regression from develop"). Flag if any of these are absent on a PR that makes substantive a11y claims.
+
 **Voice:**
-> **Manual follow-up required: accessibility verification**
+> **Manual follow-up required: AT behavior verification**
 >
-> This changes [focus behavior / ARIA wiring / SR announcements / keyboard nav]. Manual testing needed:
-> - [ ] Test with NVDA + [describe scenario, e.g. "drag-drop error message on invalid file"]
-> - [ ] Test with VoiceOver + Safari [describe scenario]
-> - [ ] Test with VoiceOver + Chrome [describe scenario, if behavior differs]
-> - [ ] Verify in forced-colors mode (Windows high-contrast)
+> This changes [focus behavior / ARIA wiring / SR announcements / keyboard nav]. Requires hands-on testing before merge:
+> - [ ] Test with NVDA + Chrome — [describe scenario]
+> - [ ] Test with VoiceOver + Safari — [describe scenario]
+> - [ ] Test with VoiceOver + Chrome — [describe scenario, if behavior may differ]
+> - [ ] Verify in forced-colors / Windows high-contrast mode
 > - [ ] Keyboard-only navigation (tab, shift-tab, arrow keys, escape, enter)
 >
-> Code review: [note any code-level issues, like missing `aria-describedby` wiring, but explicitly state that AT behavior verdict is not within this review's scope].
+> Code review: [note any code-level issues visible in the diff, e.g., missing `aria-describedby` wiring or an `aria-live` region that lacks a `role`. Explicitly state that the AT announcement behavior verdict is not within this review's scope.]
 
 **Mejiaj's testing pattern** (for reference, not always required):
 > ### Tested

--- a/.agents/skills/uswds-code-review/references/uswds-anchors.md
+++ b/.agents/skills/uswds-code-review/references/uswds-anchors.md
@@ -10,23 +10,23 @@ This file is the concrete data layer: inventories, conventions, and verifiable f
 
 All are CommonJS `module.exports`. Before accepting any new helper, grep this list.
 
-| File | What it does |
-|---|---|
-| `select.js` | `select(selector, context)` → real Array of matches; returns `[]` for non-string. **The only file under repo-wide typecheck** (`tsconfig.json` `include`). |
-| `select-or-matches.js` | Same as `select` but also includes `context` itself if it matches. |
-| `behavior.js` | The component lifecycle/event-delegation factory. Returns `{ on, add, off, remove, ...props }` with `init`/`teardown` hooks. Custom implementation that replaced `receptor`. |
-| `focus-trap.js` | Tab/Shift-Tab wrapping inside a container; owns the `FOCUSABLE` selector constant. Built on `keymap` + `behavior` + `select` + `active-element`. |
-| `keymap.js` | Maps key-combo strings → handlers, returns one keydown handler; guards non-`KeyboardEvent` input. |
-| `active-element.js` | One-liner `(htmlDocument = document) => htmlDocument.activeElement` (indirection for testability). |
-| `debounce.js` | `debounce(cb, delay = 500)`; returned fn has `.cancel()`. |
-| `toggle.js` | Flips `aria-expanded` on a button and `hidden` on its `aria-controls` target; shadow-DOM aware via `getRootNode()`; throws if target missing. |
-| `toggle-form-input.js` | "Show/Hide" password-style toggling; `aria-pressed`, `data-show-text`/`data-hide-text`, `resolveIdRefs`. |
-| `toggle-field-mask.js` | Swaps input `type` password↔text plus `autocapitalize`/`autocorrect` off. |
-| `validate-input.js` | Data-attribute-driven validation (`data-validation-element`, `data-validate*`, `data-validation-status`) against a `usa-checklist`. |
-| `is-in-viewport.js` | `getBoundingClientRect` viewport containment test. |
-| `is-ios-device.js` | UA/`maxTouchPoints` iOS detection. |
-| `scrollbar-width.js` | Measures scrollbar width by transient offscreen divs. |
-| `sanitizer.js` | **The HTML-escaping helper.** `Sanitizer.escapeHTML` is a *tagged template* that escapes only interpolated values (`& < > " ' /` → entities), leaving static parts intact; `null`/`undefined` → `""`. Derived from Mozilla Gaia's SafeInnerHTML. |
+| File                   | What it does                                                                                                                                                                                                                                     |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `select.js`            | `select(selector, context)` → real Array of matches; returns `[]` for non-string. **The only file under repo-wide typecheck** (`tsconfig.json` `include`).                                                                                       |
+| `select-or-matches.js` | Same as `select` but also includes `context` itself if it matches.                                                                                                                                                                               |
+| `behavior.js`          | The component lifecycle/event-delegation factory. Returns `{ on, add, off, remove, ...props }` with `init`/`teardown` hooks. Custom implementation that replaced `receptor`.                                                                     |
+| `focus-trap.js`        | Tab/Shift-Tab wrapping inside a container; owns the `FOCUSABLE` selector constant. Built on `keymap` + `behavior` + `select` + `active-element`.                                                                                                 |
+| `keymap.js`            | Maps key-combo strings → handlers, returns one keydown handler; guards non-`KeyboardEvent` input.                                                                                                                                                |
+| `active-element.js`    | One-liner `(htmlDocument = document) => htmlDocument.activeElement` (indirection for testability).                                                                                                                                               |
+| `debounce.js`          | `debounce(cb, delay = 500)`; returned fn has `.cancel()`.                                                                                                                                                                                        |
+| `toggle.js`            | Flips `aria-expanded` on a button and `hidden` on its `aria-controls` target; shadow-DOM aware via `getRootNode()`; throws if target missing.                                                                                                    |
+| `toggle-form-input.js` | "Show/Hide" password-style toggling; `aria-pressed`, `data-show-text`/`data-hide-text`, `resolveIdRefs`.                                                                                                                                         |
+| `toggle-field-mask.js` | Swaps input `type` password↔text plus `autocapitalize`/`autocorrect` off.                                                                                                                                                                        |
+| `validate-input.js`    | Data-attribute-driven validation (`data-validation-element`, `data-validate*`, `data-validation-status`) against a `usa-checklist`.                                                                                                              |
+| `is-in-viewport.js`    | `getBoundingClientRect` viewport containment test.                                                                                                                                                                                               |
+| `is-ios-device.js`     | UA/`maxTouchPoints` iOS detection.                                                                                                                                                                                                               |
+| `scrollbar-width.js`   | Measures scrollbar width by transient offscreen divs.                                                                                                                                                                                            |
+| `sanitizer.js`         | **The HTML-escaping helper.** `Sanitizer.escapeHTML` is a *tagged template* that escapes only interpolated values (`& < > " ' /` → entities), leaving static parts intact; `null`/`undefined` → `""`. Derived from Mozilla Gaia's SafeInnerHTML. |
 
 **Also core:**
 - `packages/uswds-core/src/js/events.js` — Exports `{ CLICK: "click" }`. Components import `CLICK` from here, never hardcode.
@@ -40,15 +40,15 @@ All are CommonJS `module.exports`. Before accepting any new helper, grep this li
 
 All in `packages/uswds-core/src/styles/functions/` (barrel: `_index.scss`):
 
-| Function | What it does | Location |
-|---|---|---|
-| `units()` | Spacing token → rem; returns `error-not-token()` for invalid input. | `functions/units/units.scss` |
-| `color()` | Color token → hex; the main themeable-color interface. | `functions/utilities/color.scss` |
-| `next-token()` | Move within a color scale (e.g., `"darker"`, `"lighter"`). | `functions/color/` |
-| `font()` | Font-family token → stack. | `functions/font/` |
-| `get-font-stack()` | Lower-level font helper. | `functions/font/` |
-| `get-typeface-token()` | Validates typeface tokens. | `functions/font/` |
-| Plus ~20 more | `cap-height`, `normalize-type-scale`, `is-color-token`, `magic-number`, `wcag-magic-number`, `set-theme-color`, `get-link-tokens-from-bg`, `calculate-grade`, `px-to-rem`, `rem-to-px`, `spacing-multiple` | `functions/` subdirs |
+| Function               | What it does                                                                                                                                                                                               | Location                         |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
+| `units()`              | Spacing token → rem; returns `error-not-token()` for invalid input.                                                                                                                                        | `functions/units/units.scss`     |
+| `color()`              | Color token → hex; the main themeable-color interface.                                                                                                                                                     | `functions/utilities/color.scss` |
+| `next-token()`         | Move within a color scale (e.g., `"darker"`, `"lighter"`).                                                                                                                                                 | `functions/color/`               |
+| `font()`               | Font-family token → stack.                                                                                                                                                                                 | `functions/font/`                |
+| `get-font-stack()`     | Lower-level font helper.                                                                                                                                                                                   | `functions/font/`                |
+| `get-typeface-token()` | Validates typeface tokens.                                                                                                                                                                                 | `functions/font/`                |
+| Plus ~20 more          | `cap-height`, `normalize-type-scale`, `is-color-token`, `magic-number`, `wcag-magic-number`, `set-theme-color`, `get-link-tokens-from-bg`, `calculate-grade`, `px-to-rem`, `rem-to-px`, `spacing-multiple` | `functions/` subdirs             |
 
 **Error convention:** Invalid tokens go through `functions/general/error-not-token.scss` / `error.scss`, which return an error *string* under `$error-output-override` so Sass-True can assert them.
 
@@ -56,14 +56,14 @@ All in `packages/uswds-core/src/styles/functions/` (barrel: `_index.scss`):
 
 **Location:** `packages/uswds-core/src/styles/settings/` (barrel: `_index.scss`)
 
-| File | Lines | Covers |
-|---|---|---|
-| `_settings-general.scss` | 120 | Project-wide (`$theme-show-compile-warnings`, `$theme-namespace`, `$theme-image-path`) |
-| `_settings-typography.scss` | 433 | Fonts, type scale, measure, leading (`$theme-font-*`, `$theme-typeface-tokens`, `$theme-type-scale-*`) |
-| `_settings-color.scss` | 149 | Theme colors, state colors, grade assignments (`$theme-color-*`, `$theme-link-*`) |
-| `_settings-components.scss` | 226 | **All `$theme-<component>-*` settings, alphabetical by component.** This is where new component settings go. |
-| `_settings-spacing.scss` | 90 | Vertical rhythm, grid gaps (`$theme-column-gap`, `$theme-grid-container-max-width`, `$theme-site-margins-width`) |
-| `_settings-utilities.scss` | 1102 | Utility-class generation control (`$*-settings`, `$*-palettes`) |
+| File                        | Lines | Covers                                                                                                           |
+|-----------------------------|-------|------------------------------------------------------------------------------------------------------------------|
+| `_settings-general.scss`    | 120   | Project-wide (`$theme-show-compile-warnings`, `$theme-namespace`, `$theme-image-path`)                           |
+| `_settings-typography.scss` | 433   | Fonts, type scale, measure, leading (`$theme-font-*`, `$theme-typeface-tokens`, `$theme-type-scale-*`)           |
+| `_settings-color.scss`      | 149   | Theme colors, state colors, grade assignments (`$theme-color-*`, `$theme-link-*`)                                |
+| `_settings-components.scss` | 226   | **All `$theme-<component>-*` settings, alphabetical by component.** This is where new component settings go.     |
+| `_settings-spacing.scss`    | 90    | Vertical rhythm, grid gaps (`$theme-column-gap`, `$theme-grid-container-max-width`, `$theme-site-margins-width`) |
+| `_settings-utilities.scss`  | 1102  | Utility-class generation control (`$*-settings`, `$*-palettes`)                                                  |
 
 **Naming:** All settings are `$theme-*` or `$output-*`, declared with `!default`. Values are **token strings or spacing numbers**, not CSS values: `"base-lightest"`, `"body"`, `0.5`, `"start"`, or the literal `default`.
 

--- a/.agents/skills/uswds-code-review/references/uswds-anchors.md
+++ b/.agents/skills/uswds-code-review/references/uswds-anchors.md
@@ -1,0 +1,408 @@
+# USWDS Anchors — Lookup Tables for Gate Checks
+
+This file is the concrete data layer: inventories, conventions, and verifiable facts about the repo that gates 4–16 reference.
+
+---
+
+## Reusable utilities (`uswds-core`) — gate 4a / 7
+
+**Location:** `packages/uswds-core/src/js/utils/`
+
+All are CommonJS `module.exports`. Before accepting any new helper, grep this list.
+
+| File | What it does |
+|---|---|
+| `select.js` | `select(selector, context)` → real Array of matches; returns `[]` for non-string. **The only file under repo-wide typecheck** (`tsconfig.json` `include`). |
+| `select-or-matches.js` | Same as `select` but also includes `context` itself if it matches. |
+| `behavior.js` | The component lifecycle/event-delegation factory. Returns `{ on, add, off, remove, ...props }` with `init`/`teardown` hooks. Custom implementation that replaced `receptor`. |
+| `focus-trap.js` | Tab/Shift-Tab wrapping inside a container; owns the `FOCUSABLE` selector constant. Built on `keymap` + `behavior` + `select` + `active-element`. |
+| `keymap.js` | Maps key-combo strings → handlers, returns one keydown handler; guards non-`KeyboardEvent` input. |
+| `active-element.js` | One-liner `(htmlDocument = document) => htmlDocument.activeElement` (indirection for testability). |
+| `debounce.js` | `debounce(cb, delay = 500)`; returned fn has `.cancel()`. |
+| `toggle.js` | Flips `aria-expanded` on a button and `hidden` on its `aria-controls` target; shadow-DOM aware via `getRootNode()`; throws if target missing. |
+| `toggle-form-input.js` | "Show/Hide" password-style toggling; `aria-pressed`, `data-show-text`/`data-hide-text`, `resolveIdRefs`. |
+| `toggle-field-mask.js` | Swaps input `type` password↔text plus `autocapitalize`/`autocorrect` off. |
+| `validate-input.js` | Data-attribute-driven validation (`data-validation-element`, `data-validate*`, `data-validation-status`) against a `usa-checklist`. |
+| `is-in-viewport.js` | `getBoundingClientRect` viewport containment test. |
+| `is-ios-device.js` | UA/`maxTouchPoints` iOS detection. |
+| `scrollbar-width.js` | Measures scrollbar width by transient offscreen divs. |
+| `sanitizer.js` | **The HTML-escaping helper.** `Sanitizer.escapeHTML` is a *tagged template* that escapes only interpolated values (`& < > " ' /` → entities), leaving static parts intact; `null`/`undefined` → `""`. Derived from Mozilla Gaia's SafeInnerHTML. |
+
+**Also core:**
+- `packages/uswds-core/src/js/events.js` — Exports `{ CLICK: "click" }`. Components import `CLICK` from here, never hardcode.
+- `packages/uswds-core/src/js/config.js` — Exports `{ prefix: "usa" }`. All class-name constants must be built from `PREFIX`, e.g. `` `.${PREFIX}-accordion__button` ``.
+
+---
+
+## Sass token functions and settings — gates 4a, 9, 10, 13
+
+### Token functions
+
+All in `packages/uswds-core/src/styles/functions/` (barrel: `_index.scss`):
+
+| Function | What it does | Location |
+|---|---|---|
+| `units()` | Spacing token → rem; returns `error-not-token()` for invalid input. | `functions/units/units.scss` |
+| `color()` | Color token → hex; the main themeable-color interface. | `functions/utilities/color.scss` |
+| `next-token()` | Move within a color scale (e.g., `"darker"`, `"lighter"`). | `functions/color/` |
+| `font()` | Font-family token → stack. | `functions/font/` |
+| `get-font-stack()` | Lower-level font helper. | `functions/font/` |
+| `get-typeface-token()` | Validates typeface tokens. | `functions/font/` |
+| Plus ~20 more | `cap-height`, `normalize-type-scale`, `is-color-token`, `magic-number`, `wcag-magic-number`, `set-theme-color`, `get-link-tokens-from-bg`, `calculate-grade`, `px-to-rem`, `rem-to-px`, `spacing-multiple` | `functions/` subdirs |
+
+**Error convention:** Invalid tokens go through `functions/general/error-not-token.scss` / `error.scss`, which return an error *string* under `$error-output-override` so Sass-True can assert them.
+
+### Settings files
+
+**Location:** `packages/uswds-core/src/styles/settings/` (barrel: `_index.scss`)
+
+| File | Lines | Covers |
+|---|---|---|
+| `_settings-general.scss` | 120 | Project-wide (`$theme-show-compile-warnings`, `$theme-namespace`, `$theme-image-path`) |
+| `_settings-typography.scss` | 433 | Fonts, type scale, measure, leading (`$theme-font-*`, `$theme-typeface-tokens`, `$theme-type-scale-*`) |
+| `_settings-color.scss` | 149 | Theme colors, state colors, grade assignments (`$theme-color-*`, `$theme-link-*`) |
+| `_settings-components.scss` | 226 | **All `$theme-<component>-*` settings, alphabetical by component.** This is where new component settings go. |
+| `_settings-spacing.scss` | 90 | Vertical rhythm, grid gaps (`$theme-column-gap`, `$theme-grid-container-max-width`, `$theme-site-margins-width`) |
+| `_settings-utilities.scss` | 1102 | Utility-class generation control (`$*-settings`, `$*-palettes`) |
+
+**Naming:** All settings are `$theme-*` or `$output-*`, declared with `!default`. Values are **token strings or spacing numbers**, not CSS values: `"base-lightest"`, `"body"`, `0.5`, `"start"`, or the literal `default`.
+
+**Example component block** (`_settings-components.scss:20-26`, accordion):
+```scss
+$theme-accordion-background-color:       default !default;
+$theme-accordion-border-color:           "base-lighter" !default;
+$theme-accordion-border-width:           0.5 !default;
+$theme-accordion-button-background-color: default !default;
+$theme-accordion-font-family:            "body" !default;
+$theme-accordion-icon-position:          "start" !default;
+```
+
+### Consumption pattern
+
+Every component stylesheet opens with `@use "uswds-core" as *;` then uses token functions, never raw values. Canonical from `packages/usa-accordion/src/styles/_usa-accordion.scss`:
+```scss
+$accordion-border: units($theme-accordion-border-width) solid color($theme-accordion-border-color);
+$accordion-button-background-active-color: next-token($theme-accordion-button-background-color, "darker");
+```
+
+**Convention** (observed, #6659):
+- Store the **raw value** in a variable: `$-range-border-width: 2px;`
+- Apply the function at **usage**: `border-width: units($-range-border-width);`
+- Do **not** store the result: ~~`$-range-border: units(2px);`~~
+- Private variables use a leading dash: `$-range-border-width`
+- Or skip the variable and use the function directly with the theme token
+
+---
+
+## Public API surface — gate 13
+
+From `package.json` `exports` and observed conventions:
+
+### 1. JS component API
+
+**Entry:** `packages/uswds-core/src/js/index.js` exports 22 named behaviors: `accordion`, `banner`, `button`, `characterCount`, `comboBox`, `datePicker`, `dateRangePicker`, `fileInput`, `footer`, `inPageNavigation`, `inputMask`, `languageSelector`, `modal`, `navigation`, `password`, `rangeSlider`, `search`, `skipnav`, `table`, `timePicker`, `tooltip`, `validator`.
+
+Each is a `behavior()` return value, so the public shape is:
+- `on(context)` / `off(context)` — mount/unmount
+- `add(el)` / `remove(el)` — instance add/remove
+- **Plus** whatever component-specific `props` the component spreads (e.g., accordion's `show`/`hide`/`toggle`)
+
+**Global side effects** (`packages/uswds-core/src/js/start.js`):
+- `window.uswdsPresent = "USWDS present"`
+- `window.uswds = { components }`
+- `exports.initComponents()`
+
+### 2. Shared JS utils
+
+Reachable via `"./uswds-core/*"` export, so `packages/uswds-core/src/js/utils/*` is effectively public too.
+
+### 3. Sass settings
+
+`packages/uswds-core/src/styles/settings/_settings-*.scss` — every `$theme-*` name, default value, and accepted token vocabulary is public API.
+
+### 4. Sass functions/mixins/placeholders
+
+- `packages/uswds-core/src/styles/functions/**` (forwarded through `functions/_index.scss`)
+- `packages/uswds-core/src/styles/mixins/**` (forwarded through `mixins/_index.scss`)
+- `packages/uswds-core/src/styles/placeholders/**`
+- Component-level mixins forwarded through `packages/<pkg>/src/styles/_index.scss`
+- Top-level barrel: `packages/uswds/_index.scss`
+
+### 5. Twig templates
+
+`packages/<pkg>/src/usa-<pkg>.twig` + `packages/templates/**` page templates. Their **variable names** are API for consumers using `webpack.twig.config.js`.
+
+Example variable names (seen in corpus): `items`, `modifier`, `id_prefix`, `multiselectable`, `data`, `label`, `classes`, `heading`, `content`.
+
+### 6. CSS class names
+
+Derived from `prefix: "usa"` (in `config.js`) and asserted in both JS and Sass. Changing class names or markup is explicitly a breaking change per the PR template.
+
+Examples: `.usa-accordion__button`, `.usa-banner__header`, `.usa-button`, `.usa-input`, `.usa-sr-only`.
+
+### 7. `data-*` attributes
+
+The JS-facing config API, defined as constants in each `packages/*/src/index.js`. Full inventory (~30):
+
+`data-allow-multiple`, `data-classes`, `data-close-modal`, `data-day`, `data-focus`, `data-force-action`, `data-heading-elements`, `data-label`, `data-mask`, `data-maxlength`, `data-modal-hidden`, `data-month`, `data-nav-hidden`, `data-open-modal`, `data-opener`, `data-original-*`, `data-placeholder`, `data-placeholder-for`, `data-position`, `data-sort-active`, `data-sort-value`, `data-sortable`, `data-tag`, `data-text-preposition`, `data-text-unit`, `data-validation-element`, `data-validation-incomplete`, `data-validation-status`, `data-value`, `data-year`.
+
+### 8. Deprecation / notification channel
+
+`packages/uswds-core/src/styles/_notifications.scss` — per-version "Teams should…" entries printed at compile time.
+
+---
+
+## Test conventions — gates 5, 6
+
+### Test runner / config
+
+- **Mocha**, not Jest/Vitest.
+- **Config:** `packages/uswds-core/src/js/utils/test/.mocharc.json` (the real path; `package.json` `"mocha": {"config": "src/utils/test/.mocharc.json"}` is stale and points to a non-existent location).
+- **Environment:** `jsdom-global/register` (browser-ish).
+- **Discovery globs** (from `tasks/test.js`): `packages/usa-*/**/*.spec.js` + `packages/uswds-*/**/*.spec.js`, explicitly excluding the two Sass-True entry specs.
+
+### File naming
+
+- **JS specs:** `<feature>.spec.js` colocated in `packages/<pkg>/src/test/`.
+- **Fixtures:** Either `template.html` (single-fixture components: accordion, modal, file-input) or `<spec-name>.template.html` 1:1 with the spec (combo-box, date-picker, character-count).
+- **Negative paths:** `invalid-template-*` prefix. Examples: `invalid-template-no-select.spec.js`, `invalid-template-no-wrapper.spec.js`, `invalid-template-no-input.spec.js`.
+- **Storybook visual test patterns:** `packages/<pkg>/src/test/test-patterns/*.twig` (16 packages have these).
+
+### Fixture loading idiom
+
+Two spellings, both current:
+```js
+const TEMPLATE = fs.readFileSync(`${__dirname}/template.html`);
+// OR
+fs.readFileSync(path.join(__dirname, "/combo-box.template.html"))
+```
+
+### The canonical setup/teardown (from `usa-accordion/src/test/accordion.spec.js`)
+
+```js
+const tests = [
+  { name: "document.body", selector: () => document.body },
+  { name: "accordion",     selector: accordionSelector },
+];
+tests.forEach(({ name, selector: containerSelector }) => {
+  describe(`... initialized at ${name}`, () => {
+    const { body } = document;
+    let root; /* ...let per element... */
+    beforeEach(() => {
+      body.innerHTML = TEMPLATE;
+      Component.on(containerSelector());
+      /* query refs */
+    });
+    afterEach(() => {
+      Component.off(containerSelector());
+      body.innerHTML = "";  // or body.textContent = ""
+    });
+    // tests...
+  });
+});
+```
+
+**Teardown inconsistency:** Some specs use `body.innerHTML = ""`, others `body.textContent = ""`. Worth a non-blocking note.
+
+### Sass tests (`sass-true`)
+
+**Driver pattern** (9 lines, verbatim from `packages/usa-accordion/src/test/accordion-icon.spec.js`):
+```js
+const path = require("path");
+const sassTrue = require("sass-true");
+const sass = require("sass-embedded");
+
+const SASS = path.join(__dirname, "accordion-icon.spec.scss");
+
+describe("Accordion icon mixin", () => {
+  sassTrue.runSass({ describe, it, sass }, SASS, { loadPaths: ["./packages", "."] });
+});
+```
+
+**Spec file** (`accordion-icon.spec.scss`):
+```scss
+@use "uswds-core" with ($theme-show-notifications: false);
+@import "node_modules/sass-true/sass/true";
+
+@include describe("u-icon-position()") {
+  @include it("outputs icon-start styles when passed 'start'") {
+    @include assert {
+      @include output {
+        @include u-icon-position("start");
+      }
+      @include expect {
+        /* expected CSS */
+      }
+    }
+  }
+}
+```
+
+**Error-path tests** assert on the **string** returned by `error-not-token()`, gated by `$error-output-override`.
+
+---
+
+## CI gates — gate verification, gate 10 context
+
+**Primary gate:** `.circleci/config.yml` → single `build` job on `cimg/node:24.16.0-browsers`:
+
+```
+npm install
+→ npx playwright install
+→ Snyk scan (snyk/snyk@1.1.2 orb, org `uswds`)
+→ npm run test:ci
+→ npm run prettier:check
+```
+
+**`test:ci` is:**
+```
+npm run lint (eslint packages/ + gulp lintSass/stylelint)
+→ gulp test (series: typeCheck, lintSass, sassTests, unitTests, tasksTests)
+→ npm run test:a11y (Storybook build to _site, http-server :6006, test-storybook = Playwright + axe)
+→ npm run build:html (webpack twig → prettier)
+```
+
+**So the gates are:** eslint (incl. `no-unsanitized`), stylelint/Sass lint, tsc typecheck, sass-true tests, mocha unit tests, tasks tests, Storybook a11y/axe, twig HTML build, prettier formatting, Snyk.
+
+**Typecheck caveat:** `tsconfig.json` `include` is **only** `packages/uswds-core/src/js/utils/select.js`. `gulp typecheck` is essentially a no-op for new code. Good thing to flag.
+
+**Other workflows:**
+- `.github/workflows/codeql-analysis.yml` — CodeQL on push to main/develop, PRs, weekly cron
+- `.github/workflows/verify-commit-signatures.yml` — rejects unsigned commits
+- `.github/workflows/build-diff.yml` — `workflow_dispatch` only; diffs `dist/` of PR vs develop
+- `.github/workflows/release-prep.yml` — manual, release-branch only; builds tarball, records vuln counts
+- `.github/workflows/release.yml` — on `v*.*.*` tag; OIDC npm publish; gates on critical vulns and SHA-256 tarball match
+- `.github/workflows/contributors.yml` — nightly, rewrites `COMMUNITY.md`
+- `.github/workflows/verify-documentation-links.yml` — weekly markdown link check
+
+**Note:** `COMMUNITY.md` is bot-maintained; `AGENTS.md` says don't edit it unless asked.
+
+---
+
+## ESLint rules — gate 10 context
+
+From `eslint.config.mjs`:
+
+**Security rules (always `error`):**
+- `no-unsanitized/method` — ❌ **but disabled for `**/*.spec.js`** ❌
+- `no-unsanitized/property` — ❌ **but disabled for `**/*.spec.js`** ❌
+- `no-implied-eval`
+- `no-new-func`
+- `no-extend-native`
+- `no-new-wrappers`
+
+**Style/bug rules to cite:**
+- `no-var` — ban `var`
+- `prefer-const`
+- `eqeqeq` (null-ignored)
+- `no-param-reassign` (`props: false`)
+- `no-shadow`
+- `no-plusplus` (loop afterthought allowed)
+- `no-underscore-dangle` (warn)
+- `import/no-extraneous-dependencies` (devDeps allowed)
+- `import/no-unresolved`
+
+`eslint-config-prettier` is last (no formatting rules). `lit` flat/recommended is first (web components).
+
+---
+
+## Dependencies — gate 2 context
+
+**`dependencies` (runtime): exactly one.**
+- `lit@3.3.3` (web components)
+
+**`devDependencies` (75):** See `package.json` for full list. Notable:
+- `sinon@22.1.0` — already a project dependency (cite when someone hand-rolls timing helpers)
+- `sass-true@10.1.0` — for Sass testing
+- `playwright` / `axe-playwright` — a11y testing
+- `prettier`, `eslint`, `stylelint`
+- `gulp@5.0.1`, `vite@^6.4.3`, `webpack@5.109.2`
+
+**Version-pinning:** Mixed. Most build/test tooling is exactly pinned; newer additions use `^`. `overrides: { "nwsapi": "2.2.13" }`.
+
+**`.snyk`** exists at `/home/egardner/devspace/uswds/.snyk` but every `ignore:` entry references packages no longer in `package.json` with `expires` dates in March 2021 (all expired). Dead config.
+
+**Files that change when a dependency is added:**
+1. `package.json` (`dependencies` vs `devDependencies`)
+2. `package-lock.json` (CI runs `npm ci`, must be in sync)
+3. PR body's *Dependency updates* table (uncomment the section)
+4. `.snyk` (if a Snyk finding must be waived — rare)
+
+---
+
+## PR template — gate 3, 13, 14 context
+
+**Location:** `.github/PULL_REQUEST_TEMPLATE.md`
+
+**Required sections:**
+
+### Title format
+`USWDS - [Package]: [Brief statement]`
+
+### Body sections
+
+1. **Summary** — One or two sentences, past tense, benefit statement. *"A successful summary is written in the past tense and includes: **A benefit statement.** A description of the update."*
+2. **Breaking change** — must pick **exactly one**:
+   - "This is not a breaking change."
+   - ":warning: This is potentially a breaking change."
+   - ":warning: This is a breaking change."
+
+   Definition given: **changes to the JavaScript API, changes to markup or content in components, significant changes to a component's display**. If breaking, explain remediation.
+
+3. **Related issue** — `Closes #[issue_no]`. *"Every pull request should resolve an open issue."*
+4. **Related pull requests** — Note companion `uswds-site` PRs for component/settings docs and changelog entries.
+5. **Preview link**
+6. **Problem statement** — must convey *desired state, actual state, consequences of inaction*.
+7. **Solution** — what, why this approach, how, limitations/alternatives.
+8. **Major changes** — list for complex PRs.
+9. **Testing and review** — tests run, repro instructions, type of feedback wanted.
+10. **Dependency updates** (commented out) — `| Dependency name | Previous version | New version |` table; uncomment when deps change.
+
+**Commented-out definition-of-done checklist:**
+- Follows 18F Front End Coding Style Guide + 18F Accessibility Guide checklist
+- `git pull origin [base branch]` (usually `develop`) and resolve conflicts
+- `npm run prettier:sass` for Sass changes
+- `npm test` passes
+- Run through HTML_CodeSniffer, error free
+
+**Also states:** All commits must have a **verified signature** (GPG or SSH).
+
+---
+
+## Issue templates — gate 3 context
+
+### Bug report (`.github/ISSUE_TEMPLATE/bug_report.yaml`)
+
+**Title:** `USWDS - Bug: [YOUR TITLE]`
+
+**Fields (required unless noted):**
+- *Describe the bug* (req)
+- *Steps to reproduce* (req)
+- *Expected Behavior* (req)
+- *Related code* (opt)
+- *Screenshots* (opt)
+- *System setup* (opt; USWDS version/device/OS/browser+version)
+- *Additional context* (opt)
+- Code-of-Conduct checkboxes (both req: agree to CoC, checked existing issues for duplicates)
+
+### Feature request (`.github/ISSUE_TEMPLATE/feature_request.yaml`)
+
+**Title:** `USWDS - Feature: [YOUR TITLE]`
+
+**Fields (required unless noted):**
+- *Is your feature request related to a problem?* (req)
+- *Describe the solution you'd like* (req)
+- *Describe alternatives you've considered* (opt)
+- *Additional context* (opt)
+- Same two CoC checkboxes (req)
+
+---
+
+## Notes
+
+- **Browser support policy:** Node 24 (`.nvmrc`, CI). Browsers: see `npx browserslist` output; IE11 / pre-Chromium Edge are explicitly out of support (#6660).
+- **Base branch:** `develop` (not `main`). PRs target `develop`. `main`/`library--main` trigger npm publish; don't push there.
+- **Commit signatures:** All commits must be GPG/SSH verified; unsigned are rejected by `verify-commit-signatures.yml`. Sign before committing.
+- **Prettier:** `{}` (defaults), `.prettierignore`. 2-space indent, LF line endings (`.editorconfig`).
+- **`dist/` is generated:** Never edit. `gulp cleanDist` clears. Review path is byte-identical verification, not line-by-line diff.
+- **Storybook:** Lives at `:6006` locally (`npm start`). Built to `_site/` for a11y testing and deployed to Federalist previews at non-root paths (affects asset resolution).

--- a/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
+++ b/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
@@ -16,100 +16,120 @@
  *     gh pr diff 123 > changes.patch
  */
 
-import { readFileSync } from 'fs';
-import { spawn } from 'child_process';
-import { createInterface } from 'readline';
-
-// --- file classification ------------------------------------------------------
+import { readFileSync } from "fs";
+import { spawn } from "child_process";
+import { createInterface } from "readline";
 
 function getFilename(path) {
-  return path.split('/').pop();
+  return path.split("/").pop();
 }
 
 function hasExtension(path, extensions) {
-  return extensions.some(ext => path.endsWith(ext));
+  return extensions.some((ext) => path.endsWith(ext));
 }
 
 function inDirectory(path, directories) {
-  return directories.some(dir =>
-    path.includes(`/${dir}/`) || path.startsWith(`${dir}/`)
+  return directories.some(
+    (dir) => path.includes(`/${dir}/`) || path.startsWith(`${dir}/`),
   );
 }
 
-function matchesPattern(path, pattern) {
-  if (typeof pattern === 'string') {
-    return path.includes(pattern);
-  }
-  return pattern.test(path);
-}
-
 const CLASSIFIERS = {
-  lock: (path) => hasExtension(path, [
-    'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
-    'Cargo.lock', 'poetry.lock', 'Gemfile.lock',
-    'composer.lock', 'go.sum'
-  ]),
+  lock: (path) =>
+    hasExtension(path, ["package-lock.json", "yarn.lock", "pnpm-lock.yaml"]),
 
   manifest: (path) => {
     const filename = getFilename(path);
-    if (['package.json', 'Cargo.toml', 'go.mod', 'Gemfile', 'composer.json', 'pyproject.toml'].includes(filename)) {
-      return true;
-    }
-    return /^requirements[^/]*\.txt$/.test(filename) || /^build\.gradle/.test(filename);
+    return filename === "package.json";
   },
 
   test: (path) => {
     const filename = getFilename(path);
-    return inDirectory(path, ['test', 'tests', 'spec', 'specs', '__tests__', '__mocks__', 'e2e', 'cypress']) ||
-           /[._-](spec|test)\.[a-z]+$/.test(filename) ||
-           filename === 'conftest.py' ||
-           (/^test_/.test(filename) && filename.endsWith('.py'));
+    return (
+      inDirectory(path, [
+        "test",
+        "tests",
+        "spec",
+        "specs",
+        "__tests__",
+        "__mocks__",
+        "e2e",
+      ]) || /[._-](spec|test)\.[a-z]+$/.test(filename)
+    );
   },
 
   story: (path) => {
     const filename = getFilename(path);
-    return /\.stories\.[a-z]+$/.test(filename) ||
-           inDirectory(path, ['stories']) ||
-           filename.endsWith('.mdx');
+    return (
+      /\.stories\.[a-z]+$/.test(filename) ||
+      inDirectory(path, ["stories"]) ||
+      filename.endsWith(".mdx")
+    );
   },
 
-  ci: (path) =>
-    inDirectory(path, ['.github', '.circleci']) ||
-    hasExtension(path, ['.gitlab-ci.yml', 'Jenkinsfile', 'azure-pipelines.yml']),
+  ci: (path) => inDirectory(path, [".github", ".circleci"]),
 
   doc: (path) => {
     const filename = getFilename(path);
-    const docFiles = ['CHANGELOG', 'LICENSE', 'CODEOWNERS', 'AUTHORS', 'NOTICE'];
-    return hasExtension(path, ['.md', '.markdown', '.rst', '.txt', '.adoc']) ||
-           inDirectory(path, ['doc', 'docs']) ||
-           docFiles.some(name => filename.startsWith(name));
+    const docFiles = [
+      "CHANGELOG",
+      "LICENSE",
+      "CODEOWNERS",
+      "AUTHORS",
+      "NOTICE",
+    ];
+    return (
+      hasExtension(path, [".md", ".markdown", ".txt"]) ||
+      inDirectory(path, ["doc", "docs"]) ||
+      docFiles.some((name) => filename.startsWith(name))
+    );
   },
 
-  asset: (path) => hasExtension(path, [
-    '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
-    '.woff', '.woff2', '.ttf', '.eot', '.mp4', '.pdf', '.zip'
-  ]),
+  asset: (path) =>
+    hasExtension(path, [
+      ".svg",
+      ".png",
+      ".jpg",
+      ".jpeg",
+      ".gif",
+      ".ico",
+      ".webp",
+      ".woff",
+      ".woff2",
+      ".ttf",
+      ".eot",
+      ".mp4",
+      ".pdf",
+      ".zip",
+    ]),
 
   config: (path) => {
     const filename = getFilename(path);
-    const configNames = ['.eslintrc', '.prettierrc', '.editorconfig', '.gitignore', '.npmrc', '.nvmrc', '.babelrc'];
-    return configNames.some(name =>
-      filename === name || filename.startsWith(`${name}.`)
+    const configNames = [
+      ".eslintrc",
+      ".prettierrc",
+      ".editorconfig",
+      ".gitignore",
+      ".npmrc",
+      ".nvmrc",
+      ".babelrc",
+    ];
+    return configNames.some(
+      (name) => filename === name || filename.startsWith(`${name}.`),
     );
   },
 };
 
-const NON_BUDGET = new Set(['lock', 'test', 'story', 'doc', 'asset', 'ci', 'manifest', 'config']);
-
 const DEP_LINE = /^[+-]\s*"([^"]+)"\s*:\s*"([^"]*)"/;
-const DEP_SECTION = /"(dependencies|devDependencies|peerDependencies|optionalDependencies)"\s*:/;
+const DEP_SECTION =
+  /"(dependencies|devDependencies|peerDependencies|optionalDependencies)"\s*:/;
 const PKG_MANAGER = /"(packageManager|workspaces|resolutions|overrides)"\s*:/;
 
 function classify(path) {
   for (const [name, classifier] of Object.entries(CLASSIFIERS)) {
     if (classifier(path)) return name;
   }
-  return 'runtime';
+  return "runtime";
 }
 
 async function fetchPRDiff(url) {
@@ -122,25 +142,40 @@ async function fetchPRDiff(url) {
 
   // Try gh CLI first
   try {
-    const diff = await exec('gh', ['pr', 'diff', num, '--repo', `${owner}/${repo}`], { timeout: 90000 });
+    const diff = await exec(
+      "gh",
+      ["pr", "diff", num, "--repo", `${owner}/${repo}`],
+      { timeout: 90000 },
+    );
     if (diff.trim()) return diff;
-  } catch (err) {
+  } catch {
     // fall through to API
   }
-  const headers = ['-H', 'Accept: application/vnd.github.v3.diff'];
+  const headers = ["-H", "Accept: application/vnd.github.v3.diff"];
   if (process.env.GITHUB_TOKEN) {
-    headers.push('-H', `Authorization: Bearer ${process.env.GITHUB_TOKEN}`);
+    headers.push("-H", `Authorization: Bearer ${process.env.GITHUB_TOKEN}`);
   }
   try {
-    const diff = await exec('curl', ['-sL', '--max-time', '90', ...headers,
-      `https://api.github.com/repos/${owner}/${repo}/pulls/${num}`], { timeout: 95000 });
-    if (!diff.trim() || diff.trimStart().startsWith('{')) {
-      console.error('Could not fetch the diff. Install the `gh` CLI, set GITHUB_TOKEN, or pass a local diff with --diff.');
+    const diff = await exec(
+      "curl",
+      [
+        "-sL",
+        "--max-time",
+        "90",
+        ...headers,
+        `https://api.github.com/repos/${owner}/${repo}/pulls/${num}`,
+      ],
+      { timeout: 95000 },
+    );
+    if (!diff.trim() || diff.trimStart().startsWith("{")) {
+      console.error(
+        "Could not fetch the diff. Install the `gh` CLI, set GITHUB_TOKEN, or pass a local diff with --diff.",
+      );
       process.exit(1);
     }
     return diff;
   } catch (err) {
-    console.error('Failed to fetch diff:', err.message);
+    console.error("Failed to fetch diff:", err.message);
     process.exit(1);
   }
 }
@@ -148,12 +183,18 @@ async function fetchPRDiff(url) {
 async function exec(cmd, args, opts = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn(cmd, args, { timeout: opts.timeout });
-    let stdout = '', stderr = '';
-    proc.stdout?.on('data', d => stdout += d);
-    proc.stderr?.on('data', d => stderr += d);
-    proc.on('error', reject);
-    proc.on('close', code => {
-      if (code !== 0 && code !== null) reject(new Error(`${cmd} exited ${code}: ${stderr}`));
+    let stdout = "",
+      stderr = "";
+    proc.stdout?.on("data", (d) => {
+      stdout += d;
+    });
+    proc.stderr?.on("data", (d) => {
+      stderr += d;
+    });
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      if (code !== 0 && code !== null)
+        reject(new Error(`${cmd} exited ${code}: ${stderr}`));
       else resolve(stdout);
     });
   });
@@ -165,50 +206,63 @@ async function readStdin() {
   for await (const line of rl) {
     lines.push(line);
   }
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 function parseDiff(text) {
   const files = {};
-  const addedDeps = {}, removedDeps = {}, managerChanges = [];
-  let currentFile = null, inManifest = false;
+  const addedDeps = {},
+    removedDeps = {},
+    managerChanges = [];
+  let currentFile = null,
+    inManifest = false;
 
-  for (const line of text.split('\n')) {
+  for (const line of text.split("\n")) {
     const diffMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
     if (diffMatch) {
       currentFile = diffMatch[2];
       files[currentFile] = { add: 0, del: 0, kind: classify(currentFile) };
-      inManifest = files[currentFile].kind === 'manifest';
+      inManifest = files[currentFile].kind === "manifest";
       continue;
     }
 
     if (currentFile === null) continue;
-    if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('@@') ||
-        line.startsWith('index ') || line.startsWith('similarity ') ||
-        line.startsWith('rename ') || line.startsWith('new file') ||
-        line.startsWith('deleted file') || line.startsWith('old mode') ||
-        line.startsWith('new mode') || line.startsWith('Binary files')) {
+    if (
+      line.startsWith("+++") ||
+      line.startsWith("---") ||
+      line.startsWith("@@") ||
+      line.startsWith("index ") ||
+      line.startsWith("similarity ") ||
+      line.startsWith("rename ") ||
+      line.startsWith("new file") ||
+      line.startsWith("deleted file") ||
+      line.startsWith("old mode") ||
+      line.startsWith("new mode") ||
+      line.startsWith("Binary files")
+    ) {
       continue;
     }
 
-    if (line.startsWith('+')) {
-      files[currentFile].add++;
-    } else if (line.startsWith('-')) {
-      files[currentFile].del++;
+    if (line.startsWith("+")) {
+      files[currentFile].add += 1;
+    } else if (line.startsWith("-")) {
+      files[currentFile].del += 1;
     } else {
       continue;
     }
 
     if (inManifest) {
-      if (PKG_MANAGER.test(line) && line[0] === '+') {
+      if (PKG_MANAGER.test(line) && line[0] === "+") {
         managerChanges.push(line.slice(1).trim().slice(0, 100));
       }
       const depMatch = DEP_LINE.exec(line);
       if (depMatch && !DEP_SECTION.test(line)) {
         const [, name, ver] = depMatch;
         // crude but effective: dependency values look like version ranges
-        if (/^[\^~>=<*\d]|^(latest|next|workspace:|file:|git|https?)/.test(ver)) {
-          (line[0] === '+' ? addedDeps : removedDeps)[name] = ver;
+        if (
+          /^[\^~>=<*\d]|^(latest|next|workspace:|file:|git|https?)/.test(ver)
+        ) {
+          (line[0] === "+" ? addedDeps : removedDeps)[name] = ver;
         }
       }
     }
@@ -219,8 +273,9 @@ function parseDiff(text) {
 
 function buildReport(files, added, removed, managers, budget) {
   const buckets = {};
-  for (const [filePath, stats] of Object.entries(files)) {
-    if (!buckets[stats.kind]) buckets[stats.kind] = { add: 0, del: 0, files: 0 };
+  for (const [, stats] of Object.entries(files)) {
+    if (!buckets[stats.kind])
+      buckets[stats.kind] = { add: 0, del: 0, files: 0 };
     buckets[stats.kind].add += stats.add;
     buckets[stats.kind].del += stats.del;
     buckets[stats.kind].files += 1;
@@ -228,18 +283,23 @@ function buildReport(files, added, removed, managers, budget) {
 
   const runtime = buckets.runtime?.add || 0;
   const tests = buckets.test?.add || 0;
-  const newDeps = Object.fromEntries(Object.entries(added).filter(([name]) => !(name in removed)));
-  const dropped = Object.fromEntries(Object.entries(removed).filter(([name]) => !(name in added)));
+  const newDeps = Object.fromEntries(
+    Object.entries(added).filter(([name]) => !(name in removed)),
+  );
+  const dropped = Object.fromEntries(
+    Object.entries(removed).filter(([name]) => !(name in added)),
+  );
   const bumped = Object.fromEntries(
-    Object.keys(added).filter(name => name in removed && removed[name] !== added[name])
-      .map(name => [name, `${removed[name]} -> ${added[name]}`])
+    Object.keys(added)
+      .filter((name) => name in removed && removed[name] !== added[name])
+      .map((name) => [name, `${removed[name]} -> ${added[name]}`]),
   );
 
   return {
     runtime_added: runtime,
     budget,
     over_budget: runtime > budget,
-    budget_pct: budget ? Math.round(100 * runtime / budget) : null,
+    budget_pct: budget ? Math.round((100 * runtime) / budget) : null,
     test_added: tests,
     test_ratio: runtime ? Math.round((tests / runtime) * 100) / 100 : null,
     total_files: Object.keys(files).length,
@@ -249,96 +309,134 @@ function buildReport(files, added, removed, managers, budget) {
     bumped_dependencies: bumped,
     package_manager_changes: managers,
     files: Object.entries(files)
-      .map(([path, stats]) => ({ path, kind: stats.kind, add: stats.add, del: stats.del }))
+      .map(([path, stats]) => ({
+        path,
+        kind: stats.kind,
+        add: stats.add,
+        del: stats.del,
+      }))
       .sort((a, b) => b.add - a.add),
   };
 }
 
 function render(report) {
   const lines = [];
-  lines.push('PR METRICS');
-  lines.push('='.repeat(62));
+  lines.push("PR METRICS");
+  lines.push("=".repeat(62));
 
   const { runtime_added: runtime, budget, over_budget, budget_pct } = report;
-  const flag = over_budget ? 'OVER BUDGET' : 'within budget';
-  lines.push(`Runtime lines added : ${runtime} / ${budget}  (${budget_pct}% — ${flag})`);
+  const flag = over_budget ? "OVER BUDGET" : "within budget";
+  lines.push(
+    `Runtime lines added : ${runtime} / ${budget}  (${budget_pct}% — ${flag})`,
+  );
   if (!over_budget && runtime > budget * 0.5) {
-    lines.push('                      note: inside budget but a large PR — consider a split');
+    lines.push(
+      "                      note: inside budget but a large PR — consider a split",
+    );
   }
 
   const { test_added, test_ratio: testRatio } = report;
-  lines.push(`Test lines added    : ${test_added}` +
-    (testRatio !== null ? `  (ratio ${testRatio}:1 vs runtime)` : ''));
+  lines.push(
+    `Test lines added    : ${test_added}` +
+      (testRatio !== null ? `  (ratio ${testRatio}:1 vs runtime)` : ""),
+  );
   if (runtime >= 5 && test_added === 0) {
-    lines.push('                      *** no tests accompany changed runtime code ***');
+    lines.push(
+      "                      *** no tests accompany changed runtime code ***",
+    );
   } else if (testRatio !== null && runtime >= 20 && testRatio < 0.5) {
-    lines.push('                      note: low test ratio for the amount of new logic');
+    lines.push(
+      "                      note: low test ratio for the amount of new logic",
+    );
   }
 
   lines.push(`Files changed       : ${report.total_files}`);
-  lines.push('');
-  lines.push('Breakdown by kind:');
-  for (const [kind, bucket] of Object.entries(report.buckets).sort((a, b) => b[1].add - a[1].add)) {
-    const mark = kind === 'runtime' ? '*' : ' ';
-    lines.push(`  ${mark} ${kind.padEnd(10)} ${String(bucket.files).padStart(3)} files  +${String(bucket.add).padEnd(6)} -${bucket.del}`);
+  lines.push("");
+  lines.push("Breakdown by kind:");
+  for (const [kind, bucket] of Object.entries(report.buckets).sort(
+    (a, b) => b[1].add - a[1].add,
+  )) {
+    const mark = kind === "runtime" ? "*" : " ";
+    lines.push(
+      `  ${mark} ${kind.padEnd(10)} ${String(bucket.files).padStart(3)} files  +${String(bucket.add).padEnd(6)} -${bucket.del}`,
+    );
   }
 
-  lines.push('');
-  lines.push('Dependencies:');
+  lines.push("");
+  lines.push("Dependencies:");
   if (Object.keys(report.new_dependencies).length) {
-    lines.push('  !! NEW (require explicit justification from the issue):');
+    lines.push("  !! NEW (require explicit justification from the issue):");
     for (const [name, version] of Object.entries(report.new_dependencies)) {
       lines.push(`       + ${name} @ ${version}`);
     }
   }
   if (Object.keys(report.bumped_dependencies).length) {
-    lines.push('  ~  version bumps:');
+    lines.push("  ~  version bumps:");
     for (const [name, versions] of Object.entries(report.bumped_dependencies)) {
       lines.push(`       ${name}: ${versions}`);
     }
   }
   if (Object.keys(report.dropped_dependencies).length) {
-    lines.push('  -  removed (verify nothing still imports these):');
+    lines.push("  -  removed (verify nothing still imports these):");
     for (const name of Object.keys(report.dropped_dependencies)) {
       lines.push(`       - ${name}`);
     }
   }
   if (report.package_manager_changes.length) {
-    lines.push('  !! PACKAGE MANAGER / WORKSPACE CHANGES — project-wide decision:');
+    lines.push(
+      "  !! PACKAGE MANAGER / WORKSPACE CHANGES — project-wide decision:",
+    );
     for (const change of report.package_manager_changes) {
       lines.push(`       ${change}`);
     }
   }
-  if (!Object.keys(report.new_dependencies).length &&
-      !Object.keys(report.bumped_dependencies).length &&
-      !Object.keys(report.dropped_dependencies).length &&
-      !report.package_manager_changes.length) {
-    lines.push('  none');
+  if (
+    !Object.keys(report.new_dependencies).length &&
+    !Object.keys(report.bumped_dependencies).length &&
+    !Object.keys(report.dropped_dependencies).length &&
+    !report.package_manager_changes.length
+  ) {
+    lines.push("  none");
   }
 
-  lines.push('');
-  lines.push('Largest files by lines added:');
+  lines.push("");
+  lines.push("Largest files by lines added:");
   for (const file of report.files.slice(0, 12)) {
-    lines.push(`  +${String(file.add).padEnd(6)} -${String(file.del).padEnd(6)} [${file.kind.padEnd(8)}] ${file.path}`);
+    lines.push(
+      `  +${String(file.add).padEnd(6)} -${String(file.del).padEnd(6)} [${file.kind.padEnd(8)}] ${file.path}`,
+    );
   }
 
-  lines.push('');
-  lines.push('-'.repeat(62));
-  lines.push('These are inputs to judgment, not a verdict. Size within budget does not');
-  lines.push('mean the scope is right; tests present does not mean coverage is adequate.');
-  return lines.join('\n');
+  lines.push("");
+  lines.push("-".repeat(62));
+  lines.push(
+    "These are inputs to judgment, not a verdict. Size within budget does not",
+  );
+  lines.push(
+    "mean the scope is right; tests present does not mean coverage is adequate.",
+  );
+  return lines.join("\n");
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  let diffPath = null, prUrl = null, budget = 400, jsonOutput = false;
+  let diffPath = null,
+    prUrl = null,
+    budget = 400,
+    jsonOutput = false;
 
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--diff') diffPath = args[++i];
-    else if (args[i] === '--pr') prUrl = args[++i];
-    else if (args[i] === '--budget') budget = parseInt(args[++i], 10);
-    else if (args[i] === '--json') jsonOutput = true;
-    else if (args[i] === '--help' || args[i] === '-h') {
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--diff") {
+      i += 1;
+      diffPath = args[i];
+    } else if (args[i] === "--pr") {
+      i += 1;
+      prUrl = args[i];
+    } else if (args[i] === "--budget") {
+      i += 1;
+      budget = parseInt(args[i], 10);
+    } else if (args[i] === "--json") jsonOutput = true;
+    else if (args[i] === "--help" || args[i] === "-h") {
       console.log(`Usage:
   node pr-metrics.mjs --diff <path>
   node pr-metrics.mjs --pr <github-url>
@@ -356,18 +454,18 @@ Options:
   }
 
   if (!diffPath && !prUrl) {
-    console.error('Error: must specify either --diff or --pr\n');
+    console.error("Error: must specify either --diff or --pr\n");
     process.exit(1);
   }
 
   let text;
   if (prUrl) {
     text = await fetchPRDiff(prUrl);
-  } else if (diffPath === '-') {
+  } else if (diffPath === "-") {
     text = await readStdin();
   } else {
     try {
-      text = readFileSync(diffPath, 'utf-8');
+      text = readFileSync(diffPath, "utf-8");
     } catch (err) {
       console.error(`Error reading ${diffPath}:`, err.message);
       process.exit(1);
@@ -375,21 +473,27 @@ Options:
   }
 
   if (!text.trim()) {
-    console.error('Empty diff.');
+    console.error("Empty diff.");
     process.exit(1);
   }
 
   const { files, addedDeps, removedDeps, managerChanges } = parseDiff(text);
   if (Object.keys(files).length === 0) {
-    console.error('No files parsed — is this a unified diff?');
+    console.error("No files parsed — is this a unified diff?");
     process.exit(1);
   }
 
-  const report = buildReport(files, addedDeps, removedDeps, managerChanges, budget);
+  const report = buildReport(
+    files,
+    addedDeps,
+    removedDeps,
+    managerChanges,
+    budget,
+  );
   console.log(jsonOutput ? JSON.stringify(report, null, 2) : render(report));
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err.message);
+main().catch((err) => {
+  console.error("Fatal error:", err.message);
   process.exit(1);
 });

--- a/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
+++ b/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
@@ -67,6 +67,8 @@ const CLASSIFIERS = {
     );
   },
 
+  agents: (path) => inDirectory(path, [".agents"]),
+
   ci: (path) => inDirectory(path, [".github", ".circleci"]),
 
   doc: (path) => {

--- a/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
+++ b/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
@@ -21,16 +21,84 @@ import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 
 // --- file classification ------------------------------------------------------
-const RULES = [
-  ['lock', /(^|\/)((package-lock|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|poetry\.lock|Gemfile\.lock|composer\.lock|go\.sum))$/],
-  ['manifest', /(^|\/)(package\.json|requirements[^/]*\.txt|pyproject\.toml|Cargo\.toml|go\.mod|Gemfile|composer\.json|build\.gradle[^/]*)$/],
-  ['test', /(^|\/)((tests?|specs?|__tests__|__mocks__|e2e|cypress)\/|[._-](spec|test)\.[a-z]+$|(^|\/)conftest\.py$|(^|\/)test_[^/]+\.py$)/],
-  ['story', /\.stories\.[a-z]+$|(^|\/)stories\/|\.mdx$/],
-  ['ci', /(^|\/)\.github\/|(^|\/)\.gitlab-ci\.yml$|(^|\/)Jenkinsfile$|(^|\/)\.circleci\/|(^|\/)azure-pipelines\.yml$/],
-  ['doc', /\.(md|markdown|rst|txt|adoc)$|(^|\/)docs?\/|(^|\/)(CHANGELOG|LICENSE|CODEOWNERS|AUTHORS|NOTICE)/],
-  ['asset', /\.(svg|png|jpe?g|gif|ico|webp|woff2?|ttf|eot|mp4|pdf|zip)$/],
-  ['config', /(^|\/)\.(eslintrc|prettierrc|editorconfig|gitignore|npmrc|nvmrc|babelrc)|\.(eslintrc|prettierrc)\.[a-z]+$/],
-];
+
+function getFilename(path) {
+  return path.split('/').pop();
+}
+
+function hasExtension(path, extensions) {
+  return extensions.some(ext => path.endsWith(ext));
+}
+
+function inDirectory(path, directories) {
+  return directories.some(dir =>
+    path.includes(`/${dir}/`) || path.startsWith(`${dir}/`)
+  );
+}
+
+function matchesPattern(path, pattern) {
+  if (typeof pattern === 'string') {
+    return path.includes(pattern);
+  }
+  return pattern.test(path);
+}
+
+const CLASSIFIERS = {
+  lock: (path) => hasExtension(path, [
+    'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
+    'Cargo.lock', 'poetry.lock', 'Gemfile.lock',
+    'composer.lock', 'go.sum'
+  ]),
+
+  manifest: (path) => {
+    const filename = getFilename(path);
+    if (['package.json', 'Cargo.toml', 'go.mod', 'Gemfile', 'composer.json', 'pyproject.toml'].includes(filename)) {
+      return true;
+    }
+    return /^requirements[^/]*\.txt$/.test(filename) || /^build\.gradle/.test(filename);
+  },
+
+  test: (path) => {
+    const filename = getFilename(path);
+    return inDirectory(path, ['test', 'tests', 'spec', 'specs', '__tests__', '__mocks__', 'e2e', 'cypress']) ||
+           /[._-](spec|test)\.[a-z]+$/.test(filename) ||
+           filename === 'conftest.py' ||
+           (/^test_/.test(filename) && filename.endsWith('.py'));
+  },
+
+  story: (path) => {
+    const filename = getFilename(path);
+    return /\.stories\.[a-z]+$/.test(filename) ||
+           inDirectory(path, ['stories']) ||
+           filename.endsWith('.mdx');
+  },
+
+  ci: (path) =>
+    inDirectory(path, ['.github', '.circleci']) ||
+    hasExtension(path, ['.gitlab-ci.yml', 'Jenkinsfile', 'azure-pipelines.yml']),
+
+  doc: (path) => {
+    const filename = getFilename(path);
+    const docFiles = ['CHANGELOG', 'LICENSE', 'CODEOWNERS', 'AUTHORS', 'NOTICE'];
+    return hasExtension(path, ['.md', '.markdown', '.rst', '.txt', '.adoc']) ||
+           inDirectory(path, ['doc', 'docs']) ||
+           docFiles.some(name => filename.startsWith(name));
+  },
+
+  asset: (path) => hasExtension(path, [
+    '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
+    '.woff', '.woff2', '.ttf', '.eot', '.mp4', '.pdf', '.zip'
+  ]),
+
+  config: (path) => {
+    const filename = getFilename(path);
+    const configNames = ['.eslintrc', '.prettierrc', '.editorconfig', '.gitignore', '.npmrc', '.nvmrc', '.babelrc'];
+    return configNames.some(name =>
+      filename === name || filename.startsWith(`${name}.`)
+    );
+  },
+};
+
 const NON_BUDGET = new Set(['lock', 'test', 'story', 'doc', 'asset', 'ci', 'manifest', 'config']);
 
 const DEP_LINE = /^[+-]\s*"([^"]+)"\s*:\s*"([^"]*)"/;
@@ -38,8 +106,8 @@ const DEP_SECTION = /"(dependencies|devDependencies|peerDependencies|optionalDep
 const PKG_MANAGER = /"(packageManager|workspaces|resolutions|overrides)"\s*:/;
 
 function classify(path) {
-  for (const [name, rx] of RULES) {
-    if (rx.test(path)) return name;
+  for (const [name, classifier] of Object.entries(CLASSIFIERS)) {
+    if (classifier(path)) return name;
   }
   return 'runtime';
 }
@@ -59,8 +127,6 @@ async function fetchPRDiff(url) {
   } catch (err) {
     // fall through to API
   }
-
-  // Fall back to GitHub API
   const headers = ['-H', 'Accept: application/vnd.github.v3.diff'];
   if (process.env.GITHUB_TOKEN) {
     headers.push('-H', `Authorization: Bearer ${process.env.GITHUB_TOKEN}`);
@@ -105,18 +171,18 @@ async function readStdin() {
 function parseDiff(text) {
   const files = {};
   const addedDeps = {}, removedDeps = {}, managerChanges = [];
-  let cur = null, inManifest = false;
+  let currentFile = null, inManifest = false;
 
   for (const line of text.split('\n')) {
     const diffMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
     if (diffMatch) {
-      cur = diffMatch[2];
-      files[cur] = { add: 0, del: 0, kind: classify(cur) };
-      inManifest = files[cur].kind === 'manifest';
+      currentFile = diffMatch[2];
+      files[currentFile] = { add: 0, del: 0, kind: classify(currentFile) };
+      inManifest = files[currentFile].kind === 'manifest';
       continue;
     }
 
-    if (cur === null) continue;
+    if (currentFile === null) continue;
     if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('@@') ||
         line.startsWith('index ') || line.startsWith('similarity ') ||
         line.startsWith('rename ') || line.startsWith('new file') ||
@@ -126,9 +192,9 @@ function parseDiff(text) {
     }
 
     if (line.startsWith('+')) {
-      files[cur].add++;
+      files[currentFile].add++;
     } else if (line.startsWith('-')) {
-      files[cur].del++;
+      files[currentFile].del++;
     } else {
       continue;
     }
@@ -153,20 +219,20 @@ function parseDiff(text) {
 
 function buildReport(files, added, removed, managers, budget) {
   const buckets = {};
-  for (const [f, st] of Object.entries(files)) {
-    if (!buckets[st.kind]) buckets[st.kind] = { add: 0, del: 0, files: 0 };
-    buckets[st.kind].add += st.add;
-    buckets[st.kind].del += st.del;
-    buckets[st.kind].files += 1;
+  for (const [filePath, stats] of Object.entries(files)) {
+    if (!buckets[stats.kind]) buckets[stats.kind] = { add: 0, del: 0, files: 0 };
+    buckets[stats.kind].add += stats.add;
+    buckets[stats.kind].del += stats.del;
+    buckets[stats.kind].files += 1;
   }
 
   const runtime = buckets.runtime?.add || 0;
   const tests = buckets.test?.add || 0;
-  const newDeps = Object.fromEntries(Object.entries(added).filter(([k]) => !(k in removed)));
-  const dropped = Object.fromEntries(Object.entries(removed).filter(([k]) => !(k in added)));
+  const newDeps = Object.fromEntries(Object.entries(added).filter(([name]) => !(name in removed)));
+  const dropped = Object.fromEntries(Object.entries(removed).filter(([name]) => !(name in added)));
   const bumped = Object.fromEntries(
-    Object.keys(added).filter(k => k in removed && removed[k] !== added[k])
-      .map(k => [k, `${removed[k]} -> ${added[k]}`])
+    Object.keys(added).filter(name => name in removed && removed[name] !== added[name])
+      .map(name => [name, `${removed[name]} -> ${added[name]}`])
   );
 
   return {
@@ -183,84 +249,84 @@ function buildReport(files, added, removed, managers, budget) {
     bumped_dependencies: bumped,
     package_manager_changes: managers,
     files: Object.entries(files)
-      .map(([path, s]) => ({ path, kind: s.kind, add: s.add, del: s.del }))
+      .map(([path, stats]) => ({ path, kind: stats.kind, add: stats.add, del: stats.del }))
       .sort((a, b) => b.add - a.add),
   };
 }
 
-function render(r) {
-  const L = [];
-  L.push('PR METRICS');
-  L.push('='.repeat(62));
+function render(report) {
+  const lines = [];
+  lines.push('PR METRICS');
+  lines.push('='.repeat(62));
 
-  const { runtime_added: rt, budget, over_budget, budget_pct } = r;
+  const { runtime_added: runtime, budget, over_budget, budget_pct } = report;
   const flag = over_budget ? 'OVER BUDGET' : 'within budget';
-  L.push(`Runtime lines added : ${rt} / ${budget}  (${budget_pct}% — ${flag})`);
-  if (!over_budget && rt > budget * 0.5) {
-    L.push('                      note: inside budget but a large PR — consider a split');
+  lines.push(`Runtime lines added : ${runtime} / ${budget}  (${budget_pct}% — ${flag})`);
+  if (!over_budget && runtime > budget * 0.5) {
+    lines.push('                      note: inside budget but a large PR — consider a split');
   }
 
-  const { test_added, test_ratio: tr } = r;
-  L.push(`Test lines added    : ${test_added}` +
-    (tr !== null ? `  (ratio ${tr}:1 vs runtime)` : ''));
-  if (rt >= 5 && test_added === 0) {
-    L.push('                      *** no tests accompany changed runtime code ***');
-  } else if (tr !== null && rt >= 20 && tr < 0.5) {
-    L.push('                      note: low test ratio for the amount of new logic');
+  const { test_added, test_ratio: testRatio } = report;
+  lines.push(`Test lines added    : ${test_added}` +
+    (testRatio !== null ? `  (ratio ${testRatio}:1 vs runtime)` : ''));
+  if (runtime >= 5 && test_added === 0) {
+    lines.push('                      *** no tests accompany changed runtime code ***');
+  } else if (testRatio !== null && runtime >= 20 && testRatio < 0.5) {
+    lines.push('                      note: low test ratio for the amount of new logic');
   }
 
-  L.push(`Files changed       : ${r.total_files}`);
-  L.push('');
-  L.push('Breakdown by kind:');
-  for (const [kind, b] of Object.entries(r.buckets).sort((a, b) => b[1].add - a[1].add)) {
+  lines.push(`Files changed       : ${report.total_files}`);
+  lines.push('');
+  lines.push('Breakdown by kind:');
+  for (const [kind, bucket] of Object.entries(report.buckets).sort((a, b) => b[1].add - a[1].add)) {
     const mark = kind === 'runtime' ? '*' : ' ';
-    L.push(`  ${mark} ${kind.padEnd(10)} ${String(b.files).padStart(3)} files  +${String(b.add).padEnd(6)} -${b.del}`);
+    lines.push(`  ${mark} ${kind.padEnd(10)} ${String(bucket.files).padStart(3)} files  +${String(bucket.add).padEnd(6)} -${bucket.del}`);
   }
 
-  L.push('');
-  L.push('Dependencies:');
-  if (Object.keys(r.new_dependencies).length) {
-    L.push('  !! NEW (require explicit justification from the issue):');
-    for (const [k, v] of Object.entries(r.new_dependencies)) {
-      L.push(`       + ${k} @ ${v}`);
+  lines.push('');
+  lines.push('Dependencies:');
+  if (Object.keys(report.new_dependencies).length) {
+    lines.push('  !! NEW (require explicit justification from the issue):');
+    for (const [name, version] of Object.entries(report.new_dependencies)) {
+      lines.push(`       + ${name} @ ${version}`);
     }
   }
-  if (Object.keys(r.bumped_dependencies).length) {
-    L.push('  ~  version bumps:');
-    for (const [k, v] of Object.entries(r.bumped_dependencies)) {
-      L.push(`       ${k}: ${v}`);
+  if (Object.keys(report.bumped_dependencies).length) {
+    lines.push('  ~  version bumps:');
+    for (const [name, versions] of Object.entries(report.bumped_dependencies)) {
+      lines.push(`       ${name}: ${versions}`);
     }
   }
-  if (Object.keys(r.dropped_dependencies).length) {
-    L.push('  -  removed (verify nothing still imports these):');
-    for (const k of Object.keys(r.dropped_dependencies)) {
-      L.push(`       - ${k}`);
+  if (Object.keys(report.dropped_dependencies).length) {
+    lines.push('  -  removed (verify nothing still imports these):');
+    for (const name of Object.keys(report.dropped_dependencies)) {
+      lines.push(`       - ${name}`);
     }
   }
-  if (r.package_manager_changes.length) {
-    L.push('  !! PACKAGE MANAGER / WORKSPACE CHANGES — project-wide decision:');
-    for (const c of r.package_manager_changes) {
-      L.push(`       ${c}`);
+  if (report.package_manager_changes.length) {
+    lines.push('  !! PACKAGE MANAGER / WORKSPACE CHANGES — project-wide decision:');
+    for (const change of report.package_manager_changes) {
+      lines.push(`       ${change}`);
     }
   }
-  if (!Object.keys(r.new_dependencies).length &&
-      !Object.keys(r.bumped_dependencies).length &&
-      !Object.keys(r.dropped_dependencies).length &&
-      !r.package_manager_changes.length) {
-    L.push('  none');
+  if (!Object.keys(report.new_dependencies).length &&
+      !Object.keys(report.bumped_dependencies).length &&
+      !Object.keys(report.dropped_dependencies).length &&
+      !report.package_manager_changes.length) {
+    lines.push('  none');
   }
 
-  L.push('');
-  L.push('Largest files by lines added:');
-  for (const f of r.files.slice(0, 12)) {
-    L.push(`  +${String(f.add).padEnd(6)} -${String(f.del).padEnd(6)} [${f.kind.padEnd(8)}] ${f.path}`);
+  lines.push('');
+  lines.push('Largest files by lines added:');
+  for (const file of report.files.slice(0, 12)) {
+    lines.push(`  +${String(file.add).padEnd(6)} -${String(file.del).padEnd(6)} [${file.kind.padEnd(8)}] ${file.path}`);
   }
 
-  L.push('');
-  L.push('-'.repeat(62));
-  L.push('These are inputs to judgment, not a verdict. Size within budget does not');
-  L.push('mean the scope is right; tests present does not mean coverage is adequate.');
-  return L.join('\n');
+  lines.push('');
+  lines.push('-'.repeat(62));
+  lines.push('These are inputs to judgment, not a verdict. Size within budget does not');
+  lines.push('mean the scope is right; tests present does not mean coverage is adequate.');
+  return lines.join('\n');
 }
 
 async function main() {

--- a/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
+++ b/.agents/skills/uswds-code-review/scripts/pr-metrics.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+/**
+ * Compute the mechanical gate inputs for a pull request.
+ *
+ * Reports runtime lines added (excluding tests, docs, lockfiles, assets), the
+ * test-to-runtime ratio, dependency manifest changes, and per-file classification.
+ *
+ * Usage:
+ *     node pr-metrics.mjs --diff changes.patch
+ *     node pr-metrics.mjs --pr https://github.com/org/repo/pull/123
+ *     node pr-metrics.mjs --diff - < changes.patch
+ *     node pr-metrics.mjs --diff changes.patch --budget 400 --json
+ *
+ * Getting a diff without network access to the API:
+ *     git diff main...HEAD > changes.patch
+ *     gh pr diff 123 > changes.patch
+ */
+
+import { readFileSync } from 'fs';
+import { spawn } from 'child_process';
+import { createInterface } from 'readline';
+
+// --- file classification ------------------------------------------------------
+const RULES = [
+  ['lock', /(^|\/)((package-lock|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|poetry\.lock|Gemfile\.lock|composer\.lock|go\.sum))$/],
+  ['manifest', /(^|\/)(package\.json|requirements[^/]*\.txt|pyproject\.toml|Cargo\.toml|go\.mod|Gemfile|composer\.json|build\.gradle[^/]*)$/],
+  ['test', /(^|\/)((tests?|specs?|__tests__|__mocks__|e2e|cypress)\/|[._-](spec|test)\.[a-z]+$|(^|\/)conftest\.py$|(^|\/)test_[^/]+\.py$)/],
+  ['story', /\.stories\.[a-z]+$|(^|\/)stories\/|\.mdx$/],
+  ['ci', /(^|\/)\.github\/|(^|\/)\.gitlab-ci\.yml$|(^|\/)Jenkinsfile$|(^|\/)\.circleci\/|(^|\/)azure-pipelines\.yml$/],
+  ['doc', /\.(md|markdown|rst|txt|adoc)$|(^|\/)docs?\/|(^|\/)(CHANGELOG|LICENSE|CODEOWNERS|AUTHORS|NOTICE)/],
+  ['asset', /\.(svg|png|jpe?g|gif|ico|webp|woff2?|ttf|eot|mp4|pdf|zip)$/],
+  ['config', /(^|\/)\.(eslintrc|prettierrc|editorconfig|gitignore|npmrc|nvmrc|babelrc)|\.(eslintrc|prettierrc)\.[a-z]+$/],
+];
+const NON_BUDGET = new Set(['lock', 'test', 'story', 'doc', 'asset', 'ci', 'manifest', 'config']);
+
+const DEP_LINE = /^[+-]\s*"([^"]+)"\s*:\s*"([^"]*)"/;
+const DEP_SECTION = /"(dependencies|devDependencies|peerDependencies|optionalDependencies)"\s*:/;
+const PKG_MANAGER = /"(packageManager|workspaces|resolutions|overrides)"\s*:/;
+
+function classify(path) {
+  for (const [name, rx] of RULES) {
+    if (rx.test(path)) return name;
+  }
+  return 'runtime';
+}
+
+async function fetchPRDiff(url) {
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!match) {
+    console.error(`Could not parse a GitHub PR URL from: ${url}`);
+    process.exit(1);
+  }
+  const [, owner, repo, num] = match;
+
+  // Try gh CLI first
+  try {
+    const diff = await exec('gh', ['pr', 'diff', num, '--repo', `${owner}/${repo}`], { timeout: 90000 });
+    if (diff.trim()) return diff;
+  } catch (err) {
+    // fall through to API
+  }
+
+  // Fall back to GitHub API
+  const headers = ['-H', 'Accept: application/vnd.github.v3.diff'];
+  if (process.env.GITHUB_TOKEN) {
+    headers.push('-H', `Authorization: Bearer ${process.env.GITHUB_TOKEN}`);
+  }
+  try {
+    const diff = await exec('curl', ['-sL', '--max-time', '90', ...headers,
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${num}`], { timeout: 95000 });
+    if (!diff.trim() || diff.trimStart().startsWith('{')) {
+      console.error('Could not fetch the diff. Install the `gh` CLI, set GITHUB_TOKEN, or pass a local diff with --diff.');
+      process.exit(1);
+    }
+    return diff;
+  } catch (err) {
+    console.error('Failed to fetch diff:', err.message);
+    process.exit(1);
+  }
+}
+
+async function exec(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, args, { timeout: opts.timeout });
+    let stdout = '', stderr = '';
+    proc.stdout?.on('data', d => stdout += d);
+    proc.stderr?.on('data', d => stderr += d);
+    proc.on('error', reject);
+    proc.on('close', code => {
+      if (code !== 0 && code !== null) reject(new Error(`${cmd} exited ${code}: ${stderr}`));
+      else resolve(stdout);
+    });
+  });
+}
+
+async function readStdin() {
+  const lines = [];
+  const rl = createInterface({ input: process.stdin });
+  for await (const line of rl) {
+    lines.push(line);
+  }
+  return lines.join('\n');
+}
+
+function parseDiff(text) {
+  const files = {};
+  const addedDeps = {}, removedDeps = {}, managerChanges = [];
+  let cur = null, inManifest = false;
+
+  for (const line of text.split('\n')) {
+    const diffMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (diffMatch) {
+      cur = diffMatch[2];
+      files[cur] = { add: 0, del: 0, kind: classify(cur) };
+      inManifest = files[cur].kind === 'manifest';
+      continue;
+    }
+
+    if (cur === null) continue;
+    if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('@@') ||
+        line.startsWith('index ') || line.startsWith('similarity ') ||
+        line.startsWith('rename ') || line.startsWith('new file') ||
+        line.startsWith('deleted file') || line.startsWith('old mode') ||
+        line.startsWith('new mode') || line.startsWith('Binary files')) {
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      files[cur].add++;
+    } else if (line.startsWith('-')) {
+      files[cur].del++;
+    } else {
+      continue;
+    }
+
+    if (inManifest) {
+      if (PKG_MANAGER.test(line) && line[0] === '+') {
+        managerChanges.push(line.slice(1).trim().slice(0, 100));
+      }
+      const depMatch = DEP_LINE.exec(line);
+      if (depMatch && !DEP_SECTION.test(line)) {
+        const [, name, ver] = depMatch;
+        // crude but effective: dependency values look like version ranges
+        if (/^[\^~>=<*\d]|^(latest|next|workspace:|file:|git|https?)/.test(ver)) {
+          (line[0] === '+' ? addedDeps : removedDeps)[name] = ver;
+        }
+      }
+    }
+  }
+
+  return { files, addedDeps, removedDeps, managerChanges };
+}
+
+function buildReport(files, added, removed, managers, budget) {
+  const buckets = {};
+  for (const [f, st] of Object.entries(files)) {
+    if (!buckets[st.kind]) buckets[st.kind] = { add: 0, del: 0, files: 0 };
+    buckets[st.kind].add += st.add;
+    buckets[st.kind].del += st.del;
+    buckets[st.kind].files += 1;
+  }
+
+  const runtime = buckets.runtime?.add || 0;
+  const tests = buckets.test?.add || 0;
+  const newDeps = Object.fromEntries(Object.entries(added).filter(([k]) => !(k in removed)));
+  const dropped = Object.fromEntries(Object.entries(removed).filter(([k]) => !(k in added)));
+  const bumped = Object.fromEntries(
+    Object.keys(added).filter(k => k in removed && removed[k] !== added[k])
+      .map(k => [k, `${removed[k]} -> ${added[k]}`])
+  );
+
+  return {
+    runtime_added: runtime,
+    budget,
+    over_budget: runtime > budget,
+    budget_pct: budget ? Math.round(100 * runtime / budget) : null,
+    test_added: tests,
+    test_ratio: runtime ? Math.round((tests / runtime) * 100) / 100 : null,
+    total_files: Object.keys(files).length,
+    buckets,
+    new_dependencies: newDeps,
+    dropped_dependencies: dropped,
+    bumped_dependencies: bumped,
+    package_manager_changes: managers,
+    files: Object.entries(files)
+      .map(([path, s]) => ({ path, kind: s.kind, add: s.add, del: s.del }))
+      .sort((a, b) => b.add - a.add),
+  };
+}
+
+function render(r) {
+  const L = [];
+  L.push('PR METRICS');
+  L.push('='.repeat(62));
+
+  const { runtime_added: rt, budget, over_budget, budget_pct } = r;
+  const flag = over_budget ? 'OVER BUDGET' : 'within budget';
+  L.push(`Runtime lines added : ${rt} / ${budget}  (${budget_pct}% — ${flag})`);
+  if (!over_budget && rt > budget * 0.5) {
+    L.push('                      note: inside budget but a large PR — consider a split');
+  }
+
+  const { test_added, test_ratio: tr } = r;
+  L.push(`Test lines added    : ${test_added}` +
+    (tr !== null ? `  (ratio ${tr}:1 vs runtime)` : ''));
+  if (rt >= 5 && test_added === 0) {
+    L.push('                      *** no tests accompany changed runtime code ***');
+  } else if (tr !== null && rt >= 20 && tr < 0.5) {
+    L.push('                      note: low test ratio for the amount of new logic');
+  }
+
+  L.push(`Files changed       : ${r.total_files}`);
+  L.push('');
+  L.push('Breakdown by kind:');
+  for (const [kind, b] of Object.entries(r.buckets).sort((a, b) => b[1].add - a[1].add)) {
+    const mark = kind === 'runtime' ? '*' : ' ';
+    L.push(`  ${mark} ${kind.padEnd(10)} ${String(b.files).padStart(3)} files  +${String(b.add).padEnd(6)} -${b.del}`);
+  }
+
+  L.push('');
+  L.push('Dependencies:');
+  if (Object.keys(r.new_dependencies).length) {
+    L.push('  !! NEW (require explicit justification from the issue):');
+    for (const [k, v] of Object.entries(r.new_dependencies)) {
+      L.push(`       + ${k} @ ${v}`);
+    }
+  }
+  if (Object.keys(r.bumped_dependencies).length) {
+    L.push('  ~  version bumps:');
+    for (const [k, v] of Object.entries(r.bumped_dependencies)) {
+      L.push(`       ${k}: ${v}`);
+    }
+  }
+  if (Object.keys(r.dropped_dependencies).length) {
+    L.push('  -  removed (verify nothing still imports these):');
+    for (const k of Object.keys(r.dropped_dependencies)) {
+      L.push(`       - ${k}`);
+    }
+  }
+  if (r.package_manager_changes.length) {
+    L.push('  !! PACKAGE MANAGER / WORKSPACE CHANGES — project-wide decision:');
+    for (const c of r.package_manager_changes) {
+      L.push(`       ${c}`);
+    }
+  }
+  if (!Object.keys(r.new_dependencies).length &&
+      !Object.keys(r.bumped_dependencies).length &&
+      !Object.keys(r.dropped_dependencies).length &&
+      !r.package_manager_changes.length) {
+    L.push('  none');
+  }
+
+  L.push('');
+  L.push('Largest files by lines added:');
+  for (const f of r.files.slice(0, 12)) {
+    L.push(`  +${String(f.add).padEnd(6)} -${String(f.del).padEnd(6)} [${f.kind.padEnd(8)}] ${f.path}`);
+  }
+
+  L.push('');
+  L.push('-'.repeat(62));
+  L.push('These are inputs to judgment, not a verdict. Size within budget does not');
+  L.push('mean the scope is right; tests present does not mean coverage is adequate.');
+  return L.join('\n');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let diffPath = null, prUrl = null, budget = 400, jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--diff') diffPath = args[++i];
+    else if (args[i] === '--pr') prUrl = args[++i];
+    else if (args[i] === '--budget') budget = parseInt(args[++i], 10);
+    else if (args[i] === '--json') jsonOutput = true;
+    else if (args[i] === '--help' || args[i] === '-h') {
+      console.log(`Usage:
+  node pr-metrics.mjs --diff <path>
+  node pr-metrics.mjs --pr <github-url>
+  node pr-metrics.mjs --diff - < changes.patch
+  node pr-metrics.mjs --diff changes.patch --budget 400 --json
+
+Options:
+  --diff <path>    Path to a diff/patch file, or - for stdin
+  --pr <url>       GitHub pull request URL
+  --budget <n>     Runtime line budget (default 400)
+  --json           Output JSON instead of a formatted report
+  --help, -h       Show this help`);
+      process.exit(0);
+    }
+  }
+
+  if (!diffPath && !prUrl) {
+    console.error('Error: must specify either --diff or --pr\n');
+    process.exit(1);
+  }
+
+  let text;
+  if (prUrl) {
+    text = await fetchPRDiff(prUrl);
+  } else if (diffPath === '-') {
+    text = await readStdin();
+  } else {
+    try {
+      text = readFileSync(diffPath, 'utf-8');
+    } catch (err) {
+      console.error(`Error reading ${diffPath}:`, err.message);
+      process.exit(1);
+    }
+  }
+
+  if (!text.trim()) {
+    console.error('Empty diff.');
+    process.exit(1);
+  }
+
+  const { files, addedDeps, removedDeps, managerChanges } = parseDiff(text);
+  if (Object.keys(files).length === 0) {
+    console.error('No files parsed — is this a unified diff?');
+    process.exit(1);
+  }
+
+  const report = buildReport(files, addedDeps, removedDeps, managerChanges, budget);
+  console.log(jsonOutput ? JSON.stringify(report, null, 2) : render(report));
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add code review skill to USWDS with 16 calibrated gates and verification layer. This introduces a reusable skill to support USWDS team reviews with consistent guidance based on core team patterns and project values. Includes calibration references, gate documentation, verification procedures, and supporting automation.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6836

## Related pull requests

This change does not require updates to the uswds-site repo.

## Preview link

Not applicable (tooling/skill documentation).

## Problem statement

USWDS team needs a consistent, AI-assisted code review capability that mirrors the judgment of engineering leads, product, and accessibility specialists. Current process relies on manual review without structured guidance or calibration. A reusable skill can help maintain quality and consistency while augmenting human review.

## Solution

This PR adds a fully-documented code review skill that:

1. **Enforces 16 specific gates** — Size, dependencies, DRY, sanitization, test coverage, error handling, API surface, breaking changes, accessibility, and more.
2. **Calibrates against real team patterns** — References past USWDS PR reviews and team feedback to establish consistent tone and judgment.
3. **Routes specialist decisions** — Explicitly identifies when accessibility, product, or design judgment is required (not automated).
4. **Distinguishes impact levels** — Separates what all downstream consumers inherit from style preferences.
5. **Includes verification layer** — Provides before/after case studies to validate review output quality.

### Files added:

- `.agents/skills/uswds-code-review/SKILL.md` — Main skill entry point and process documentation
- `.agents/skills/uswds-code-review/VERIFICATION.md` — Case studies and calibration validation
- `.agents/skills/uswds-code-review/references/gates.md` — Detailed gate definitions with runnable checks
- `.agents/skills/uswds-code-review/references/calibration.md` — Team patterns and judgment precedents
- `.agents/skills/uswds-code-review/references/uswds-anchors.md` — Technical anchors and repo patterns
- `.agents/skills/uswds-code-review/scripts/pr-metrics.mjs` — Automation helper for PR analysis
- `.agents/README.md` — Agent and skill inventory for the repo

### Major changes

1. **16-gate code review process** enforced by `uswds-code-review` skill:
   - Gate 1-16: Covers size, dependencies, tests, patterns, DRY, error handling, sanitization, accessibility, breaking changes, API surface
   - Each gate includes runnable checks and explicit carve-outs
   - Cascade test applied to all findings (does it affect all consumers?)

2. **Calibration references** from past USWDS team reviews:
   - 370 lines of patterns, examples, and team judgment precedents
   - Documents product lead vs. code reviewer responsibility split
   - Accessibility specialist decision matrix (when to flag vs. when to pass)

3. **Verification layer**:
   - Before/after case studies showing skill output vs. expected team judgment
   - Validation procedures to catch divergence from team patterns
   - Quality assurance before deployment

4. **Supporting automation**:
   - PR metrics script to analyze change scope and complexity
   - Glossary and technical anchors to standardize terminology

### Testing and review

- **Local tests**: All passing (`npm test` — 828 unit tests + 28 task tests)
- **Manual verification**: Reviewed past 30 USWDS PRs to calibrate gates and judgment
- **Skill auto-detection**: Works with PR numbers, URLs, or local branches
- **Output**: Generates structured findings with disposition, severity, and specialist routing

**How to test:**
1. Local skill invocation: `/uswds-code-review` (current branch) or `/uswds-code-review 6767` (specific PR)
2. Review output structure and tone against calibration cases in `VERIFICATION.md`

This is a **local tool for now** (not auto-submitted to PRs until team validates output quality over time). Team members can invoke it when reviewing their own work or assisting peers.

## Future enhancements

1. Add a cache directory so we can keep track of what PRs were run through the automation and what the commit hash was.
2. Add a mechanism to have the skill update and improve so it doesn't become stale.
