### PR TITLE
USWDS - Combo box: Allow iOS VoiceOver to swipe combo box options

### DIFF
--- a/packages/usa-combo-box/src/index.js
+++ b/packages/usa-combo-box/src/index.js
@@ -222,7 +222,6 @@ const enhanceComboBox = (_comboBoxEl) => {
   // sanitize doesn't like functions in template literals
   const input = document.createElement("input");
   input.setAttribute("id", selectId);
-  input.setAttribute("aria-owns", listId);
   input.setAttribute("aria-controls", listId);
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-expanded", "false");


### PR DESCRIPTION
USWDS - Combo box: Allow iOS VoiceOver to swipe combo box options

# Summary
Fixed a bug that prevented iOS VoiceOver users from swiping through open combo box options. Removing aria-owns from the combobox input keeps the listbox in linear swipe order. aria-controls still associates the list with the input.

## Breaking change
This is not a breaking change.

## Related issue
Closes #6840

## Related pull requests

## Preview link
https://federalist-3b6ba08e-0df4-44c9-ac73-6fc193b0e19c.sites.pages.cloud.gov/preview/uswds/uswds/bug/5316-remove-focusable-false/

## Problem statement
Desired: When a combo box list is open, iOS VoiceOver users can swipe through the available options to discover and select a value.

Actual: Swiping right from an open combo box jumped past the listbox to the next DOM item. Options were visible on screen but unreachable by swipe. This reproduced on the live site at https://designsystem.digital.gov/components/combo-box/. Collapsed-state announcements already included the current value, so 4.1.2 was met when the list was closed.

Consequence: VoiceOver users on iPhone could tap a visible option, but they could not browse the list by swipe, which is the primary VoiceOver navigation pattern.

## Solution
Removed `aria-owns` from the combo box input. The listbox is a sibling of the input, not a DOM child. `aria-owns` reparented it under the combobox in the accessibility tree, so iOS VoiceOver skipped it during linear swipe.

`aria-controls` already points at the list id, and `aria-activedescendant` still marks the highlighted option while focus stays on the input. That is enough for desktop screen readers to follow arrow-key highlighting.

This approach was chosen over moving real DOM focus into the options on open. Focusing options would likely dismiss the iOS keyboard and break type-to-filter on desktop.

Limitations: macOS VoiceOver + Safari combobox behavior is unchanged (still imperfect). iOS VoiceOver swipe is the path this PR fixes.

## Major changes

- Removed aria-owns from the combo box input in packages/usa-combo-box/src/index.js
- Left aria-controls in place to associate the listbox with the combobox

## Testing and review
- Run npm test and confirm all tests pass

### Manual verification

- [ ] Run npm start and open Components / Combo box
- [ ] iOS VoiceOver: Open the list. Swipe through options. Confirm each option is reachable. Select one. Confirm the collapsed input still announces the value.
- [ ] iOS VoiceOver: Type to filter, then swipe the reduced list. Close with the toggle and with a selection.
- [ ] Keyboard, no SR: Arrow from the input, Enter to select, Escape to close. Type-to-filter still works with focus on the input.
- [ ] macOS VoiceOver + Safari: Tab to the combobox. Open and arrow through options. Behavior should match the live site (same as before this change).
- [ ] NVDA + Chrome: Open the list and arrow. NVDA should still announce the active option.

## References
https://www.w3.org/WAI/ARIA/apg/patterns/combobox/ 