### PR TITLE
Update references to design systems in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,10 +550,7 @@ Joining the [USWDS Open Source Community](https://github.com/uswds/uswds/blob/de
 Much of the guidance in USWDS leans on open source designs, code, and patterns from other civic and government organizations, including:
 
 - Consumer Financial Protection Bureau’s [Design Manual](https://cfpb.github.io/design-manual/)
-- U.S. Patent and Trademark Office’s [Design System](https://web.archive.org/web/20250830060151/https://uspto.github.io/USPTO-Design-System/)
-- Healthcare.gov [Style Guide](http://styleguide.healthcare.gov/)
-- UK’s Government Digital Service’s [UI Elements](http://govuk-elements.herokuapp.com/)
-- Code for America’s Chime [Styleguide](https://github.com/chimecms/chime-starter)
+- UK’s Government Digital Service’s [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/)
 - Pivotal Labs [Component Library](https://pivotal-cf.github.io/pivotal-ui/)
 
 ## Licenses and attribution


### PR DESCRIPTION
Removed outdated links and added GOV.UK Frontend link.

Even pointing to an Archive.org page for a design system reference isn't a good idea so I removed the link to:  https://web.archive.org/web/20250830060151/https://uspto.github.io/USPTO-Design-System