### PR TITLE
USWDS - Icons: Remove legacy `focusable="false"` from SVGs

### DIFF
--- a/packages/usa-banner/src/usa-banner.twig
+++ b/packages/usa-banner/src/usa-banner.twig
@@ -1,6 +1,6 @@
 {% set lock %}
   <span class="icon-lock">
-    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description" focusable="false">
+    <svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-description">
       <title id="banner-lock-title">Lock</title>
       <desc id="banner-lock-description">Locked padlock icon</desc>
       <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"/>

--- a/packages/usa-button/src/usa-button.twig
+++ b/packages/usa-button/src/usa-button.twig
@@ -19,7 +19,7 @@
 {% set icon %}
   <!-- @TODO: Allow size to be passed as a argument. -->
   <!-- Example: usa-icon--size-{3-9} -->
-  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <svg class="usa-icon" aria-hidden="true" role="img">
     <use href="./img/sprite.svg#{{ icon_name | default("add_circle_outline") }}"></use>
   </svg>
 {% endset %}

--- a/packages/usa-form/src/test/test-pattern/test-usa-form.twig
+++ b/packages/usa-form/src/test/test-pattern/test-usa-form.twig
@@ -204,7 +204,7 @@
     {% if error_state == true %}<span class="usa-error-message" role="alert">Helpful error message</span>{% endif %}
     <div class="usa-input-group {% if error_state == true %}usa-input--error{% endif %}">
       <div class="usa-input-prefix" aria-hidden="true">
-        <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+        <svg aria-hidden="true" role="img" class="usa-icon">
           <use href="./img/sprite.svg#credit_card"></use>
         </svg>
       </div>

--- a/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.twig
+++ b/packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.twig
@@ -1,14 +1,14 @@
 <div>
   <p class="font-sans-2xl line-height-body-1 text-bold margin-y-0">
     An icon relative to font size
-    <svg class="usa-icon bottom-neg-05" aria-hidden="true" focusable="false" role="img">
+    <svg class="usa-icon bottom-neg-05" aria-hidden="true" role="img">
       <use href="{{ img_path }}/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
 
   <p class="">
     An icon relative to font size
-    <svg class="usa-icon bottom-neg-2px" aria-hidden="true" focusable="false" role="img">
+    <svg class="usa-icon bottom-neg-2px" aria-hidden="true" role="img">
       <use href="{{ img_path }}/sprite.svg#arrow_forward"></use>
     </svg>
   </p>
@@ -26,7 +26,7 @@
         <tr>
           <th><code>.usa-icon--size-{{ item.units }}</code></th>
           <td>
-            <svg class="usa-icon usa-icon--size-{{ item.units }}" aria-hidden="true" focusable="false" role="img">
+            <svg class="usa-icon usa-icon--size-{{ item.units }}" aria-hidden="true" role="img">
               <use href="{{ img_path }}/sprite.svg#accessibility_new"></use>
             </svg>
           </td>

--- a/packages/usa-icon/src/usa-icon.twig
+++ b/packages/usa-icon/src/usa-icon.twig
@@ -7,7 +7,7 @@
 {% for item in icons.items %}
   <div role="region" aria-atomic="true" class="font-sans-xl position-relative icon-example border-1px border-base-lighter hover:text-white hover:bg-primary-vivid hover:border-primary-darker " data-meta="{{ item.name }} {{ item.meta }}" aria-label="{{ item.name }} icon.">
     <button type="button" onclick="copyHTML(this)" class="bg-transparent cursor-pointer text-no-underline text-black display-flex width-card height-card flex-align-center flex-align-center border-0 flex-column flex-justify-center padding-2  hover:text-white" aria-label="Copy icon to clipboard" style="-webkit-user-select: text; -moz-user-select: text; -ms-user-select: text; user-select: text;">
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <svg class="usa-icon" aria-hidden="true" role="img">
         <use href="{{ icons.img_path }}/sprite.svg#{{ item.name }}"></use>
       </svg>
       <span class="font-sans-3xs margin-top-2 display-block" aria-hidden="true">{{ item.name }}</span>

--- a/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
+++ b/packages/usa-input-prefix-suffix/src/usa-input-prefix.twig
@@ -2,7 +2,7 @@
   <label class="usa-label" for="example-input-prefix">Credit card number</label>
   <div class="usa-input-group{% if utilities %} {{ utilities }}{% endif %}">
     <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <svg aria-hidden="true" role="img" class="usa-icon">
         <use href="./img/sprite.svg#credit_card"></use>
       </svg>
     </div>
