### PR TITLE
USWDS - Testing: Verify compiled CSS release artifacts

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -66,6 +66,74 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
           echo "Bumped to version: $NEW_VERSION"
 
+      - name: Verify compiled CSS artifacts
+        run: |
+          CSS_FILE="dist/css/uswds.css"
+          MIN_CSS_FILE="dist/css/uswds.min.css"
+          EXPECTED_BANNER="/*! uswds v${NEW_VERSION} */"
+          MIN_SIZE=102400
+          CSS_SIZE=0
+          MIN_CSS_SIZE=0
+          ERRORS=()
+
+          if [ -f "$CSS_FILE" ]; then
+            CSS_SIZE=$(stat -c%s "$CSS_FILE")
+          else
+            ERRORS+=("Missing compiled CSS artifact: $CSS_FILE")
+          fi
+
+          if [ -f "$MIN_CSS_FILE" ]; then
+            MIN_CSS_SIZE=$(stat -c%s "$MIN_CSS_FILE")
+          else
+            ERRORS+=("Missing compiled CSS artifact: $MIN_CSS_FILE")
+          fi
+
+          for FILE in "$CSS_FILE" "$MIN_CSS_FILE"; do
+            if [ -f "$FILE" ] && ! grep -Fq "$EXPECTED_BANNER" "$FILE"; then
+              ERRORS+=("$FILE does not contain the expected version banner: $EXPECTED_BANNER")
+            fi
+            if [ -f "$FILE" ] && ! grep -Fq ".usa-button" "$FILE"; then
+              ERRORS+=("$FILE does not contain the .usa-button compiled-rule sentinel")
+            fi
+          done
+
+          if [ "$CSS_SIZE" -lt "$MIN_SIZE" ]; then
+            ERRORS+=("$CSS_FILE is below the 102,400-byte size floor ($CSS_SIZE bytes)")
+          fi
+          if [ "$MIN_CSS_SIZE" -lt "$MIN_SIZE" ]; then
+            ERRORS+=("$MIN_CSS_FILE is below the 102,400-byte size floor ($MIN_CSS_SIZE bytes)")
+          fi
+          if [ "$CSS_SIZE" -gt 0 ] && [ "$CSS_SIZE" -eq "$MIN_CSS_SIZE" ]; then
+            ERRORS+=("Compiled and minified CSS have the same size ($CSS_SIZE bytes)")
+          fi
+
+          echo "Verifying USWDS version: $NEW_VERSION"
+          echo "$CSS_FILE: $CSS_SIZE bytes"
+          echo "$MIN_CSS_FILE: $MIN_CSS_SIZE bytes"
+
+          {
+            echo "## Compiled CSS verification"
+            echo ""
+            echo "- Version: \`$NEW_VERSION\`"
+            echo "- \`$CSS_FILE\`: $CSS_SIZE bytes"
+            echo "- \`$MIN_CSS_FILE\`: $MIN_CSS_SIZE bytes"
+            if [ "${#ERRORS[@]}" -eq 0 ]; then
+              echo "- Result: ✅ Passed"
+            else
+              echo "- Result: ❌ Failed (${#ERRORS[@]} errors)"
+            fi
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${#ERRORS[@]}" -gt 0 ]; then
+            for ERROR in "${ERRORS[@]}"; do
+              echo "::error::$ERROR"
+            done
+            exit 1
+          fi
+
+          echo "Compiled CSS verification passed."
+
       # The version hook (gulp release) writes security/uswds-<version>-zip-hash.txt.
       # Recompute and assert the tarball and hash file agree.
       - name: Verify tarball hash matches generated security file


### PR DESCRIPTION
## Summary
- add a release-prep smoke test for the compiled and minified CSS artifacts
- verify the bumped version banner, `.usa-button` compiled-rule sentinel, 100 KB size floors, and distinct minified output
- collect all failures as workflow error annotations and include artifact sizes and status in the job summary

## Release notes
**Release preparation now verifies compiled CSS artifacts before packaging.** The workflow blocks releases with missing, stale, empty, undersized, or unminified CSS output.

## How to test
- `npx --yes yaml-lint@1.7.0 .github/workflows/release-prep.yml` — passed
- extracted inline shell: `bash -n` — passed
- generated USWDS 3.14.0 CSS: verification passed (`uswds.css` 660,311 bytes; `uswds.min.css` 527,075 bytes)
- truncated `uswds.min.css`: failed as expected with banner, selector, and size errors
- copied `uswds.css` over `uswds.min.css`: failed as expected with equal-size error
- tested with version `9.9.9`: failed as expected with both stale-banner errors
- `git diff --check` — passed

`npm ci` generated the CSS used above successfully. Its subsequent, unrelated web-component phase cannot complete under Windows because the existing single-quoted Vite config path is interpreted literally by `cmd.exe`; release CI runs Ubuntu.

Closes #6877