### PR TITLE
Repository Settings - Add AI Usage Section to PR Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -139,3 +139,30 @@ Before opening this PR, make sure you’ve done whichever of these applies to yo
 - [ ] Run `npm test` and confirm that all tests pass.
 - [ ] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
 -->
+
+## AI Usage
+
+- [ ] Generative AI was used in this contribution
+
+If checked, please provide an explanation on how AI was used in the development of this pull request:
+
+
+- Description: <!-- Include a high level description of Gen AI utilization -->
+- Type of assistance:
+  - [ ] Code generation
+  - [ ] Documentation
+  - [ ] Debugging
+  - [ ] Testing
+  - [ ] Refactoring
+  - [ ] Other:
+- Scope of usage: <!-- Which files, functions, or sections were AI-assisted -->
+- AI System used:
+  - [ ] ChatGPT
+  - [ ] Claude
+  - [ ] Gemini
+  - [ ] GitHub Copilot
+- Level of modification: 
+  - [ ] As-is
+  - [ ] Modified
+  - [ ] Used as inspiration
+- Prompts used: <!-- Please list or explain prompts that were used to develop this contribution -->

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -29,6 +29,7 @@ Members of the USWDS Open Source Community are responsible for guiding its devel
 - [@acolter](https://github.com/acolter), The Bridge Chief Operating Officer, Former Executive Director at 18F
 - [@jeana-adhoc](https://github.com/jeana-adhoc), Design Lead & Accessibility Specialist at Ad Hoc; Contractor on VA.gov Design System
 - [@opensource-joe](https://github.com/opensource-joe), Principal technologist building open-source AI; Former Code.gov Director (GSA / TTS)
+- [@natalialuzuriaga](https://github.com/natalialuzuriaga), Open Source Software Engineer at the CMS Open Source Program Office
 
 ### USWDS Alumni
 


### PR DESCRIPTION
# Summary

As requested, we would like to add a new AI Usage section to the PR template for contributors to disclose Generative AI usage in their contributions.

## Breaking change
This is not a breaking change.

## Problem statement

As AI-assisted coding becomes more common, there is no way for contributors to disclose generative AI usage, thus reviewers lack visibility into the origin and reliability of the code.

## Solution

For transparency and promoting responsible AI use, we updated the pull request template to include a new "AI Usage" section. Contributors are asked to disclose details of the usage such as type of assistance, tool, scope of usage, level of modification, prompts. 

## Major changes

Going forward, all PRs will include the AI Usage section. As part of the USWDS development workflow, those who would like to make a PR to the repository are now required to disclose AI usage in their contributions.

## Notes
This is what the CMS OSPO uses in our PR templates: https://dsacms.github.io/ospo-guide/outbound/gen-ai-policy/
Example of a completed PR template: https://github.com/DSACMS/automated-codejson-generator/pull/138

Feel free to modify the template text to fit the needs and development practices/workflows of USWDS!