@@ -21,7 +21,7 @@
   <label class="usa-label" for="example-input-prefix-error">Credit card number (Error)</label>
   <div class="usa-input-group usa-input-group--error{% if utilities %} {{ utilities }}{% endif %}">
     <div class="usa-input-prefix" aria-hidden="true">
-      <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+      <svg aria-hidden="true" role="img" class="usa-icon">
         <use href="./img/sprite.svg#credit_card"></use>
       </svg>
     </div>

--- a/packages/usa-modal/src/test/template.html
+++ b/packages/usa-modal/src/test/template.html
@@ -44,7 +44,7 @@
       </div>
     </div>
     <button type="button" id="close-button" class="usa-button usa-modal__close" aria-label="close this window" data-close-modal>
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+      <svg class="usa-icon" aria-hidden="true" role="img">
         <use href="{{ uswds.path }}/img/sprite.svg#close"></use>
       </svg>
       Close

--- a/packages/usa-modal/src/test/test-patterns/test-usa-modal--nested-forms.twig
+++ b/packages/usa-modal/src/test/test-patterns/test-usa-modal--nested-forms.twig
@@ -1,5 +1,5 @@
 {% set close_icon %}
-  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <svg class="usa-icon" aria-hidden="true" role="img">
     <use href="./img/sprite.svg#{{ close_button.icon_type | default("close") }}"></use>
   </svg>
 {% endset %}

--- a/packages/usa-modal/src/usa-modal.twig
+++ b/packages/usa-modal/src/usa-modal.twig
@@ -1,5 +1,5 @@
 {% set close_icon %}
-  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <svg class="usa-icon" aria-hidden="true" role="img">
     <use href="./img/sprite.svg#{{ close_button.icon_type | default("close") }}"></use>
   </svg>
 {% endset %}


### PR DESCRIPTION
USWDS - Icons: Remove legacy `focusable="false"` from SVGs

# Summary

Removed the legacy `focusable="false"` attribute from inline SVGs. Decorative icons still use `aria-hidden="true"`. Modern browsers do not put these SVGs in the tab order, so the Internet Explorer-only attribute is no longer needed.

## Breaking change

This is not a breaking change.

## Related issue

Closes #5316

Related discussion: https://github.com/uswds/uswds/issues/4307#issuecomment-1559410923

## Related pull requests

Documentation examples on [uswds-site](https://github.com/uswds/uswds-site) that still show `focusable="false"` on SVGs may need a follow-up PR.

## Preview link

Preview link: N/A

## Problem statement

**Desired:** Inline USWDS SVGs use only the attributes current browsers need. Decorative icons stay hidden from assistive technology. They are not in the tab order.

**Actual:** Markup still included `focusable="false"` on SVGs, a workaround for Internet Explorer putting inline SVGs in the tab order. USWDS no longer supports IE. The extra attribute added noise to examples and did not change behavior in current browsers.

**Consequence:** Teams copy outdated markup, and it is unclear whether `aria-hidden="true"` is enough.

## Solution

Removed `focusable="false"` from every inline SVG in component Twig and related test templates. Left `aria-hidden="true"` (and existing `role="img"`) in place for decorative icons.

The banner lock SVG is labeled with `aria-labelledby` and is not `aria-hidden`. It also no longer has `focusable="false"`.

This matches current browser behavior: an SVG without `tabindex` is not keyboard-focusable, so the IE attribute is unnecessary.

## Major changes

- Removed `focusable="false"` from SVGs in:
  - `packages/usa-banner/src/usa-banner.twig`
  - `packages/usa-button/src/usa-button.twig`
  - `packages/usa-icon/src/usa-icon.twig`
  - `packages/usa-icon/src/usa-icon--sizes/usa-icon--sizes.twig`
  - `packages/usa-input-prefix-suffix/src/usa-input-prefix.twig`
  - `packages/usa-modal/src/usa-modal.twig`
  - Modal and form test templates

## Testing and review

- [ ] Run `npm test` and confirm all tests pass

**Manual verification**

1. Run `npm start:storybook` and spot-check **Icon**, **Button** (with icon), **Banner**, **Modal**, and **Input prefix**.
2. Confirm decorative icons are still skipped by the screen reader (`aria-hidden="true"`).
3. Tab through each component. Confirm the SVG itself does not receive focus. Focus should stay on the control (button, input, banner accordion, modal close).
4. **VoiceOver + Safari** (macOS) and **VoiceOver on iOS:** icons remain decorative. Tab/swipe order is unchanged.
5. **NVDA + Chrome** and **NVDA + Edge:** same as above.

No visual change is expected. The review is markup and focus order only.