### PR TITLE
USWDS - Code Review: Add caching layer to eliminate redundant PR reviews

### DIFF
--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -33,9 +33,6 @@ PR reviews are cached in an unversioned `.review-cache/` directory at the projec
 # Check if PR is already cached at current commit
 node .agents/skills/uswds-code-review/scripts/review-cache.mjs check --pr <N>
 
-# List all cached reviews
-node .agents/skills/uswds-code-review/scripts/review-cache.mjs list
-
 # Refresh open/merged status for every cached review
 node .agents/skills/uswds-code-review/scripts/review-cache.mjs sync
 ```

--- a/.agents/skills/uswds-code-review/SKILL.md
+++ b/.agents/skills/uswds-code-review/SKILL.md
@@ -12,7 +12,7 @@ Perform a judgment-based code review of USWDS changes, reproducing the calibrati
 ## Entry point
 
 **Auto-detected:**
-- **Given a PR number or URL** → fetch via `gh pr view --json body,title,additions,deletions,files,baseRefName` + `gh pr diff`. All gates apply, including PR-body hygiene and definition-of-done checks.
+- **Given a PR number or URL** → fetch via `gh pr view --json body,title,additions,deletions,files,baseRefName,headRefOid` + `gh pr diff`. All gates apply, including PR-body hygiene and definition-of-done checks.
 - **No argument (local branch)** → `git diff develop...HEAD`. PR-body and DoD gates are *skipped* and reported as such, not silently passed.
 
 Example invocations:
@@ -20,15 +20,47 @@ Example invocations:
 - `/uswds-code-review https://github.com/uswds/uswds/pull/6789`
 - `/uswds-code-review` (reviews current branch)
 
+## Review Cache
+
+PR reviews are cached in an unversioned `.review-cache/` directory at the project root to prevent re-reviewing unchanged commits:
+
+- **`.review-cache/cache.json`**: Index tracking reviewed PRs, commit hashes, recommendations, summaries, and each PR's `status` (`open` or `merged`).
+- **`.review-cache/<commit-sha>.md`**: Full markdown review findings saved per commit ID.
+- **Retention**: Nothing is deleted. When a PR merges, its entry is marked `status: "merged"` and both the metadata and the findings markdown are kept — the review of a merged PR is the record you want when a regression surfaces later.
+- **Local branches are not cached.** A local branch's HEAD moves with every amend and there's no remote state to compare against, so `check` and `save` both require `--pr`. Reviewing the current branch always runs the full pass.
+
+```bash
+# Check if PR is already cached at current commit
+node .agents/skills/uswds-code-review/scripts/review-cache.mjs check --pr <N>
+
+# List all cached reviews
+node .agents/skills/uswds-code-review/scripts/review-cache.mjs list
+
+# Refresh open/merged status for every cached review
+node .agents/skills/uswds-code-review/scripts/review-cache.mjs sync
+```
+
 ## Process
 
-### 1. Gather context
+### 1. Check cache and gather context
 
-Run these in parallel:
+**Step 1a: Check cache**
+Before pulling full diffs and re-evaluating gates on a PR, check if the PR has already been reviewed at its current commit:
+```bash
+node .agents/skills/uswds-code-review/scripts/review-cache.mjs check --pr <N> --json
+```
+- If status is `CACHED` (exit 0): Output the cached recommendation, summary, and the findings from `reportContent`. Skip redundant review work unless the user passes `--force`. If `reportExists` is `false`, the findings are gone — treat it as a `MISS` and re-review.
+- If status is `MERGED` (exit 2): The PR is already merged. Report that, along with the retained prior review if `cached` is `true`. Don't review a merged PR unless the user explicitly asks.
+- If status is `MISS` (exit 1): Proceed with review.
+- If status is `ERROR` (exit 3): Report the failure. Don't silently proceed as if the cache were empty.
+
+Skip this step entirely when reviewing a local branch — only PR reviews are cached.
+
+**Step 1b: Gather context (in parallel):**
 
 **If reviewing a PR:**
 ```bash
-gh pr view <N> --repo uswds/uswds --json number,title,body,additions,deletions,changedFiles,files,baseRefName,url
+gh pr view <N> --repo uswds/uswds --json number,title,body,additions,deletions,changedFiles,files,baseRefName,headRefOid,url
 gh pr diff <N> --repo uswds/uswds
 gh api repos/uswds/uswds/pulls/<N>/files --paginate --jq '.[] | {filename, additions, deletions, status, patch}'
 ```
@@ -224,7 +256,28 @@ Legend: ✅ pass, ⚠️ flag (non-blocking), ❌ fail (blocking), ⏭️ skippe
 - [any other items from silence list]
 ```
 
-### 6. Evidence and voice
+### 6. Save review to cache
+
+After generating the review findings, save the review to the cache. Write the report to a file and pass `--report-file`; `--recommendation` must lead with one of the four enum values, since downstream tooling buckets on that prefix:
+```bash
+node .agents/skills/uswds-code-review/scripts/review-cache.mjs save \
+  --pr <N> \
+  --sha <commitSha> \
+  --recommendation "<Approve|Approve with suggestions|Request changes|Hold>" \
+  --summary "<1-2 sentence census of findings>" \
+  --report-file /tmp/review-<N>.md
+```
+
+`--report-file -` reads the markdown from stdin. Use `--report-text "<markdown>"` only for a short inline report — a nonexistent `--report-file` path is an error rather than being silently stored as the report body.
+
+This ensures:
+1. The full review findings markdown is saved to `.review-cache/<commit-sha>.md`.
+2. `.review-cache/cache.json` is updated with PR number, commit SHA, recommendation, summary, and `status: "open"`.
+3. Subsequent runs with no new commits will immediately return the cached result.
+
+Skip this step for local-branch reviews; only PR reviews are cached.
+
+### 7. Evidence and voice
 
 **Every substantive finding must include:**
 - A code block showing the issue, OR

--- a/.agents/skills/uswds-code-review/VERIFICATION.md
+++ b/.agents/skills/uswds-code-review/VERIFICATION.md
@@ -141,10 +141,74 @@ The corpus doubles as a regression suite — these PRs have known outcomes, so t
 
 **Check:** After running any of the above, confirm:
 - No `gh pr review` or `gh pr comment` calls were made
-- No writes outside `/tmp` or the review report itself
+- No writes outside `/tmp`, `.review-cache/`, or the review report itself
 - The skill produced a local markdown report only
 
 **Success criteria:** The skill never touches GitHub without explicit user action. All output is local.
+
+---
+
+### 10. Review cache verification
+
+Runs entirely offline against a scratch cache directory, so it doesn't depend on
+the live state of any PR. (An earlier version of this section used real PR #6786
+and could never pass: #6786 merged on 2026-08-10, so `check` reports `MERGED`
+rather than a cache hit.)
+
+**Setup & Execution:**
+1. Save a review into a scratch cache:
+   ```bash
+   CACHE=$(mktemp -d)
+   node .agents/skills/uswds-code-review/scripts/review-cache.mjs save \
+     --pr 6786 \
+     --sha "e4f1a23b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f" \
+     --recommendation "Approve" \
+     --summary "Clean review with AT specialist routing" \
+     --report-text "# PR Review: Modal" \
+     --cache-dir "$CACHE"
+   ```
+2. Verify the cache hit, skipping the `gh` lookup so the check is deterministic:
+   ```bash
+   node .agents/skills/uswds-code-review/scripts/review-cache.mjs check \
+     --pr 6786 \
+     --sha "e4f1a23b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f" \
+     --offline --cache-dir "$CACHE"
+   echo "exit: $?"
+   ```
+   Must report `[CACHE HIT]`, print the report path *without* `(MISSING ON DISK)`, and exit `0`.
+3. Verify a mistyped `--report-file` fails loudly instead of storing the filename as the report:
+   ```bash
+   node .agents/skills/uswds-code-review/scripts/review-cache.mjs save \
+     --pr 6787 --sha "abc1234" --report-file ./no-such-report.md --cache-dir "$CACHE"
+   echo "exit: $?"   # must be 1, with no 6787 entry created
+   ```
+4. Clean up: `rm -rf "$CACHE"`.
+
+**Success criteria:**
+- Cache hit prevents re-running gates when commit SHA is unchanged, and returns the findings markdown (not just metadata).
+- Markdown file exists at `<cache-dir>/<sha>.md`, and resolves correctly under a non-default `--cache-dir`.
+- `.review-cache/` is unversioned and ignored by git.
+- Merged PRs keep their cache entry and findings file; only `status` changes.
+
+**Unit coverage:** the cache tooling has its own spec, run via npm
+(it is deliberately *not* wired into `gulp test` — this is skill tooling, not
+library code, so it stays out of the main test config):
+
+```bash
+npm run test:agents
+
+# Narrow to one group while iterating:
+npm run test:agents -- --grep syncCache
+```
+
+No mocha config or flags are needed — `.mjs` is treated as ESM, and these are
+pure-function tests with no jsdom dependency. Exits `0` on pass, `1` on failure.
+
+Covers merge-status tracking, report resolution under a custom cache dir, SHA
+validation, and `execCmd` signal handling.
+
+**If you change `review-cache.mjs`, run this by hand.** Nothing runs it
+automatically.
 
 ---
 

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -24,10 +24,16 @@
  *   node review-cache.mjs list
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { resolve, join, dirname } from "path";
-import { spawn } from "child_process";
-import { fileURLToPath } from "url";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
+import { parseArgs } from "node:util";
+
+// ============================================================================
+// 1. Constants & Enums
+// ============================================================================
 
 /** Lifecycle state of the PR a cached review belongs to. */
 export const STATUS_OPEN = "open";
@@ -36,9 +42,27 @@ export const STATUS_MERGED = "merged";
 /** Conventional cache directory name, relative to the repo root. */
 export const CACHE_DIR_NAME = ".review-cache";
 
+export const CHECK_STATUS = {
+  CACHED: "CACHED",
+  MISS: "MISS",
+  MERGED: "MERGED",
+  ERROR: "ERROR",
+};
+
+export const CHECK_EXIT_CODES = {
+  [CHECK_STATUS.CACHED]: 0,
+  [CHECK_STATUS.MISS]: 1,
+  [CHECK_STATUS.MERGED]: 2,
+  [CHECK_STATUS.ERROR]: 3,
+};
+
 function emptyCache() {
   return { version: 1, reviews: {} };
 }
+
+// ============================================================================
+// 2. Path & Environment Resolution
+// ============================================================================
 
 export function findRepoRoot(startDir = process.cwd()) {
   let cur = resolve(startDir);
@@ -58,6 +82,15 @@ export function getDefaultCacheDir(startDir = process.cwd()) {
 function cacheFilePath(cacheDir) {
   return join(cacheDir, "cache.json");
 }
+
+/** Findings for a commit always live at <cacheDir>/<sha>.md. */
+export function reportFilePath(cacheDir, sha) {
+  return join(cacheDir, `${sha}.md`);
+}
+
+// ============================================================================
+// 3. Storage & Persistence
+// ============================================================================
 
 export function loadCache(cacheDir = getDefaultCacheDir()) {
   const cacheFile = cacheFilePath(cacheDir);
@@ -79,6 +112,10 @@ export function loadCache(cacheDir = getDefaultCacheDir()) {
   }
 }
 
+/**
+ * Write cache atomically to prevent corrupted cache.json files if the process
+ * is interrupted or terminated midway through writing.
+ */
 export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
   mkdirSync(cacheDir, { recursive: true });
   const payload = {
@@ -86,12 +123,32 @@ export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
     updatedAt: new Date().toISOString(),
     reviews: cacheData.reviews || {},
   };
-  writeFileSync(
-    cacheFilePath(cacheDir),
-    JSON.stringify(payload, null, 2),
-    "utf-8",
-  );
+  const targetPath = cacheFilePath(cacheDir);
+  const tempPath = `${targetPath}.${randomBytes(6).toString("hex")}.tmp`;
+
+  writeFileSync(tempPath, JSON.stringify(payload, null, 2), "utf-8");
+  renameSync(tempPath, targetPath);
 }
+
+function readReport(cacheDir, entry) {
+  const absolutePath = reportFilePath(cacheDir, entry.headSha);
+  if (!existsSync(absolutePath)) {
+    return { reportExists: false, reportContent: null };
+  }
+  try {
+    return {
+      reportExists: true,
+      reportContent: readFileSync(absolutePath, "utf-8"),
+    };
+  } catch {
+    // Unreadable report degrades to metadata-only; not fatal.
+    return { reportExists: true, reportContent: null };
+  }
+}
+
+// ============================================================================
+// 4. Child Process & GitHub CLI Integration
+// ============================================================================
 
 export async function execCmd(cmd, args, opts = {}) {
   return new Promise((resolvePromise, rejectPromise) => {
@@ -100,22 +157,21 @@ export async function execCmd(cmd, args, opts = {}) {
       killSignal: opts.killSignal || "SIGKILL",
       ...opts,
     });
+
+    proc.stdout?.setEncoding("utf-8");
+    proc.stderr?.setEncoding("utf-8");
+
     let stdout = "";
     let stderr = "";
+
     proc.stdout?.on("data", (d) => {
       stdout += d;
     });
     proc.stderr?.on("data", (d) => {
       stderr += d;
     });
+
     proc.on("error", rejectPromise);
-    proc.on("exit", (code, signal) => {
-      if (signal) {
-        rejectPromise(
-          new Error(`${cmd} terminated by signal ${signal}: ${stderr.trim()}`),
-        );
-      }
-    });
     proc.on("close", (code, signal) => {
       if (signal) {
         rejectPromise(
@@ -163,27 +219,6 @@ export async function fetchPRInfo(
   }
 }
 
-/** Findings for a commit always live at <cacheDir>/<sha>.md. */
-export function reportFilePath(cacheDir, sha) {
-  return join(cacheDir, `${sha}.md`);
-}
-
-function readReport(cacheDir, entry) {
-  const absolutePath = reportFilePath(cacheDir, entry.headSha);
-  if (!existsSync(absolutePath)) {
-    return { reportExists: false, reportContent: null };
-  }
-  try {
-    return {
-      reportExists: true,
-      reportContent: readFileSync(absolutePath, "utf-8"),
-    };
-  } catch {
-    // Unreadable report degrades to metadata-only; not fatal.
-    return { reportExists: true, reportContent: null };
-  }
-}
-
 /**
  * `state` is authoritative, but a PR fetched right after a merge can still
  * report OPEN while carrying a mergedAt timestamp, so trust either signal.
@@ -225,6 +260,10 @@ async function resolvePRHead({
   }
 }
 
+// ============================================================================
+// 5. Core Domain Operations
+// ============================================================================
+
 export async function checkReview({
   pr,
   sha = null,
@@ -238,7 +277,7 @@ export async function checkReview({
 
   if (!prNum) {
     return {
-      status: "ERROR",
+      status: CHECK_STATUS.ERROR,
       pr: null,
       message:
         "A PR number is required. Local-branch reviews are not cached; run the review directly.",
@@ -257,12 +296,12 @@ export async function checkReview({
   });
 
   if (error) {
-    return { status: "ERROR", pr: prNum, message: error };
+    return { status: CHECK_STATUS.ERROR, pr: prNum, message: error };
   }
 
   if (!currentSha) {
     return {
-      status: "ERROR",
+      status: CHECK_STATUS.ERROR,
       pr: prNum,
       message:
         "--offline requires --sha, since the head commit cannot be read.",
@@ -273,7 +312,7 @@ export async function checkReview({
 
   if (isMerged && !cachedEntry) {
     return {
-      status: "MERGED",
+      status: CHECK_STATUS.MERGED,
       pr: prNum,
       headSha: currentSha,
       cached: false,
@@ -291,7 +330,7 @@ export async function checkReview({
       writeCache(cache, cacheDir);
     }
     return {
-      status: "MERGED",
+      status: CHECK_STATUS.MERGED,
       pr: prNum,
       headSha: currentSha,
       cached: true,
@@ -308,7 +347,7 @@ export async function checkReview({
 
   if (cachedEntry?.headSha === currentSha) {
     return {
-      status: "CACHED",
+      status: CHECK_STATUS.CACHED,
       pr: prNum,
       headSha: currentSha,
       recommendation: cachedEntry.recommendation,
@@ -321,7 +360,7 @@ export async function checkReview({
   }
 
   return {
-    status: "MISS",
+    status: CHECK_STATUS.MISS,
     pr: prNum,
     headSha: currentSha,
     title: prInfo?.title || null,
@@ -401,6 +440,23 @@ export function saveReview({
   };
 }
 
+/** Helper for bounded concurrency mapping */
+async function mapConcurrent(items, limit, fn) {
+  const results = [];
+  const executing = new Set();
+  for (const item of items) {
+    const p = Promise.resolve().then(() => fn(item));
+    results.push(p);
+    executing.add(p);
+    const clean = () => executing.delete(p);
+    p.then(clean, clean);
+    if (executing.size >= limit) {
+      await Promise.race(executing);
+    }
+  }
+  return Promise.all(results);
+}
+
 /**
  * Refresh the merge status of every cached entry against the remote.
  *
@@ -413,17 +469,19 @@ export async function syncCache({
   cacheDir = getDefaultCacheDir(),
   fetchPRInfoFn = fetchPRInfo,
   execFn = execCmd,
+  concurrency = 5,
 }) {
   const cache = loadCache(cacheDir);
+  const entries = Object.values(cache.reviews || {});
   const merged = [];
   const open = [];
   const unreachable = [];
 
-  for (const entry of Object.values(cache.reviews || {})) {
+  await mapConcurrent(entries, concurrency, async (entry) => {
     const prNum = parsePRNumber(entry.pr);
     if (!prNum) {
       unreachable.push({ pr: entry.pr, headSha: entry.headSha });
-      continue;
+      return;
     }
 
     try {
@@ -450,7 +508,7 @@ export async function syncCache({
       // Network/auth failure must not rewrite state we can't verify.
       unreachable.push({ pr: prNum, headSha: entry.headSha });
     }
-  }
+  });
 
   writeCache(cache, cacheDir);
 
@@ -470,9 +528,11 @@ export async function syncCache({
   };
 }
 
-// CLI Execution
+// ============================================================================
+// 6. CLI Formatting & Utilities
+// ============================================================================
 
-const HELP_TEXT = `USWDS Code Review Cache Tool
+export const HELP_TEXT = `USWDS Code Review Cache Tool
 
 Usage:
   node review-cache.mjs check --pr <number|url> [--sha <hash>] [--offline] [--repo <owner/repo>] [--json]
@@ -498,60 +558,13 @@ Options:
 Note: only PR reviews are cached; --pr is required for check and save.
 `;
 
