### PR TITLE
fix(nav): preserve hover icons and theme overrides

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -216,7 +216,7 @@ If anyone involved with USWDS in the past would like to be reflected on this pag
 
 None of us can do this alone. We never have. We never will. We [learn from each other](https://designsystem.digital.gov/design-principles/#listen), and [share with each other](https://designsystem.digital.gov/about/product-values/#share-what-we-do), and continuing _that_ will continue to make things better over time. Thanks for being here.
 
-Total number of contributors to this particular repository: <!--CONTRIBUTOR COUNT START--> 190 <!--CONTRIBUTOR COUNT END--> (!)
+Total number of contributors to this particular repository: <!--CONTRIBUTOR COUNT START--> 191 <!--CONTRIBUTOR COUNT END--> (!)
 
 <!-- readme: contributors -start -->
 <table role="presentation">
@@ -311,6 +311,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
 		</tr>
 		<tr>
         <td align="center">
+            <a href="https://github.com/jonathanbobel">
+                <img src="https://avatars.githubusercontent.com/u/1233986?v=4" width="100;" alt="jonathanbobel"/>
+                <br />
+                <sub><b>Jonathan Bobel</b></sub>
+            </a>
+        </td>
+        <td align="center">
             <a href="https://github.com/toolness">
                 <img src="https://avatars.githubusercontent.com/u/124687?v=4" width="100;" alt="toolness"/>
                 <br />
@@ -329,13 +336,6 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <img src="https://avatars.githubusercontent.com/u/1779930?v=4" width="100;" alt="aduth"/>
                 <br />
                 <sub><b>Andrew Duthie</b></sub>
-            </a>
-        </td>
-        <td align="center">
-            <a href="https://github.com/jonathanbobel">
-                <img src="https://avatars.githubusercontent.com/u/1233986?v=4" width="100;" alt="jonathanbobel"/>
-                <br />
-                <sub><b>Jonathan Bobel</b></sub>
             </a>
         </td>
         <td align="center">
@@ -443,17 +443,17 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
 		</tr>
 		<tr>
         <td align="center">
-            <a href="https://github.com/alexose">
-                <img src="https://avatars.githubusercontent.com/u/627264?v=4" width="100;" alt="alexose"/>
-                <br />
-                <sub><b>Alexander Ose</b></sub>
-            </a>
-        </td>
-        <td align="center">
             <a href="https://github.com/CTGM-Bixal">
                 <img src="https://avatars.githubusercontent.com/u/157414761?v=4" width="100;" alt="CTGM-Bixal"/>
                 <br />
                 <sub><b>Rachel Corsino</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/alexose">
+                <img src="https://avatars.githubusercontent.com/u/627264?v=4" width="100;" alt="alexose"/>
+                <br />
+                <sub><b>Alexander Ose</b></sub>
             </a>
         </td>
         <td align="center">
@@ -545,17 +545,10 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/nickjs">
-                <img src="https://avatars.githubusercontent.com/u/22133?v=4" width="100;" alt="nickjs"/>
+            <a href="https://github.com/chandracarney">
+                <img src="https://avatars.githubusercontent.com/u/8561841?v=4" width="100;" alt="chandracarney"/>
                 <br />
-                <sub><b>Nicholas J. Small</b></sub>
-            </a>
-        </td>
-        <td align="center">
-            <a href="https://github.com/IHIutch">
-                <img src="https://avatars.githubusercontent.com/u/20825047?v=4" width="100;" alt="IHIutch"/>
-                <br />
-                <sub><b>Jonathan Hutchison</b></sub>
+                <sub><b>Chandra</b></sub>
             </a>
         </td>
         <td align="center">
@@ -566,19 +559,26 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/yowill">
-                <img src="https://avatars.githubusercontent.com/u/406607?v=4" width="100;" alt="yowill"/>
+            <a href="https://github.com/IHIutch">
+                <img src="https://avatars.githubusercontent.com/u/20825047?v=4" width="100;" alt="IHIutch"/>
                 <br />
-                <sub><b>Will Sullivan</b></sub>
+                <sub><b>Jonathan Hutchison</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/nickjs">
+                <img src="https://avatars.githubusercontent.com/u/22133?v=4" width="100;" alt="nickjs"/>
+                <br />
+                <sub><b>Nicholas J. Small</b></sub>
             </a>
         </td>
 		</tr>
 		<tr>
         <td align="center">
-            <a href="https://github.com/fureigh">
-                <img src="https://avatars.githubusercontent.com/u/1244599?v=4" width="100;" alt="fureigh"/>
+            <a href="https://github.com/ravitejapioneerblaze-code">
+                <img src="https://avatars.githubusercontent.com/u/287091548?v=4" width="100;" alt="ravitejapioneerblaze-code"/>
                 <br />
-                <sub><b>Fureigh</b></sub>
+                <sub><b>ravitejapioneerblaze-code</b></sub>
             </a>
         </td>
         <td align="center">
@@ -589,10 +589,17 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/ravitejapioneerblaze-code">
-                <img src="https://avatars.githubusercontent.com/u/287091548?v=4" width="100;" alt="ravitejapioneerblaze-code"/>
+            <a href="https://github.com/fureigh">
+                <img src="https://avatars.githubusercontent.com/u/1244599?v=4" width="100;" alt="fureigh"/>
                 <br />
-                <sub><b>ravitejapioneerblaze-code</b></sub>
+                <sub><b>Fureigh</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/yowill">
+                <img src="https://avatars.githubusercontent.com/u/406607?v=4" width="100;" alt="yowill"/>
+                <br />
+                <sub><b>Will Sullivan</b></sub>
             </a>
         </td>
         <td align="center">
@@ -609,6 +616,8 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>Josh Kramer</b></sub>
             </a>
         </td>
+		</tr>
+		<tr>
         <td align="center">
             <a href="https://github.com/daresTheDevil">
                 <img src="https://avatars.githubusercontent.com/u/16613132?v=4" width="100;" alt="daresTheDevil"/>
@@ -616,8 +625,6 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>David Kay</b></sub>
             </a>
         </td>
-		</tr>
-		<tr>
         <td align="center">
             <a href="https://github.com/kodyjackson">
                 <img src="https://avatars.githubusercontent.com/u/180445400?v=4" width="100;" alt="kodyjackson"/>
@@ -653,41 +660,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>Chris</b></sub>
             </a>
         </td>
-        <td align="center">
-            <a href="https://github.com/mgifford">
-                <img src="https://avatars.githubusercontent.com/u/116832?v=4" width="100;" alt="mgifford"/>
-                <br />
-                <sub><b>Mike Gifford</b></sub>
-            </a>
-        </td>
 		</tr>
 		<tr>
-        <td align="center">
-            <a href="https://github.com/lpsinger">
-                <img src="https://avatars.githubusercontent.com/u/728407?v=4" width="100;" alt="lpsinger"/>
-                <br />
-                <sub><b>Leo Singer</b></sub>
-            </a>
-        </td>
-        <td align="center">
-            <a href="https://github.com/fpigeonjr">
-                <img src="https://avatars.githubusercontent.com/u/4629398?v=4" width="100;" alt="fpigeonjr"/>
-                <br />
-                <sub><b>Frank Pigeon Jr.</b></sub>
-            </a>
-        </td>
         <td align="center">
             <a href="https://github.com/chazchumley">
                 <img src="https://avatars.githubusercontent.com/u/1307376?v=4" width="100;" alt="chazchumley"/>
                 <br />
                 <sub><b>Chaz Chumley</b></sub>
-            </a>
-        </td>
-        <td align="center">
-            <a href="https://github.com/miguelsousa">
-                <img src="https://avatars.githubusercontent.com/u/2119742?v=4" width="100;" alt="miguelsousa"/>
-                <br />
-                <sub><b>Miguel Sousa</b></sub>
             </a>
         </td>
         <td align="center">
@@ -698,10 +677,31 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/chandracarney">
-                <img src="https://avatars.githubusercontent.com/u/8561841?v=4" width="100;" alt="chandracarney"/>
+            <a href="https://github.com/miguelsousa">
+                <img src="https://avatars.githubusercontent.com/u/2119742?v=4" width="100;" alt="miguelsousa"/>
                 <br />
-                <sub><b>Chandra</b></sub>
+                <sub><b>Miguel Sousa</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/mgifford">
+                <img src="https://avatars.githubusercontent.com/u/116832?v=4" width="100;" alt="mgifford"/>
+                <br />
+                <sub><b>Mike Gifford</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/fpigeonjr">
+                <img src="https://avatars.githubusercontent.com/u/4629398?v=4" width="100;" alt="fpigeonjr"/>
+                <br />
+                <sub><b>Frank Pigeon Jr.</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/lpsinger">
+                <img src="https://avatars.githubusercontent.com/u/728407?v=4" width="100;" alt="lpsinger"/>
+                <br />
+                <sub><b>Leo Singer</b></sub>
             </a>
         </td>
 		</tr>
@@ -985,10 +985,10 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/awolfe76">
-                <img src="https://avatars.githubusercontent.com/u/2932572?v=4" width="100;" alt="awolfe76"/>
+            <a href="https://github.com/bengm">
+                <img src="https://avatars.githubusercontent.com/u/819222?v=4" width="100;" alt="bengm"/>
                 <br />
-                <sub><b>Andrew Wolfe</b></sub>
+                <sub><b>Ben Morris</b></sub>
             </a>
         </td>
         <td align="center">
@@ -999,17 +999,17 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/bengm">
-                <img src="https://avatars.githubusercontent.com/u/819222?v=4" width="100;" alt="bengm"/>
-                <br />
-                <sub><b>Ben Morris</b></sub>
-            </a>
-        </td>
-        <td align="center">
             <a href="https://github.com/bonnieAcameron">
                 <img src="https://avatars.githubusercontent.com/u/96838068?v=4" width="100;" alt="bonnieAcameron"/>
                 <br />
                 <sub><b>Bonnie Cameron</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/awolfe76">
+                <img src="https://avatars.githubusercontent.com/u/2932572?v=4" width="100;" alt="awolfe76"/>
+                <br />
+                <sub><b>Andrew Wolfe</b></sub>
             </a>
         </td>
 		</tr>
@@ -1029,24 +1029,24 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/NSKbot">
-                <img src="https://avatars.githubusercontent.com/u/110927712?v=4" width="100;" alt="NSKbot"/>
+            <a href="https://github.com/konklone">
+                <img src="https://avatars.githubusercontent.com/u/4592?v=4" width="100;" alt="konklone"/>
                 <br />
-                <sub><b>Noah Kunin</b></sub>
+                <sub><b>Eric Mill</b></sub>
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/nickbristow">
-                <img src="https://avatars.githubusercontent.com/u/5296248?v=4" width="100;" alt="nickbristow"/>
+            <a href="https://github.com/fsierra">
+                <img src="https://avatars.githubusercontent.com/u/903042?v=4" width="100;" alt="fsierra"/>
                 <br />
-                <sub><b>Nick</b></sub>
+                <sub><b>Fabian Sierra</b></sub>
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/mikki-stacey">
-                <img src="https://avatars.githubusercontent.com/u/91696171?v=4" width="100;" alt="mikki-stacey"/>
+            <a href="https://github.com/jeffpw-goog">
+                <img src="https://avatars.githubusercontent.com/u/165937506?v=4" width="100;" alt="jeffpw-goog"/>
                 <br />
-                <sub><b>Mikki Stacey</b></sub>
+                <sub><b>jeffpw-goog</b></sub>
             </a>
         </td>
         <td align="center">
@@ -1059,31 +1059,31 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
 		</tr>
 		<tr>
         <td align="center">
-            <a href="https://github.com/konklone">
-                <img src="https://avatars.githubusercontent.com/u/4592?v=4" width="100;" alt="konklone"/>
+            <a href="https://github.com/NSKbot">
+                <img src="https://avatars.githubusercontent.com/u/110927712?v=4" width="100;" alt="NSKbot"/>
                 <br />
-                <sub><b>Eric Mill</b></sub>
+                <sub><b>Noah Kunin</b></sub>
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/jeffpw-goog">
-                <img src="https://avatars.githubusercontent.com/u/165937506?v=4" width="100;" alt="jeffpw-goog"/>
+            <a href="https://github.com/mikki-stacey">
+                <img src="https://avatars.githubusercontent.com/u/91696171?v=4" width="100;" alt="mikki-stacey"/>
                 <br />
-                <sub><b>jeffpw-goog</b></sub>
+                <sub><b>Mikki Stacey</b></sub>
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/fsierra">
-                <img src="https://avatars.githubusercontent.com/u/903042?v=4" width="100;" alt="fsierra"/>
+            <a href="https://github.com/nickbristow">
+                <img src="https://avatars.githubusercontent.com/u/5296248?v=4" width="100;" alt="nickbristow"/>
                 <br />
-                <sub><b>Fabian Sierra</b></sub>
+                <sub><b>Nick</b></sub>
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/skonzem">
-                <img src="https://avatars.githubusercontent.com/u/11252754?v=4" width="100;" alt="skonzem"/>
+            <a href="https://github.com/chenxsan">
+                <img src="https://avatars.githubusercontent.com/u/1091472?v=4" width="100;" alt="chenxsan"/>
                 <br />
-                <sub><b>Scott Konzem</b></sub>
+                <sub><b>Sam Chen</b></sub>
             </a>
         </td>
         <td align="center">
@@ -1205,6 +1205,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
+            <a href="https://github.com/jeana-adhoc">
+                <img src="https://avatars.githubusercontent.com/u/117098918?v=4" width="100;" alt="jeana-adhoc"/>
+                <br />
+                <sub><b>Jeana Clark</b></sub>
+            </a>
+        </td>
+        <td align="center">
             <a href="https://github.com/vssinghh">
                 <img src="https://avatars.githubusercontent.com/u/11586143?v=4" width="100;" alt="vssinghh"/>
                 <br />
@@ -1225,20 +1232,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>Kal Keckler</b></sub>
             </a>
         </td>
+		</tr>
+		<tr>
         <td align="center">
             <a href="https://github.com/jbouder">
                 <img src="https://avatars.githubusercontent.com/u/61591423?v=4" width="100;" alt="jbouder"/>
                 <br />
                 <sub><b>Johnny Bouder</b></sub>
-            </a>
-        </td>
-		</tr>
-		<tr>
-        <td align="center">
-            <a href="https://github.com/chenxsan">
-                <img src="https://avatars.githubusercontent.com/u/1091472?v=4" width="100;" alt="chenxsan"/>
-                <br />
-                <sub><b>Sam Chen</b></sub>
             </a>
         </td>
         <td align="center">
@@ -1337,10 +1337,10 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
-            <a href="https://github.com/dsturley">
-                <img src="https://avatars.githubusercontent.com/u/421380?v=4" width="100;" alt="dsturley"/>
+            <a href="https://github.com/skonzem">
+                <img src="https://avatars.githubusercontent.com/u/11252754?v=4" width="100;" alt="skonzem"/>
                 <br />
-                <sub><b>David Sturley</b></sub>
+                <sub><b>Scott Konzem</b></sub>
             </a>
         </td>
         <td align="center">
@@ -1418,6 +1418,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
             </a>
         </td>
         <td align="center">
+            <a href="https://github.com/ANONYMOUSZED-beep">
+                <img src="https://avatars.githubusercontent.com/u/72853699?v=4" width="100;" alt="ANONYMOUSZED-beep"/>
+                <br />
+                <sub><b>Arun</b></sub>
+            </a>
+        </td>
+        <td align="center">
             <a href="https://github.com/arielkennan">
                 <img src="https://avatars.githubusercontent.com/u/3219885?v=4" width="100;" alt="arielkennan"/>
                 <br />
@@ -1445,6 +1452,8 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>Andrew Hughey</b></sub>
             </a>
         </td>
+		</tr>
+		<tr>
         <td align="center">
             <a href="https://github.com/adunkman">
                 <img src="https://avatars.githubusercontent.com/u/14930?v=4" width="100;" alt="adunkman"/>
@@ -1452,8 +1461,6 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <sub><b>Andrew Dunkman (he/him)</b></sub>
             </a>
         </td>
-		</tr>
-		<tr>
         <td align="center">
             <a href="https://github.com/alex">
                 <img src="https://avatars.githubusercontent.com/u/772?v=4" width="100;" alt="alex"/>
@@ -1473,13 +1480,6 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <img src="https://avatars.githubusercontent.com/u/144495202?v=4" width="100;" alt="AKnassa"/>
                 <br />
                 <sub><b>AK</b></sub>
-            </a>
-        </td>
-        <td align="center">
-            <a href="https://github.com/jeana-adhoc">
-                <img src="https://avatars.githubusercontent.com/u/117098918?v=4" width="100;" alt="jeana-adhoc"/>
-                <br />
-                <sub><b>Jeana Clark</b></sub>
             </a>
         </td>
         <td align="center">
@@ -1612,6 +1612,13 @@ Total number of contributors to this particular repository: <!--CONTRIBUTOR COUN
                 <img src="https://avatars.githubusercontent.com/u/6078452?v=4" width="100;" alt="David-Way"/>
                 <br />
                 <sub><b>David Way</b></sub>
+            </a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/dsturley">
+                <img src="https://avatars.githubusercontent.com/u/421380?v=4" width="100;" alt="dsturley"/>
+                <br />
+                <sub><b>David Sturley</b></sub>
             </a>
         </td>
 		</tr>

--- a/packages/usa-nav/src/styles/_usa-nav.scss
+++ b/packages/usa-nav/src/styles/_usa-nav.scss
@@ -253,7 +253,7 @@ $expand-less-icon: map.merge(
       span {
         @include place-icon($-add-icon, "after");
 
-        &::after:hover {
+        &:hover::after {
           background-color: buttonText;
         }
       }


### PR DESCRIPTION
## Summary

Correct the collapsed navigation icon selector from `::after:hover` to `:where(:hover)::after`. Applying hover to the containing span produces a valid selector. Using `:where()` preserves the previous specificity, so application styles that customize the icon continue to win.

A plain `:hover::after` introduces an override regression. With this later application rule, the icon should remain red on hover:

```css
.usa-nav__primary button[aria-expanded=false] span::after {
  background-color: rgb(190, 0, 0);
}
```

The previous PR head changed the icon to the system button-text color. The repaired head retains red. Originally reported by @nektro.

## Breaking change

This is not a breaking change. Existing markup and customization precedence remain supported. The demonstrated override regression in the earlier PR head is repaired.

## Testing and review

Verified at `ec3e720edcbcd20f2dd69cf13da70ae6621d5e43`:

- Compiled the actual base and PR Sass and reproduced the consumer override failure in Chromium, Firefox, and WebKit. All three engines pass the repaired case.
- Compared idle, hover, keyboard-focus, and expanded states at 375px and 1200px with normal and emulated forced colors. All 16 base/repair observations per engine match for default styling.
- Retained before/after screenshots using the pinned Material icon assets. Formatting and whitespace checks pass.
- Current build, signature, CodeQL, and security checks pass. The title follows the current conventional-title policy.

These are browser probes, not a committed regression test in the repository suite. A jsdom hover assertion cannot verify rendered pseudo-element styling. Durable CSS-aware browser coverage remains a useful follow-up. Forced-colors emulation does not establish actual Windows high-contrast behavior, and WebKit is not released Safari.

Before merge, refresh the branch base and rerun final verification. The current `PR title` workflow checks an older trusted base that lacks `.github/scripts/check-pr-title.test.mjs`, so it fails before validating the title. This PR remains open.
