### PR TITLE
Add mobile and desktop to $project-column-gaps

### DIFF
--- a/packages/uswds-core/src/styles/variables/column-gaps.scss
+++ b/packages/uswds-core/src/styles/variables/column-gaps.scss
@@ -4,4 +4,6 @@ $project-column-gaps: (
   "sm": settings.$theme-column-gap-sm,
   "md": settings.$theme-column-gap-md,
   "lg": settings.$theme-column-gap-lg,
+  "mobile": settings.$theme-column-gap-mobile,
+  "desktop": settings.$theme-column-gap-desktop,
 );


### PR DESCRIPTION
## Summary

Generated with AI.

Adds `"mobile"` and `"desktop"` responsive gap variants to the `$project-column-gaps` map in `packages/uswds-core/src/styles/variables/column-gaps.scss`.

## Problem

The settings file defines `$theme-column-gap-mobile` and `$theme-column-gap-desktop`, but `$project-column-gaps` only exposes `sm`, `md`, and `lg`. This means projects cannot override the responsive mobile/desktop gap values at the project level through the `$project-column-gaps` map.

The `grid-gap-responsive` mixin (invoked by `@include grid-gap` with no arguments) reads directly from the settings variables:

```scss
// In layout-grid.scss — grid-gap-responsive mixin
$gap-mobile: map.get($system-column-gaps, settings.$theme-column-gap-mobile);
$gap-desktop: map.get($system-column-gaps, settings.$theme-column-gap-desktop);
```

But the project-level override map `$project-column-gaps` doesn't include these keys, so there's no way to override them through the same interface used for `sm`/`md`/`lg`.

## Change

```scss
$project-column-gaps: (
  "sm": settings.$theme-column-gap-sm,
  "md": settings.$theme-column-gap-md,
  "lg": settings.$theme-column-gap-lg,
+ "mobile": settings.$theme-column-gap-mobile,
+ "desktop": settings.$theme-column-gap-desktop,
);
```

## Testing

Verified that the map keys are accessible and that the settings variables (`$theme-column-gap-mobile`, `$theme-column-gap-desktop`) are defined in `_settings-spacing.scss`.