-/** Flags that consume the following argument, keyed to their option name. */
-const VALUE_FLAGS = {
-  "--pr": "pr",
-  "--sha": "sha",
-  "--repo": "repo",
-  "--recommendation": "recommendation",
-  "--rec": "recommendation",
-  "--summary": "summary",
-  "--title": "title",
-  "--report-file": "reportFile",
-  "--report-text": "reportText",
-  "--cache-dir": "cacheDir",
+const useColor = Boolean(process.stdout.isTTY && !process.env.NO_COLOR);
+const color = {
+  green: (s) => (useColor ? `\x1b[32m${s}\x1b[0m` : s),
+  yellow: (s) => (useColor ? `\x1b[33m${s}\x1b[0m` : s),
+  red: (s) => (useColor ? `\x1b[31m${s}\x1b[0m` : s),
+  cyan: (s) => (useColor ? `\x1b[36m${s}\x1b[0m` : s),
 };
-
-/** Flags that are their own value. */
-const BOOLEAN_FLAGS = {
-  "--json": "json",
-  "--force": "force",
-  "--offline": "offline",
-};
-
-const CHECK_EXIT_CODES = { CACHED: 0, MISS: 1, MERGED: 2, ERROR: 3 };
-
-function fail(message) {
-  console.error(message);
-  process.exit(1);
-}
-
-function parseOptions(args) {
-  const options = {
-    cacheDir: getDefaultCacheDir(),
-    repo: "uswds/uswds",
-    json: false,
-    force: false,
-    offline: false,
-  };
-
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (arg === "--report") {
-      fail(
-        "Error: --report is ambiguous. Use --report-file <path> (or '-' for stdin), or --report-text <markdown>.",
-      );
-    } else if (VALUE_FLAGS[arg]) {
-      i += 1;
-      options[VALUE_FLAGS[arg]] = args[i];
-    } else if (BOOLEAN_FLAGS[arg]) {
-      options[BOOLEAN_FLAGS[arg]] = true;
-    }
-  }
-
-  options.cacheDir = resolve(options.cacheDir);
-  return options;
-}
 
 /** Print `label: value`, skipping fields the saved review never filled in. */
 function printField(label, value) {
@@ -567,117 +580,18 @@ function printCachedReview(result, reportLabel) {
 }
 
 function printCheckResult(result) {
-  if (result.status === "CACHED") {
-    console.log(`\x1b[32m[CACHE HIT]\x1b[0m ${result.message}`);
+  if (result.status === CHECK_STATUS.CACHED) {
+    console.log(`${color.green("[CACHE HIT]")} ${result.message}`);
     printCachedReview(result, "Full report");
-  } else if (result.status === "MERGED") {
-    console.log(`\x1b[33m[MERGED]\x1b[0m ${result.message}`);
+  } else if (result.status === CHECK_STATUS.MERGED) {
+    console.log(`${color.yellow("[MERGED]")} ${result.message}`);
     if (result.cached) {
       printCachedReview(result, "Retained report");
     }
-  } else if (result.status === "ERROR") {
-    console.error(`\x1b[31m[ERROR]\x1b[0m ${result.message}`);
+  } else if (result.status === CHECK_STATUS.ERROR) {
+    console.error(`${color.red("[ERROR]")} ${result.message}`);
   } else {
-    console.log(`\x1b[36m[CACHE MISS]\x1b[0m ${result.message}`);
-  }
-}
-
-async function runCheck(options) {
-  if (!options.pr) {
-    fail(
-      "Error: --pr is required for check. Local-branch reviews are not cached.",
-    );
-  }
-
-  if (options.force) {
-    if (options.json) {
-      console.log(
-        JSON.stringify({
-          status: "FORCED_MISS",
-          pr: options.pr,
-          message: "Forced review bypass",
-        }),
-      );
-    } else {
-      console.log(`Forced cache bypass for PR #${options.pr}.`);
-    }
-    process.exit(CHECK_EXIT_CODES.MISS);
-  }
-
-  const result = await checkReview({
-    pr: options.pr,
-    sha: options.sha,
-    repo: options.repo,
-    offline: options.offline,
-    cacheDir: options.cacheDir,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    printCheckResult(result);
-  }
-
-  process.exit(CHECK_EXIT_CODES[result.status] ?? 3);
-}
-
-/** Resolve the findings markdown a `save` should persist. */
-function readReportContent({ reportFile, reportText }) {
-  if (reportFile && reportText !== undefined) {
-    fail("Error: pass only one of --report-file or --report-text.");
-  }
-  if (!reportFile) {
-    return reportText ?? "";
-  }
-  if (reportFile === "-") {
-    return readFileSync(0, "utf-8");
-  }
-  if (!existsSync(reportFile)) {
-    // Never silently fall back to treating the path as content: a typo would
-    // otherwise be cached as a valid review whose body is the filename.
-    fail(
-      `Error: report file not found: ${reportFile}. Use --report-text for inline markdown.`,
-    );
-  }
-  return readFileSync(reportFile, "utf-8");
-}
-
-function runSave(options) {
-  const result = saveReview({
-    pr: options.pr,
-    sha: options.sha,
-    title: options.title,
-    recommendation: options.recommendation,
-    summary: options.summary,
-    reportContent: readReportContent(options),
-    cacheDir: options.cacheDir,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(
-      `Saved review for PR #${result.pr} (${result.headSha.slice(0, 7)}) to ${result.reportPath}`,
-    );
-  }
-}
-
-async function runSync(options) {
-  const result = await syncCache({
-    repo: options.repo,
-    cacheDir: options.cacheDir,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-    return;
-  }
-
-  console.log(
-    `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
-  );
-  for (const item of result.merged.filter((entry) => entry.changed)) {
-    console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
+    console.log(`${color.cyan("[CACHE MISS]")} ${result.message}`);
   }
 }
 
@@ -695,11 +609,168 @@ function formatDateOnly(isoString) {
   }
 }
 
-function runList(options) {
+// ============================================================================
+// 7. CLI Option Parsing & Dispatcher
+// ============================================================================
+
+export function parseCliArgs(rawArgs) {
+  // Check for ambiguous --report before standard parsing
+  if (rawArgs.includes("--report")) {
+    throw new Error(
+      "Error: --report is ambiguous. Use --report-file <path> (or '-' for stdin), or --report-text <markdown>.",
+    );
+  }
+
+  const { values, positionals } = parseArgs({
+    args: rawArgs,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      pr: { type: "string" },
+      sha: { type: "string" },
+      repo: { type: "string", default: "uswds/uswds" },
+      recommendation: { type: "string" },
+      rec: { type: "string" },
+      summary: { type: "string" },
+      title: { type: "string" },
+      "report-file": { type: "string" },
+      "report-text": { type: "string" },
+      "cache-dir": { type: "string" },
+      json: { type: "boolean", default: false },
+      force: { type: "boolean", default: false },
+      offline: { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+  });
+
+  return {
+    command: positionals[0],
+    options: {
+      pr: values.pr,
+      sha: values.sha,
+      repo: values.repo,
+      recommendation: values.recommendation || values.rec,
+      summary: values.summary,
+      title: values.title,
+      reportFile: values["report-file"],
+      reportText: values["report-text"],
+      cacheDir: resolve(values["cache-dir"] || getDefaultCacheDir()),
+      json: values.json,
+      force: values.force,
+      offline: values.offline,
+      help: values.help,
+    },
+  };
+}
+
+/** Resolve the findings markdown a `save` should persist. */
+function readReportContent({ reportFile, reportText }) {
+  if (reportFile && reportText !== undefined) {
+    throw new Error("Error: pass only one of --report-file or --report-text.");
+  }
+  if (!reportFile) {
+    return reportText ?? "";
+  }
+  if (reportFile === "-") {
+    return readFileSync(0, "utf-8");
+  }
+  if (!existsSync(reportFile)) {
+    // Never silently fall back to treating the path as content: a typo would
+    // otherwise be cached as a valid review whose body is the filename.
+    throw new Error(
+      `Error: report file not found: ${reportFile}. Use --report-text for inline markdown.`,
+    );
+  }
+  return readFileSync(reportFile, "utf-8");
+}
+
+export async function runCheck(options) {
+  if (!options.pr) {
+    throw new Error(
+      "Error: --pr is required for check. Local-branch reviews are not cached.",
+    );
+  }
+
+  if (options.force) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          status: "FORCED_MISS",
+          pr: options.pr,
+          message: "Forced review bypass",
+        }),
+      );
+    } else {
+      console.log(`Forced cache bypass for PR #${options.pr}.`);
+    }
+    return { exitCode: CHECK_EXIT_CODES[CHECK_STATUS.MISS] };
+  }
+
+  const result = await checkReview({
+    pr: options.pr,
+    sha: options.sha,
+    repo: options.repo,
+    offline: options.offline,
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printCheckResult(result);
+  }
+
+  return { exitCode: CHECK_EXIT_CODES[result.status] ?? 3, result };
+}
+
+export function runSave(options) {
+  const result = saveReview({
+    pr: options.pr,
+    sha: options.sha,
+    title: options.title,
+    recommendation: options.recommendation,
+    summary: options.summary,
+    reportContent: readReportContent(options),
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(
+      `Saved review for PR #${result.pr} (${result.headSha.slice(0, 7)}) to ${result.reportPath}`,
+    );
+  }
+
+  return { exitCode: 0, result };
+}
+
+export async function runSync(options) {
+  const result = await syncCache({
+    repo: options.repo,
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return { exitCode: 0, result };
+  }
+
+  console.log(
+    `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
+  );
+  for (const item of result.merged.filter((entry) => entry.changed)) {
+    console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
+  }
+
+  return { exitCode: 0, result };
+}
+
+export function runList(options) {
   const cache = loadCache(options.cacheDir);
   if (options.json) {
     console.log(JSON.stringify(cache, null, 2));
-    return;
+    return { exitCode: 0, result: cache };
   }
 
   const entries = Object.values(cache.reviews || {});
@@ -715,37 +786,55 @@ function runList(options) {
       console.log(`      ${item.summary}`);
     }
   }
+
+  return { exitCode: 0, result: cache };
 }
 
-const COMMANDS = {
+export const COMMANDS = {
   check: runCheck,
   save: runSave,
   sync: runSync,
   list: runList,
 };
 
-async function main() {
-  const args = process.argv.slice(2);
-  const command = args[0];
+export async function main(rawArgs = process.argv.slice(2)) {
+  let parsed;
+  try {
+    parsed = parseCliArgs(rawArgs);
+  } catch (err) {
+    console.error(err.message);
+    return 1;
+  }
 
-  if (!command || args.includes("--help") || args.includes("-h")) {
+  const { command, options } = parsed;
+
+  if (!command || options.help || rawArgs.includes("--help") || rawArgs.includes("-h")) {
     console.log(HELP_TEXT);
-    process.exit(0);
+    return 0;
   }
 
   const run = COMMANDS[command];
   if (!run) {
-    fail(`Unknown command: ${command}`);
+    console.error(`Unknown command: ${command}`);
+    return 1;
   }
 
-  await run(parseOptions(args.slice(1)));
+  try {
+    const { exitCode = 0 } = await run(options);
+    return exitCode;
+  } catch (err) {
+    console.error(err.message);
+    return 1;
+  }
 }
 
 if (
   process.argv[1] &&
   fileURLToPath(import.meta.url) === resolve(process.argv[1])
 ) {
-  main().catch((err) => {
+  main().then((code) => {
+    process.exit(code);
+  }).catch((err) => {
     console.error("Fatal error in review-cache:", err.message);
     process.exit(1);
   });

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -21,10 +21,15 @@
  *   node review-cache.mjs check --pr 6767
  *   node review-cache.mjs save --pr 6767 --sha abc1234 --recommendation "Request changes" --summary "..." --report-file report.md
  *   node review-cache.mjs sync
- *   node review-cache.mjs list
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from "node:fs";
 import { resolve, join, dirname } from "node:path";
 import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -35,6 +40,7 @@ const execFileAsync = promisify(execFile);
 
 export const STATUS_OPEN = "open";
 export const STATUS_MERGED = "merged";
+export const STATUS_CLOSED = "closed";
 
 /** Conventional cache directory name, relative to the repo root. */
 export const CACHE_DIR_NAME = ".review-cache";
@@ -43,6 +49,7 @@ export const CHECK_STATUS = {
   CACHED: "CACHED",
   MISS: "MISS",
   MERGED: "MERGED",
+  CLOSED: "CLOSED",
   ERROR: "ERROR",
 };
 
@@ -50,6 +57,7 @@ export const CHECK_EXIT_CODES = {
   [CHECK_STATUS.CACHED]: 0,
   [CHECK_STATUS.MISS]: 1,
   [CHECK_STATUS.MERGED]: 2,
+  [CHECK_STATUS.CLOSED]: 2,
   [CHECK_STATUS.ERROR]: 3,
 };
 
@@ -68,7 +76,30 @@ export function findRepoRoot(startDir = process.cwd()) {
 }
 
 export function getDefaultCacheDir(startDir = process.cwd()) {
+  if (process.env.USWDS_REVIEW_CACHE_DIR) {
+    return resolve(process.env.USWDS_REVIEW_CACHE_DIR);
+  }
   return join(findRepoRoot(startDir), CACHE_DIR_NAME);
+}
+
+export function isTestEnv() {
+  return (
+    process.env.NODE_ENV === "test" ||
+    Boolean(process.env.MOCHA_COLORS) ||
+    Boolean(process.env.npm_lifecycle_event?.includes("test"))
+  );
+}
+
+export function assertSafeCacheDir(cacheDir) {
+  if (isTestEnv() && !process.env.USWDS_ALLOW_PROD_CACHE_IN_TEST) {
+    const realProdCache = resolve(join(findRepoRoot(), CACHE_DIR_NAME));
+    if (resolve(cacheDir) === realProdCache) {
+      throw new Error(
+        `Refusing to modify production review cache (${realProdCache}) during tests. ` +
+          `Set USWDS_REVIEW_CACHE_DIR to a temporary directory or pass --cache-dir.`,
+      );
+    }
+  }
 }
 
 /** Findings for a commit always live at <cacheDir>/<sha>.md. */
@@ -101,6 +132,7 @@ export function loadCache(cacheDir = getDefaultCacheDir()) {
  * is interrupted or terminated midway through writing.
  */
 export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
+  assertSafeCacheDir(cacheDir);
   mkdirSync(cacheDir, { recursive: true });
   const payload = {
     version: cacheData.version || 1,
@@ -181,7 +213,7 @@ export async function fetchPRInfo(
       "--repo",
       repo,
       "--json",
-      "number,title,state,mergedAt,headRefOid,url,baseRefName",
+      "number,title,state,mergedAt,closedAt,headRefOid,url,baseRefName",
     ]);
     return JSON.parse(jsonStr);
   } catch (err) {
@@ -197,7 +229,11 @@ export async function fetchPRInfo(
  * report OPEN while carrying a mergedAt timestamp, so trust either signal.
  */
 function isMergedPR(prInfo) {
-  return prInfo.state === "MERGED" || Boolean(prInfo.mergedAt);
+  return prInfo?.state === "MERGED" || Boolean(prInfo?.mergedAt);
+}
+
+function isClosedPR(prInfo) {
+  return prInfo?.state === "CLOSED" && !isMergedPR(prInfo);
 }
 
 /**
@@ -222,6 +258,7 @@ async function resolvePRHead({
         prInfo,
         currentSha: prInfo.headRefOid,
         isMerged: isMergedPR(prInfo),
+        isClosed: isClosedPR(prInfo),
       };
     } catch (err) {
       if (!sha) {
@@ -229,7 +266,7 @@ async function resolvePRHead({
       }
     }
   }
-  return { prInfo: null, currentSha: sha, isMerged: false };
+  return { prInfo: null, currentSha: sha, isMerged: false, isClosed: false };
 }
 
 export async function checkReview({
@@ -254,14 +291,16 @@ export async function checkReview({
 
   const cache = loadCache(cacheDir);
 
-  const { prInfo, currentSha, isMerged, error } = await resolvePRHead({
-    prNum,
-    sha,
-    repo,
-    offline,
-    fetchPRInfoFn,
-    execFn,
-  });
+  const { prInfo, currentSha, isMerged, isClosed, error } = await resolvePRHead(
+    {
+      prNum,
+      sha,
+      repo,
+      offline,
+      fetchPRInfoFn,
+      execFn,
+    },
+  );
 
   if (error) {
     return { status: CHECK_STATUS.ERROR, pr: prNum, message: error };
@@ -294,6 +333,7 @@ export async function checkReview({
     if (cachedEntry.status !== STATUS_MERGED) {
       cachedEntry.status = STATUS_MERGED;
       cachedEntry.mergedAt = prInfo?.mergedAt || new Date().toISOString();
+      delete cachedEntry.closedAt;
       writeCache(cache, cacheDir);
     }
     return {
@@ -305,6 +345,37 @@ export async function checkReview({
       mergedAt: cachedEntry.mergedAt,
       ...getCachedReviewDetails(cacheDir, cachedEntry),
       message: `PR #${prNum} is merged. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
+    };
+  }
+
+  if (isClosed && !cachedEntry) {
+    return {
+      status: CHECK_STATUS.CLOSED,
+      pr: prNum,
+      headSha: currentSha,
+      cached: false,
+      message: `PR #${prNum} is closed and was never reviewed through this cache.`,
+    };
+  }
+
+  // A closed PR keeps its entry and its findings markdown; only the status
+  // changes.
+  if (isClosed) {
+    if (cachedEntry.status !== STATUS_CLOSED) {
+      cachedEntry.status = STATUS_CLOSED;
+      cachedEntry.closedAt = prInfo?.closedAt || new Date().toISOString();
+      delete cachedEntry.mergedAt;
+      writeCache(cache, cacheDir);
+    }
+    return {
+      status: CHECK_STATUS.CLOSED,
+      pr: prNum,
+      headSha: currentSha,
+      cached: true,
+      reviewedSha: cachedEntry.headSha,
+      closedAt: cachedEntry.closedAt,
+      ...getCachedReviewDetails(cacheDir, cachedEntry),
+      message: `PR #${prNum} is closed. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
     };
   }
 
@@ -357,6 +428,7 @@ export function saveReview({
   status = STATUS_OPEN,
   cacheDir = getDefaultCacheDir(),
 }) {
+  assertSafeCacheDir(cacheDir);
   assertValidSha(sha);
 
   const prNum = parsePRNumber(pr);
@@ -416,6 +488,7 @@ export async function syncCache({
   const cache = loadCache(cacheDir);
   const entries = Object.values(cache.reviews || {});
   const merged = [];
+  const closed = [];
   const open = [];
   const unreachable = [];
 
@@ -432,14 +505,28 @@ export async function syncCache({
         try {
           const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
           const isMerged = isMergedPR(prInfo);
-          const nextStatus = isMerged ? STATUS_MERGED : STATUS_OPEN;
+          const isClosed = isClosedPR(prInfo);
+          let nextStatus = STATUS_OPEN;
+          if (isMerged) nextStatus = STATUS_MERGED;
+          else if (isClosed) nextStatus = STATUS_CLOSED;
+
           const changed = entry.status !== nextStatus;
 
           entry.status = nextStatus;
           entry.title = entry.title || prInfo.title || "";
           if (isMerged) {
             entry.mergedAt = prInfo.mergedAt || entry.mergedAt || null;
+            delete entry.closedAt;
             merged.push({
+              pr: prNum,
+              headSha: entry.headSha,
+              title: entry.title,
+              changed,
+            });
+          } else if (isClosed) {
+            entry.closedAt = prInfo.closedAt || entry.closedAt || null;
+            delete entry.mergedAt;
+            closed.push({
               pr: prNum,
               headSha: entry.headSha,
               title: entry.title,
@@ -447,6 +534,7 @@ export async function syncCache({
             });
           } else {
             delete entry.mergedAt;
+            delete entry.closedAt;
             open.push({ pr: prNum, headSha: entry.headSha, changed });
           }
         } catch {
@@ -459,14 +547,18 @@ export async function syncCache({
 
   writeCache(cache, cacheDir);
 
-  const changedCount = [...merged, ...open].filter((e) => e.changed).length;
+  const changedCount = [...merged, ...closed, ...open].filter(
+    (e) => e.changed,
+  ).length;
 
   return {
     mergedCount: merged.length,
+    closedCount: closed.length,
     openCount: open.length,
     unreachableCount: unreachable.length,
     changedCount,
     merged,
+    closed,
     open,
     unreachable,
     totalCount: Object.keys(cache.reviews || {}).length,
@@ -479,12 +571,12 @@ Usage:
   node review-cache.mjs check --pr <number|url> [--sha <hash>] [--offline] [--repo <owner/repo>] [--json]
   node review-cache.mjs save --pr <number> --sha <hash> --recommendation <text> --summary <text> [--report-file <file> | --report-text <md>] [--title <text>]
   node review-cache.mjs sync [--repo <owner/repo>] [--json]
-  node review-cache.mjs list [--json]
 
 Exit codes for check:
   0  CACHED  — already reviewed at this commit
   1  MISS    — review needed
   2  MERGED  — PR is merged; prior review (if any) is retained
+  2  CLOSED  — PR is closed; prior review (if any) is retained
   3  ERROR   — could not determine state
 
 Options:
@@ -510,6 +602,7 @@ const color = {
 const CHECK_BADGES = {
   [CHECK_STATUS.CACHED]: () => color.green("[CACHE HIT]"),
   [CHECK_STATUS.MERGED]: () => color.yellow("[MERGED]"),
+  [CHECK_STATUS.CLOSED]: () => color.red("[CLOSED]"),
   [CHECK_STATUS.ERROR]: () => color.red("[ERROR]"),
   [CHECK_STATUS.MISS]: () => color.cyan("[CACHE MISS]"),
 };
@@ -528,28 +621,20 @@ function printCachedReview(result, reportLabel) {
 }
 
 function printCheckResult(result) {
-  const badgeFn = CHECK_BADGES[result.status] || CHECK_BADGES[CHECK_STATUS.MISS];
-  const out = result.status === CHECK_STATUS.ERROR ? console.error : console.log;
+  const badgeFn =
+    CHECK_BADGES[result.status] || CHECK_BADGES[CHECK_STATUS.MISS];
+  const out =
+    result.status === CHECK_STATUS.ERROR ? console.error : console.log;
   out(`${badgeFn()} ${result.message}`);
 
   if (result.status === CHECK_STATUS.CACHED) {
     printCachedReview(result, "Full report");
-  } else if (result.status === CHECK_STATUS.MERGED && result.cached) {
+  } else if (
+    (result.status === CHECK_STATUS.MERGED ||
+      result.status === CHECK_STATUS.CLOSED) &&
+    result.cached
+  ) {
     printCachedReview(result, "Retained report");
-  }
-}
-
-/** Pluralize `count` of `singular`, e.g. `pluralize(1, "item")` -> "item". */
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural;
-}
-
-function formatDateOnly(isoString) {
-  if (!isoString) return "-";
-  try {
-    return new Date(isoString).toISOString().split("T")[0];
-  } catch {
-    return isoString;
   }
 }
 
@@ -672,29 +757,13 @@ export async function runSync(options) {
 
   return outputResult(options, result, () => {
     console.log(
-      `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
+      `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.closedCount} closed, ${result.unreachableCount} unreachable.`,
     );
     for (const item of result.merged.filter((entry) => entry.changed)) {
       console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
     }
-  });
-}
-
-export function runList(options) {
-  const cache = loadCache(options.cacheDir);
-
-  return outputResult(options, cache, () => {
-    const entries = Object.values(cache.reviews || {});
-    console.log(
-      `Cached reviews (${entries.length} ${pluralize(entries.length, "item")}):`,
-    );
-    for (const item of entries) {
-      console.log(
-        `  PR #${item.pr || "?"} [${shortSha(item.headSha)}] (${item.status || STATUS_OPEN}) - ${item.recommendation || "Reviewed"} (${formatDateOnly(item.reviewedAt)})`,
-      );
-      if (item.summary) {
-        console.log(`      ${item.summary}`);
-      }
+    for (const item of result.closed.filter((entry) => entry.changed)) {
+      console.log(`  - #${item.pr} now closed: ${item.title || item.headSha}`);
     }
   });
 }
@@ -703,7 +772,6 @@ export const COMMANDS = {
   check: runCheck,
   save: runSave,
   sync: runSync,
-  list: runList,
 };
 
 export async function main(rawArgs = process.argv.slice(2)) {
@@ -741,10 +809,12 @@ if (
   process.argv[1] &&
   fileURLToPath(import.meta.url) === resolve(process.argv[1])
 ) {
-  main().then((code) => {
-    process.exit(code);
-  }).catch((err) => {
-    console.error("Fatal error in review-cache:", err.message);
-    process.exit(1);
-  });
+  main()
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      console.error("Fatal error in review-cache:", err.message);
+      process.exit(1);
+    });
 }

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -26,16 +26,13 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
-import { parseArgs } from "node:util";
+import { parseArgs, promisify } from "node:util";
 
-// ============================================================================
-// 1. Constants & Enums
-// ============================================================================
+const execFileAsync = promisify(execFile);
 
-/** Lifecycle state of the PR a cached review belongs to. */
 export const STATUS_OPEN = "open";
 export const STATUS_MERGED = "merged";
 
@@ -56,13 +53,8 @@ export const CHECK_EXIT_CODES = {
   [CHECK_STATUS.ERROR]: 3,
 };
 
-function emptyCache() {
-  return { version: 1, reviews: {} };
-}
-
-// ============================================================================
-// 2. Path & Environment Resolution
-// ============================================================================
+const shortSha = (sha, fallback = "unknown") =>
+  sha ? String(sha).slice(0, 7) : fallback;
 
 export function findRepoRoot(startDir = process.cwd()) {
   let cur = resolve(startDir);
@@ -79,23 +71,15 @@ export function getDefaultCacheDir(startDir = process.cwd()) {
   return join(findRepoRoot(startDir), CACHE_DIR_NAME);
 }
 
-function cacheFilePath(cacheDir) {
-  return join(cacheDir, "cache.json");
-}
-
 /** Findings for a commit always live at <cacheDir>/<sha>.md. */
 export function reportFilePath(cacheDir, sha) {
   return join(cacheDir, `${sha}.md`);
 }
 
-// ============================================================================
-// 3. Storage & Persistence
-// ============================================================================
-
 export function loadCache(cacheDir = getDefaultCacheDir()) {
-  const cacheFile = cacheFilePath(cacheDir);
+  const cacheFile = join(cacheDir, "cache.json");
   if (!existsSync(cacheFile)) {
-    return emptyCache();
+    return { version: 1, reviews: {} };
   }
   try {
     const data = JSON.parse(readFileSync(cacheFile, "utf-8"));
@@ -123,7 +107,7 @@ export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
     updatedAt: new Date().toISOString(),
     reviews: cacheData.reviews || {},
   };
-  const targetPath = cacheFilePath(cacheDir);
+  const targetPath = join(cacheDir, "cache.json");
   const tempPath = `${targetPath}.${randomBytes(6).toString("hex")}.tmp`;
 
   writeFileSync(tempPath, JSON.stringify(payload, null, 2), "utf-8");
@@ -146,46 +130,35 @@ function readReport(cacheDir, entry) {
   }
 }
 
-// ============================================================================
-// 4. Child Process & GitHub CLI Integration
-// ============================================================================
+function getCachedReviewDetails(cacheDir, entry) {
+  return {
+    recommendation: entry.recommendation,
+    summary: entry.summary,
+    reviewedAt: entry.reviewedAt,
+    reportPath: reportFilePath(cacheDir, entry.headSha),
+    ...readReport(cacheDir, entry),
+  };
+}
 
 export async function execCmd(cmd, args, opts = {}) {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const proc = spawn(cmd, args, {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, {
       timeout: opts.timeout || 60000,
       killSignal: opts.killSignal || "SIGKILL",
+      encoding: "utf-8",
       ...opts,
     });
-
-    proc.stdout?.setEncoding("utf-8");
-    proc.stderr?.setEncoding("utf-8");
-
-    let stdout = "";
-    let stderr = "";
-
-    proc.stdout?.on("data", (d) => {
-      stdout += d;
-    });
-    proc.stderr?.on("data", (d) => {
-      stderr += d;
-    });
-
-    proc.on("error", rejectPromise);
-    proc.on("close", (code, signal) => {
-      if (signal) {
-        rejectPromise(
-          new Error(`${cmd} terminated by signal ${signal}: ${stderr.trim()}`),
-        );
-      } else if (code !== 0) {
-        rejectPromise(
-          new Error(`${cmd} exited with code ${code}: ${stderr.trim()}`),
-        );
-      } else {
-        resolvePromise(stdout.trim());
-      }
-    });
-  });
+    return stdout.trim();
+  } catch (err) {
+    const stderr = (err.stderr || "").trim();
+    if (err.signal) {
+      throw new Error(`${cmd} terminated by signal ${err.signal}: ${stderr}`);
+    }
+    if (err.code !== undefined && err.code !== null) {
+      throw new Error(`${cmd} exited with code ${err.code}: ${stderr}`);
+    }
+    throw err;
+  }
 }
 
 export function parsePRNumber(prInput) {
@@ -242,27 +215,22 @@ async function resolvePRHead({
   fetchPRInfoFn,
   execFn,
 }) {
-  if (offline) {
-    return { prInfo: null, currentSha: sha, isMerged: false };
-  }
-  try {
-    const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
-    return {
-      prInfo,
-      currentSha: prInfo.headRefOid,
-      isMerged: isMergedPR(prInfo),
-    };
-  } catch (err) {
-    if (!sha) {
-      return { error: err.message };
+  if (!offline) {
+    try {
+      const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
+      return {
+        prInfo,
+        currentSha: prInfo.headRefOid,
+        isMerged: isMergedPR(prInfo),
+      };
+    } catch (err) {
+      if (!sha) {
+        return { error: err.message };
+      }
     }
-    return { prInfo: null, currentSha: sha, isMerged: false };
   }
+  return { prInfo: null, currentSha: sha, isMerged: false };
 }
-
-// ============================================================================
-// 5. Core Domain Operations
-// ============================================================================
 
 export async function checkReview({
   pr,
@@ -323,7 +291,6 @@ export async function checkReview({
   // A merged PR keeps its entry and its findings markdown; only the status
   // changes. The review is still the best record of what was examined.
   if (isMerged) {
-    const report = readReport(cacheDir, cachedEntry);
     if (cachedEntry.status !== STATUS_MERGED) {
       cachedEntry.status = STATUS_MERGED;
       cachedEntry.mergedAt = prInfo?.mergedAt || new Date().toISOString();
@@ -335,13 +302,9 @@ export async function checkReview({
       headSha: currentSha,
       cached: true,
       reviewedSha: cachedEntry.headSha,
-      recommendation: cachedEntry.recommendation,
-      summary: cachedEntry.summary,
-      reviewedAt: cachedEntry.reviewedAt,
       mergedAt: cachedEntry.mergedAt,
-      reportPath: reportFilePath(cacheDir, cachedEntry.headSha),
-      ...report,
-      message: `PR #${prNum} is merged. Its review of ${cachedEntry.headSha.slice(0, 7)} is retained in the cache.`,
+      ...getCachedReviewDetails(cacheDir, cachedEntry),
+      message: `PR #${prNum} is merged. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
     };
   }
 
@@ -350,12 +313,8 @@ export async function checkReview({
       status: CHECK_STATUS.CACHED,
       pr: prNum,
       headSha: currentSha,
-      recommendation: cachedEntry.recommendation,
-      summary: cachedEntry.summary,
-      reviewedAt: cachedEntry.reviewedAt,
-      reportPath: reportFilePath(cacheDir, cachedEntry.headSha),
-      ...readReport(cacheDir, cachedEntry),
-      message: `PR #${prNum} was already reviewed at commit ${currentSha.slice(0, 7)}. No new commit activity.`,
+      ...getCachedReviewDetails(cacheDir, cachedEntry),
+      message: `PR #${prNum} was already reviewed at commit ${shortSha(currentSha)}. No new commit activity.`,
     };
   }
 
@@ -366,7 +325,7 @@ export async function checkReview({
     title: prInfo?.title || null,
     previousSha: cachedEntry?.headSha || null,
     message: cachedEntry
-      ? `PR #${prNum} has new commit activity (${cachedEntry.headSha.slice(0, 7)} -> ${currentSha.slice(0, 7)}). Re-review needed.`
+      ? `PR #${prNum} has new commit activity (${shortSha(cachedEntry.headSha)} -> ${shortSha(currentSha)}). Re-review needed.`
       : `PR #${prNum} is not in cache. Review needed.`,
   };
 }
@@ -440,23 +399,6 @@ export function saveReview({
   };
 }
 
-/** Helper for bounded concurrency mapping */
-async function mapConcurrent(items, limit, fn) {
-  const results = [];
-  const executing = new Set();
-  for (const item of items) {
-    const p = Promise.resolve().then(() => fn(item));
-    results.push(p);
-    executing.add(p);
-    const clean = () => executing.delete(p);
-    p.then(clean, clean);
-    if (executing.size >= limit) {
-      await Promise.race(executing);
-    }
-  }
-  return Promise.all(results);
-}
-
 /**
  * Refresh the merge status of every cached entry against the remote.
  *
@@ -477,44 +419,47 @@ export async function syncCache({
   const open = [];
   const unreachable = [];
 
-  await mapConcurrent(entries, concurrency, async (entry) => {
-    const prNum = parsePRNumber(entry.pr);
-    if (!prNum) {
-      unreachable.push({ pr: entry.pr, headSha: entry.headSha });
-      return;
-    }
+  for (let i = 0; i < entries.length; i += concurrency) {
+    const chunk = entries.slice(i, i + concurrency);
+    await Promise.all(
+      chunk.map(async (entry) => {
+        const prNum = parsePRNumber(entry.pr);
+        if (!prNum) {
+          unreachable.push({ pr: entry.pr, headSha: entry.headSha });
+          return;
+        }
 
-    try {
-      const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
-      const isMerged = isMergedPR(prInfo);
-      const nextStatus = isMerged ? STATUS_MERGED : STATUS_OPEN;
-      const changed = entry.status !== nextStatus;
+        try {
+          const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
+          const isMerged = isMergedPR(prInfo);
+          const nextStatus = isMerged ? STATUS_MERGED : STATUS_OPEN;
+          const changed = entry.status !== nextStatus;
 
-      entry.status = nextStatus;
-      entry.title = entry.title || prInfo.title || "";
-      if (isMerged) {
-        entry.mergedAt = prInfo.mergedAt || entry.mergedAt || null;
-        merged.push({
-          pr: prNum,
-          headSha: entry.headSha,
-          title: entry.title,
-          changed,
-        });
-      } else {
-        delete entry.mergedAt;
-        open.push({ pr: prNum, headSha: entry.headSha, changed });
-      }
-    } catch {
-      // Network/auth failure must not rewrite state we can't verify.
-      unreachable.push({ pr: prNum, headSha: entry.headSha });
-    }
-  });
+          entry.status = nextStatus;
+          entry.title = entry.title || prInfo.title || "";
+          if (isMerged) {
+            entry.mergedAt = prInfo.mergedAt || entry.mergedAt || null;
+            merged.push({
+              pr: prNum,
+              headSha: entry.headSha,
+              title: entry.title,
+              changed,
+            });
+          } else {
+            delete entry.mergedAt;
+            open.push({ pr: prNum, headSha: entry.headSha, changed });
+          }
+        } catch {
+          // Network/auth failure must not rewrite state we can't verify.
+          unreachable.push({ pr: prNum, headSha: entry.headSha });
+        }
+      }),
+    );
+  }
 
   writeCache(cache, cacheDir);
 
-  const changedCount =
-    merged.filter((e) => e.changed).length +
-    open.filter((e) => e.changed).length;
+  const changedCount = [...merged, ...open].filter((e) => e.changed).length;
 
   return {
     mergedCount: merged.length,
@@ -527,10 +472,6 @@ export async function syncCache({
     totalCount: Object.keys(cache.reviews || {}).length,
   };
 }
-
-// ============================================================================
-// 6. CLI Formatting & Utilities
-// ============================================================================
 
 export const HELP_TEXT = `USWDS Code Review Cache Tool
 
@@ -566,6 +507,13 @@ const color = {
   cyan: (s) => (useColor ? `\x1b[36m${s}\x1b[0m` : s),
 };
 
+const CHECK_BADGES = {
+  [CHECK_STATUS.CACHED]: () => color.green("[CACHE HIT]"),
+  [CHECK_STATUS.MERGED]: () => color.yellow("[MERGED]"),
+  [CHECK_STATUS.ERROR]: () => color.red("[ERROR]"),
+  [CHECK_STATUS.MISS]: () => color.cyan("[CACHE MISS]"),
+};
+
 /** Print `label: value`, skipping fields the saved review never filled in. */
 function printField(label, value) {
   if (value) console.log(`${label}: ${value}`);
@@ -580,18 +528,14 @@ function printCachedReview(result, reportLabel) {
 }
 
 function printCheckResult(result) {
+  const badgeFn = CHECK_BADGES[result.status] || CHECK_BADGES[CHECK_STATUS.MISS];
+  const out = result.status === CHECK_STATUS.ERROR ? console.error : console.log;
+  out(`${badgeFn()} ${result.message}`);
+
   if (result.status === CHECK_STATUS.CACHED) {
-    console.log(`${color.green("[CACHE HIT]")} ${result.message}`);
     printCachedReview(result, "Full report");
-  } else if (result.status === CHECK_STATUS.MERGED) {
-    console.log(`${color.yellow("[MERGED]")} ${result.message}`);
-    if (result.cached) {
-      printCachedReview(result, "Retained report");
-    }
-  } else if (result.status === CHECK_STATUS.ERROR) {
-    console.error(`${color.red("[ERROR]")} ${result.message}`);
-  } else {
-    console.log(`${color.cyan("[CACHE MISS]")} ${result.message}`);
+  } else if (result.status === CHECK_STATUS.MERGED && result.cached) {
+    printCachedReview(result, "Retained report");
   }
 }
 
@@ -608,10 +552,6 @@ function formatDateOnly(isoString) {
     return isoString;
   }
 }
-
-// ============================================================================
-// 7. CLI Option Parsing & Dispatcher
-// ============================================================================
 
 export function parseCliArgs(rawArgs) {
   // Check for ambiguous --report before standard parsing
@@ -646,19 +586,11 @@ export function parseCliArgs(rawArgs) {
   return {
     command: positionals[0],
     options: {
-      pr: values.pr,
-      sha: values.sha,
-      repo: values.repo,
+      ...values,
       recommendation: values.recommendation || values.rec,
-      summary: values.summary,
-      title: values.title,
       reportFile: values["report-file"],
       reportText: values["report-text"],
       cacheDir: resolve(values["cache-dir"] || getDefaultCacheDir()),
-      json: values.json,
-      force: values.force,
-      offline: values.offline,
-      help: values.help,
     },
   };
 }
@@ -684,6 +616,15 @@ function readReportContent({ reportFile, reportText }) {
   return readFileSync(reportFile, "utf-8");
 }
 
+function outputResult(options, result, printHumanFn, exitCode = 0) {
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printHumanFn?.(result);
+  }
+  return { exitCode, result };
+}
+
 export async function runCheck(options) {
   if (!options.pr) {
     throw new Error(
@@ -692,102 +633,70 @@ export async function runCheck(options) {
   }
 
   if (options.force) {
-    if (options.json) {
-      console.log(
-        JSON.stringify({
-          status: "FORCED_MISS",
-          pr: options.pr,
-          message: "Forced review bypass",
-        }),
-      );
-    } else {
-      console.log(`Forced cache bypass for PR #${options.pr}.`);
-    }
-    return { exitCode: CHECK_EXIT_CODES[CHECK_STATUS.MISS] };
+    return outputResult(
+      options,
+      {
+        status: "FORCED_MISS",
+        pr: options.pr,
+        message: "Forced review bypass",
+      },
+      () => console.log(`Forced cache bypass for PR #${options.pr}.`),
+      CHECK_EXIT_CODES[CHECK_STATUS.MISS],
+    );
   }
 
-  const result = await checkReview({
-    pr: options.pr,
-    sha: options.sha,
-    repo: options.repo,
-    offline: options.offline,
-    cacheDir: options.cacheDir,
-  });
-
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    printCheckResult(result);
-  }
-
-  return { exitCode: CHECK_EXIT_CODES[result.status] ?? 3, result };
+  const result = await checkReview(options);
+  return outputResult(
+    options,
+    result,
+    printCheckResult,
+    CHECK_EXIT_CODES[result.status] ?? 3,
+  );
 }
 
 export function runSave(options) {
   const result = saveReview({
-    pr: options.pr,
-    sha: options.sha,
-    title: options.title,
-    recommendation: options.recommendation,
-    summary: options.summary,
+    ...options,
     reportContent: readReportContent(options),
-    cacheDir: options.cacheDir,
   });
 
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
+  return outputResult(options, result, () => {
     console.log(
-      `Saved review for PR #${result.pr} (${result.headSha.slice(0, 7)}) to ${result.reportPath}`,
+      `Saved review for PR #${result.pr} (${shortSha(result.headSha)}) to ${result.reportPath}`,
     );
-  }
-
-  return { exitCode: 0, result };
+  });
 }
 
 export async function runSync(options) {
-  const result = await syncCache({
-    repo: options.repo,
-    cacheDir: options.cacheDir,
+  const result = await syncCache(options);
+
+  return outputResult(options, result, () => {
+    console.log(
+      `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
+    );
+    for (const item of result.merged.filter((entry) => entry.changed)) {
+      console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
+    }
   });
-
-  if (options.json) {
-    console.log(JSON.stringify(result, null, 2));
-    return { exitCode: 0, result };
-  }
-
-  console.log(
-    `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
-  );
-  for (const item of result.merged.filter((entry) => entry.changed)) {
-    console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
-  }
-
-  return { exitCode: 0, result };
 }
 
 export function runList(options) {
   const cache = loadCache(options.cacheDir);
-  if (options.json) {
-    console.log(JSON.stringify(cache, null, 2));
-    return { exitCode: 0, result: cache };
-  }
 
-  const entries = Object.values(cache.reviews || {});
-  console.log(
-    `Cached reviews (${entries.length} ${pluralize(entries.length, "item")}):`,
-  );
-  for (const item of entries) {
-    const sha = item.headSha ? item.headSha.slice(0, 7) : "unknown";
+  return outputResult(options, cache, () => {
+    const entries = Object.values(cache.reviews || {});
     console.log(
-      `  PR #${item.pr || "?"} [${sha}] (${item.status || STATUS_OPEN}) - ${item.recommendation || "Reviewed"} (${formatDateOnly(item.reviewedAt)})`,
+      `Cached reviews (${entries.length} ${pluralize(entries.length, "item")}):`,
     );
-    if (item.summary) {
-      console.log(`      ${item.summary}`);
+    for (const item of entries) {
+      console.log(
+        `  PR #${item.pr || "?"} [${shortSha(item.headSha)}] (${item.status || STATUS_OPEN}) - ${item.recommendation || "Reviewed"} (${formatDateOnly(item.reviewedAt)})`,
+      );
+      if (item.summary) {
+        console.log(`      ${item.summary}`);
+      }
     }
-  }
-
-  return { exitCode: 0, result: cache };
+  });
 }
 
 export const COMMANDS = {
@@ -808,7 +717,7 @@ export async function main(rawArgs = process.argv.slice(2)) {
 
   const { command, options } = parsed;
 
-  if (!command || options.help || rawArgs.includes("--help") || rawArgs.includes("-h")) {
+  if (!command || options.help) {
     console.log(HELP_TEXT);
     return 0;
   }

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -317,65 +317,39 @@ export async function checkReview({
 
   const cachedEntry = cache.reviews?.[String(prNum)] || null;
 
-  if (isMerged && !cachedEntry) {
-    return {
-      status: CHECK_STATUS.MERGED,
-      pr: prNum,
-      headSha: currentSha,
-      cached: false,
-      message: `PR #${prNum} is merged and was never reviewed through this cache.`,
-    };
-  }
+  if (isMerged || isClosed) {
+    const status = isMerged ? STATUS_MERGED : STATUS_CLOSED;
+    const checkStatus = isMerged ? CHECK_STATUS.MERGED : CHECK_STATUS.CLOSED;
+    const stateLabel = isMerged ? "merged" : "closed";
+    const timeKey = isMerged ? "mergedAt" : "closedAt";
+    const otherTimeKey = isMerged ? "closedAt" : "mergedAt";
 
-  // A merged PR keeps its entry and its findings markdown; only the status
-  // changes. The review is still the best record of what was examined.
-  if (isMerged) {
-    if (cachedEntry.status !== STATUS_MERGED) {
-      cachedEntry.status = STATUS_MERGED;
-      cachedEntry.mergedAt = prInfo?.mergedAt || new Date().toISOString();
-      delete cachedEntry.closedAt;
+    if (!cachedEntry) {
+      return {
+        status: checkStatus,
+        pr: prNum,
+        headSha: currentSha,
+        cached: false,
+        message: `PR #${prNum} is ${stateLabel} and was never reviewed through this cache.`,
+      };
+    }
+
+    // A merged/closed PR keeps its entry and findings markdown; only status updates.
+    if (cachedEntry.status !== status) {
+      cachedEntry.status = status;
+      cachedEntry[timeKey] = prInfo?.[timeKey] || new Date().toISOString();
+      delete cachedEntry[otherTimeKey];
       writeCache(cache, cacheDir);
     }
     return {
-      status: CHECK_STATUS.MERGED,
+      status: checkStatus,
       pr: prNum,
       headSha: currentSha,
       cached: true,
       reviewedSha: cachedEntry.headSha,
-      mergedAt: cachedEntry.mergedAt,
+      [timeKey]: cachedEntry[timeKey],
       ...getCachedReviewDetails(cacheDir, cachedEntry),
-      message: `PR #${prNum} is merged. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
-    };
-  }
-
-  if (isClosed && !cachedEntry) {
-    return {
-      status: CHECK_STATUS.CLOSED,
-      pr: prNum,
-      headSha: currentSha,
-      cached: false,
-      message: `PR #${prNum} is closed and was never reviewed through this cache.`,
-    };
-  }
-
-  // A closed PR keeps its entry and its findings markdown; only the status
-  // changes.
-  if (isClosed) {
-    if (cachedEntry.status !== STATUS_CLOSED) {
-      cachedEntry.status = STATUS_CLOSED;
-      cachedEntry.closedAt = prInfo?.closedAt || new Date().toISOString();
-      delete cachedEntry.mergedAt;
-      writeCache(cache, cacheDir);
-    }
-    return {
-      status: CHECK_STATUS.CLOSED,
-      pr: prNum,
-      headSha: currentSha,
-      cached: true,
-      reviewedSha: cachedEntry.headSha,
-      closedAt: cachedEntry.closedAt,
-      ...getCachedReviewDetails(cacheDir, cachedEntry),
-      message: `PR #${prNum} is closed. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
+      message: `PR #${prNum} is ${stateLabel}. Its review of ${shortSha(cachedEntry.headSha)} is retained in the cache.`,
     };
   }
 
@@ -506,9 +480,11 @@ export async function syncCache({
           const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
           const isMerged = isMergedPR(prInfo);
           const isClosed = isClosedPR(prInfo);
-          let nextStatus = STATUS_OPEN;
-          if (isMerged) nextStatus = STATUS_MERGED;
-          else if (isClosed) nextStatus = STATUS_CLOSED;
+          const nextStatus = isMerged
+            ? STATUS_MERGED
+            : isClosed
+              ? STATUS_CLOSED
+              : STATUS_OPEN;
 
           const changed = entry.status !== nextStatus;
 
@@ -586,7 +562,6 @@ Options:
   --offline           Skip the gh lookup and trust --sha (requires --sha)
   --json              Output raw JSON
   --force             Ignore cache on check
-  --rec <text>        Alias for --recommendation
 
 Note: only PR reviews are cached; --pr is required for check and save.
 `;
@@ -600,11 +575,11 @@ const color = {
 };
 
 const CHECK_BADGES = {
-  [CHECK_STATUS.CACHED]: () => color.green("[CACHE HIT]"),
-  [CHECK_STATUS.MERGED]: () => color.yellow("[MERGED]"),
-  [CHECK_STATUS.CLOSED]: () => color.red("[CLOSED]"),
-  [CHECK_STATUS.ERROR]: () => color.red("[ERROR]"),
-  [CHECK_STATUS.MISS]: () => color.cyan("[CACHE MISS]"),
+  [CHECK_STATUS.CACHED]: color.green("[CACHE HIT]"),
+  [CHECK_STATUS.MERGED]: color.yellow("[MERGED]"),
+  [CHECK_STATUS.CLOSED]: color.red("[CLOSED]"),
+  [CHECK_STATUS.ERROR]: color.red("[ERROR]"),
+  [CHECK_STATUS.MISS]: color.cyan("[CACHE MISS]"),
 };
 
 /** Print `label: value`, skipping fields the saved review never filled in. */
@@ -621,11 +596,10 @@ function printCachedReview(result, reportLabel) {
 }
 
 function printCheckResult(result) {
-  const badgeFn =
-    CHECK_BADGES[result.status] || CHECK_BADGES[CHECK_STATUS.MISS];
+  const badge = CHECK_BADGES[result.status] || CHECK_BADGES[CHECK_STATUS.MISS];
   const out =
     result.status === CHECK_STATUS.ERROR ? console.error : console.log;
-  out(`${badgeFn()} ${result.message}`);
+  out(`${badge} ${result.message}`);
 
   if (result.status === CHECK_STATUS.CACHED) {
     printCachedReview(result, "Full report");
@@ -655,7 +629,6 @@ export function parseCliArgs(rawArgs) {
       sha: { type: "string" },
       repo: { type: "string", default: "uswds/uswds" },
       recommendation: { type: "string" },
-      rec: { type: "string" },
       summary: { type: "string" },
       title: { type: "string" },
       "report-file": { type: "string" },
@@ -672,7 +645,6 @@ export function parseCliArgs(rawArgs) {
     command: positionals[0],
     options: {
       ...values,
-      recommendation: values.recommendation || values.rec,
       reportFile: values["report-file"],
       reportText: values["report-text"],
       cacheDir: resolve(values["cache-dir"] || getDefaultCacheDir()),

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -95,7 +95,11 @@ export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
 
 export async function execCmd(cmd, args, opts = {}) {
   return new Promise((resolvePromise, rejectPromise) => {
-    const proc = spawn(cmd, args, { timeout: opts.timeout || 60000 });
+    const proc = spawn(cmd, args, {
+      timeout: opts.timeout || 60000,
+      killSignal: opts.killSignal || "SIGKILL",
+      ...opts,
+    });
     let stdout = "";
     let stderr = "";
     proc.stdout?.on("data", (d) => {
@@ -105,9 +109,14 @@ export async function execCmd(cmd, args, opts = {}) {
       stderr += d;
     });
     proc.on("error", rejectPromise);
+    proc.on("exit", (code, signal) => {
+      if (signal) {
+        rejectPromise(
+          new Error(`${cmd} terminated by signal ${signal}: ${stderr.trim()}`),
+        );
+      }
+    });
     proc.on("close", (code, signal) => {
-      // A timed-out child is SIGKILLed and reports code === null. Treating that
-      // as success would resolve with whatever partial stdout had arrived.
       if (signal) {
         rejectPromise(
           new Error(`${cmd} terminated by signal ${signal}: ${stderr.trim()}`),
@@ -126,12 +135,8 @@ export async function execCmd(cmd, args, opts = {}) {
 export function parsePRNumber(prInput) {
   if (!prInput) return null;
   if (typeof prInput === "number") return prInput;
-  const str = String(prInput).trim();
-  const match = str.match(/(?:pull\/|#|^)(\d+)(?:\/|\b|$)/);
-  if (match) {
-    return parseInt(match[1], 10);
-  }
-  return null;
+  const match = String(prInput).match(/(?:pull\/|#|^)(\d+)(?:\/|\b|$)/);
+  return match ? parseInt(match[1], 10) : null;
 }
 
 export async function fetchPRInfo(
@@ -449,11 +454,15 @@ export async function syncCache({
 
   writeCache(cache, cacheDir);
 
+  const changedCount =
+    merged.filter((e) => e.changed).length +
+    open.filter((e) => e.changed).length;
+
   return {
     mergedCount: merged.length,
     openCount: open.length,
     unreachableCount: unreachable.length,
-    changedCount: [...merged, ...open].filter((e) => e.changed).length,
+    changedCount,
     merged,
     open,
     unreachable,

--- a/.agents/skills/uswds-code-review/scripts/review-cache.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.mjs
@@ -1,0 +1,743 @@
+#!/usr/bin/env node
+/**
+ * Review Cache Manager for uswds-code-review skill.
+ *
+ * Manages the unversioned review cache stored in .review-cache/ at repo root.
+ * - Prevents re-reviewing PRs when commit hash has not changed
+ * - Saves full findings markdown to .review-cache/<commit-sha>.md
+ * - Stores review metadata and summary in .review-cache/cache.json
+ * - Tracks whether each reviewed PR is still open or has merged
+ *
+ * Entries are never deleted. A merged PR keeps its cache entry and its findings
+ * markdown, and is marked `status: "merged"` instead — the review of a merged PR
+ * is exactly the artifact you want when a regression surfaces later.
+ *
+ * Only PR reviews are cached. Local-branch reviews (`/uswds-code-review` with no
+ * argument) have no stable identity to key on — a local branch's HEAD moves with
+ * every amend and there is no remote state to compare against — so `save` and
+ * `check` both require --pr.
+ *
+ * Usage:
+ *   node review-cache.mjs check --pr 6767
+ *   node review-cache.mjs save --pr 6767 --sha abc1234 --recommendation "Request changes" --summary "..." --report-file report.md
+ *   node review-cache.mjs sync
+ *   node review-cache.mjs list
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { resolve, join, dirname } from "path";
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+
+/** Lifecycle state of the PR a cached review belongs to. */
+export const STATUS_OPEN = "open";
+export const STATUS_MERGED = "merged";
+
+/** Conventional cache directory name, relative to the repo root. */
+export const CACHE_DIR_NAME = ".review-cache";
+
+function emptyCache() {
+  return { version: 1, reviews: {} };
+}
+
+export function findRepoRoot(startDir = process.cwd()) {
+  let cur = resolve(startDir);
+  while (cur !== dirname(cur)) {
+    if (existsSync(join(cur, ".git"))) {
+      return cur;
+    }
+    cur = dirname(cur);
+  }
+  return resolve(startDir);
+}
+
+export function getDefaultCacheDir(startDir = process.cwd()) {
+  return join(findRepoRoot(startDir), CACHE_DIR_NAME);
+}
+
+function cacheFilePath(cacheDir) {
+  return join(cacheDir, "cache.json");
+}
+
+export function loadCache(cacheDir = getDefaultCacheDir()) {
+  const cacheFile = cacheFilePath(cacheDir);
+  if (!existsSync(cacheFile)) {
+    return emptyCache();
+  }
+  try {
+    const data = JSON.parse(readFileSync(cacheFile, "utf-8"));
+    if (!data.reviews || typeof data.reviews !== "object") {
+      throw new Error("no reviews object");
+    }
+    return data;
+  } catch (err) {
+    throw new Error(
+      `Cache at ${cacheFile} is unreadable (${err.message}). Move it aside to ` +
+        `start fresh — the report markdown in that directory is not affected.`,
+      { cause: err },
+    );
+  }
+}
+
+export function writeCache(cacheData, cacheDir = getDefaultCacheDir()) {
+  mkdirSync(cacheDir, { recursive: true });
+  const payload = {
+    version: cacheData.version || 1,
+    updatedAt: new Date().toISOString(),
+    reviews: cacheData.reviews || {},
+  };
+  writeFileSync(
+    cacheFilePath(cacheDir),
+    JSON.stringify(payload, null, 2),
+    "utf-8",
+  );
+}
+
+export async function execCmd(cmd, args, opts = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const proc = spawn(cmd, args, { timeout: opts.timeout || 60000 });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (d) => {
+      stdout += d;
+    });
+    proc.stderr?.on("data", (d) => {
+      stderr += d;
+    });
+    proc.on("error", rejectPromise);
+    proc.on("close", (code, signal) => {
+      // A timed-out child is SIGKILLed and reports code === null. Treating that
+      // as success would resolve with whatever partial stdout had arrived.
+      if (signal) {
+        rejectPromise(
+          new Error(`${cmd} terminated by signal ${signal}: ${stderr.trim()}`),
+        );
+      } else if (code !== 0) {
+        rejectPromise(
+          new Error(`${cmd} exited with code ${code}: ${stderr.trim()}`),
+        );
+      } else {
+        resolvePromise(stdout.trim());
+      }
+    });
+  });
+}
+
+export function parsePRNumber(prInput) {
+  if (!prInput) return null;
+  if (typeof prInput === "number") return prInput;
+  const str = String(prInput).trim();
+  const match = str.match(/(?:pull\/|#|^)(\d+)(?:\/|\b|$)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  return null;
+}
+
+export async function fetchPRInfo(
+  prNumber,
+  repo = "uswds/uswds",
+  execFn = execCmd,
+) {
+  try {
+    const jsonStr = await execFn("gh", [
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      repo,
+      "--json",
+      "number,title,state,mergedAt,headRefOid,url,baseRefName",
+    ]);
+    return JSON.parse(jsonStr);
+  } catch (err) {
+    throw new Error(
+      `Failed to fetch PR #${prNumber} from ${repo}: ${err.message}`,
+      { cause: err },
+    );
+  }
+}
+
+/** Findings for a commit always live at <cacheDir>/<sha>.md. */
+export function reportFilePath(cacheDir, sha) {
+  return join(cacheDir, `${sha}.md`);
+}
+
+function readReport(cacheDir, entry) {
+  const absolutePath = reportFilePath(cacheDir, entry.headSha);
+  if (!existsSync(absolutePath)) {
+    return { reportExists: false, reportContent: null };
+  }
+  try {
+    return {
+      reportExists: true,
+      reportContent: readFileSync(absolutePath, "utf-8"),
+    };
+  } catch {
+    // Unreadable report degrades to metadata-only; not fatal.
+    return { reportExists: true, reportContent: null };
+  }
+}
+
+/**
+ * `state` is authoritative, but a PR fetched right after a merge can still
+ * report OPEN while carrying a mergedAt timestamp, so trust either signal.
+ */
+function isMergedPR(prInfo) {
+  return prInfo.state === "MERGED" || Boolean(prInfo.mergedAt);
+}
+
+/**
+ * Resolve a PR's current head commit and merge state.
+ *
+ * `offline` skips the network entirely and trusts the caller's sha. Otherwise a
+ * successful fetch is authoritative, and `sha` is only a fallback for when the
+ * lookup fails. Returns `{ error }` when neither source yields a commit.
+ */
+async function resolvePRHead({
+  prNum,
+  sha,
+  repo,
+  offline,
+  fetchPRInfoFn,
+  execFn,
+}) {
+  if (offline) {
+    return { prInfo: null, currentSha: sha, isMerged: false };
+  }
+  try {
+    const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
+    return {
+      prInfo,
+      currentSha: prInfo.headRefOid,
+      isMerged: isMergedPR(prInfo),
+    };
+  } catch (err) {
+    if (!sha) {
+      return { error: err.message };
+    }
+    return { prInfo: null, currentSha: sha, isMerged: false };
+  }
+}
+
+export async function checkReview({
+  pr,
+  sha = null,
+  repo = "uswds/uswds",
+  cacheDir = getDefaultCacheDir(),
+  offline = false,
+  fetchPRInfoFn = fetchPRInfo,
+  execFn = execCmd,
+}) {
+  const prNum = parsePRNumber(pr);
+
+  if (!prNum) {
+    return {
+      status: "ERROR",
+      pr: null,
+      message:
+        "A PR number is required. Local-branch reviews are not cached; run the review directly.",
+    };
+  }
+
+  const cache = loadCache(cacheDir);
+
+  const { prInfo, currentSha, isMerged, error } = await resolvePRHead({
+    prNum,
+    sha,
+    repo,
+    offline,
+    fetchPRInfoFn,
+    execFn,
+  });
+
+  if (error) {
+    return { status: "ERROR", pr: prNum, message: error };
+  }
+
+  if (!currentSha) {
+    return {
+      status: "ERROR",
+      pr: prNum,
+      message:
+        "--offline requires --sha, since the head commit cannot be read.",
+    };
+  }
+
+  const cachedEntry = cache.reviews?.[String(prNum)] || null;
+
+  if (isMerged && !cachedEntry) {
+    return {
+      status: "MERGED",
+      pr: prNum,
+      headSha: currentSha,
+      cached: false,
+      message: `PR #${prNum} is merged and was never reviewed through this cache.`,
+    };
+  }
+
+  // A merged PR keeps its entry and its findings markdown; only the status
+  // changes. The review is still the best record of what was examined.
+  if (isMerged) {
+    const report = readReport(cacheDir, cachedEntry);
+    if (cachedEntry.status !== STATUS_MERGED) {
+      cachedEntry.status = STATUS_MERGED;
+      cachedEntry.mergedAt = prInfo?.mergedAt || new Date().toISOString();
+      writeCache(cache, cacheDir);
+    }
+    return {
+      status: "MERGED",
+      pr: prNum,
+      headSha: currentSha,
+      cached: true,
+      reviewedSha: cachedEntry.headSha,
+      recommendation: cachedEntry.recommendation,
+      summary: cachedEntry.summary,
+      reviewedAt: cachedEntry.reviewedAt,
+      mergedAt: cachedEntry.mergedAt,
+      reportPath: reportFilePath(cacheDir, cachedEntry.headSha),
+      ...report,
+      message: `PR #${prNum} is merged. Its review of ${cachedEntry.headSha.slice(0, 7)} is retained in the cache.`,
+    };
+  }
+
+  if (cachedEntry?.headSha === currentSha) {
+    return {
+      status: "CACHED",
+      pr: prNum,
+      headSha: currentSha,
+      recommendation: cachedEntry.recommendation,
+      summary: cachedEntry.summary,
+      reviewedAt: cachedEntry.reviewedAt,
+      reportPath: reportFilePath(cacheDir, cachedEntry.headSha),
+      ...readReport(cacheDir, cachedEntry),
+      message: `PR #${prNum} was already reviewed at commit ${currentSha.slice(0, 7)}. No new commit activity.`,
+    };
+  }
+
+  return {
+    status: "MISS",
+    pr: prNum,
+    headSha: currentSha,
+    title: prInfo?.title || null,
+    previousSha: cachedEntry?.headSha || null,
+    message: cachedEntry
+      ? `PR #${prNum} has new commit activity (${cachedEntry.headSha.slice(0, 7)} -> ${currentSha.slice(0, 7)}). Re-review needed.`
+      : `PR #${prNum} is not in cache. Review needed.`,
+  };
+}
+
+/**
+ * A SHA is interpolated straight into a cache filename, so reject anything that
+ * isn't one rather than letting `../` escape the cache directory. Also catches
+ * truncated or mistyped hashes before they become a phantom cache entry.
+ */
+export function assertValidSha(sha) {
+  if (!sha) {
+    throw new Error("Cannot save review without commit SHA (sha is required)");
+  }
+  if (!/^[0-9a-f]{7,40}$/i.test(String(sha))) {
+    throw new Error(
+      `Invalid commit SHA: ${sha}. Expected 7-40 hexadecimal characters.`,
+    );
+  }
+  return String(sha);
+}
+
+export function saveReview({
+  pr,
+  sha,
+  title = "",
+  recommendation = "Review completed",
+  summary = "",
+  reportContent = "",
+  status = STATUS_OPEN,
+  cacheDir = getDefaultCacheDir(),
+}) {
+  assertValidSha(sha);
+
+  const prNum = parsePRNumber(pr);
+  if (!prNum) {
+    throw new Error(
+      "Cannot save review without a PR number. Local-branch reviews are not cached.",
+    );
+  }
+
+  mkdirSync(cacheDir, { recursive: true });
+
+  // 1. Save full findings markdown by commit ID
+  const absolutePath = reportFilePath(cacheDir, sha);
+  writeFileSync(absolutePath, reportContent, "utf-8");
+
+  // 2. Update cache.json
+  const cache = loadCache(cacheDir);
+  const prKey = String(prNum);
+
+  cache.reviews[prKey] = {
+    pr: prNum,
+    headSha: sha,
+    title: title || cache.reviews[prKey]?.title || "",
+    recommendation,
+    summary,
+    status,
+    reviewedAt: new Date().toISOString(),
+  };
+
+  writeCache(cache, cacheDir);
+
+  return {
+    success: true,
+    pr: prNum,
+    headSha: sha,
+    status,
+    reportPath: absolutePath,
+    recommendation,
+    summary,
+  };
+}
+
+/**
+ * Refresh the merge status of every cached entry against the remote.
+ *
+ * Replaces the earlier prune-on-merge behavior: nothing is deleted, so a review
+ * of a merged PR stays available for later regression archaeology. Entries whose
+ * lookup fails keep their existing status rather than being guessed at.
+ */
+export async function syncCache({
+  repo = "uswds/uswds",
+  cacheDir = getDefaultCacheDir(),
+  fetchPRInfoFn = fetchPRInfo,
+  execFn = execCmd,
+}) {
+  const cache = loadCache(cacheDir);
+  const merged = [];
+  const open = [];
+  const unreachable = [];
+
+  for (const entry of Object.values(cache.reviews || {})) {
+    const prNum = parsePRNumber(entry.pr);
+    if (!prNum) {
+      unreachable.push({ pr: entry.pr, headSha: entry.headSha });
+      continue;
+    }
+
+    try {
+      const prInfo = await fetchPRInfoFn(prNum, repo, execFn);
+      const isMerged = isMergedPR(prInfo);
+      const nextStatus = isMerged ? STATUS_MERGED : STATUS_OPEN;
+      const changed = entry.status !== nextStatus;
+
+      entry.status = nextStatus;
+      entry.title = entry.title || prInfo.title || "";
+      if (isMerged) {
+        entry.mergedAt = prInfo.mergedAt || entry.mergedAt || null;
+        merged.push({
+          pr: prNum,
+          headSha: entry.headSha,
+          title: entry.title,
+          changed,
+        });
+      } else {
+        delete entry.mergedAt;
+        open.push({ pr: prNum, headSha: entry.headSha, changed });
+      }
+    } catch {
+      // Network/auth failure must not rewrite state we can't verify.
+      unreachable.push({ pr: prNum, headSha: entry.headSha });
+    }
+  }
+
+  writeCache(cache, cacheDir);
+
+  return {
+    mergedCount: merged.length,
+    openCount: open.length,
+    unreachableCount: unreachable.length,
+    changedCount: [...merged, ...open].filter((e) => e.changed).length,
+    merged,
+    open,
+    unreachable,
+    totalCount: Object.keys(cache.reviews || {}).length,
+  };
+}
+
+// CLI Execution
+
+const HELP_TEXT = `USWDS Code Review Cache Tool
+
+Usage:
+  node review-cache.mjs check --pr <number|url> [--sha <hash>] [--offline] [--repo <owner/repo>] [--json]
+  node review-cache.mjs save --pr <number> --sha <hash> --recommendation <text> --summary <text> [--report-file <file> | --report-text <md>] [--title <text>]
+  node review-cache.mjs sync [--repo <owner/repo>] [--json]
+  node review-cache.mjs list [--json]
+
+Exit codes for check:
+  0  CACHED  — already reviewed at this commit
+  1  MISS    — review needed
+  2  MERGED  — PR is merged; prior review (if any) is retained
+  3  ERROR   — could not determine state
+
+Options:
+  --cache-dir <dir>   Cache directory path (defaults to .review-cache)
+  --report-file <f>   Read findings markdown from a file ("-" for stdin)
+  --report-text <md>  Use the argument itself as the findings markdown
+  --offline           Skip the gh lookup and trust --sha (requires --sha)
+  --json              Output raw JSON
+  --force             Ignore cache on check
+  --rec <text>        Alias for --recommendation
+
+Note: only PR reviews are cached; --pr is required for check and save.
+`;
+
+/** Flags that consume the following argument, keyed to their option name. */
+const VALUE_FLAGS = {
+  "--pr": "pr",
+  "--sha": "sha",
+  "--repo": "repo",
+  "--recommendation": "recommendation",
+  "--rec": "recommendation",
+  "--summary": "summary",
+  "--title": "title",
+  "--report-file": "reportFile",
+  "--report-text": "reportText",
+  "--cache-dir": "cacheDir",
+};
+
+/** Flags that are their own value. */
+const BOOLEAN_FLAGS = {
+  "--json": "json",
+  "--force": "force",
+  "--offline": "offline",
+};
+
+const CHECK_EXIT_CODES = { CACHED: 0, MISS: 1, MERGED: 2, ERROR: 3 };
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseOptions(args) {
+  const options = {
+    cacheDir: getDefaultCacheDir(),
+    repo: "uswds/uswds",
+    json: false,
+    force: false,
+    offline: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--report") {
+      fail(
+        "Error: --report is ambiguous. Use --report-file <path> (or '-' for stdin), or --report-text <markdown>.",
+      );
+    } else if (VALUE_FLAGS[arg]) {
+      i += 1;
+      options[VALUE_FLAGS[arg]] = args[i];
+    } else if (BOOLEAN_FLAGS[arg]) {
+      options[BOOLEAN_FLAGS[arg]] = true;
+    }
+  }
+
+  options.cacheDir = resolve(options.cacheDir);
+  return options;
+}
+
+/** Print `label: value`, skipping fields the saved review never filled in. */
+function printField(label, value) {
+  if (value) console.log(`${label}: ${value}`);
+}
+
+function printCachedReview(result, reportLabel) {
+  printField("Recommendation", result.recommendation);
+  printField("Summary", result.summary);
+  console.log(
+    `${reportLabel}: ${result.reportPath}${result.reportExists ? "" : " (MISSING ON DISK)"}`,
+  );
+}
+
+function printCheckResult(result) {
+  if (result.status === "CACHED") {
+    console.log(`\x1b[32m[CACHE HIT]\x1b[0m ${result.message}`);
+    printCachedReview(result, "Full report");
+  } else if (result.status === "MERGED") {
+    console.log(`\x1b[33m[MERGED]\x1b[0m ${result.message}`);
+    if (result.cached) {
+      printCachedReview(result, "Retained report");
+    }
+  } else if (result.status === "ERROR") {
+    console.error(`\x1b[31m[ERROR]\x1b[0m ${result.message}`);
+  } else {
+    console.log(`\x1b[36m[CACHE MISS]\x1b[0m ${result.message}`);
+  }
+}
+
+async function runCheck(options) {
+  if (!options.pr) {
+    fail(
+      "Error: --pr is required for check. Local-branch reviews are not cached.",
+    );
+  }
+
+  if (options.force) {
+    if (options.json) {
+      console.log(
+        JSON.stringify({
+          status: "FORCED_MISS",
+          pr: options.pr,
+          message: "Forced review bypass",
+        }),
+      );
+    } else {
+      console.log(`Forced cache bypass for PR #${options.pr}.`);
+    }
+    process.exit(CHECK_EXIT_CODES.MISS);
+  }
+
+  const result = await checkReview({
+    pr: options.pr,
+    sha: options.sha,
+    repo: options.repo,
+    offline: options.offline,
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printCheckResult(result);
+  }
+
+  process.exit(CHECK_EXIT_CODES[result.status] ?? 3);
+}
+
+/** Resolve the findings markdown a `save` should persist. */
+function readReportContent({ reportFile, reportText }) {
+  if (reportFile && reportText !== undefined) {
+    fail("Error: pass only one of --report-file or --report-text.");
+  }
+  if (!reportFile) {
+    return reportText ?? "";
+  }
+  if (reportFile === "-") {
+    return readFileSync(0, "utf-8");
+  }
+  if (!existsSync(reportFile)) {
+    // Never silently fall back to treating the path as content: a typo would
+    // otherwise be cached as a valid review whose body is the filename.
+    fail(
+      `Error: report file not found: ${reportFile}. Use --report-text for inline markdown.`,
+    );
+  }
+  return readFileSync(reportFile, "utf-8");
+}
+
+function runSave(options) {
+  const result = saveReview({
+    pr: options.pr,
+    sha: options.sha,
+    title: options.title,
+    recommendation: options.recommendation,
+    summary: options.summary,
+    reportContent: readReportContent(options),
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(
+      `Saved review for PR #${result.pr} (${result.headSha.slice(0, 7)}) to ${result.reportPath}`,
+    );
+  }
+}
+
+async function runSync(options) {
+  const result = await syncCache({
+    repo: options.repo,
+    cacheDir: options.cacheDir,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(
+    `Synced ${result.totalCount} cached reviews: ${result.openCount} open, ${result.mergedCount} merged, ${result.unreachableCount} unreachable.`,
+  );
+  for (const item of result.merged.filter((entry) => entry.changed)) {
+    console.log(`  - #${item.pr} now merged: ${item.title || item.headSha}`);
+  }
+}
+
+/** Pluralize `count` of `singular`, e.g. `pluralize(1, "item")` -> "item". */
+function pluralize(count, singular, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
+}
+
+function formatDateOnly(isoString) {
+  if (!isoString) return "-";
+  try {
+    return new Date(isoString).toISOString().split("T")[0];
+  } catch {
+    return isoString;
+  }
+}
+
+function runList(options) {
+  const cache = loadCache(options.cacheDir);
+  if (options.json) {
+    console.log(JSON.stringify(cache, null, 2));
+    return;
+  }
+
+  const entries = Object.values(cache.reviews || {});
+  console.log(
+    `Cached reviews (${entries.length} ${pluralize(entries.length, "item")}):`,
+  );
+  for (const item of entries) {
+    const sha = item.headSha ? item.headSha.slice(0, 7) : "unknown";
+    console.log(
+      `  PR #${item.pr || "?"} [${sha}] (${item.status || STATUS_OPEN}) - ${item.recommendation || "Reviewed"} (${formatDateOnly(item.reviewedAt)})`,
+    );
+    if (item.summary) {
+      console.log(`      ${item.summary}`);
+    }
+  }
+}
+
+const COMMANDS = {
+  check: runCheck,
+  save: runSave,
+  sync: runSync,
+  list: runList,
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (!command || args.includes("--help") || args.includes("-h")) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
+
+  const run = COMMANDS[command];
+  if (!run) {
+    fail(`Unknown command: ${command}`);
+  }
+
+  await run(parseOptions(args.slice(1)));
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  main().catch((err) => {
+    console.error("Fatal error in review-cache:", err.message);
+    process.exit(1);
+  });
+}

--- a/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
@@ -591,14 +591,14 @@ describe("review-cache", () => {
       assert.strictEqual(options.json, true);
     });
 
-    it("parses save options including alias --rec", () => {
+    it("parses save options", () => {
       const { command, options } = parseCliArgs([
         "save",
         "--pr",
         "6767",
         "--sha",
         "abc1234",
-        "--rec",
+        "--recommendation",
         "Request changes",
         "--summary",
         "some notes",

--- a/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
@@ -1,0 +1,504 @@
+/**
+ * Unit tests for the review-cache tooling in uswds-code-review.
+ *
+ * Exercises:
+ *  - Cache read, write, and schema formatting
+ *  - Cache hit on unchanged commit SHA, including report retrieval from disk
+ *  - Cache miss / invalidation on new commit SHA
+ *  - Markdown report persistence by commit SHA
+ *  - Merge status tracking (entries are marked, never deleted)
+ *
+ * Every test runs against a fresh scratch cache directory. The `save`, `check`,
+ * and `sync` fixtures below bind that directory and fill in fields the test
+ * under discussion doesn't care about, so each test body shows only what it is
+ * actually asserting on. Tests of argument validation call the underlying
+ * functions directly, since a defaulting fixture would supply the very
+ * argument they check for.
+ *
+ * This spec is intentionally NOT part of `gulp test`: it covers agent tooling,
+ * not shipped library code, so it stays out of the main test config. Run it by
+ * hand after changing review-cache.mjs:
+ *
+ *   npm run test:agents
+ *   npm run test:agents -- --grep syncCache
+ */
+
+import assert from "node:assert";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+import {
+  loadCache,
+  writeCache,
+  checkReview,
+  saveReview,
+  syncCache,
+  parsePRNumber,
+  assertValidSha,
+  execCmd,
+  STATUS_OPEN,
+  STATUS_MERGED,
+} from "./review-cache.mjs";
+
+/** Any merge timestamp; only tests that assert on it need to know the value. */
+const MERGED_AT = "2026-08-20T10:00:00Z";
+
+/**
+ * A distinct, valid SHA for tests that need *a* commit id but don't assert on
+ * it. Unique per call so two saves never collide on one report filename.
+ */
+let shaCounter = 0;
+function nextSha() {
+  shaCounter += 1;
+  return String(shaCounter).padStart(40, "0");
+}
+
+/** A `fetchPRInfo` stub answering with one fixed payload for any PR. */
+function stubLookup(payload) {
+  return async () => ({ state: "OPEN", ...payload });
+}
+
+/** A `fetchPRInfo` stub answering per PR number. */
+function stubLookupByPR(byNumber) {
+  return async (prNum) => ({ state: "OPEN", ...byNumber[prNum] });
+}
+
+/** A `fetchPRInfo` stub that fails, as an unauthenticated `gh` would. */
+function stubLookupFailure(message = "gh not authenticated") {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+/**
+ * Default lookup for the fixtures: a test that reaches the network has forgotten
+ * to stub, and should say so rather than shelling out to the real `gh`.
+ */
+const stubLookupUnset = stubLookupFailure(
+  "fetchPRInfoFn was not stubbed for this test",
+);
+
+describe("review-cache", () => {
+  let cacheDir;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(path.join(tmpdir(), "uswds-review-cache-"));
+  });
+
+  afterEach(async () => {
+    if (cacheDir && existsSync(cacheDir)) {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  /** `saveReview` against the scratch cache, with filler for incidental fields. */
+  const save = (overrides = {}) =>
+    saveReview({
+      sha: nextSha(),
+      recommendation: "Approve",
+      reportContent: "report",
+      ...overrides,
+      cacheDir,
+    });
+
+  /** `checkReview` against the scratch cache. */
+  const check = (overrides = {}) =>
+    checkReview({ fetchPRInfoFn: stubLookupUnset, ...overrides, cacheDir });
+
+  /** `syncCache` against the scratch cache. */
+  const sync = (overrides = {}) =>
+    syncCache({ fetchPRInfoFn: stubLookupUnset, ...overrides, cacheDir });
+
+  const readCache = () => loadCache(cacheDir);
+  const cacheJson = () => path.join(cacheDir, "cache.json");
+  const reportFile = (sha) => path.join(cacheDir, `${sha}.md`);
+
+  describe("parsePRNumber", () => {
+    it("parses numbers, strings, and github URLs", () => {
+      assert.strictEqual(parsePRNumber(6767), 6767);
+      assert.strictEqual(parsePRNumber("6767"), 6767);
+      assert.strictEqual(parsePRNumber("#6767"), 6767);
+      assert.strictEqual(
+        parsePRNumber("https://github.com/uswds/uswds/pull/6789"),
+        6789,
+      );
+      assert.strictEqual(
+        parsePRNumber("https://github.com/uswds/uswds/pull/6789/files"),
+        6789,
+      );
+      assert.strictEqual(parsePRNumber(null), null);
+      assert.strictEqual(parsePRNumber("invalid"), null);
+    });
+  });
+
+  describe("execCmd", () => {
+    it("rejects when the child is killed by a signal", async () => {
+      // A timed-out `gh` is SIGKILLed and reports code === null. Resolving there
+      // would hand back truncated stdout as if the command had succeeded.
+      await assert.rejects(
+        execCmd("bash", ["-c", "echo partial; sleep 5"], { timeout: 300 }),
+        /terminated by signal/,
+      );
+    });
+
+    it("rejects on a non-zero exit and surfaces stderr", async () => {
+      await assert.rejects(
+        execCmd("bash", ["-c", "echo boom >&2; exit 3"]),
+        /exited with code 3: boom/,
+      );
+    });
+
+    it("resolves with trimmed stdout on success", async () => {
+      assert.strictEqual(await execCmd("bash", ["-c", "echo ok"]), "ok");
+    });
+  });
+
+  describe("assertValidSha", () => {
+    it("accepts short and full hex SHAs", () => {
+      assert.strictEqual(assertValidSha("abc1234"), "abc1234");
+      assert.strictEqual(
+        assertValidSha("e4f1a23b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f"),
+        "e4f1a23b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f",
+      );
+    });
+
+    it("rejects a missing SHA", () => {
+      assert.throws(() => assertValidSha(null), /sha is required/i);
+    });
+
+    it("rejects path traversal and non-hex input", () => {
+      // A SHA is interpolated into a cache filename, so `../` must not survive.
+      assert.throws(
+        () => assertValidSha("../../escaped"),
+        /Invalid commit SHA/,
+      );
+      assert.throws(() => assertValidSha("abc"), /Invalid commit SHA/);
+      assert.throws(() => assertValidSha("zzzzzzz"), /Invalid commit SHA/);
+    });
+  });
+
+  describe("loadCache and writeCache", () => {
+    it("returns an empty cache structure if cache.json does not exist", () => {
+      const cache = readCache();
+      assert.strictEqual(cache.version, 1);
+      assert.deepStrictEqual(cache.reviews, {});
+    });
+
+    it("writes and reads back cache data accurately", () => {
+      writeCache(
+        {
+          version: 1,
+          reviews: {
+            6767: {
+              pr: 6767,
+              headSha: "abc1234567890",
+              recommendation: "Request changes",
+              summary: "3 blocking issues",
+              status: STATUS_OPEN,
+              reportPath: ".review-cache/abc1234567890.md",
+            },
+          },
+        },
+        cacheDir,
+      );
+
+      const loaded = readCache();
+      assert.strictEqual(loaded.version, 1);
+      assert.ok(loaded.updatedAt);
+      assert.strictEqual(loaded.reviews["6767"].headSha, "abc1234567890");
+    });
+
+    it("throws when cache.json is corrupted, rather than silently discarding it", () => {
+      writeFileSync(cacheJson(), "{ invalid json ");
+      assert.throws(() => readCache(), /unreadable/);
+    });
+
+    it("does not overwrite a corrupted cache.json when a save is attempted", () => {
+      // Regression: loadCache used to swallow a parse failure and return an
+      // empty cache, so the next save silently wrote a fresh cache.json over
+      // the corrupt one, wiping every prior review with no error at all.
+      const corrupt = "{ invalid json ";
+      writeFileSync(cacheJson(), corrupt);
+
+      assert.throws(() => save({ pr: 6767 }), /unreadable/);
+
+      assert.strictEqual(readFileSync(cacheJson(), "utf-8"), corrupt);
+    });
+  });
+
+  describe("saveReview", () => {
+    it("saves markdown report named by commit SHA and updates cache.json", () => {
+      const sha = "e4f1a23b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f";
+      const reportMarkdown =
+        "# PR Review: Test PR\n\n### Recommendation\n✅ **Approve**";
+
+      const res = save({
+        pr: 6786,
+        sha,
+        title: "Modal: restore page content",
+        recommendation: "Approve",
+        summary: "No blockers found; route AT verification.",
+        reportContent: reportMarkdown,
+      });
+
+      assert.strictEqual(res.success, true);
+      assert.strictEqual(res.pr, 6786);
+      assert.strictEqual(res.headSha, sha);
+
+      // Verify file written
+      assert.ok(
+        existsSync(reportFile(sha)),
+        "Commit SHA markdown report file must exist",
+      );
+      assert.strictEqual(
+        readFileSync(reportFile(sha), "utf-8"),
+        reportMarkdown,
+      );
+
+      // Verify cache.json updated
+      const cache = readCache();
+      assert.ok(cache.reviews["6786"]);
+      assert.strictEqual(cache.reviews["6786"].headSha, sha);
+      assert.strictEqual(cache.reviews["6786"].recommendation, "Approve");
+      assert.strictEqual(cache.reviews["6786"].status, STATUS_OPEN);
+    });
+
+    // Argument validation goes through saveReview directly: the `save` fixture
+    // defaults the very fields these tests assert are required.
+    it("throws an error if commit SHA is omitted", () => {
+      assert.throws(() => {
+        saveReview({ pr: 6786, summary: "test", cacheDir });
+      }, /sha is required/i);
+    });
+
+    it("throws if no PR number is given, since local reviews are not cached", () => {
+      assert.throws(() => {
+        saveReview({
+          sha: "abc1234",
+          summary: "local branch review",
+          cacheDir,
+        });
+      }, /PR number/i);
+    });
+  });
+
+  describe("checkReview", () => {
+    it("reports CACHED (hit) when PR commit SHA matches cache", async () => {
+      const sha = nextSha();
+      save({
+        pr: 6767,
+        sha,
+        recommendation: "Request changes",
+        summary: "3 blocking issues",
+        reportContent: "# Findings",
+      });
+
+      const res = await check({
+        pr: 6767,
+        fetchPRInfoFn: stubLookup({
+          number: 6767,
+          headRefOid: sha,
+          title: "Character count fix",
+        }),
+      });
+
+      assert.strictEqual(res.status, "CACHED");
+      assert.strictEqual(res.pr, 6767);
+      assert.strictEqual(res.headSha, sha);
+      assert.strictEqual(res.recommendation, "Request changes");
+      assert.strictEqual(res.summary, "3 blocking issues");
+    });
+
+    it("returns the findings markdown on a hit, in a non-default cacheDir", async () => {
+      // Regression: the report path was resolved against cacheDir's *parent*,
+      // so a hit under --cache-dir reported CACHED with no findings attached —
+      // and the skill skips re-review on a hit, so the findings vanished.
+      const sha = nextSha();
+      save({
+        pr: 6767,
+        sha,
+        recommendation: "Request changes",
+        summary: "3 blocking issues",
+        reportContent: "# Findings\n\nB1. Something concrete.",
+      });
+
+      const res = await check({ pr: 6767, sha, offline: true });
+
+      assert.strictEqual(res.status, "CACHED");
+      assert.strictEqual(res.reportExists, true);
+      assert.match(res.reportContent, /B1\. Something concrete\./);
+    });
+
+    it("honors --offline by trusting the caller's sha without any lookup", async () => {
+      const sha = nextSha();
+      save({ pr: 6789, sha, reportContent: "# Findings" });
+
+      // Counted rather than thrown: resolvePRHead catches a failed lookup and
+      // falls back to --sha, so a throwing stub would still report CACHED and
+      // prove nothing.
+      let lookups = 0;
+      const countingLookup = async () => {
+        lookups += 1;
+        return { number: 6789, state: "OPEN", headRefOid: sha };
+      };
+
+      const res = await check({
+        pr: 6789,
+        sha,
+        offline: true,
+        fetchPRInfoFn: countingLookup,
+      });
+
+      assert.strictEqual(res.status, "CACHED");
+      assert.strictEqual(lookups, 0, "offline must not touch the network");
+    });
+
+    it("errors when offline is set without a sha", async () => {
+      const res = await check({ pr: 6789, offline: true });
+
+      assert.strictEqual(res.status, "ERROR");
+      assert.match(res.message, /--offline requires --sha/);
+    });
+
+    it("errors when no PR number is given", async () => {
+      const res = await check({ sha: "abc1234" });
+
+      assert.strictEqual(res.status, "ERROR");
+      assert.match(res.message, /PR number is required/);
+    });
+
+    it("reports MISS when PR has new commit activity", async () => {
+      const oldSha = nextSha();
+      const newSha = nextSha();
+
+      save({
+        pr: 6767,
+        sha: oldSha,
+        recommendation: "Request changes",
+        summary: "Old findings",
+        reportContent: "# Old",
+      });
+
+      const res = await check({
+        pr: 6767,
+        fetchPRInfoFn: stubLookup({
+          number: 6767,
+          headRefOid: newSha,
+          title: "Character count fix",
+        }),
+      });
+
+      assert.strictEqual(res.status, "MISS");
+      assert.strictEqual(res.headSha, newSha);
+      assert.strictEqual(res.previousSha, oldSha);
+    });
+
+    it("reports MISS when PR is not in cache", async () => {
+      const sha = nextSha();
+
+      const res = await check({
+        pr: 6789,
+        fetchPRInfoFn: stubLookup({
+          number: 6789,
+          headRefOid: sha,
+          title: "Accordion alignment",
+        }),
+      });
+
+      assert.strictEqual(res.status, "MISS");
+      assert.strictEqual(res.headSha, sha);
+      assert.strictEqual(res.previousSha, null);
+    });
+
+    it("marks a merged PR without deleting its review or report", async () => {
+      const sha = nextSha();
+      save({
+        pr: 6659,
+        sha,
+        recommendation: "Approve",
+        summary: "Clean review",
+        reportContent: "# Merged PR findings",
+      });
+
+      const res = await check({
+        pr: 6659,
+        fetchPRInfoFn: stubLookup({
+          number: 6659,
+          state: "MERGED",
+          headRefOid: sha,
+          mergedAt: MERGED_AT,
+        }),
+      });
+
+      assert.strictEqual(res.status, "MERGED");
+      assert.strictEqual(res.cached, true);
+      assert.strictEqual(res.recommendation, "Approve");
+
+      // The review survives: a merged PR's review is the record you want when a
+      // regression surfaces months later.
+      const updatedCache = readCache();
+      assert.ok(updatedCache.reviews["6659"], "entry must be retained");
+      assert.strictEqual(updatedCache.reviews["6659"].status, STATUS_MERGED);
+      assert.strictEqual(updatedCache.reviews["6659"].mergedAt, MERGED_AT);
+      assert.ok(
+        existsSync(reportFile(sha)),
+        "findings markdown must be retained",
+      );
+      assert.match(res.reportContent, /# Merged PR findings/);
+    });
+
+    it("reports a merged PR it never reviewed without inventing an entry", async () => {
+      const res = await check({
+        pr: 6600,
+        fetchPRInfoFn: stubLookup({
+          number: 6600,
+          state: "MERGED",
+          headRefOid: nextSha(),
+          mergedAt: MERGED_AT,
+        }),
+      });
+
+      assert.strictEqual(res.status, "MERGED");
+      assert.strictEqual(res.cached, false);
+      assert.deepStrictEqual(readCache().reviews, {});
+    });
+  });
+
+  describe("syncCache", () => {
+    it("marks merged entries and leaves open ones alone, deleting nothing", async () => {
+      // Fixed SHAs: the report filenames are asserted on below.
+      save({ pr: 101, sha: "a101101" });
+      save({ pr: 102, sha: "b102102", recommendation: "Request changes" });
+
+      const res = await sync({
+        fetchPRInfoFn: stubLookupByPR({
+          101: { number: 101, state: "MERGED", mergedAt: MERGED_AT },
+          102: { number: 102, headRefOid: "b102102" },
+        }),
+      });
+
+      assert.strictEqual(res.mergedCount, 1);
+      assert.strictEqual(res.openCount, 1);
+      assert.strictEqual(res.totalCount, 2);
+
+      const cache = readCache();
+      assert.strictEqual(cache.reviews["101"].status, STATUS_MERGED);
+      assert.strictEqual(cache.reviews["102"].status, STATUS_OPEN);
+      assert.ok(existsSync(reportFile("a101101")));
+      assert.ok(existsSync(reportFile("b102102")));
+    });
+
+    it("leaves status untouched when the lookup fails", async () => {
+      save({ pr: 103 });
+
+      const res = await sync({ fetchPRInfoFn: stubLookupFailure() });
+
+      assert.strictEqual(res.unreachableCount, 1);
+      const cache = readCache();
+      assert.ok(cache.reviews["103"], "entry must survive a failed lookup");
+      assert.strictEqual(cache.reviews["103"].status, STATUS_OPEN);
+    });
+  });
+});

--- a/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
@@ -38,8 +38,12 @@ import {
   parsePRNumber,
   assertValidSha,
   execCmd,
+  parseCliArgs,
+  main,
   STATUS_OPEN,
   STATUS_MERGED,
+  CHECK_STATUS,
+  CHECK_EXIT_CODES,
 } from "./review-cache.mjs";
 
 /** Any merge timestamp; only tests that assert on it need to know the value. */
@@ -499,6 +503,83 @@ describe("review-cache", () => {
       const cache = readCache();
       assert.ok(cache.reviews["103"], "entry must survive a failed lookup");
       assert.strictEqual(cache.reviews["103"].status, STATUS_OPEN);
+    });
+
+    it("handles multiple concurrent lookups accurately", async () => {
+      for (let i = 201; i <= 210; i += 1) {
+        save({ pr: i, sha: `a000${i}` });
+      }
+
+      const byPR = {};
+      for (let i = 201; i <= 210; i += 1) {
+        byPR[i] = {
+          number: i,
+          state: i % 2 === 0 ? "MERGED" : "OPEN",
+          mergedAt: i % 2 === 0 ? MERGED_AT : undefined,
+        };
+      }
+
+      const res = await sync({
+        fetchPRInfoFn: stubLookupByPR(byPR),
+        concurrency: 3,
+      });
+
+      assert.strictEqual(res.totalCount, 10);
+      assert.strictEqual(res.mergedCount, 5);
+      assert.strictEqual(res.openCount, 5);
+    });
+  });
+
+  describe("parseCliArgs and main CLI dispatcher", () => {
+    it("parses check options and aliases", () => {
+      const { command, options } = parseCliArgs([
+        "check",
+        "--pr",
+        "6767",
+        "--sha",
+        "abc1234",
+        "--offline",
+        "--json",
+      ]);
+      assert.strictEqual(command, "check");
+      assert.strictEqual(options.pr, "6767");
+      assert.strictEqual(options.sha, "abc1234");
+      assert.strictEqual(options.offline, true);
+      assert.strictEqual(options.json, true);
+    });
+
+    it("parses save options including alias --rec", () => {
+      const { command, options } = parseCliArgs([
+        "save",
+        "--pr",
+        "6767",
+        "--sha",
+        "abc1234",
+        "--rec",
+        "Request changes",
+        "--summary",
+        "some notes",
+      ]);
+      assert.strictEqual(command, "save");
+      assert.strictEqual(options.recommendation, "Request changes");
+      assert.strictEqual(options.summary, "some notes");
+    });
+
+    it("throws a clear error on ambiguous --report argument", () => {
+      assert.throws(
+        () => parseCliArgs(["save", "--report", "findings.md"]),
+        /--report is ambiguous/,
+      );
+    });
+
+    it("returns exit code 0 on --help", async () => {
+      const code = await main(["--help"]);
+      assert.strictEqual(code, 0);
+    });
+
+    it("returns exit code 1 on unknown command", async () => {
+      const code = await main(["unknown-command"]);
+      assert.strictEqual(code, 1);
     });
   });
 });

--- a/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
+++ b/.agents/skills/uswds-code-review/scripts/review-cache.spec.mjs
@@ -40,8 +40,13 @@ import {
   execCmd,
   parseCliArgs,
   main,
+  getDefaultCacheDir,
+  assertSafeCacheDir,
+  findRepoRoot,
+  CACHE_DIR_NAME,
   STATUS_OPEN,
   STATUS_MERGED,
+  STATUS_CLOSED,
   CHECK_STATUS,
   CHECK_EXIT_CODES,
 } from "./review-cache.mjs";
@@ -468,30 +473,68 @@ describe("review-cache", () => {
       assert.strictEqual(res.cached, false);
       assert.deepStrictEqual(readCache().reviews, {});
     });
+
+    it("marks a closed (unmerged) PR without deleting its review or report", async () => {
+      const sha = nextSha();
+      save({
+        pr: 6652,
+        sha,
+        recommendation: "Approve",
+        reportContent: "# Closed PR findings\n\nNo blockers.",
+      });
+
+      const res = await check({
+        pr: 6652,
+        fetchPRInfoFn: stubLookup({
+          number: 6652,
+          state: "CLOSED",
+          headRefOid: sha,
+          closedAt: MERGED_AT,
+        }),
+      });
+
+      assert.strictEqual(res.status, "CLOSED");
+      assert.strictEqual(res.cached, true);
+      assert.strictEqual(res.recommendation, "Approve");
+
+      const updatedCache = readCache();
+      assert.ok(updatedCache.reviews["6652"], "entry must be retained");
+      assert.strictEqual(updatedCache.reviews["6652"].status, STATUS_CLOSED);
+      assert.strictEqual(updatedCache.reviews["6652"].closedAt, MERGED_AT);
+      assert.ok(
+        existsSync(reportFile(sha)),
+        "findings markdown must be retained",
+      );
+    });
   });
 
   describe("syncCache", () => {
-    it("marks merged entries and leaves open ones alone, deleting nothing", async () => {
+    it("marks merged and closed entries and leaves open ones alone, deleting nothing", async () => {
       // Fixed SHAs: the report filenames are asserted on below.
       save({ pr: 101, sha: "a101101" });
       save({ pr: 102, sha: "b102102", recommendation: "Request changes" });
+      save({ pr: 103, sha: "c103103", recommendation: "Approve" });
 
       const res = await sync({
         fetchPRInfoFn: stubLookupByPR({
           101: { number: 101, state: "MERGED", mergedAt: MERGED_AT },
           102: { number: 102, headRefOid: "b102102" },
+          103: { number: 103, state: "CLOSED", closedAt: MERGED_AT },
         }),
       });
 
       assert.strictEqual(res.mergedCount, 1);
+      assert.strictEqual(res.closedCount, 1);
       assert.strictEqual(res.openCount, 1);
-      assert.strictEqual(res.totalCount, 2);
+      assert.strictEqual(res.totalCount, 3);
 
       const cache = readCache();
       assert.strictEqual(cache.reviews["101"].status, STATUS_MERGED);
       assert.strictEqual(cache.reviews["102"].status, STATUS_OPEN);
+      assert.strictEqual(cache.reviews["103"].status, STATUS_CLOSED);
       assert.ok(existsSync(reportFile("a101101")));
       assert.ok(existsSync(reportFile("b102102")));
+      assert.ok(existsSync(reportFile("c103103")));
     });
 
     it("leaves status untouched when the lookup fails", async () => {

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ src/stylesheets/lib
 
 # ignore sassdoc build
 sassdoc/
+
+# ignore review cache
+.review-cache/

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "federalist": "npm run build && npm run build:storybook",
     "start": "npm run start:storybook",
     "test": "npm run lint && gulp typecheck && gulp test",
+    "test:agents": "mocha .agents/skills/uswds-code-review/scripts/*.spec.mjs",
     "test:ci": "npm run lint && gulp test && npm run test:a11y && npm run build:html",
     "test:a11y": "storybook build -o _site && concurrently -k -s first -n \"SB,TEST\" \"http-server _site --port 6006 --silent\" \"wait-on --timeout 30000 http://127.0.0.1:6006 && test-storybook --url http://127.0.0.1:6006\"",
     "test:sass": "gulp sassTests",


### PR DESCRIPTION
**Review caches now prevent re-reviewing unchanged PRs, reducing agent latency and cost.** The uswds-code-review skill stores findings from each PR review, looks them up on subsequent calls, and only re-reviews when the commit changes.

## Breaking change

This is not a breaking change.

## Related issue

Closes #6838

## Related pull requests

None yet. This PR was originally scoped to include a review-digest tool (a summary table across all cached reviews) on top of the cache, but that pushed the change well past this repo's PR size norms and mixed two concerns that don't depend on each other — nothing in the cache imports the digest module. The digest layer, a merge-status states PR (closed-but-unmerged PRs, and disclosing when merge state can't be verified offline), and an unrelated `pr-metrics.mjs` timeout fix are split into follow-up PRs against #6838, to be opened once this one lands.

## Preview link

N/A (tooling change)

## Problem statement

Every time the code review skill is invoked on the same PR before it merges, the skill re-runs the full review gate analysis, re-reads changed files, and regenerates findings — even though the commit hash hasn't changed. For high-traffic PRs or when the same PR is reviewed multiple times in a session, this wastes compute, increases agent latency, and duplicates findings documents that are identical.

## Solution

Added a persistent review cache that:
- **Stores findings per commit SHA** (in `.review-cache/<sha>.md`) to avoid re-analyzing unchanged code
- **Caches review metadata** (recommendation, summary, gates pass/fail status) in `.review-cache/cache.json` for fast lookup
- **Tracks PR lifecycle** (marks reviews as `open` or `merged` so reviewers know when a cached finding is stale)
- **Provides `review-cache.mjs`**: check if a PR is already cached at its current commit, save findings after a new review, sync PR status with GitHub, and list all cached reviews

The cache is **unversioned** (in `.gitignore`), lives at the repo root, and retains merged PR reviews indefinitely — so the review findings become the audit trail if a regression surfaces later.

**On the size of `review-cache.mjs` (743 lines, over this repo's 400-line PR guideline):** a working cache is one atomic unit that doesn't decompose further once the digest reporting layer is split out into its own PR. Suggested reading order: cache I/O (`loadCache`/`writeCache`) → PR lookup (`fetchPRInfo`/`resolvePRHead`/`isMergedPR`) → the three cache operations (`checkReview`/`saveReview`/`syncCache`) → the CLI layer at the bottom of the file.

## Major changes

- **`review-cache.mjs`**: Cache manager. Handles check/save/sync/list operations on the `.review-cache/` directory. Prevents re-review of unchanged commits.
- **`review-cache.spec.mjs`**: Test suite for cache operations — cache hits/misses, entry creation/updates, PR status syncing, report file lifecycle, and corrupted-cache handling.
- **Updated `SKILL.md`** and **`VERIFICATION.md`**: Documented the cache-only workflow and CLI usage for `check`/`save`/`sync`.
- **`.gitignore`**: Added `.review-cache/` to exclude the cache directory from version control.
- **`package.json`**: Added `npm run test:agents` so the spec (intentionally kept out of `gulp test` — this is skill tooling, not shipped library code) is runnable without memorizing the raw mocha invocation.

Also fixed, rather than left for a follow-up patch, since none of these had shipped yet:
- `reportPath` was stored as a conventional-but-fake repo-relative string, reconstructed into a real path via a `resolveReportPath` indirection that existed solely to `basename()` it back apart. Collapsed into one `reportFilePath(cacheDir, sha)` helper computed directly from `cacheDir` — this also fixes `check --cache-dir <dir>` printing a report path that didn't actually exist on disk.
- A corrupted `cache.json` was caught and silently replaced with an empty cache object in memory; the next `save` would then overwrite the corrupt file on disk with a fresh one, discarding every prior cached review with no error at all. `loadCache` now throws instead, surfaced by the CLI's existing top-level error handler.
- `check`'s CACHED and MERGED output were inconsistent (only CACHED showed the summary and a "MISSING ON DISK" flag), and `list` never printed the summary and showed raw ISO timestamps. Unified via shared formatting helpers.
- `--rec` was a working shorthand for `--recommendation` but undocumented in `--help`; `--force` hardcoded its exit code instead of reading it from the exit-code table.

## Testing and review

To verify:

1. **Unit tests**: `npm run test:agents` — covers cache hits/misses, status transitions, corrupted-cache handling, and report resolution under a custom `--cache-dir`.
2. **Manual cache operations**:
   ```bash
   # Check cache status for a PR
   node .agents/skills/uswds-code-review/scripts/review-cache.mjs check --pr 6789


   # Sync open/merged status with GitHub
   node .agents/skills/uswds-code-review/scripts/review-cache.mjs sync
   ```
3. **Corrupted cache**: write invalid JSON to `.review-cache/cache.json` and confirm `check`/`save` all fail loudly (non-zero exit, clear error) instead of silently discarding the file.
4. **Integration**: The `/uswds-code-review` skill auto-detects and uses the cache before running a full review. A cache hit skips the expensive re-review; a cache miss or a forced review (`--force`) runs the full pass and saves the findings.
