### PR TITLE
USWDS - Modal: Fix typo in error message (aria-describedby)

### DIFF
--- a/packages/usa-modal/src/index.js
+++ b/packages/usa-modal/src/index.js
@@ -240,7 +240,7 @@ const setModalAttributes = (baseComponent, modalContentWrapper) => {
     throw new Error(`${modalID} is missing aria-labelledby attribute`);
 
   if (!ariaDescribedBy)
-    throw new Error(`${modalID} is missing aria-desribedby attribute`);
+    throw new Error(`${modalID} is missing aria-describedby attribute`);
 
   // Set attributes
   modalContentWrapper.setAttribute("role", "dialog");


### PR DESCRIPTION


<!---
Welcome! Thank you for contributing to the U.S. Web Design System.
Your contributions are vital to our success and we are glad you're here.

Please keep in mind:
- This pull request (PR) template exists to help speed up integration.
  The USWDS Core team reviews and approves every PR
  before merging it into the public code base,
  so the better we can understand the problem and solution,
  the sooner we can merge this change.
  The point here is: clear explanations matter!

- You can erase any part of this template
  that doesn't apply to your pull request (including these instructions!).

- You can find more information about contributing in
  [contributing.md](https://github.com/uswds/uswds/blob/develop/CONTRIBUTING.md)
  or you can reach out to us directly at uswds@gsa.gov.

- For security reasons, all commits to this repository must have a verified signature.
  Use one of the following GitHub guides to set up your commit verification signature:
    - GPG commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification
    - SSH commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification
 -->

<!---
Step 1 - Title this PR with the following format:
USWDS - [Package]: [Brief statement describing what this pull request solves]
eg: "USWDS - Button: Increase font size"
 -->

# Summary

_Fixed a typo within the error message within 'aria-described by' in Modal._
<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
-->

## Breaking change

_This is not a breaking change_

<!--
Breaking changes include:
  - Changes to the JavaScript API
  - Changes to markup or content in our components
  - Significant changes to the display of a component
If applicable, explain what actions are required for the user to remediate the break.
-->

## Related issue

Closes _#5652_
<!--
Every pull request should resolve an open issue.
If no open issue exists, you can open one here:
https://github.com/uswds/uswds/issues/new/choose.
-->

## Related pull requests

_There are no other related/necessary pull requests_
<!--
Some changes to the USWDS codebase require a change to the documentation site,
and need a pull request in the [uswds-site repo](https://github.com/uswds/uswds-site).

This could include:
- New or updated component documentation,
- New or updated settings documentation, or
- Changelog entries.

Add links to any related PRs in this section. If this change requires an update
to the uswds-site repo, but that PR does not yet exist, just make sure to note that here.
-->


## Problem statement

_The desired state for line 227 was to handle the throw correctly. The actual state was short a 'c' in aria-describedby. The consequences of the state were that a developer-side message was not displayed correctly._
<!--
A successful problem statement conveys:
1. The desired state,
2. The actual state, and
3. Consequences of remaining in the current state
   (who does this affect and to what degree?)
-->

## Solution

_This pull request fixes a typo in the error message thrown by setModalAttributes() in the modal component. The fix was just a single line string correction. This was resolved by adding a 'c' in aria-describedby on line 227. This has no functional limitations with no impact on runtime or logic._
<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Major changes

_N/A, a minor change._

## Testing and review

_1. Since this is a single line correction inside a string literal with no logic changes, I manually verified the fix by inspecting and then correcting the spelling to 'aria-describedby' 

2. Open packages/usa-modal/src/index.js and view line 227. Trigger the error condition by initializing a modal that is missing the aria-describedby attribute and confirm the thrown error message now reads  'is missing aria-describedby attribute' instead of the previous misspelled version without the c.
3.  This is a minimal, low risk fix, so I'm just looking for confirmation that the correction is accurate and that the commit meets USWDS's contribution requirements. Please let me know if i need more adjustments!_
<!--
1. Describe the tests that you ran to verify your changes,
2. Provide instructions to reproduce these tests, and
5. Clarify the type of feedback you are looking for at this phase.
-->

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- [ ] Confirm that this code follows the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [ ] Run `git pull origin [base branch]` to pull in the most recent updates from your base and check for merge conflicts. (Often, the base branch is `develop`).
- [ ] Run `npm run prettier:sass` to format any Sass updates.
- [ ] Run `npm test` and confirm that all tests pass.
- [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
-->
