### PR TITLE
USWDS - Footer: Replace deprecated media query listeners

### DIFF
--- a/packages/usa-footer/src/index.js
+++ b/packages/usa-footer/src/index.js
@@ -98,11 +98,11 @@ module.exports = behavior(
       this.mediaQueryList = window.matchMedia(
         `(max-width: ${HIDE_MAX_WIDTH - 0.1}px)`,
       );
-      this.mediaQueryList.addListener(resize);
+      this.mediaQueryList.addEventListener("change", resize);
     },
 
     teardown() {
-      this.mediaQueryList.removeListener(resize);
+      this.mediaQueryList.removeEventListener("change", resize);
     },
   },
 );

--- a/packages/usa-footer/src/test/footer.spec.js
+++ b/packages/usa-footer/src/test/footer.spec.js
@@ -14,6 +14,29 @@ const PRIMARY_CONTENT_SELECTOR =
 const BUTTON_SELECTOR = ".usa-footer__primary-link";
 
 /**
+ * mq-polyfill implements the legacy listener methods internally.
+ * This adapter exposes only the standard EventTarget API to the footer behavior.
+ */
+const withEventListeners = (mediaQueryList) => ({
+  get matches() {
+    return mediaQueryList.matches;
+  },
+  get media() {
+    return mediaQueryList.media;
+  },
+  addEventListener(type, listener) {
+    if (type === "change") {
+      mediaQueryList.addListener(listener);
+    }
+  },
+  removeEventListener(type, listener) {
+    if (type === "change") {
+      mediaQueryList.removeListener(listener);
+    }
+  },
+});
+
+/**
  * Resize the window's width, then dispatch a 'resize' event
  *
  * @param {number} width
@@ -41,6 +64,7 @@ const tests = [
 tests.forEach(({ name, selector: containerSelector }) => {
   describe(`big footer accordion initialized at ${name}`, () => {
     const { body } = document;
+    const originalMatchMedia = window.matchMedia;
 
     document.head.insertAdjacentHTML("beforeend", `<style>${STYLES}</style>`);
 
@@ -49,6 +73,13 @@ tests.forEach(({ name, selector: containerSelector }) => {
 
     before(() => {
       matchMediaPolyfill(window);
+      const matchMedia = window.matchMedia;
+
+      window.matchMedia = (query) => withEventListeners(matchMedia(query));
+    });
+
+    after(() => {
+      window.matchMedia = originalMatchMedia;
     });
 
     beforeEach(() => {


### PR DESCRIPTION
# Summary

**Improved footer compatibility with modern browser APIs.** Replaced the deprecated `MediaQueryList.addListener()` and `removeListener()` methods with the standard `addEventListener("change", ...)` and `removeEventListener("change", ...)` methods.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6844

## Related pull requests

None.

## Preview link

Not applicable. This change does not alter the footer’s visual appearance.

## Problem statement

The USA Footer package uses the deprecated `MediaQueryList.addListener()` and `removeListener()` methods to respond to viewport changes. Supported browsers provide the standard `EventTarget` listener methods, so continuing to use the deprecated methods creates unnecessary technical debt and may produce deprecation warnings.

## Solution

Updated the footer behavior to register and remove its media query change handler using `addEventListener("change", resize)` and `removeEventListener("change", resize)`.

The existing footer tests use `mq-polyfill`, which exposes only the legacy listener methods. The test setup now wraps the polyfilled media query list with an adapter that exposes the standard event-listener API to the footer behavior while preserving the polyfill’s existing resize simulation.

## Major changes

- Replaced the deprecated listener methods in `packages/usa-footer/src/index.js`.
- Updated the footer test setup to exercise the standard `MediaQueryList` event-listener API.
- Made no dependency, styling, markup, or public API changes.

## Testing and review

The following checks completed successfully:

1. Targeted USA Footer tests:
   npx mocha --require jsdom-global/register packages/usa-footer/src/test/footer.spec.js
Result: 20 tests passing.

2. ESLint on the changed files:
   npx eslint packages/usa-footer/src/index.js packages/usa-footer/src/test/footer.spec.js
   Result: No linting errors.

3. Prettier formatting check:
   npx prettier --check packages/usa-footer/src/index.js packages/usa-footer/src/test/footer.spec.js
   Result: All changed files use Prettier formatting.

4. Full repository test suite:
   npm test
   Result: Completed successfully, including 828 unit tests and 28 task tests.

Reviewers can focus on confirming that the media query change listener is registered during footer initialization, removed during teardown, and continues to update the responsive footer behavior when the viewport crosses the configured breakpoint.